### PR TITLE
Apply $abr convention to compressed docs (AGENT-001)

### DIFF
--- a/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md
+++ b/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md
@@ -16,62 +16,62 @@ ts=thoughts/shared nfr=non-functional requirement
 
 §SUMMARY
 Multi-agent team for redistricting-sim. Extends polyglot TDD workflow ($ts/research/2026-04-21-multi-agent-tdd-workflow.md)
-with: PM, GES, VDA added as standing; 7 on-demand reviewers; SCRUM-like sprint rhythm.
-Two prerequisites before impl: tech stack session (GES+ARCH) + game vision doc (PM+user).
+with: $PM, $GES, $VDA added as standing; 7 on-demand reviewers; SCRUM-like sprint rhythm.
+Two prerequisites before impl: tech stack session ($GES+$ARCH) + game vision doc ($PM+user).
 
 §STANDING_ROLES
 
-PM
+$PM
   domain: what+why; feature specs; acceptance criteria; sprint priorities
   proxy: represents user to all agents; escalates to user for direction changes,
     practical-constraint deviations, large-scope changes, educational-fidelity tradeoffs,
     and regular sprint demos (user plays game each sprint)
-  nfr ownership: DoD, test sufficiency, a11y standards, privacy policy, browser/device targets,
+  $nfr ownership: DoD, test sufficiency, a11y standards, privacy policy, browser/device targets,
     educational effectiveness as product req
 
-GES
+$GES
   domain: game mechanics; simulation design; electoral algorithms(FPTP v1; STV/party-list stretch);
     district validity rules(contiguity,compactness); population modeling; scenario mechanics
   absorbs: domain research for own mechanics design
-  does NOT own: domain accuracy checks → DR(on-demand)
-  vs ARCH: peers, both answer to PM; GES="what can simulation do+how";
-    ARCH="how does system hang together"; negotiate boundary in Phase 1
+  does NOT own: domain accuracy checks → $DR(on-demand)
+  vs $ARCH: peers, both answer to $PM; $GES="what can simulation do+how";
+    $ARCH="how does system hang together"; negotiate boundary in Phase 1
 
-ARCH
+$ARCH
   domain: system design; API; service boundaries; deployment; data flow; tech choices
-  peers with GES on simulation layer; with DBA on persistence layer
-  nfr ownership: scale targets; perf budgets(page load,latency,animation); security model;
-    observability strategy; cost-aware design (budget envelope from CFR)
+  peers with $GES on simulation layer; with DBA on persistence layer
+  $nfr ownership: scale targets; perf budgets(page load,latency,animation); security model;
+    observability strategy; cost-aware design (budget envelope from $CFR)
 
 DBA
   domain: schema; migrations; seeding; portability; test data strategy
   participates: when features touch persistence; absent for frontend-only or simulation-only work
 
-WD
+$WD
   domain: map interface design; district-drawing UX; information architecture; user flows
-  outputs: wireframes + interaction specs → TDDF
+  outputs: wireframes + interaction specs → $TDDF
   key challenge: data overlays(population density, voting preference, race) readable at a glance
-  works with VDA on visual language
+  works with $VDA on visual language
 
-VDA
+$VDA
   domain: visual identity; style guide; data viz design; game assets(illustrations,
     cut-scene storyboards/animations, tutorial art, icons, UI chrome)
   outputs: design specs(color system, typography, animation timing, SVG specs) + actual assets
   intensity: high up-front(identity+map rendering approach); iterative later(scenario/tutorial assets)
   CRITICAL: colorblindness — district viz IS the game's visual language; ~8% men affected;
     accessible color design must be in brief from day one, not retrofitted
-  collaborates: PM(tone,cut-scene vision) GES(simulation data viz) DR(geographic accuracy)
-    WD(visual language,motion) TDDF+CF(SVG/CSS/animation contracts)
+  collaborates: $PM(tone,cut-scene vision) $GES(simulation data viz) $DR(geographic accuracy)
+    $WD(visual language,motion) $TDDF+$CF(SVG/CSS/animation contracts)
 
-TDDB + TDDF
-  domain: tactical API completion; test-first; fill ARCH open space with concrete interfaces,
+$TDDB + $TDDF
+  domain: tactical API completion; test-first; fill $ARCH open space with concrete interfaces,
     method sigs, error contracts, type shapes, failing tests
-  TDDB reads: ARCH doc + DBA schema
-  TDDF reads: WD interaction specs + ARCH API contract
+  $TDDB reads: $ARCH doc + DBA schema
+  $TDDF reads: $WD interaction specs + $ARCH API contract
   can work in parallel when API contract is clear
