### PR TITLE
Clarify agent roles (GES/GXS/user); add spike guidance

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -39,6 +39,9 @@ spike/002-build-poc/  SPIKE-002: harmonized Bazel build proof-of-concept — ind
 before non-trivial impl: check $ts/vision/ + $ts/tickets/TICKETS.md + $ts/research/ for prior work
 
 SPIKE ISOLATION: agents working a spike touch ONLY their spike subdirectory; no other repo files
+SPIKE COMMIT WORKFLOW:
+  during: commit after each logical chunk; run build+tests before commit; squash fixes freely; no PR
+  at completion: all AC met + SPIKE-REPORT.md written → one PR → full critique cycle → merge
 
 §TICKETS
 TICKETS.md=canonical index; do NOT maintain ticket inventories elsewhere

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,11 @@ Before starting any non-trivial implementation work: check `thoughts/shared/visi
 
 **Spike directories are completely independent source roots.** Each has its own build toolchain, dependencies, and cannot import from or depend on anything outside its own directory. Agents working on a spike must only create or modify files under their designated `spike/NNN-*/` subdirectory — no changes to other repo files, no cross-spike imports.
 
+**Spike commit workflow** — spikes use a lightweight commit discipline; full PR rigor applies only at completion:
+
+- *During the spike:* commit locally after each logical chunk; run the spike's build and tests (`npm test`, `bazel test //...`, etc.) before each commit; squash small fixes into the relevant commit freely; no PR during active execution.
+- *At completion:* when all acceptance criteria are met and `SPIKE-REPORT.md` is written, open one PR for the full spike result. Run the standard PR review cycle (critique → response → merge) at that point.
+
 ---
 
 ## Working with Tickets

--- a/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md
+++ b/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md
@@ -2,10 +2,10 @@
 §META
 date:2026-04-23 researcher:claude+cgruber branch:main repo:cgruber/redistricting-sim
 topic:multi-agent team design+workflow tags:agents,workflow,roles,team-design,product,architecture
-status:provisional — tech stack session pending last_updated:2026-04-23
+status:provisional — spikes running (SPIKE-001,SPIKE-002) last_updated:2026-04-23
 
 §ABBREV
-PM=Product Manager GES=Game Engine Specialist ARCH=Architect
+PM=Product Manager GES=Game Engine Specialist GXS=Game Experience Specialist ARCH=Architect
 WD=Web/UI Designer VDA=Visual Designer/Artist
 TDDB=TDD Designer(backend) TDDF=TDD Designer(frontend)
 CB=Coder(backend) CF=Coder(frontend)
@@ -16,8 +16,9 @@ ts=thoughts/shared nfr=non-functional requirement
 
 §SUMMARY
 Multi-agent team for redistricting-sim. Extends polyglot TDD workflow ($ts/research/2026-04-21-multi-agent-tdd-workflow.md)
-with: $PM, $GES, $VDA added as standing; 7 on-demand reviewers; SCRUM-like sprint rhythm.
-Two prerequisites before impl: tech stack session ($GES+$ARCH) + game vision doc ($PM+user).
+with: $PM, $GES, $VDA added as standing; 8 on-demand reviewers (incl. new $GXS); SCRUM-like sprint rhythm.
+Prerequisites: tech stack(decided: TypeScript v1+spikes running) + game vision doc(written). Both resolved.
+User=project owner+customer; escalation target; not an agent role.
 
 §STANDING_ROLES
 
@@ -29,11 +30,11 @@ $PM
   $nfr ownership: DoD, test sufficiency, a11y standards, privacy policy, browser/device targets,
     educational effectiveness as product req
 
-$GES
+$GES [technical role — not the user]
   domain: game mechanics; simulation design; electoral algorithms(FPTP v1; STV/party-list stretch);
     district validity rules(contiguity,compactness); population modeling; scenario mechanics
   absorbs: domain research for own mechanics design
-  does NOT own: domain accuracy checks → $DR(on-demand)
+  does NOT own: domain accuracy checks → $DR(on-demand); game feel → $GXS(on-demand)
   vs $ARCH: peers, both answer to $PM; $GES="what can simulation do+how";
     $ARCH="how does system hang together"; negotiate boundary in Phase 1
 
@@ -80,6 +81,7 @@ $CB + $CF
 
 | Role | Trigger(s) |
 |---|---|
