### PR TITLE
Pre-flight: checkpoint paradigm, subagent working-dir, map generation plan

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -15,6 +15,9 @@ client-side election simulation. See $ts/vision/game-vision.compressed.md for fu
 $ts/ docs have two forms: <name>.md(human) + <name>.compressed.md(token-efficient,lossless)
 compressed: §SECTION markers + §ABBREV table; all §ABBREV refs use $abr format; definition left-sides bare
 
+§SUBAGENTS
+always include working directory in subagent prompt — eliminates navigation errors + wrong-place failures
+
 §NOINLINE [NON-OPTIONAL]
 FORBIDDEN in any Bash tool call:
   heredocs: cmd << 'EOF'...EOF
@@ -39,9 +42,14 @@ spike/002-build-poc/  SPIKE-002: harmonized Bazel build proof-of-concept — ind
 before non-trivial impl: check $ts/vision/ + $ts/tickets/TICKETS.md + $ts/research/ for prior work
 
 SPIKE ISOLATION: agents working a spike touch ONLY their spike subdirectory; no other repo files
+SPIKE COMMANDS: use names (npm,bazel,node) not absolute paths; all tooling must be on PATH
 SPIKE COMMIT WORKFLOW:
   during: commit after each logical chunk; run build+tests before commit; squash fixes freely; no PR
   at completion: all AC met + SPIKE-REPORT.md written → one PR → full critique cycle → merge
+SPIKE CHECKPOINTING: maintain PROGRESS.md in spike dir; update+commit with each chunk
+  format: working-dir(absolute path; jj workspace sibling e.g. .../redistricting-sim-spike-NNN/spike/NNN-name/) | status | AC checklist(next-up bolded) | decisions(non-obvious only) | blockers
+  resuming agent: read ticket → PROGRESS.md → jj log; continue from Next up
+  keep under 30 lines; skip anything evident from ticket or code
 
 §TICKETS
 TICKETS.md=canonical index; do NOT maintain ticket inventories elsewhere

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,18 @@ The `thoughts/` directory contains research, plans, tickets, and handoffs. Many 
 
 The compressed format uses `§SECTION` markers and an `§ABBREV` table at the top for decoding all shorthands. All `§ABBREV` key references in the body use `$abr` dollar-prefix format (e.g. `$ts/tickets/` not `ts/tickets/`). Definition left-sides stay bare.
 
+## Spawning Subagents
+
+**Always include the working directory in a subagent's prompt.** This eliminates an
+entire class of navigation errors and file-not-found failures. A subagent that doesn't
+know where it is will spend tokens figuring it out — or worse, silently work in the
+wrong place. State it explicitly: "Your working directory is `<path>`."
+
+Follow the **No Inline Content** rule when writing the subagent's prompt — write it to a
+temp file and reference it by path.
+
+---
+
 ## No Inline Content in Shell Commands
 
 Never pass non-trivial text inline to any shell command or tool call. Characters such as backticks, `---`, and `*` are misinterpreted by shell argument parsers and security hooks even when the content is benign.
@@ -55,10 +67,46 @@ Before starting any non-trivial implementation work: check `thoughts/shared/visi
 
 **Spike directories are completely independent source roots.** Each has its own build toolchain, dependencies, and cannot import from or depend on anything outside its own directory. Agents working on a spike must only create or modify files under their designated `spike/NNN-*/` subdirectory — no changes to other repo files, no cross-spike imports.
 
+**Spike commands** — use commands by name (e.g. `npm`, `bazel`, `node`), never by
+absolute path (e.g. `/usr/local/bin/node`). All spike tooling must be on PATH. This
+keeps the spike portable and avoids permission guardrails on path-specific rules.
+
 **Spike commit workflow** — spikes use a lightweight commit discipline; full PR rigor applies only at completion:
 
 - *During the spike:* commit locally after each logical chunk; run the spike's build and tests (`npm test`, `bazel test //...`, etc.) before each commit; squash small fixes into the relevant commit freely; no PR during active execution.
 - *At completion:* when all acceptance criteria are met and `SPIKE-REPORT.md` is written, open one PR for the full spike result. Run the standard PR review cycle (critique → response → merge) at that point.
+
+**Spike checkpointing — `PROGRESS.md`** — each spike maintains a `PROGRESS.md` in its
+spike directory. Update and commit it with every logical chunk of work. A session resuming
+after failure reads ticket → `PROGRESS.md` → `jj log` and has everything needed to
+continue without re-doing work.
+
+Format:
+
+```markdown
+## Working Directory
+`<absolute path to spike dir>`
+# Note: spikes run in jj workspaces created with `jj workspace add ../redistricting-sim-spike-NNN`.
+# The spike dir is therefore a sibling of the repo root, e.g.:
+# /Users/cgruber/Projects/github/cgruber/redistricting-sim-spike-001/spike/001-game-poc/
+
+## Status: In Progress | Blocked: <reason> | Complete
+
+## Acceptance Criteria
+- [x] Completed item
+- [ ] **Next up** — specific next action in one line
+- [ ] Future item
+
+## Decisions
+- <non-obvious choice>: <why; what alternatives were rejected>
+
+## Blockers / Open Questions
+- <anything needing user input or an unresolved external answer>
+```
+
+Rules: `Decisions` captures only non-obvious choices — skip anything evident from reading
+the ticket or the code. `Next up` is the single most valuable field; keep it to one
+concrete action. The whole file should rarely exceed 30 lines.
 
 ---
 