-  public contract is fixed once defined; propose changes back to ARCH; never unilateral
+  public contract is fixed once defined; propose changes back to $ARCH; never unilateral
 
-CB + CF
+$CB + $CF
   domain: private implementation below public surface defined by TDD Designer
   latitude: private types, helpers, internal state, utility extraction, library selection(approved deps)
   may propose public changes back to TDD Designer; may not change unilaterally
@@ -80,18 +80,18 @@ CB + CF
 
 | Role | Trigger(s) |
 |---|---|
-| DR(Domain) | electoral accuracy; scenario validity; VRA representation; domain UI text |
-| EER(Educ.Effectiveness) | scenario design; tutorial design; "does this teach the lesson?" |
-| SR(Security) | any trust boundary: exposed API, user data, UGC, auth |
-| A11Y(Accessibility) | every UI feature before ship; non-optional step in WD→CF pipeline |
-| CFR(Cost/Finance) | infra decisions; 3rd-party service choices; build-vs-buy; cost at scale |
-| LR(Legal) | COPPA/GDPR; map data licensing; real-event scenarios |
-| BS(Build) | new Bazel targets(TS,WASM,Docker); significant CI changes |
+| $DR(Domain) | electoral accuracy; scenario validity; VRA representation; domain UI text |
+| $EER(Educ.Effectiveness) | scenario design; tutorial design; "does this teach the lesson?" |
+| $SR(Security) | any trust boundary: exposed API, user data, UGC, auth |
+| $A11Y(Accessibility) | every UI feature before ship; non-optional step in $WD→$CF pipeline |
+| $CFR(Cost/Finance) | infra decisions; 3rd-party service choices; build-vs-buy; cost at scale |
+| $LR(Legal) | COPPA/GDPR; map data licensing; real-event scenarios |
+| $BS(Build) | new Bazel targets(TS,WASM,Docker); significant CI changes |
 
 COPPA flag: if game reaches US schools, data collection from <13 regulated federally — even
   anonymised telemetry may be in scope; needs legal position before any analytics added
 Map tile flag: commercial providers charge per-tile-load; compounds fast under classroom load;
-  OpenStreetMap(ODbL) or pre-rendered tiles preferred; CFR+ARCH must evaluate early
+  OpenStreetMap(ODbL) or pre-rendered tiles preferred; $CFR+$ARCH must evaluate early
 
 reviewer advantage: stable reusable prompt templates; improve over sprints; outputs auditable
 
@@ -101,64 +101,64 @@ NOT waterfall — iterative cycle. Vision evolves continuously through demos+lea
 Phases describe type-of-work, not a one-time sequence.
 
 Cycle:
-  Vision(PM↔user) → Feature Design(PM→GES/ARCH/WD/VDA) → Implementation(TDD→Coder)
+  Vision($PM↔user) → Feature Design($PM→$GES/$ARCH/$WD/$VDA) → Implementation(TDD→Coder)
        ↑                                                           ↓
        └──────────────── Demo(user plays; feedback) ──────────────┘
 
 Vision (living doc, updated every sprint):
-  PM↔user ongoing; not frozen; updated when: demos surface new understanding;
-    GES/ARCH learnings change feasibility; domain/EE review changes what's appropriate
-  GES consulted on feasibility; VDA on tone; direction changes reviewed with user before acting
+  $PM↔user ongoing; not frozen; updated when: demos surface new understanding;
+    $GES/$ARCH learnings change feasibility; domain/EE review changes what's appropriate
+  $GES consulted on feasibility; $VDA on tone; direction changes reviewed with user before acting
 
 Feature Design (per sprint, reads current vision):
-  PM → feature spec+AC(from vision)
+  $PM → feature spec+AC(from vision)
        ↓
   ┌────┴──────────────────┐
-  GES↔ARCH               VDA
+  $GES↔$ARCH               $VDA
   (sim+system design)    (visual language+tone)
   ↓        ↓              ↓
-  └──→DBA←┘            WD
+  └──→DBA←┘            $WD
   (schema if needed)   (wireframes+user flows)
   ↓                      ↓
-  ARCH system doc      interaction specs
+  $ARCH system doc      interaction specs
 
 Implementation (per PR):
-  TDDB(reads ARCH+schema) ║ TDDF(reads interaction specs+API contract) [parallel]
+  $TDDB(reads $ARCH+schema) ║ $TDDF(reads interaction specs+API contract) [parallel]
       ↓                   ║       ↓
-     CB                   ║      CF
+     $CB                   ║      $CF
 
 Demo (closes loop → vision):
