### PR TITLE
Add game vision and agent team design documents

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -31,11 +31,12 @@ use Write tool for /tmp files (unique names prevent exists-error); cat > heredoc
 THIS RULE APPLIES TO SUBAGENTS TOO: embed it verbatim at the top of every prompt written to /tmp before spawning
 
 §LAYOUT
+$ts/vision/     game vision+design docs — read first; anchors everything
 $ts/research/   read before implementing
 $ts/tickets/    TICKETS.md index + ticket files; check before starting new work
 $ts/plans/      implementation plans
 $ts/handoffs/   session handoff documents
-before non-trivial impl: check $ts/tickets/TICKETS.md + $ts/research/ for prior work
+before non-trivial impl: check $ts/vision/ + $ts/tickets/TICKETS.md + $ts/research/ for prior work
 
 §TICKETS
 TICKETS.md=canonical index; do NOT maintain ticket inventories elsewhere

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,13 +46,14 @@ Always write content to a file first, then reference it by path:
 ## Repository Layout (Key Directories)
 
 ```
+thoughts/shared/vision/     # Game vision and design documents (read first — anchors everything)
 thoughts/shared/research/   # Research documents (read before implementing)
 thoughts/shared/tickets/    # Ticket files + TICKETS.md index (check before starting new work)
 thoughts/shared/plans/      # Implementation plans
 thoughts/shared/handoffs/   # Session handoff documents
 ```
 
-Before starting any non-trivial implementation work: check `thoughts/shared/tickets/TICKETS.md` for a summary of open and resolved work, and `thoughts/shared/research/` for relevant prior research.
+Before starting any non-trivial implementation work: check `thoughts/shared/vision/` for the current game vision (it anchors all design decisions), `thoughts/shared/tickets/TICKETS.md` for a summary of open and resolved work, and `thoughts/shared/research/` for relevant prior research.
 
 ---
 

--- a/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md
+++ b/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md
@@ -1,0 +1,166 @@
+<!--COMPRESSED v1; source:2026-04-23-agent-team-and-workflow-design.md-->
+§META
+date:2026-04-23 researcher:claude+cgruber branch:main repo:cgruber/redistricting-sim
+topic:multi-agent team design+workflow tags:agents,workflow,roles,team-design,product,architecture
+status:provisional — tech stack session pending last_updated:2026-04-23
+
+§ABBREV
+PM=Product Manager GES=Game Engine Specialist ARCH=Architect
+WD=Web/UI Designer VDA=Visual Designer/Artist
+TDDB=TDD Designer(backend) TDDF=TDD Designer(frontend)
+CB=Coder(backend) CF=Coder(frontend)
+DR=Domain Reviewer EER=Educational Effectiveness Reviewer
+SR=Security Reviewer A11Y=Accessibility Reviewer CFR=Cost/Finance Reviewer
+LR=Legal Reviewer BS=Build Specialist
+ts=thoughts/shared nfr=non-functional requirement
+
+§SUMMARY
+Multi-agent team for redistricting-sim. Extends polyglot TDD workflow ($ts/research/2026-04-21-multi-agent-tdd-workflow.md)
+with: PM, GES, VDA added as standing; 7 on-demand reviewers; SCRUM-like sprint rhythm.
+Two prerequisites before impl: tech stack session (GES+ARCH) + game vision doc (PM+user).
+
+§STANDING_ROLES
+
+PM
+  domain: what+why; feature specs; acceptance criteria; sprint priorities
+  proxy: represents user to all agents; escalates to user for direction changes,
+    practical-constraint deviations, large-scope changes, educational-fidelity tradeoffs,
+    and regular sprint demos (user plays game each sprint)
+  nfr ownership: DoD, test sufficiency, a11y standards, privacy policy, browser/device targets,
+    educational effectiveness as product req
+
+GES
+  domain: game mechanics; simulation design; electoral algorithms(FPTP v1; STV/party-list stretch);
+    district validity rules(contiguity,compactness); population modeling; scenario mechanics
+  absorbs: domain research for own mechanics design
+  does NOT own: domain accuracy checks → DR(on-demand)
+  vs ARCH: peers, both answer to PM; GES="what can simulation do+how";
+    ARCH="how does system hang together"; negotiate boundary in Phase 1
+
+ARCH
+  domain: system design; API; service boundaries; deployment; data flow; tech choices
+  peers with GES on simulation layer; with DBA on persistence layer
+  nfr ownership: scale targets; perf budgets(page load,latency,animation); security model;
+    observability strategy; cost-aware design (budget envelope from CFR)
+
+DBA
+  domain: schema; migrations; seeding; portability; test data strategy
+  participates: when features touch persistence; absent for frontend-only or simulation-only work
+
+WD
+  domain: map interface design; district-drawing UX; information architecture; user flows
+  outputs: wireframes + interaction specs → TDDF
+  key challenge: data overlays(population density, voting preference, race) readable at a glance
+  works with VDA on visual language
+
+VDA
+  domain: visual identity; style guide; data viz design; game assets(illustrations,
+    cut-scene storyboards/animations, tutorial art, icons, UI chrome)
+  outputs: design specs(color system, typography, animation timing, SVG specs) + actual assets
+  intensity: high up-front(identity+map rendering approach); iterative later(scenario/tutorial assets)
+  CRITICAL: colorblindness — district viz IS the game's visual language; ~8% men affected;
+    accessible color design must be in brief from day one, not retrofitted
+  collaborates: PM(tone,cut-scene vision) GES(simulation data viz) DR(geographic accuracy)
+    WD(visual language,motion) TDDF+CF(SVG/CSS/animation contracts)
+
+TDDB + TDDF
+  domain: tactical API completion; test-first; fill ARCH open space with concrete interfaces,
+    method sigs, error contracts, type shapes, failing tests
+  TDDB reads: ARCH doc + DBA schema
+  TDDF reads: WD interaction specs + ARCH API contract
+  can work in parallel when API contract is clear
+  public contract is fixed once defined; propose changes back to ARCH; never unilateral
+
+CB + CF
+  domain: private implementation below public surface defined by TDD Designer
+  latitude: private types, helpers, internal state, utility extraction, library selection(approved deps)
+  may propose public changes back to TDD Designer; may not change unilaterally
+
+§REVIEWERS
+
+| Role | Trigger(s) |
+|---|---|
+| DR(Domain) | electoral accuracy; scenario validity; VRA representation; domain UI text |
+| EER(Educ.Effectiveness) | scenario design; tutorial design; "does this teach the lesson?" |
+| SR(Security) | any trust boundary: exposed API, user data, UGC, auth |
+| A11Y(Accessibility) | every UI feature before ship; non-optional step in WD→CF pipeline |
+| CFR(Cost/Finance) | infra decisions; 3rd-party service choices; build-vs-buy; cost at scale |
+| LR(Legal) | COPPA/GDPR; map data licensing; real-event scenarios |
+| BS(Build) | new Bazel targets(TS,WASM,Docker); significant CI changes |
+
+COPPA flag: if game reaches US schools, data collection from <13 regulated federally — even
+  anonymised telemetry may be in scope; needs legal position before any analytics added
+Map tile flag: commercial providers charge per-tile-load; compounds fast under classroom load;
+  OpenStreetMap(ODbL) or pre-rendered tiles preferred; CFR+ARCH must evaluate early
+
+reviewer advantage: stable reusable prompt templates; improve over sprints; outputs auditable
+
+§WORKFLOW
+
+NOT waterfall — iterative cycle. Vision evolves continuously through demos+learnings.
+Phases describe type-of-work, not a one-time sequence.
+
+Cycle:
+  Vision(PM↔user) → Feature Design(PM→GES/ARCH/WD/VDA) → Implementation(TDD→Coder)
+       ↑                                                           ↓
+       └──────────────── Demo(user plays; feedback) ──────────────┘
+
+Vision (living doc, updated every sprint):
+  PM↔user ongoing; not frozen; updated when: demos surface new understanding;
+    GES/ARCH learnings change feasibility; domain/EE review changes what's appropriate
+  GES consulted on feasibility; VDA on tone; direction changes reviewed with user before acting
+
+Feature Design (per sprint, reads current vision):
+  PM → feature spec+AC(from vision)
+       ↓
+  ┌────┴──────────────────┐
+  GES↔ARCH               VDA
+  (sim+system design)    (visual language+tone)
+  ↓        ↓              ↓
+  └──→DBA←┘            WD
+  (schema if needed)   (wireframes+user flows)
+  ↓                      ↓
+  ARCH system doc      interaction specs
+
+Implementation (per PR):
+  TDDB(reads ARCH+schema) ║ TDDF(reads interaction specs+API contract) [parallel]
+      ↓                   ║       ↓
+     CB                   ║      CF
+
+Demo (closes loop → vision):
+  user plays sprint output; PM synthesises feedback →
+    update vision doc | new ticket | defer
+  feedback can surface: mechanics not teaching intended lesson; confusing UX;
+    wrong scope; new ideas vision didn't anticipate
+
+PM escalation to user: direction changes; constraint deviations; large scope; educ-fidelity
+  tradeoffs; sprint demos
+
+§NFRS
+PM owns: DoD test-sufficiency; a11y standards; privacy policy; browser/device targets; educational effectiveness
+ARCH owns: scale; perf budgets; security model; observability; cost-aware design
+Shared: i18n(PM decides; ARCH implements) — unresolved
+COPPA+GDPR: LR trigger; fire before any telemetry or school use
+
+§AGENT_MECHANICS
+Four advantages of specialty agents vs general-purpose:
+1. context signal/noise: less irrelevant material; mitigates "lost in the middle" degradation
+2. parametric knowledge activation: focused context = focused query into model weights;
+   tighter-scoped prompt activates more precise training knowledge (priming, not attention per se)
+3. parallelism: TDDB+TDDF share only API contract; non-overlapping concerns, no context contamination
+4. prompt reusability: stable reviewer prompts improve over sprints; outputs predictable+auditable
+
+§OPEN
+1. tech stack — in-browser vs server; mobile; WASM(Kotlin Multiplatform?); map tile source
+   → needs GES+ARCH session before any system design
+2. ~~game vision doc — v1 scenarios; player session flow; learning objectives
+   → PM-driven; user-reviewed; required before GES+ARCH design work~~
+   RESOLVED: vision doc written; see $ts/vision/game-vision.compressed.md
+3. LR segmentation(privacy vs IP/licensing) — deferred
+4. component inventory format (WD→TDDF handoff) — deferred until tech stack known
+5. i18n support — PM+user decision; if yes must enter ARCH brief early
+
+§REFS
+prior workflow: $ts/research/2026-04-21-multi-agent-tdd-workflow.md
+project purpose: README.md
+game vision (living doc): $ts/vision/game-vision.compressed.md — scenarios, mechanics, educational goals, v1 scope