--- a/thoughts/shared/tickets/SPIKE-001-game-tech-stack-poc.md
+++ b/thoughts/shared/tickets/SPIKE-001-game-tech-stack-poc.md
@@ -56,6 +56,42 @@ This spike runs in parallel with SPIKE-002 (build system). To avoid conflicts:
 before each commit; squash small fixes into the relevant commit freely. No PR during
 active execution — one PR at completion covers the whole spike.
 
+## Map Generation
+
+The spike region must be procedurally generated — do not hand-author 50 precincts.
+The generator itself is part of the spike deliverable.
+
+**Geometry:** Regular hexagonal grid (e.g. 7×8 offset grid ≈ 50 cells). Hex grids give
+natural 6-neighbor adjacency without the artificial look of a square grid. Adjacency can
+be derived directly from grid coordinates at generation time and stored in the precinct
+data (no need to compute it at runtime).
+
+**Population distribution:** Place 1–3 epicenters at fixed or randomly chosen grid
+positions. Each precinct's population is the sum of contributions from each epicenter,
+with contribution falling off with distance. This produces realistic clustering —
+dense urban cores, sparse periphery, occasional secondary clusters — without requiring
+real geographic data.
+
+**Partisan lean:** Assign a lean that has geographic coherence — nearby precincts should
+have correlated lean, not independent noise. A smooth random field (e.g. low-frequency
+noise or a 2D sinusoidal gradient) mapped to party share works well. Do **not** hardcode
+real-world urban/rural stereotypes; this is a fictional region.
+
+**Before implementing the generator:**
+
+1. Create `PROGRESS.md` from the template in AGENTS.md (see Spike Checkpointing).
+2. Spin up a Domain Researcher subagent to investigate:
+   - State-of-the-art or widely-used approaches for cheaply simulating realistic
+     population distribution snapshots (Gaussian mixture? gravity model? something else
+     in the redistricting or synthetic-geography literature?)
+   - Whether redistricting research uses established parameterizations for synthetic
+     partisan geographic distributions
+3. The researcher returns findings as text. Write a one-paragraph summary into
+   `PROGRESS.md`'s Decisions section before coding the generator.
+
+The goal is "informed simple" — pick a defensible approach, not the most sophisticated
+one. The generator is a means to an end; the spike is about the game stack.
+
 ## Precinct Data Format
 
 The spike's static JSON file should prototype the structure that production will use.
@@ -151,9 +187,14 @@ The game vision is at `thoughts/shared/vision/game-vision.compressed.md`.
 
 ## Definition of Done
 
-Spike is done when all acceptance criteria are checked and a short written report is
-added to `spike/001-game-poc/SPIKE-REPORT.md` covering:
-- What worked well
-- What was harder than expected
-- Any open questions for GES/ARCH
-- Recommended adjustments to the planned stack (if any)
+Spike is done when all acceptance criteria are checked and:
+
+1. `spike/001-game-poc/SPIKE-REPORT.md` is written covering:
+   - What worked well
+   - What was harder than expected
+   - Any open questions for GES/ARCH
+   - Recommended adjustments to the planned stack (if any)
+   - Map generator: which population distribution approach was used and why
+
+2. `spike/001-game-poc/PROGRESS.md` is updated to `Status: Complete` with all criteria
+   checked — this is the clean handoff signal for the coordinating agent.

--- a/thoughts/shared/tickets/SPIKE-002-harmonized-bazel-build-poc.md
+++ b/thoughts/shared/tickets/SPIKE-002-harmonized-bazel-build-poc.md
@@ -171,10 +171,15 @@ rustfmt <changed-files>   # or: cargo fmt
 
 ## Definition of Done
 
-Spike is done when all acceptance criteria are checked and a written report is added
-to `spike/002-build-poc/SPIKE-REPORT.md` covering:
-- Which Bazel rules versions were used and whether they were stable
-- Any hermeticity gaps found (tools from host PATH, generated files not gitignored, etc.)
-- Build time for a clean build (baseline for future optimisation)
-- Any open questions for the BUILD specialist or ARCH
-- Go/no-go recommendation for adopting this build setup for the full game
+Spike is done when all acceptance criteria are checked and:
+
+1. `spike/002-build-poc/SPIKE-REPORT.md` is written covering:
+   - Which Bazel rules versions were used and whether they were stable
+   - Any hermeticity gaps found (tools from host PATH, generated files not gitignored, etc.)
+   - Friction classification: what was setup friction (one-time) vs. ongoing friction
+   - Build time for a clean build (baseline for future optimisation)
+   - Any open questions for the BUILD specialist or ARCH
+   - Go/no-go recommendation for adopting this build setup for the full game
+
+2. `spike/002-build-poc/PROGRESS.md` is updated to `Status: Complete` with all criteria
+   checked — this is the clean handoff signal for the coordinating agent.


### PR DESCRIPTION
## Summary

Pre-flight documentation pass before launching the parallel spikes.

- **AGENTS.md / compressed:** New `§SUBAGENTS` section — always include working directory in subagent prompts. Spike section additions: use PATH commands (not absolute paths); full `PROGRESS.md` checkpoint paradigm with format template and rules.
- **SPIKE-001:** New Map Generation section — hexagonal grid geometry, 1-3 population epicenters with distance-decay distribution, geographically coherent partisan lean (smooth field, no urban/rural stereotypes), domain researcher subagent step before implementing the generator. DoD updated to require `PROGRESS.md: Status: Complete` as coordinating-agent handoff signal.
- **SPIKE-002:** DoD updated to match SPIKE-001 structure — requires `PROGRESS.md: Status: Complete`; SPIKE-REPORT.md now includes friction classification (setup vs. ongoing).

## Validation performed

- [ ] N/A — documentation only

## Checklist

- [x] Both .md and .compressed.md updated in sync for AGENTS
- [x] No ticket status changes; TICKETS.md unchanged