+| $GXS(Game Experience) | new mechanics/scenario in playable form; major release; "does this feel right to play?" |
 | $DR(Domain) | electoral accuracy; scenario validity; VRA representation; domain UI text |
 | $EER(Educ.Effectiveness) | scenario design; tutorial design; "does this teach the lesson?" |
 | $SR(Security) | any trust boundary: exposed API, user data, UGC, auth |
@@ -87,6 +89,8 @@ $CB + $CF
 | $CFR(Cost/Finance) | infra decisions; 3rd-party service choices; build-vs-buy; cost at scale |
 | $LR(Legal) | COPPA/GDPR; map data licensing; real-event scenarios |
 | $BS(Build) | new Bazel targets(TS,WASM,Docker); significant CI changes |
+
+$GXS distinct from: $GES(mechanics design) $EER(lesson quality) user(subjective owner feedback via demos)
 
 COPPA flag: if game reaches US schools, data collection from <13 regulated federally — even
   anonymised telemetry may be in scope; needs legal position before any analytics added
@@ -151,10 +155,10 @@ Four advantages of specialty agents vs general-purpose:
 4. prompt reusability: stable reviewer prompts improve over sprints; outputs predictable+auditable
 
 §OPEN
-1. tech stack — in-browser vs server; mobile; WASM(Kotlin Multiplatform?); map tile source
-   → needs $GES+$ARCH session before any system design
-2. ~~game vision doc — v1 scenarios; player session flow; learning objectives
-   → $PM-driven; user-reviewed; required before $GES+$ARCH design work~~
+1. ~~tech stack — in-browser vs server; mobile; WASM; map tile source~~
+   RESOLVED: TypeScript v1; SVG/D3; Zustand; Vite; WASM deferred; spikes running(SPIKE-001,SPIKE-002)
+   Map tile source still open — deferred until game uses real geographic data
+2. ~~game vision doc — v1 scenarios; player session flow; learning objectives~~
    RESOLVED: vision doc written; see $ts/vision/game-vision.compressed.md
 3. $LR segmentation(privacy vs IP/licensing) — deferred
 4. component inventory format ($WD→$TDDF handoff) — deferred until tech stack known

--- a/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.md
+++ b/thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.md
@@ -5,7 +5,7 @@ branch: main
 repository: cgruber/redistricting-sim
 topic: Multi-agent team design and development workflow for redistricting-sim
 tags: agents, workflow, roles, team-design, product, architecture
-status: provisional — tech stack session pending
+status: provisional — spikes running (SPIKE-001, SPIKE-002)
 last_updated: 2026-04-23
 last_updated_by: claude+cgruber
 ---
@@ -20,8 +20,15 @@ Builds on the TDD workflow pattern established in polyglot
 substantially to cover the requirements of a game: product management, game mechanics
 design, web UI, visual design, and a set of on-demand specialist reviewers.
 
-Two open workstreams remain before implementation begins: a tech stack session (involving
-GES and Architect) and a game vision document (PM-driven, user-reviewed).
+Two prerequisites before implementation: a tech stack session (GES + Architect) and a game
+vision document (PM-driven, user-reviewed). Both are now resolved — vision doc is written
+and tech stack spikes are running (see SPIKE-001, SPIKE-002 tickets).
+
+**Note on user role:** The user is the project owner and customer — the human the PM
+escalates to, the person who plays the game at sprint demos, and the final arbiter of
+educational and product direction. The user also brings informal software architect
+expertise and subjective game-feel feedback. These contributions flow through PM escalation
+and sprint demos; the user is not an agent role.
 
 ---
 
@@ -49,13 +56,14 @@ demos — the user plays whatever has been built each sprint, giving feedback th
 the next cycle.
 
 #### Game Engine Specialist (GES)
-**Domain:** Game mechanics design and simulation. Owns: electoral algorithm design
-(FPTP for v1; STV, party-list, etc. as stretch goals), district validity rules
-(contiguity, compactness metrics), population distribution modeling, scenario mechanics,
-progression design. Does necessary domain research as part of this work (how FPTP
-counting actually works, what compactness metrics academics use, historical redistricting
-patterns). Not responsible for raw domain accuracy checks — that's the Domain Reviewer's
-role on-demand.
+**Domain:** Game mechanics design and simulation. A technical role — not the user.
+Owns: electoral algorithm design (FPTP for v1; STV, party-list, etc. as stretch goals),
+district validity rules (contiguity, compactness metrics), population distribution
+modeling, scenario mechanics, progression design. Does necessary domain research as part
+of this work (how FPTP counting actually works, what compactness metrics academics use,
+historical redistricting patterns). Not responsible for raw domain accuracy checks — that's
+the Domain Reviewer's role on-demand. Not responsible for whether the game is *fun to play*
+— that's the Game Experience Specialist (GXS, on-demand).
 
 **Relationship to Architect:** Peer/co-designer, not subordinate. Both answer to PM.
 GES owns "what is the simulation capable of and how should it work"; Architect owns "how