-  user plays sprint output; PM synthesises feedback →
+  user plays sprint output; $PM synthesises feedback →
     update vision doc | new ticket | defer
   feedback can surface: mechanics not teaching intended lesson; confusing UX;
     wrong scope; new ideas vision didn't anticipate
 
-PM escalation to user: direction changes; constraint deviations; large scope; educ-fidelity
+$PM escalation to user: direction changes; constraint deviations; large scope; educ-fidelity
   tradeoffs; sprint demos
 
 §NFRS
-PM owns: DoD test-sufficiency; a11y standards; privacy policy; browser/device targets; educational effectiveness
-ARCH owns: scale; perf budgets; security model; observability; cost-aware design
-Shared: i18n(PM decides; ARCH implements) — unresolved
-COPPA+GDPR: LR trigger; fire before any telemetry or school use
+$PM owns: DoD test-sufficiency; a11y standards; privacy policy; browser/device targets; educational effectiveness
+$ARCH owns: scale; perf budgets; security model; observability; cost-aware design
+Shared: i18n($PM decides; $ARCH implements) — unresolved
+COPPA+GDPR: $LR trigger; fire before any telemetry or school use
 
 §AGENT_MECHANICS
 Four advantages of specialty agents vs general-purpose:
 1. context signal/noise: less irrelevant material; mitigates "lost in the middle" degradation
 2. parametric knowledge activation: focused context = focused query into model weights;
    tighter-scoped prompt activates more precise training knowledge (priming, not attention per se)
-3. parallelism: TDDB+TDDF share only API contract; non-overlapping concerns, no context contamination
+3. parallelism: $TDDB+$TDDF share only API contract; non-overlapping concerns, no context contamination
 4. prompt reusability: stable reviewer prompts improve over sprints; outputs predictable+auditable
 
 §OPEN
 1. tech stack — in-browser vs server; mobile; WASM(Kotlin Multiplatform?); map tile source
-   → needs GES+ARCH session before any system design
+   → needs $GES+$ARCH session before any system design
 2. ~~game vision doc — v1 scenarios; player session flow; learning objectives
-   → PM-driven; user-reviewed; required before GES+ARCH design work~~
+   → $PM-driven; user-reviewed; required before $GES+$ARCH design work~~
    RESOLVED: vision doc written; see $ts/vision/game-vision.compressed.md
-3. LR segmentation(privacy vs IP/licensing) — deferred
-4. component inventory format (WD→TDDF handoff) — deferred until tech stack known
-5. i18n support — PM+user decision; if yes must enter ARCH brief early
+3. $LR segmentation(privacy vs IP/licensing) — deferred
+4. component inventory format ($WD→$TDDF handoff) — deferred until tech stack known
+5. i18n support — $PM+user decision; if yes must enter $ARCH brief early
 
 §REFS
 prior workflow: $ts/research/2026-04-21-multi-agent-tdd-workflow.md

--- a/thoughts/shared/vision/game-vision.compressed.md
+++ b/thoughts/shared/vision/game-vision.compressed.md
@@ -55,7 +55,7 @@ level 1: also introduces game mechanics; later levels assume familiarity, shorte
 §TEST
 animated sequence evaluating each success criterion:
   Governor(thumbs up/concerned/veto) | Legislature(cheer/grumble/close vote) |
-  Lobby groups(vary by scenario) | Legal check(equal pop, contiguity, VRA) |
+  Lobby groups(vary by scenario) | Legal check(equal pop, contiguity, $VRA) |
   Optional flavor: supreme court challenge, media reaction, incumbent reactions
 fail → shows exactly which criteria missed → return to editing with feedback
 Animation style: simple, self-contained icon reactions; cutesy; animated GIFs or
@@ -76,31 +76,31 @@ Replay motivation: achievements + optional criteria + completionism
 §MAP_MECHANICS
 Playfield: fictional sub-state region(county/metro/similar) — ONE region per scenario
   scope: NOT whole state; not multi-state; "zoom out" deferred(may be relevant for electoral-system
-  comparisons later; explicitly not v1 or near-term)
-Precincts(pc): atomic geographic unit; not subdivisible; target ~hundreds; visually small
+  comparisons later; explicitly not $v1 or near-term)
+Precincts($pc): atomic geographic unit; not subdivisible; target ~hundreds; visually small
   ("fat pixels whose edges you push around"); exact count → calibrate against real regions(see §OPEN)
-pc metadata: population(total+density) | demographic breakdown(race,partisan,gender,religion) |
+$pc metadata: population(total+density) | demographic breakdown(race,partisan,gender,religion) |
   last election result(votes by party, turnout) | scenario-specific data