--- a/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.md
+++ b/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.md
@@ -1,0 +1,363 @@
+---
+date: 2026-04-23
+researcher: claude+cgruber
+branch: main
+repository: cgruber/redistricting-sim
+topic: Multi-agent team design and development workflow for redistricting-sim
+tags: agents, workflow, roles, team-design, product, architecture
+status: provisional — tech stack session pending
+last_updated: 2026-04-23
+last_updated_by: claude+cgruber
+---
+
+# Agent Team and Workflow Design
+
+## Summary
+
+Design of the multi-agent development team and workflow for the redistricting-sim project.
+Builds on the TDD workflow pattern established in polyglot
+(`thoughts/shared/research/2026-04-21-multi-agent-tdd-workflow.md`) and expands it
+substantially to cover the requirements of a game: product management, game mechanics
+design, web UI, visual design, and a set of on-demand specialist reviewers.
+
+Two open workstreams remain before implementation begins: a tech stack session (involving
+GES and Architect) and a game vision document (PM-driven, user-reviewed).
+
+---
+
+## Role Roster
+
+### Standing Production Roles
+
+These roles participate in every sprint or every feature, depending on scope.
+
+#### Product Manager (PM)
+**Domain:** What gets built and why. Translates the user's educational goals into
+concrete feature specs, acceptance criteria, and sprint priorities. Represents the user
+to all other agents between formal checkpoints. Makes on-the-fly decisions within
+established scope; escalates to user for: fundamental direction changes, deviations from
+prior decisions due to new constraints or learnings, large-scope changes, and any tradeoff
+of educational fidelity against playability (this tradeoff is close to the project's core
+and warrants user input rather than unilateral PM decisions).
+
+**Also owns (non-functional):** Definition of Done, test sufficiency standards,
+accessibility standards, privacy/data collection policy, browser/device targets,
+educational effectiveness as a product requirement.
+
+**Workflow rhythm:** SCRUM-like. Drives sprint planning with user input. Owns regular
+demos — the user plays whatever has been built each sprint, giving feedback that feeds
+the next cycle.
+
+#### Game Engine Specialist (GES)
+**Domain:** Game mechanics design and simulation. Owns: electoral algorithm design
+(FPTP for v1; STV, party-list, etc. as stretch goals), district validity rules
+(contiguity, compactness metrics), population distribution modeling, scenario mechanics,
+progression design. Does necessary domain research as part of this work (how FPTP
+counting actually works, what compactness metrics academics use, historical redistricting
+patterns). Not responsible for raw domain accuracy checks — that's the Domain Reviewer's
+role on-demand.
+
+**Relationship to Architect:** Peer/co-designer, not subordinate. Both answer to PM.
+GES owns "what is the simulation capable of and how should it work"; Architect owns "how
+does the system hang together." They negotiate the boundary between those two in Phase 1
+of feature design.
+
+#### Architect
+**Domain:** How all systems hang together. API design, service boundaries, deployment
+strategy, data flow, technology choices, integration points. Co-designs with GES on the
+simulation layer; co-designs with DBA on the persistence layer.
+
+**Also owns (non-functional):** Scale targets, performance budgets (page load, simulation
+latency, animation frame budget), security model (threat model, input validation, rate
+limiting), observability strategy, cost-aware design (infrastructure choices must live
+within a budget envelope informed by the Cost/Finance Reviewer).
+
+#### DBA
+**Domain:** Schema design, migrations, seeding, DB portability, test data strategy.
+Serves the Architect's intent; negotiates data model constraints back. Participates when
+features touch the persistence layer; not present for purely frontend or simulation-only
+changes.
+
+#### Web/UI Designer
+**Domain:** Interactive map interface design, user experience for district drawing,
+information architecture, user flows. Produces wireframes and interaction specs as primary
+handoff artifacts to frontend TDD Designer. Works closely with Visual Designer/Artist on
+visual language. The district-drawing interaction and the data overlay design (communicating
+population density, voting preference, racial composition at a glance) are core UX challenges
+for this game.
+
+#### Visual Designer/Artist
+**Domain:** Visual identity, style guide, data visualization design, game assets
+(illustrations, cut-scene storyboards/animations, tutorial art, icons, UI chrome).
+Produces both design specs (color systems, typography, animation timing contracts, SVG
+specs) and actual assets.
+
+**Role intensity varies:** High up-front work establishing visual identity and map
+rendering approach (before Web Designer can produce meaningful wireframes); shifts to
+iterative asset production for specific scenarios, tutorials, and cut-scenes in later
+sprints.
+
+**Key constraint to establish early:** Colorblindness. District boundary visualization
+and data overlays are the entire visual language of the game. ~8% of men have color
+vision deficiency. Accessible color design must be in the brief from the start, not
+retrofitted.
+
+**Collaboration graph (widest of any role):**
+- PM: tone, educational intent, scenario cut-scene vision
+- GES: how simulation data is visualized; what the map communicates
+- Domain Reviewer: visual accuracy of geographic/demographic representations
+- Web Designer: visual language, component design, interaction motion design
+- Frontend TDD Designer/Coder: SVG specs, CSS variables, animation timing contracts
+
+#### TDD Designer (Backend) and TDD Designer (Frontend)
+**Domain:** Tactical API completion and test-first design for their layer. Fill the
+Architect's open design space with concrete interfaces, method signatures, error contracts,
+type shapes, and tests. Their definitions are the public contract Coders must implement.
+Can propose contract changes back to the Architect but may not unilaterally change
+signatures.
+
+Frontend TDD Designer works from Web Designer interaction specs + Architect's API contract.
+Backend TDD Designer works from Architect's system design + DBA schema.
+Both can work in parallel on the same feature when the API contract is clear.
+
+#### Coder (Backend) and Coder (Frontend)
+**Domain:** Private implementation — everything below the public surface defined by TDD
+Designer. Full creative latitude on: private types, helpers, internal state, utility
+extraction, library selection within approved deps. May propose public contract changes
+back to TDD Designer; may not change them unilaterally.
+
+---
+
+### On-Demand Reviewer Roles
+
+These roles are not present in every sprint. They are invoked at specific trigger points.
+Each should have a stable, reusable prompt template that improves over time.
+
+#### Domain Reviewer
+**Invoked for:** Electoral accuracy checks, scenario validity ("is this redistricting
+scenario realistic?"), Voting Rights Act representation accuracy, domain-specific text in
+the UI.
+**Distinct from GES:** GES reasons about what mechanics are possible; Domain Reviewer
+reasons about whether those mechanics accurately represent the real domain.
+
+#### Educational Effectiveness Reviewer
+**Invoked for:** Scenario design review, tutorial design, "does this actually teach the
+intended lesson?" The game can be mechanically correct and pedagogically ineffective.
+Someone needs to own this review at the scenario level.
+**Distinct from GES:** GES reasons about mechanics; this role reasons about learning
+outcomes and instructional design.
+
+#### Security Reviewer
+**Invoked for:** Every sprint touching a trust boundary: API endpoints exposed to the
+internet, anything involving user data, scenario sharing if user-generated content is
+added, auth if user accounts are introduced.
+
+#### Accessibility Reviewer
+**Invoked for:** Every UI feature before it ships. Given the educational target audience
+and the visual complexity of the game's core interface, this should be a non-optional
+step in the Web Designer → Frontend Coder pipeline, not an afterthought.
+
+#### Cost/Finance Reviewer
+**Invoked for:** Infrastructure decisions, third-party service choices, build-vs-buy
+decisions. Evaluates "what does this cost at 100 concurrent users? At 10,000 during a
+viral classroom moment?" Output feeds directly into Architect's tradeoff decisions.
+**Context:** The game is intended to be free and donation-supported. Fixed operational
+costs must stay within what a small donation base can sustain. Map tile costs in
+particular can compound fast under load (see map data licensing note below).
+
+#### Legal Reviewer
+**Invoked for:** COPPA/GDPR analysis (if we collect any telemetry — even anonymised —
+and the game reaches schools or EU users), map data licensing (OpenStreetMap ODbL vs.
+commercial), any scenario based on real political events. May be segmented into specialised
+sub-roles later (privacy law, IP/licensing) as needs clarify.
+
+**COPPA flag:** If the game is used in US schools, federal law governs data collection
+from children under 13. This applies even to anonymised telemetry. Needs a legal position
+before any analytics are added.
+
+#### Build Specialist
+**Invoked for:** Adding new build targets to Bazel (TypeScript frontend, WASM compilation,
+Docker packaging, map asset processing), significant CI pipeline changes. The Architect
+should not need to hold deep Bazel bzlmod expertise; the Build Specialist provides a
+dedicated context for "how does this new thing integrate correctly and what are the
+MODULE.bazel implications."
+
+---
+
+## Workflow
+
+**This is an iterative cycle, not a waterfall.** Vision is established first but is never
+frozen — it evolves continuously through demos and learnings. Each sprint demo feeds back
+into the vision, which shapes the next round of feature design. The three phases describe
+the *type* of work happening, not a strict sequence that happens once.
+
+```
+        ┌─────────────────────────────────────────┐
+        ↓                                         │
+  Vision (PM ↔ user)                              │
+        ↓                                         │
+  Feature Design (PM → GES/Arch/WD/VDA)           │
+        ↓                                         │
+  Implementation (TDD Designer → Coder)           │
+        ↓                                         │
+  Demo (user plays, gives feedback) ──────────────┘
+```
+
+### Vision — living document, evolves every sprint
+
+PM ↔ user: ongoing conversation that started at project inception and continues
+throughout. The game vision document (`thoughts/shared/vision/game-vision.md`) is a
+*living document*, not a frozen spec. It is updated when: demos surface new understanding,
+GES or Architect learnings change what's feasible, domain or educational effectiveness
+review changes what's appropriate.
+
+GES is consulted on simulation feasibility; Visual Designer on tone and aesthetic direction.
+Any update to the vision document that represents a meaningful direction change is reviewed
+with the user before being acted on.
+
+### Feature Design — per sprint, informed by current vision
+
+Each sprint begins with PM checking the current vision state and translating it into a
+concrete feature spec with acceptance criteria. The vision doc is the input; the feature
+spec is the output.
+
+```
+PM writes feature spec + acceptance criteria
+         ↓
+    ┌────┴─────────────────────────┐
+    ↓                              ↓
+GES ↔ Architect              Visual Designer/Artist
+(simulation + system design)  (visual language + interaction tone)
+    ↓         ↓                    ↓
+    └──→ DBA ←┘               Web Designer
+    (schema if needed)        (wireframes + user flows)
+         ↓                         ↓
+    Architect's system doc    Interaction specs
+```
+
+GES and Architect co-produce the Phase 1 design document — same collaborative model as
+DBA+Architect in the polyglot TDD workflow, but for the simulation/system layer rather
+than the data layer.
+
+Visual Designer and Web Designer work in parallel, with Visual Designer's style guide as
+a constraint on Web Designer's wireframes.
+
+### Implementation — per PR, per layer
+
+```
+Backend TDD Designer          Frontend TDD Designer
+(reads Arch doc + schema)     (reads interaction specs + API contract)
+         ↓                              ↓
+    Backend Coder              Frontend Coder
+```
+
+Both pairs work in parallel when the API contract (shared boundary) is clear. Each TDD
+Designer produces: interfaces, method signatures, error contracts, type shapes, and failing
+tests. Coders fill the implementation bodies.
+
+### Demo — closes the loop back to vision
+
+At the end of each sprint, the user plays what has been built. Demo feedback is not just
+bug reports — it can surface: mechanics that don't teach the intended lesson, UI flows
+that confuse, scope that feels wrong, or new ideas the vision document didn't anticipate.
+PM synthesises demo feedback and decides what updates the vision document, what becomes a
+new ticket, and what is deferred.
+
+### Review Gates (woven into implementation)
+
+| Trigger | Reviewer invoked |
+|---|---|
+| Any trust boundary touched | Security Reviewer |
+| Any UI feature | Accessibility Reviewer |
+| Infrastructure/service decision | Cost/Finance Reviewer |
+| Scenario or tutorial content | Educational Effectiveness Reviewer |
+| Electoral accuracy question | Domain Reviewer |
+| New Bazel target or CI change | Build Specialist |
+| Data collection, school use, map licensing | Legal Reviewer |
+
+### PM Escalation to User
+
+PM makes on-the-fly decisions within scope. Escalates to user for:
+- Fundamental direction changes
+- Deviations from prior decisions due to new constraints or learnings
+- Large-scope changes
+- Any tradeoff of educational fidelity for playability
+- Sprint demos (user plays the game, gives feedback; feeds back into vision)
+
+---
+
+## Non-Functional Requirement Ownership
+
+| NFR | Owner |
+|---|---|
+| Definition of Done, test sufficiency | PM |
+| Accessibility standards | PM (requirement); Web/Visual Designers (implementation) |
+| Privacy/data collection policy | PM + Legal Reviewer |
+| Browser/device targets | PM |
+| Educational effectiveness | PM + Educational Effectiveness Reviewer |
+| Scale targets | Architect |
+| Performance budgets | Architect |
+| Security model | Architect + Security Reviewer |
+| Observability strategy | Architect |
+| Cost-aware design | Architect + Cost/Finance Reviewer |
+| Internationalisation | PM (decision to support); Architect (how) — unresolved |
+| COPPA/GDPR compliance | Legal Reviewer; trigger: any telemetry or school use |
+
+---
+
+## Mechanical Advantage of Specialty Agents
+
+Four distinct advantages over general-purpose agents for specialist roles:
+
+1. **Context signal/noise.** Attention in transformers operates over the context window.
+   A focused specialist context has less irrelevant material to route through, improving
+   signal quality. The documented "lost in the middle" phenomenon (models perform worse on
+   information buried in long, noisy contexts) is mitigated by shorter, denser contexts.
+
+2. **Context as query into parametric knowledge.** The model's knowledge lives in weights
+   (from training). The context acts as a query that activates specific learned patterns.
+   A tightly scoped security-review prompt activates security-relevant knowledge more
+   precisely than a broad prompt spanning game design, electoral law, and frontend
+   architecture simultaneously. This is priming, not attention per se, but the effect is real.
+
+3. **Parallelism with non-overlapping concerns.** Frontend TDD Designer and Backend TDD
+   Designer working simultaneously on the same feature share only the API contract. Their
+   file sets and contexts don't overlap. Two specialists in parallel is faster and produces
+   less context contamination than one general agent working sequentially.
+
+4. **Prompt template reusability.** A stable, well-crafted reviewer prompt (Security,
+   A11y, Cost) improves over sprints. Each invocation starts from a high, consistent
+   baseline. Review outputs are predictable and auditable — you can assess whether the
+   review covered what it was supposed to cover.
+
+---
+
+## Open Questions
+
+1. **Tech stack** — in-browser vs. server computation, mobile roadmap, WASM feasibility
+   (Kotlin Multiplatform?). Needs a dedicated session with GES and Architect before
+   system design begins. Map tile data source is part of this (cost + licensing
+   implications).
+
+2. ~~**Game vision document** — what are the concrete v1 scenarios? What does a player
+   session look like start to finish? What should a player understand at the end that they
+   didn't before? PM-driven, user-reviewed. Required before GES or Architect can produce
+   meaningful designs.~~ **Resolved** — game vision doc written and included in this PR
+   (`thoughts/shared/vision/game-vision.md`).
+
+3. **Legal reviewer segmentation** — may split into privacy law and IP/licensing
+   sub-roles as the project matures. Deferred for now.
+
+4. **Component inventory format** — handoff artifact from Web Designer to Frontend TDD
+   Designer. Deferred until tech stack is chosen.
+
+5. **Internationalisation** — whether to support multiple languages is a PM/user decision.
+   Unresolved; if yes, must be in the Architect's brief early.
+
+---
+
+## References
+
+- Prior workflow research: `thoughts/shared/research/2026-04-21-multi-agent-tdd-workflow.md`
+- Project purpose: `README.md`
+- Game vision (living doc): `thoughts/shared/vision/game-vision.compressed.md` — scenarios, mechanics, educational goals, v1 scope

--- a/thoughts/shared/tickets/AGENT-001-compressed-abbrev-dollar-prefix.md
+++ b/thoughts/shared/tickets/AGENT-001-compressed-abbrev-dollar-prefix.md
@@ -1,0 +1,33 @@
+---
+id: AGENT-001
+title: Apply $abr dollar-prefix convention to all compressed docs
+area: docs, agents
+status: open
+created: 2026-04-23
+---
+
+## Summary
+
+The `.compressed.md` convention requires that all §ABBREV key references in the body of a compressed document use the `$abr` dollar-prefix format (e.g. `$ts/tickets/` not `ts/tickets/`, `$pc` not bare `pc`). This makes abbreviation expansions unambiguous at a glance.
+
+The following files were written without applying this convention and need a pass:
+
+- `thoughts/shared/vision/game-vision.compressed.md` — abbreviations: `pc`, `seg`, `dist`, `FPTP`, `VRA`, `v1`
+- `thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md` — abbreviations: `PM`, `GES`, `ARCH`, `WD`, `VDA`, `TDDB`, `TDDF`, `CB`, `CF`, `DR`, `EER`, `SR`, `A11Y`, `CFR`, `LR`, `BS`, `ts`, `nfr`
+
+Exception per convention: literal tool/target names that share a prefix (e.g. `grpc_kotlin`, `ktfmt`) stay as literals. Also watch for prose words that could be mistaken for abbreviations.
+
+## Current State
+
+Both files use bare abbreviation names in their bodies. Functionally correct but not convention-compliant.
+
+## Goals / Acceptance Criteria
+
+- [ ] All §ABBREV key references in `game-vision.compressed.md` use `$abr` format
+- [ ] All §ABBREV key references in `2026-04-23-agent-team-and-workflow-design.compressed.md` use `$abr` format
+- [ ] Any other `.compressed.md` files added in the future follow the convention from creation
+
+## References
+
+- Convention: `feedback_compressed_abbrev_format.md` in session memory
+- Flagged by: critique agent on PR #1

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -33,6 +33,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
+| `AGENT-001-compressed-abbrev-dollar-prefix.md` | docs, agents | Apply $abr dollar-prefix convention to all compressed docs (game-vision, agent-team-design) |
 | `KT-004-kotlin-docker-deployment.md` | kotlin, docker, deployment | Docker container build for Kotlin service; staging + production profiles |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `BUILD-001-grpc-kotlin-bzlmod-migration.md` | kotlin, bazel, grpc | Migrate to bzlmod-native `grpc_kotlin` when upstream supports it |

--- a/thoughts/shared/vision/game-vision.compressed.md
+++ b/thoughts/shared/vision/game-vision.compressed.md
@@ -1,0 +1,195 @@
+<!--COMPRESSED v1; source:game-vision.md-->
+§META
+type:vision status:draft created:2026-04-23 authors:cgruber+claude last_updated:2026-04-23
+LIVING DOC — updated each sprint after demo; direction changes reviewed with user before acting
+
+§ABBREV
+pc=precinct seg=segment dist=district
+FPTP=first-past-the-post VRA=Voting Rights Act
+v1=version 1 scope
+
+§GOAL
+Primary: players understand viscerally that same population+votes → wildly different outcomes
+  depending on who drew the lines and why; teach through doing — player IS the gerrymanderer
+Secondary: "neutral rules" don't eliminate politics, they constrain it differently;
+  different rule-sets → different outcomes; no apolitical map
+Stance: education not advocacy; multiple perspectives presented; player leaves with better
+  questions not predetermined answers
+Stretch(later): Arrow's impossibility — every electoral system encodes tradeoffs; no system
+  satisfies all fairness criteria simultaneously; invitation to think harder, not cynicism
+
+§NEUTRALITY
+Operational design decisions (not just a disclaimer):
+symmetric partisan: both parties get equal treatment; each partisan scenario completable
+  for either; fictional party names(Red/Blue Party); no mapping to real parties
+neutral rules NOT The Answer: scenarios show what neutral rules achieve+don't;
+  bipartisan-agreed standards still produce partisan outcomes; no rule-set declared correct
+outcome-first framing: "what happens when you do X?" not "X is wrong"
+About page: states educational intent; names designer+non-partisan intent;
+  links to diverse resources(academic,journalistic,multiple political perspectives)
+community scenarios as safety valve: pluralism distributes authorial power;
+  users submit rules-as-advocacy scenarios; game hosts conversation not conclusion
+
+§AUDIENCE
+students(secondary+): civics/electoral/political-geography learning
+engaged adults: heard about gerrymandering; want concrete understanding
+international: curious about US system; interested in comparisons
+accessible(no prior knowledge required) + rewarding(depth for experts)
+
+§MENU
+New Game | Continue(if progress) | Custom Level | Settings | About
+Tutorial: NOT separate item — baked into level 1 as guided walkthrough
+Custom Level: full scenario creator(paint populations, success criteria, rules design,
+  community sharing) — see §CUSTOM_LEVEL
+
+§LOOP
+MainMenu → ScenarioIntro(slides) → Level(map editing) → Test(animated evaluation)
+    → pass: SuccessScreen → NextLevel(unlocked)
+    → fail: Feedback(which criteria failed) → retry
+
+§SCENARIO_INTRO
+narrative context + specific objective + success criteria(required+optional) +
+  scenario-specific mechanic notes
+level 1: also introduces game mechanics; later levels assume familiarity, shorter intros
+
+§TEST
+animated sequence evaluating each success criterion:
+  Governor(thumbs up/concerned/veto) | Legislature(cheer/grumble/close vote) |
+  Lobby groups(vary by scenario) | Legal check(equal pop, contiguity, VRA) |
+  Optional flavor: supreme court challenge, media reaction, incumbent reactions
+fail → shows exactly which criteria missed → return to editing with feedback
+Animation style: simple, self-contained icon reactions; cutesy; animated GIFs or
+  equivalent(short CSS/SVG loops); NOT complex per-scenario authored sequences
+  GES to confirm evaluation model tractability
+
+§SUCCESS_SCREEN
+narrative summary of outcome | achievement notifications | NextLevel button |
+  optionally: "retry for achievements" if optional criteria missed
+
+§ACHIEVEMENTS (examples, not exhaustive)
+Surgical Precision(fewest precinct moves) | Packed to the Gills(extreme packing) |
+Efficiency Gap(notable score) | Judge-Proof(all legal+optional criteria) |
+Bipartisan Groans(both parties unhappy — neutral rules scenarios) |
+Cats and Dogs(complete cats-vs-dogs scenario)
+Replay motivation: achievements + optional criteria + completionism
+
+§MAP_MECHANICS
+Playfield: fictional sub-state region(county/metro/similar) — ONE region per scenario
+  scope: NOT whole state; not multi-state; "zoom out" deferred(may be relevant for electoral-system
+  comparisons later; explicitly not v1 or near-term)
+Precincts(pc): atomic geographic unit; not subdivisible; target ~hundreds; visually small
+  ("fat pixels whose edges you push around"); exact count → calibrate against real regions(see §OPEN)
+pc metadata: population(total+density) | demographic breakdown(race,partisan,gender,religion) |
+  last election result(votes by party, turnout) | scenario-specific data
+dist = grouping of pcs; boundary = edges between adjacent pcs in different dists
+seg = contiguous blob of pcs within a dist; dist may have multiple segs(non-contiguous)
+  non-contiguous: DISABLED by default; enabled only when scenario permits
+
+View filters(color overlay; always show dist boundaries on top):
+  population density | partisan lean | any demographic dimension | district assignment
+Hover: tooltip with all pc metadata; pin for comparison
+
+Editing:
+  brush/paint: stroke determines target dist by starting location; adjustable brush size
+    (large=rough shaping; small=fine detail); boundary updates live
+  single-pc click still available for fine-grained work
+  specific UI motif(brush vs lasso vs flood-fill) → WD+GES decision;
+    constraint: bulk editing must NOT feel like data entry
+  non-contiguous(when enabled): assign pc to non-adjacent dist | create new dist from pc
+  undo/redo always available | reset-to-start restores original scenario boundary
+
+Live validity indicators:
+  population balance(each dist vs target ±%) | contiguity warnings |
+  VRA risk highlights | compactness score(when relevant)
+
+§SCENARIOS
+
+V1 target 8-12:
+| # | Title | Objective | Lesson |
+|---|---|---|---|
+| 1 | Welcome to New Texansifornia | tutorial: draw any valid map | how redistricting works |
+| 2 | Give the Governor a Win | +1 seat for governor's party | basic partisan gerrymandering |
+| 3 | The Packing Problem | pack opposition into fewest dists | packing; efficiency gap |
+| 4 | Cracking the Opposition | dilute opposition across many dists | cracking tactic |
+| 5 | A Voice for the Valley | create majority-Latino dist after pop growth | VRA; majority-minority dists |
+| 6 | Harden the Map | maximise safe seats; minimise competitive | incumbency protection |
+| 7 | The Reform Map | apply neutral rules(compactness+contiguity+equal pop) | what neutral rules achieve+don't |
+| 8 | Both Sides Unhappy | bipartisan-agreed neutral standard | neutral rules don't eliminate politics |
+| 9 | Cats vs. Dogs | Cat Party dominates Dog Party | tone break; reinforce mechanics |
+
+Stretch v1/early v2:
+| 10 | The Canadian Way | Canada arms-length commission rules | international comparison |
+| 11 | After the Boom | census-driven redraw w/ major pop shift | population change |
+
+PR/electoral system scenarios: OUT OF SCOPE for this game — don't fit district-drawing sim;
+  possible separate game in a series; must not constrain this engine's design
+
+1+ additional v1 scenarios needed: complicate reform narrative(e.g. neutral rules →
+  worse minority representation; or "good gerrymander" → more competitive map)
+  these are a named design gap — fill before scenario set is final
+
+Later: historically-inspired(fictional pop data) | VRA s.2 | multi-party | player-designed
+
+Design principles:
+  no two scenarios same primary lesson | ≥1 silly scenario(tone break) |
+  ≥1 surprising/counterintuitive result per scenario | optional criteria add depth w/o blocking
+  character-perspective framing: player cast as specific actor(operative, reformer, etc.)
+    inhabits character's goals+bias; invites player to compare vs. own views
+    matched pairs where possible(gerrymander for A → gerrymander for B)
+  counter-scenarios: ≥1 scenario where neutral rules produce uncomfortable outcome;
+    arc must not conclude reform=good, tactics=bad
+
+§CUSTOM_LEVEL
+V1 scope: scenario data FORMAT only(shared with pre-built scenario authoring); must not
+  preclude player UI or community sharing later
+Player-facing creator(post-v1): paint population data(partisan lean, demographics, density per pc)
+  define success criteria(required+optional; any evaluation dimension)
+  design rules(which constraints apply; compactness thresholds; contiguity; equal pop ±%)
+  write scenario text(intro slides, narrative context, flavor)
+  build fictional or historically-inspired maps(no real geodata required)
+
+Community sharing(post-v1):
+  publish scenarios → shared library; others browse+play+rate
+  distributes authorial power; enables rules-as-advocacy
+  lightweight moderation(no hate speech, no doxxing); NOT filtered by political perspective
+  server-side: scenario data ONLY(no per-session compute); minimal hosting cost
+  play state remains local
+
+§PROGRESSION
+Scenarios: standalone vignettes; no narrative continuity in v1; ordered for pedagogic
+  progression(tutorial→tactics→reform), not story; each has different fictional region+cast
+sequential unlock(complete N → unlock N+1) | replay any completed scenario anytime
+scenario select: completed(+achievement status) | next unlocked | locked visible(anticipation)
+no level cap — game receives new scenarios over time
+Campaign mode(stretch/later): grouped scenarios with shifting goals; possible story arc;
+  no narrative currently in mind; worth workshopping; design must not preclude adding later
+
+§V1_SCOPE
+IN: single-player | single sub-state region/scenario | FPTP only | fictional regions+pops |
+  8-12 scenarios(partisan+demographic+neutral-rules) | desktop-first |
+  progress: local browser storage(IndexedDB/localStorage); no user accounts; no server game state
+  scenario data format(shared w/ pre-built authoring; player UI deferred)
+OUT: player-facing Custom Level UI + community sharing(post-v1) |
+  alt electoral systems(STV,party-list) | real geodata | full-state/multi-state scope |
+  multiplayer | mobile-optimised editor(TBD; may be different model on same data) |
+  international comparisons(early v2) | user accounts/cross-device(v2 if justified) |
+  campaign/narrative mode(stretch; must not be precluded)
+
+§OPEN
+1. [RESOLVED] Custom Level: scenario data format in v1; player UI+community sharing post-v1
+2. [RESOLVED] Save/profile: local browser storage(IndexedDB); no user accounts v1;
+   community scenarios(post-v1) need minimal server storage(scenario data only)
+3. [RESOLVED] Precinct naming: "precinct" confirmed
+4. Mobile: deferred; may be different interaction model on same data; may not happen; no decision needed
+5. Fictional region names+geographies: GES+VDA creative decision per scenario
+6. Tech stack: unresolved → separate GES+ARCH session
+7. Precinct count calibration: target ~hundreds; DR to research real sub-state regions+precinct
+   counts to inform GES+ARCH rendering+perf targets
+8. VRA/bloc voting model: simplified — demographic group vote-share % per pc; district outcome
+   aggregated from breakdown; GES+DR to validate educational soundness; generalises to any demographic
+9. Historical/inspired scenarios: post-v1; fictional pop data on inspired maps; DR required
+10. About page content: deferred until page exists; convey intent+non-partisan framing
+
+§REFS
+team+workflow: thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md
+project purpose: README.md

--- a/thoughts/shared/vision/game-vision.md
+++ b/thoughts/shared/vision/game-vision.md
@@ -1,0 +1,475 @@
+---
+type: vision
+status: draft — awaiting review
+created: 2026-04-23
+authors: cgruber + claude
+last_updated: 2026-04-23
+---
+
+# Redistricting Simulator — Game Vision
+
+**Living document.** Updated each sprint after demo feedback, learnings from GES/Architect,
+or domain/educational-effectiveness review. Direction changes reviewed with the user before
+acting on them.
+
+---
+
+## Educational Goal
+
+Players should finish the game understanding — viscerally, not just intellectually — that
+representative democracy is deeply sensitive to how district boundaries are drawn. The same
+population, the same votes, dramatically different outcomes depending on who drew the lines
+and why. The game teaches through doing: players are asked to *be* the gerrymanderer (and
+the reformer, and the demographer) and experience the levers firsthand.
+
+Secondary goal: show that "neutral rules" don't eliminate politics from redistricting —
+they constrain it differently. Different neutral rule-sets produce different outcomes.
+There is no apolitical map.
+
+This is education, not advocacy. The game presents multiple perspectives — partisan
+optimization, racial representation, neutral-rules idealism, incumbency protection — without
+declaring one correct. Players who finish the game should have better questions, not
+predetermined answers.
+
+A stretch goal (later versions): gesture toward Arrow's impossibility theorem — every
+electoral system encodes trade-offs; there is no system that satisfies all fairness
+criteria simultaneously. Not as a cynical conclusion but as an invitation to think harder.
+
+---
+
+## Political Neutrality and Framing
+
+The game's credibility depends on being genuinely neutral — not just claiming to be. This
+requires operational design decisions, not just a disclaimer.
+
+**Symmetric partisan framing.** Whenever a scenario involves partisan advantage, both
+parties get equal treatment in the scenario set. Scenario 2 ("Give the Governor a Win")
+can be completed for either party. Packing and cracking scenarios are not associated with
+a specific real-world party. Fictional party names (e.g., "Red Party" / "Blue Party") are
+used throughout; no mapping to real parties.
+
+**Neutral rules are not presented as The Answer.** Scenarios 7 and 8 show what neutral
+rules achieve and what they don't — including that bipartisan-agreed neutral standards
+still produce partisan outcomes. The game does not conclude that any one rule-set is
+correct. The Arrow's impossibility stretch goal reinforces that there is no system that
+satisfies all fairness criteria simultaneously.
+
+**Outcome-first scenario framing.** The game asks "what happens when you do X?" rather
+than "X is wrong." The packing/cracking scenarios teach the mechanics — understanding how
+these tactics work is the goal, not condemnation.
+
+**About page transparency.** The About page should describe the project's educational
+intent, acknowledge that redistricting is politically contested, and link to diverse
+secondary resources — academic, journalistic, from multiple political perspectives.
+The specific content and framing of the About page is deferred; it deserves its own
+review when there is a page to look at.
+
+**Community scenarios as a safety valve.** If the community can submit their own scenarios
+— including their own rule proposals — the game becomes less dependent on any single
+author's framing. A partisan user can submit a scenario that advocates for their preferred
+rules; another can submit the counterargument. The game hosts the conversation, not a
+conclusion.
+
+---
+
+## Target Audience
+
+- **Students (secondary+)** learning about US civics, electoral systems, or political geography
+- **Engaged adults** who've heard about gerrymandering and want to understand it concretely
+- **International observers** curious about the American electoral system and how it compares
+  to other countries' redistricting approaches
+
+The game should be accessible without prior knowledge (tutorial/first level covers
+everything needed) and rewarding for people who already know a lot (scenario depth,
+achievements, edge cases).
+
+---
+
+## Main Menu
+
+```
+[ New Game ]      [ Continue ]
+[ Custom Level ]  [ Settings ]  [ About ]
+```
+
+- **New Game**: starts the scenario sequence from the beginning (or from the last
+  unlocked scenario if the player has prior progress)
+- **Continue**: resumes where the player left off (visible only if prior progress exists)
+- **Custom Level**: full scenario creator — paint populations, set success criteria,
+  define rules, build fictional or historically-inspired maps; includes community
+  sharing (see §Custom Level and Community Scenarios below)
+- **Settings**: accessibility options (colorblind mode, language, motion reduction),
+  audio, display
+- **About**: project description, credits, educational resources, donation link
+
+**Tutorial** is not a separate menu item — it is baked into the first scenario as an
+in-level guided walkthrough. This avoids the common pattern where players skip standalone
+tutorials and then feel lost.
+
+---
+
+## Core Game Loop
+
+```
+Main Menu
+    ↓
+Scenario Intro Slide(s)
+    ↓
+Level (map editing)
+    ↓
+Test (animated success/failure sequence)
+    ↓  pass                    ↓  fail
+Success Screen             Feedback + retry
+    ↓
+Next Level (unlocked)
+```
+
+### 1 — Scenario Intro
+
+A slide or short slide sequence that:
+- Sets the narrative context ("The governor of [fictional state] has ordered redistricting
+  following a census...")
+- Describes the specific objective ("Redraw district boundaries so the governor's party
+  gains at least one seat")
+- Lists the success criteria clearly — required criteria and any optional bonus criteria
+- Explains any mechanics specific to this scenario (e.g., "new districts are permitted
+  in this scenario")
+
+The first scenario's intro also introduces the game mechanics (what precincts are, how
+boundaries work, what the filter views show). Subsequent scenarios assume familiarity and
+keep intros shorter.
+
+### 2 — Level (Map Editing)
+
+The main interactive phase. See §Map and Mechanics below.
+
+### 3 — Test
+
+The player submits their district map for evaluation. The test runs through each success
+criterion with a short animation:
+
+- Governor reviews and reacts (thumbs up / concerned / veto)
+- State legislature votes (cheer / grumble / close vote)
+- Relevant lobby groups react (advocacy groups, party orgs, civil rights groups — varies
+  by scenario)
+- Legal check: does the map satisfy applicable rules? (equal population, contiguity,
+  VRA compliance where applicable)
+- Optional: supreme court challenge, media reaction, incumbent reactions — flavor
+  elements that don't block success but add realism and narrative
+
+Each criterion resolves with a clear visual and short text. Animations are simple and
+self-contained — icon-level cutesy reactions, independent of each other. Animated GIFs
+or equivalent (short CSS/SVG loops) are sufficient; no complex per-scenario authored
+sequences needed. GES to confirm the evaluation model is tractable. If the test fails, the player
+sees exactly which criteria were not met and can return to editing with that feedback.
+
+### 4 — Success Screen
+
+On passing:
+- Short narrative/animation summarising what happened ("Governor Ramirez signed the new
+  map into law. In the next election...")
+- Achievement notifications (if triggered)
+- "Next Level" button; optionally "Retry for achievements" if the player didn't get all
+  optional criteria
+
+### 5 — Retry and Achievements
+
+Players can replay any completed level. Reasons to retry:
+- Achieve a passing result a different way ("minimal change" achievement vs. "maximum
+  efficiency" achievement)
+- Unlock optional/bonus criteria not hit on first pass
+- Completionism
+
+Achievement examples (not exhaustive):
+- *Surgical Precision* — pass with the fewest precinct moves
+- *Packed to the Gills* — achieve extreme packing of one party's voters
+- *Efficiency Gap* — achieve a historically notable efficiency gap score
+- *Judge-Proof* — pass all legal criteria including optional ones
+- *Bipartisan Groans* — have both party lobby groups express dissatisfaction (neutral-rules scenarios)
+- *Cats and Dogs* — complete the cats-vs-dogs scenario (see §Scenarios)
+
+---
+
+## Map and Mechanics
+
+### The Map
+
+The playfield is a fictional sub-state **region** — a county, metro area, or similar
+geographic unit — divided into **precincts**. Each scenario covers one such region.
+The game does not model whole states; redistricting at the state-legislature or
+congressional-district level happens within a single region boundary. "Zooming out" to
+full-state or multi-state scope is explicitly deferred — it may become relevant for
+electoral-system comparison scenarios but is not needed for v1 or the near term.
+
+Precincts are the atomic unit of redistricting: small, fixed-boundary geographic cells
+(a stylised grid or organic shapes depending on the scenario's aesthetic). They cannot be
+subdivided. Target count is in the hundreds — visually small, like fat pixels whose edges
+the player pushes around. The exact count should be calibrated against real regional
+examples (see §Open Questions — precinct count research).
+
+Each precinct has metadata:
+- Population (total and density)
+- Demographic breakdown (race/ethnicity, partisan affiliation, gender, religion)
+- Last election result (votes by party, turnout)
+- Any scenario-specific data (e.g., recent population change driving the redistricting)
+
+**Districts** are groupings of precincts. District boundaries are the edges between
+adjacent precincts assigned to different districts.
+
+A district may consist of multiple **segments** — non-contiguous blobs of precincts
+belonging to the same district. Non-contiguous districts are disabled by default and
+only enabled for scenarios where they are legally or narratively appropriate.
+
+### Viewing the Map
+
+The default view shows population density as a color overlay. Filter controls let the
+player switch the color dimension:
+- Population density
+- Partisan lean (last election result)
+- Any demographic dimension (race/ethnicity, age, etc.)
+- District assignment (highlights current district boundaries)
+
+Hovering a precinct shows a tooltip with all metadata. Players can keep a precinct
+pinned for comparison while browsing.
+
+District boundary lines are always overlaid on top of whichever color dimension is
+active.
+
+### Editing Boundaries
+
+The player edits district boundaries using a **brush/paint interaction**:
+- The brush paints precincts into a district; the target district is determined by where
+  the brush stroke begins (starting inside district A paints precincts into A)
+- Brush size is adjustable — large brush for rough shaping, small brush for fine detail
+- The boundary line updates live as precincts are repainted
+- Click (or tap) a single precinct for fine-grained single-precinct reassignment
+
+The specific UI motif (cursor brush vs. lasso vs. flood-fill from a boundary) is a
+Web Designer + GES decision. The constraint is that bulk editing must not feel like
+data entry — players should be able to reshape large areas quickly.
+
+Creating or extending a non-contiguous district segment (when enabled by the scenario):
+- Assign precincts to an existing district even if not adjacent to it
+- Or create a new district from a selected precinct (only when new districts are permitted)
+
+**Undo/redo** is always available. A "reset to start" option restores the original
+scenario boundary.
+
+### Validity Indicators
+
+The UI gives live feedback on validity constraints:
+- Population balance: each district's population shown relative to the target (±X%)
+- Contiguity warnings: flag if a district becomes non-contiguous (when that's not allowed)
+- VRA indicators: if a scenario has VRA requirements, districts at risk are highlighted
+- Compactness score: shown when relevant to the scenario's success criteria
+
+---
+
+## Scenarios
+
+### V1 Scenario Set (target: 8–12 scenarios)
+
+The v1 scenarios establish the core educational arc. The sequence moves from "what is
+redistricting" through partisan tactics, demographic requirements, and neutral-rules reform
+— but the arc should not read as a moral progression from bad to good. Counter-scenarios
+and character-perspective framing (see §Scenario Design Principles) are the primary tools
+for maintaining genuine neutrality. Each scenario uses a fictional region and population.
+
+| # | Working Title | Objective | Key Lesson |
+|---|---|---|---|
+| 1 | Welcome to New Texansifornia | Tutorial: draw any valid map | How redistricting works |
+| 2 | Give the Governor a Win | Gain 1 seat for the governor's party | Basic partisan gerrymandering |
+| 3 | The Packing Problem | Pack opposition into fewest districts | Packing tactic; efficiency gap |
+| 4 | Cracking the Opposition | Dilute opposition across many districts | Cracking tactic |
+| 5 | A Voice for the Valley | Create a majority-Latino district following population growth | VRA requirements; majority-minority districts |
+| 6 | Harden the Map | Maximise safe seats for incumbents; minimise competitive races | Incumbency protection tactic |
+| 7 | The Reform Map | Apply a neutral rule-set (compactness + contiguity + equal pop) | What neutral rules achieve — and don't |
+| 8 | Both Sides Unhappy | Apply a bipartisan-agreed neutral standard | Why neutral rules don't eliminate politics |
+| 9 | Cats vs. Dogs | Ensure the Cat Party dominates the Dog Party | Tone break; reinforces mechanics in absurd context |
+
+One or more additional scenarios (within the 8–12 target) should complicate the
+reform narrative — e.g., a neutral rules map that produces worse minority representation
+than a deliberately drawn one, or a "good gerrymander" that increased competitiveness.
+These are not yet designed; they are a named gap to fill before the scenario set is final.
+
+Stretch v1 / early v2:
+| # | Working Title | Notes |
+|---|---|---|
+| 10 | The Canadian Way | Apply Canada's arms-length electoral commission rules | International comparison; requires domain review |
+| 11 | After the Boom | Census-driven redistricting with major population shift | Population change scenario |
+
+**Out of scope for this game** — electoral system comparison (proportional representation,
+STV, etc.) does not fit naturally within a district-drawing simulator. These topics may
+become a separate game in a series that reuses or extends the engine, but they should not
+constrain the design of this one. The PR Country scenario is removed from the list.
+
+### Later Scenarios
+
+- Historically-inspired recreations (famous gerrymanders, with fictional population data)
+- Racial polarisation scenarios — VRA Section 2 analysis
+- Multi-party scenarios (where a third party has significant presence)
+- Player-designed scenarios (once Custom Level UI ships)
+
+### Scenario Design Principles
+
+- No two scenarios should teach the same primary lesson
+- At least one scenario should be clearly "silly" — a tone break that decouples learning
+  the mechanics from political anxiety
+- Each scenario should have at least one surprising or counterintuitive result available
+  (an outcome the player didn't expect, which is part of the lesson)
+- Optional criteria add depth without blocking completion
+- **Character-perspective framing.** Many scenarios cast the player as a specific actor —
+  "you are a political operative for Party X," "you are an electoral reform advocate." The
+  player inhabits that character's goals and bias for the duration of the scenario. This
+  is not endorsement: it is experiential framing that invites the player to notice the
+  difference between the character's interests and their own. Scenarios should be
+  designed in matched pairs or sets where possible — if one scenario lets you gerrymander
+  for Party A, another lets you do the same for Party B.
+- **Counter-scenarios.** At least one scenario should demonstrate that neutral rules
+  produce outcomes that neutral-rules advocates might find uncomfortable (e.g., worse
+  minority representation, accidental incumbency protection). The sequence should not
+  leave the player with the conclusion that reform = good, tactics = bad.
+
+---
+
+## Progression
+
+Scenarios are standalone vignettes — no narrative continuity between them in v1. Each
+scenario has a different fictional region, cast, and educational goal. They are ordered
+for pedagogic progression (tutorial → tactics → reform), not story.
+
+Scenarios unlock sequentially by default. Completing scenario N unlocks N+1. Players
+can replay any completed scenario at any time.
+
+A scenario select screen shows:
+- Completed scenarios (with achievement indicators)
+- The next unlocked scenario
+- Locked future scenarios (visible but inaccessible — creates anticipation)
+
+There is no explicit "level cap" — the game is designed to keep receiving new scenarios
+over time.
+
+**Campaign mode (stretch / later).** A possible future structure groups scenarios into
+a themed campaign — a progressive sequence with shifting goals that tells a larger story.
+A campaign could be followed by standalone "explore the space" scenarios. No narrative
+is currently in mind; this is worth workshopping if a good concept emerges. The scenario
+structure should not preclude campaigns being added later.
+
+---
+
+## Custom Level and Community Scenarios
+
+### Custom Level (Scenario Creator)
+
+Custom Level is not a sandbox with no stakes — it is a full scenario authoring tool.
+A player with Custom Level open can:
+
+- **Paint population data** — assign partisan lean, demographics, and population
+  density to precincts on a blank or template map
+- **Define success criteria** — required and optional, using any of the game's
+  evaluation dimensions (seat counts, compactness scores, VRA compliance, etc.)
+- **Design the rules** — which constraints apply (equal population tolerance, contiguity,
+  compactness thresholds); this is the key feature for rules-as-advocacy scenarios
+- **Write scenario text** — intro slides, narrative context, flavor
+- **Build fictional or historically-inspired maps** — the tool does not require real
+  geographic data; a historically-inspired map uses fictional population numbers
+
+Custom Level targets experienced players who have completed the scenario sequence and
+want to explore "what if I had drawn this differently" or "what if the rules were X?"
+
+**V1 scope note.** The player-facing Custom Level UI is not required for v1. However,
+the scenario data format and serialization model must be designed for authoring from
+the start — the pre-built scenarios are authored using that same format. The data
+model must not paint itself into a corner: the player-facing UI, community sharing,
+and historically-inspired maps should all be achievable additions without redesigning
+the core scenario format.
+
+### Community Scenario Sharing
+
+Players can publish custom scenarios to a shared library. Other players can browse,
+play, and rate community scenarios. This feature:
+
+- Distributes authorial power — the game is not solely shaped by one designer's choices
+- Enables rules-as-advocacy: someone can publish a scenario that demonstrates why
+  their preferred rule-set is better; others can publish the counterargument
+- Provides an organic content pipeline without requiring server-side game state
+  (scenarios are stored as data; play state remains local)
+
+Community scenarios go through a lightweight moderation step (no hate speech, no
+doxxing, no real-name targeting) but are not reviewed for political perspective —
+the whole point is pluralism.
+
+**Technical note:** Community scenarios require minimal server-side storage (scenario
+data only; no user game state). This is the one server-side component justified in
+an otherwise locally-run game. Design for minimum hosting cost: scenarios are
+static data once published; no per-session server compute needed.
+
+---
+
+## V1 Scope Boundary
+
+**In v1:**
+- Single-player, single sub-state region per scenario
+- FPTP (first-past-the-post) election simulation only
+- Fictional regions and populations (no real geographic data)
+- 8–12 scenarios covering partisan, demographic, and neutral-rules themes
+- Desktop-first (mouse/keyboard primary interaction)
+- Progress stored in local browser storage (IndexedDB / localStorage); no user accounts;
+  no server-side game state — minimises hosting cost
+- Scenario data format designed for authoring (pre-built scenarios use it; player-facing
+  UI deferred to post-v1)
+
+**Explicitly out of v1:**
+- Player-facing Custom Level UI and community scenario sharing (data format in v1; UI post-v1)
+- Alternative electoral systems (STV, party-list, etc.)
+- Real geographic data
+- Full-state or multi-state scope
+- Multiplayer
+- Mobile-optimised boundary drawing (TBD — may be a different interaction model on the
+  same data; decision deferred)
+- International comparison scenarios (target: early v2)
+- User accounts, cross-device sync, leaderboards (target: v2 if demand justifies cost)
+- Campaign / narrative mode (stretch — worth workshopping; must not be precluded by design)
+
+---
+
+## Open Questions
+
+1. ~~**Custom Level**~~ — **Resolved.** Scenario data format in v1 (shared with pre-built
+   scenario authoring); player-facing UI and community sharing deferred to post-v1.
+   Format must not preclude adding the UI later.
+
+2. ~~**Save/profile system**~~ — **Resolved.** Local browser storage (IndexedDB /
+   localStorage) for v1. No user accounts, no server-side game state. Minimises hosting
+   cost and eliminates COPPA exposure for game state. Community scenario sharing (post-v1)
+   requires minimal server-side storage for scenario data only.
+
+3. ~~**Precinct naming**~~ — **Resolved.** "Precinct" confirmed.
+
+4. **Mobile** — deferred. May be a different interaction model built on the same data
+   model; may not happen at all. No decision needed yet.
+
+5. **Scenario fictional region names and geographies** — placeholder. GES + Visual Designer
+   creative decision informed by educational goals per scenario.
+
+6. **Tech stack** — unresolved (separate session with GES + Architect). Affects: how
+   simulation runs, map rendering approach, save system, mobile.
+
+7. **Precinct count calibration** — target is "hundreds" (visually small, fat-pixel
+   aesthetic). Domain Reviewer should research real sub-state regions, their precinct
+   counts, and how actual redistricting breaks down at that scale. Result informs
+   GES + ARCH on rendering and performance targets.
+
+8. **VRA / bloc voting simulation model** — simplified model: each demographic group
+   has a per-precinct vote-share percentage (e.g., "Latinos in this precinct vote
+   R 44%, D 38%, other 18%"); district outcome is aggregated from precinct-level
+   demographic breakdowns. GES + Domain Reviewer to validate that this simplification
+   is educationally sound and sufficient for the VRA scenario. The same model should
+   generalise to other demographic groups.
+
+9. **Historical / inspired scenarios** — later versions may use historically-inspired
+   maps with fictional population data. Domain Reviewer required. Flag for v2.
+
+10. **About page content** — deferred. Deserves its own review when there is a page
+    to look at. Should convey educational intent and non-partisan framing without
+    making claims that require ongoing maintenance.


### PR DESCRIPTION
## Summary

- Adds game vision document (`thoughts/shared/vision/game-vision.md` + `.compressed.md`) covering educational goals, political neutrality framing, core game loop, map mechanics, v1 scenario set, progression model, custom level scope, and v1 scope boundary
- Adds agent team and workflow design research (`thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.md` + `.compressed.md`) covering 10 standing roles, 7 on-demand reviewers, iterative sprint workflow, and NFR ownership
- Updates `AGENTS.md` + `AGENTS.compressed.md` for redistricting-sim purpose; adds `thoughts/shared/vision/` as first entry in layout section
- Adds `AGENT-001` ticket tracking the deferred `$abr` convention fix for compressed docs

## Test plan

- [x] Read `thoughts/shared/vision/game-vision.md` — verify educational goal, neutrality framing, scenario set, and v1 scope boundary are coherent
- [x] Read `thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.md` — verify role roster and workflow cycle are complete
- [x] Confirm `.compressed.md` companions are in sync with their `.md` sources
- [x] Confirm `AGENTS.compressed.md` §LAYOUT lists `vision/` first

Verified by critique agent (3 rounds). Known open issue: `$abr` dollar-prefix convention in compressed docs — tracked in AGENT-001, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