@@ -132,6 +140,20 @@ back to TDD Designer; may not change them unilaterally.
 
 These roles are not present in every sprint. They are invoked at specific trigger points.
 Each should have a stable, reusable prompt template that improves over time.
+
+#### Game Experience Specialist (GXS)
+**Invoked for:** New game mechanics landing in a playable form, new scenario UX, before
+any major release. Evaluates: does the game feel engaging to play? Does the district-drawing
+interaction feel right? Does the feedback loop (draw → simulate → see result) communicate
+clearly? Is the educational point landing without being heavy-handed?
+
+**Distinct from GES:** GES reasons about what the mechanics are and how they work
+technically. GXS reasons about how those mechanics feel from the player's perspective.
+**Distinct from EER:** EER asks "does it teach the right lesson?" GXS asks "is it fun and
+clear enough for the lesson to land at all?"
+**Distinct from user:** The user provides subjective game-feel feedback through sprint
+demos (as the project owner, not as an agent). GXS provides structured UX evaluation
+that can be run against a playable build without requiring the user's direct involvement.
 
 #### Domain Reviewer
 **Invoked for:** Electoral accuracy checks, scenario validity ("is this redistricting
@@ -267,6 +289,7 @@ new ticket, and what is deferred.
 
 | Trigger | Reviewer invoked |
 |---|---|
+| New mechanics or scenario in playable form | Game Experience Specialist (GXS) |
 | Any trust boundary touched | Security Reviewer |
 | Any UI feature | Accessibility Reviewer |
 | Infrastructure/service decision | Cost/Finance Reviewer |
@@ -334,10 +357,11 @@ Four distinct advantages over general-purpose agents for specialist roles:
 
 ## Open Questions
 
-1. **Tech stack** — in-browser vs. server computation, mobile roadmap, WASM feasibility
-   (Kotlin Multiplatform?). Needs a dedicated session with GES and Architect before
-   system design begins. Map tile data source is part of this (cost + licensing
-   implications).
+1. **Tech stack** — decided: pure TypeScript v1, SVG/D3 rendering, Zustand state,
+   Vite dev server; WASM deferred. Two parallel spikes running to validate:
+   SPIKE-001 (game tech stack: TypeScript/npm) and SPIKE-002 (build system: Bazel).
+   Map tile data source (cost + licensing) remains open — deferred until game
+   reaches real geographic data.
 
 2. ~~**Game vision document** — what are the concrete v1 scenarios? What does a player
    session look like start to finish? What should a player understand at the end that they

--- a/thoughts/shared/tickets/SPIKE-001-game-tech-stack-poc.md
+++ b/thoughts/shared/tickets/SPIKE-001-game-tech-stack-poc.md
@@ -50,7 +50,38 @@ This spike runs in parallel with SPIKE-002 (build system). To avoid conflicts:
    Work exclusively in that workspace directory.
 3. All commits in this spike's change stack touch only `spike/001-game-poc/**`.
 4. Create bookmark: `jj bookmark create spike/001-game-poc -r @`
-5. Push and open PR when acceptance criteria are met.
+5. Push and open PR only when **all acceptance criteria are met and `SPIKE-REPORT.md` is written**.
+
+**Commit workflow during the spike:** commit after each logical chunk; run `npm test`
+before each commit; squash small fixes into the relevant commit freely. No PR during
+active execution — one PR at completion covers the whole spike.
+
+## Precinct Data Format
+
+The spike's static JSON file should prototype the structure that production will use.
+Design it with this in mind — spike format can be looser, but should prove the shape.
+
+**Required fields per precinct:**
+
+- `id` — unique identifier (integer or short string)
+- `neighbors` — adjacency list of neighbor IDs (prefer adjacency over raw coordinates if
+  using an abstract grid; use coordinates if doing real geographic projection)
+- `partyShare` — partisan vote-share as floats (0.0–1.0), keys: `R`, `D`, `L`, `G`, `I`
+  (Republican, Democrat, Libertarian, Green, Independent); must sum to 1.0
+- `previousResult` — simulated prior election winner (`R` | `D` | `L` | `G` | `I`) and
+  margin (e.g. `{ winner: "D", margin: 0.07 }`)
+- `demographics` — at least one additional demographic breakdown to prove multi-property
+  modeling; use sex/gender for the spike: `{ male: 0.49, female: 0.49, nonbinary: 0.02 }`
+
+**Production considerations** (for the SPIKE-REPORT.md to comment on):
+- IDs should stay compact (integer preferred)
+- Percentages as floats (0.0–1.0) rather than integers save a parse step and prevent
+  off-by-one rounding when summing
+- Adjacency list is sufficient for contiguity checks without needing full polygon topology
+
+**Agent latitude:** if the simulation model needs additional fields (population count,
+area, historical partisan lean, etc.) propose them in the data format before committing
+to the schema — the spike is the right time to surface missing properties.
 
 ## Tech Stack to Use
 

--- a/thoughts/shared/tickets/SPIKE-002-harmonized-bazel-build-poc.md
+++ b/thoughts/shared/tickets/SPIKE-002-harmonized-bazel-build-poc.md
@@ -35,6 +35,21 @@ and served with `bazel run //spike/002-build-poc:serve` (or equivalent).
 - Production-quality build configuration (caching, remote execution, CI)
 - Mobile or cross-platform targets
 
+## Fallback Build System
+
+If the Bazel hermetic build proves too painful, unstable, or the investment/benefit ratio
+doesn't justify adoption, the fallback is:
+
+- **Rust → WASM:** `cargo` + `wasm-pack` directly (not Bazel-managed)
+- **TypeScript:** `yarn` / `npm` + standard bundler (Vite or esbuild)
+- **Integration:** a `Makefile` with explicit targets for build, test, and serve
+- **Hermeticity:** not guaranteed; mitigated by version pinning, `cargo.lock`, `package-lock.json`,
+  and documentation of host-tool requirements
+
+The SPIKE-REPORT.md must state clearly if the fallback was triggered, why, and what the
+build experience pain points were. A "fallback triggered" result is a valid and useful
+spike outcome — not a failure.
+
 ## Working Directory
 
 `spike/002-build-poc/` — this is a completely independent source root with its own
@@ -57,7 +72,11 @@ This spike runs in parallel with SPIKE-001 (game tech stack). To avoid conflicts
    Work exclusively in that workspace directory.
 3. All commits in this spike's change stack touch only `spike/002-build-poc/**`.
 4. Create bookmark: `jj bookmark create spike/002-build-poc -r @`
-5. Push and open PR when acceptance criteria are met.
+5. Push and open PR only when **all acceptance criteria are met and `SPIKE-REPORT.md` is written**.
+
+**Commit workflow during the spike:** commit after each logical chunk; run
+`bazel test //...` (or fallback equivalent) before each commit; squash small fixes
+freely. No PR during active execution — one PR at completion covers the whole spike.
 
 ## Reference: polyglot Exemplar
 


### PR DESCRIPTION
## Summary

- Clarifies GES (Game Engine Specialist) as a technical role, not the user
- Adds GXS (Game Experience Specialist) as a new on-demand reviewer — evaluates gameplay feel, distinct from GES (mechanics), EER (lesson quality), and the user (owner feedback via demos)
- Explicitly documents the user's role: project owner/customer; escalation target; not an agent
- Updates agent team research doc status to reflect spikes running; marks Q1 (tech stack) as resolved
- Adds spike commit workflow to AGENTS.md and AGENTS.compressed.md: lightweight local commits + tests during execution; one PR at completion
- Adds precinct data format guidance to SPIKE-001 (id, neighbors, partyShare R/D/L/G/I, previousResult, demographics including sex/gender as second demographic)
- Adds fallback build system plan to SPIKE-002 (cargo + wasm-pack + yarn + Makefile if Bazel proves unworkable)

## Validation performed

- [ ] N/A — prose and ticket changes only; no code

## Tickets addressed

None — pre-implementation design

## Checklist

- [x] Both .md and .compressed.md updated in sync
- [x] No ticket changes required (no new tickets created or resolved)