-dist = grouping of pcs; boundary = edges between adjacent pcs in different dists
-seg = contiguous blob of pcs within a dist; dist may have multiple segs(non-contiguous)
+$dist = grouping of $pcs; boundary = edges between adjacent $pcs in different $dists
+$seg = contiguous blob of $pcs within a $dist; $dist may have multiple $segs(non-contiguous)
   non-contiguous: DISABLED by default; enabled only when scenario permits
 
-View filters(color overlay; always show dist boundaries on top):
+View filters(color overlay; always show $dist boundaries on top):
   population density | partisan lean | any demographic dimension | district assignment
-Hover: tooltip with all pc metadata; pin for comparison
+Hover: tooltip with all $pc metadata; pin for comparison
 
 Editing:
-  brush/paint: stroke determines target dist by starting location; adjustable brush size
+  brush/paint: stroke determines target $dist by starting location; adjustable brush size
     (large=rough shaping; small=fine detail); boundary updates live
-  single-pc click still available for fine-grained work
+  single-$pc click still available for fine-grained work
   specific UI motif(brush vs lasso vs flood-fill) → WD+GES decision;
     constraint: bulk editing must NOT feel like data entry
-  non-contiguous(when enabled): assign pc to non-adjacent dist | create new dist from pc
+  non-contiguous(when enabled): assign $pc to non-adjacent $dist | create new $dist from $pc
   undo/redo always available | reset-to-start restores original scenario boundary
 
 Live validity indicators:
-  population balance(each dist vs target ±%) | contiguity warnings |
-  VRA risk highlights | compactness score(when relevant)
+  population balance(each $dist vs target ±%) | contiguity warnings |
+  $VRA risk highlights | compactness score(when relevant)
 
 §SCENARIOS
 
@@ -109,26 +109,26 @@ V1 target 8-12:
 |---|---|---|---|
 | 1 | Welcome to New Texansifornia | tutorial: draw any valid map | how redistricting works |
 | 2 | Give the Governor a Win | +1 seat for governor's party | basic partisan gerrymandering |
-| 3 | The Packing Problem | pack opposition into fewest dists | packing; efficiency gap |
-| 4 | Cracking the Opposition | dilute opposition across many dists | cracking tactic |
-| 5 | A Voice for the Valley | create majority-Latino dist after pop growth | VRA; majority-minority dists |
+| 3 | The Packing Problem | pack opposition into fewest $dists | packing; efficiency gap |
+| 4 | Cracking the Opposition | dilute opposition across many $dists | cracking tactic |
+| 5 | A Voice for the Valley | create majority-Latino $dist after pop growth | $VRA; majority-minority $dists |
 | 6 | Harden the Map | maximise safe seats; minimise competitive | incumbency protection |
 | 7 | The Reform Map | apply neutral rules(compactness+contiguity+equal pop) | what neutral rules achieve+don't |
 | 8 | Both Sides Unhappy | bipartisan-agreed neutral standard | neutral rules don't eliminate politics |
 | 9 | Cats vs. Dogs | Cat Party dominates Dog Party | tone break; reinforce mechanics |
 
-Stretch v1/early v2:
+Stretch $v1/early v2:
 | 10 | The Canadian Way | Canada arms-length commission rules | international comparison |
 | 11 | After the Boom | census-driven redraw w/ major pop shift | population change |
 
 PR/electoral system scenarios: OUT OF SCOPE for this game — don't fit district-drawing sim;
   possible separate game in a series; must not constrain this engine's design
 
