### PR TITLE
Resolve AGENT-001 ticket (bookkeeping)

### DIFF
--- a/thoughts/shared/tickets/AGENT-001-compressed-abbrev-dollar-prefix.md
+++ b/thoughts/shared/tickets/AGENT-001-compressed-abbrev-dollar-prefix.md
@@ -2,7 +2,7 @@
 id: AGENT-001
 title: Apply $abr dollar-prefix convention to all compressed docs
 area: docs, agents
-status: open
+status: resolved
 created: 2026-04-23
 ---
 
@@ -17,15 +17,16 @@ The following files were written without applying this convention and need a pas
 
 Exception per convention: literal tool/target names that share a prefix (e.g. `grpc_kotlin`, `ktfmt`) stay as literals. Also watch for prose words that could be mistaken for abbreviations.
 
-## Current State
+## Resolution
 
-Both files use bare abbreviation names in their bodies. Functionally correct but not convention-compliant.
+All §ABBREV key references in both files prefixed with `$`. Merged in PR #2.
+Third criterion (future files) is a standing convention, not a one-time task.
 
 ## Goals / Acceptance Criteria
 
-- [ ] All §ABBREV key references in `game-vision.compressed.md` use `$abr` format
-- [ ] All §ABBREV key references in `2026-04-23-agent-team-and-workflow-design.compressed.md` use `$abr` format
-- [ ] Any other `.compressed.md` files added in the future follow the convention from creation
+- [x] All §ABBREV key references in `game-vision.compressed.md` use `$abr` format
+- [x] All §ABBREV key references in `2026-04-23-agent-team-and-workflow-design.compressed.md` use `$abr` format
+- [x] Any other `.compressed.md` files added in the future follow the convention from creation
 
 ## References
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -33,7 +33,6 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
-| `AGENT-001-compressed-abbrev-dollar-prefix.md` | docs, agents | Apply $abr dollar-prefix convention to all compressed docs (game-vision, agent-team-design) |
 | `KT-004-kotlin-docker-deployment.md` | kotlin, docker, deployment | Docker container build for Kotlin service; staging + production profiles |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `BUILD-001-grpc-kotlin-bzlmod-migration.md` | kotlin, bazel, grpc | Migrate to bzlmod-native `grpc_kotlin` when upstream supports it |
@@ -47,6 +46,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | Summary | Resolution |
 |---|---|
+| AGENT-001: $abr convention in compressed docs | Applied $-prefix to all §ABBREV key references in game-vision.compressed.md and agent-team-design.compressed.md; merged PR #2 |
 | KT-007: DB-backed bracket config | Implemented: `BracketPairRepository` (JOOQ), `BracketsDbModule`, `BracketsServiceTelemetry`, `@GrpcCallScope` endpoint wiring, tests; merged in PR #50 |
 | KT-002: Dagger 2 DI via dagger-grpc | `ApplicationGraph` @Component, `GrpcCallScopeGraph` subcomponent, all service modules, `@Inject` constructors |
 | KT-005: JOOQ codegen | `JooqCodegenRunner`, Bazel genrule + `jooq_db_lib`, DDLDatabase codegen from migration SQL, generated files gitignored; merged in PR #45 |


### PR DESCRIPTION
## Summary

- Marks AGENT-001 as resolved in ticket file and moves it to the Resolved section of TICKETS.md
- Bookkeeping follow-up to PR #2 (ticket update should have been in the same branch)

## Test plan

- [x] AGENT-001 ticket status set to `resolved`
- [x] AGENT-001 entry moved from Open to Resolved in TICKETS.md with resolution summary
- [x] No other content changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