-1+ additional v1 scenarios needed: complicate reform narrative(e.g. neutral rules →
+1+ additional $v1 scenarios needed: complicate reform narrative(e.g. neutral rules →
   worse minority representation; or "good gerrymander" → more competitive map)
   these are a named design gap — fill before scenario set is final
 
-Later: historically-inspired(fictional pop data) | VRA s.2 | multi-party | player-designed
+Later: historically-inspired(fictional pop data) | $VRA s.2 | multi-party | player-designed
 
 Design principles:
   no two scenarios same primary lesson | ≥1 silly scenario(tone break) |
@@ -142,13 +142,13 @@ Design principles:
 §CUSTOM_LEVEL
 V1 scope: scenario data FORMAT only(shared with pre-built scenario authoring); must not
   preclude player UI or community sharing later
-Player-facing creator(post-v1): paint population data(partisan lean, demographics, density per pc)
+Player-facing creator(post-$v1): paint population data(partisan lean, demographics, density per $pc)
   define success criteria(required+optional; any evaluation dimension)
   design rules(which constraints apply; compactness thresholds; contiguity; equal pop ±%)
   write scenario text(intro slides, narrative context, flavor)
   build fictional or historically-inspired maps(no real geodata required)
 
-Community sharing(post-v1):
+Community sharing(post-$v1):
   publish scenarios → shared library; others browse+play+rate
   distributes authorial power; enables rules-as-advocacy
   lightweight moderation(no hate speech, no doxxing); NOT filtered by political perspective
@@ -156,7 +156,7 @@ Community sharing(post-v1):
   play state remains local
 
 §PROGRESSION
-Scenarios: standalone vignettes; no narrative continuity in v1; ordered for pedagogic
+Scenarios: standalone vignettes; no narrative continuity in $v1; ordered for pedagogic
   progression(tutorial→tactics→reform), not story; each has different fictional region+cast
 sequential unlock(complete N → unlock N+1) | replay any completed scenario anytime
 scenario select: completed(+achievement status) | next unlocked | locked visible(anticipation)
@@ -165,29 +165,29 @@ Campaign mode(stretch/later): grouped scenarios with shifting goals; possible st
   no narrative currently in mind; worth workshopping; design must not preclude adding later
 
 §V1_SCOPE
-IN: single-player | single sub-state region/scenario | FPTP only | fictional regions+pops |
+IN: single-player | single sub-state region/scenario | $FPTP only | fictional regions+pops |
   8-12 scenarios(partisan+demographic+neutral-rules) | desktop-first |
   progress: local browser storage(IndexedDB/localStorage); no user accounts; no server game state
   scenario data format(shared w/ pre-built authoring; player UI deferred)
-OUT: player-facing Custom Level UI + community sharing(post-v1) |
+OUT: player-facing Custom Level UI + community sharing(post-$v1) |
   alt electoral systems(STV,party-list) | real geodata | full-state/multi-state scope |
   multiplayer | mobile-optimised editor(TBD; may be different model on same data) |
   international comparisons(early v2) | user accounts/cross-device(v2 if justified) |
   campaign/narrative mode(stretch; must not be precluded)
 
 §OPEN
-1. [RESOLVED] Custom Level: scenario data format in v1; player UI+community sharing post-v1
-2. [RESOLVED] Save/profile: local browser storage(IndexedDB); no user accounts v1;
-   community scenarios(post-v1) need minimal server storage(scenario data only)
+1. [RESOLVED] Custom Level: scenario data format in $v1; player UI+community sharing post-$v1
+2. [RESOLVED] Save/profile: local browser storage(IndexedDB); no user accounts $v1;
+   community scenarios(post-$v1) need minimal server storage(scenario data only)
 3. [RESOLVED] Precinct naming: "precinct" confirmed
 4. Mobile: deferred; may be different interaction model on same data; may not happen; no decision needed
 5. Fictional region names+geographies: GES+VDA creative decision per scenario
 6. Tech stack: unresolved → separate GES+ARCH session
 7. Precinct count calibration: target ~hundreds; DR to research real sub-state regions+precinct
    counts to inform GES+ARCH rendering+perf targets
-8. VRA/bloc voting model: simplified — demographic group vote-share % per pc; district outcome
+8. $VRA/bloc voting model: simplified — demographic group vote-share % per $pc; district outcome
    aggregated from breakdown; GES+DR to validate educational soundness; generalises to any demographic
-9. Historical/inspired scenarios: post-v1; fictional pop data on inspired maps; DR required
+9. Historical/inspired scenarios: post-$v1; fictional pop data on inspired maps; DR required
 10. About page content: deferred until page exists; convey intent+non-partisan framing
 
 §REFS


### PR DESCRIPTION
## Summary

- Applies `$abr` dollar-prefix convention to all §ABBREV key references in the two compressed docs added in PR #1
- `thoughts/shared/vision/game-vision.compressed.md`: prefixed `$pc`, `$pcs`, `$seg`, `$segs`, `$dist`, `$dists`, `$FPTP`, `$VRA`, `$v1`
- `thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md`: prefixed all 17 role/path abbreviations (`$PM`, `$GES`, `$ARCH`, `$WD`, `$VDA`, `$TDDB`, `$TDDF`, `$CB`, `$CF`, `$DR`, `$EER`, `$SR`, `$A11Y`, `$CFR`, `$LR`, `$BS`, `$nfr`)
- §ABBREV definition left-sides and non-§ABBREV tokens left bare per convention

Closes AGENT-001.

## Test plan

- [x] §ABBREV definition lines unchanged (left-side keys still bare)
- [x] All body references to §ABBREV keys use `$abr` format
- [x] Tokens not in §ABBREV left bare (`FPTP`/`COPPA`/`DBA` in agent-team doc; role names in game-vision doc)
- [x] Formatting-only change — no semantic content altered

Verified by critique agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
