### PR TITLE
Simplify spike jj discipline: work in main repo, no workspaces

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -41,13 +41,13 @@ spike/002-build-poc/  SPIKE-002: harmonized Bazel build proof-of-concept — ind
 
 before non-trivial impl: check $ts/vision/ + $ts/tickets/TICKETS.md + $ts/research/ for prior work
 
-SPIKE ISOLATION: agents working a spike touch ONLY their spike subdirectory; no other repo files
+SPIKE ISOLATION: work directly in main repo checkout; touch ONLY spike/NNN-name/**; no other repo files; no jj workspaces
 SPIKE COMMANDS: use names (npm,bazel,node) not absolute paths; all tooling must be on PATH
 SPIKE COMMIT WORKFLOW:
   during: commit after each logical chunk; run build+tests before commit; squash fixes freely; no PR
   at completion: all AC met + SPIKE-REPORT.md written → one PR → full critique cycle → merge
 SPIKE CHECKPOINTING: maintain PROGRESS.md in spike dir; update+commit with each chunk
-  format: working-dir(absolute path; jj workspace sibling e.g. .../redistricting-sim-spike-NNN/spike/NNN-name/) | status | AC checklist(next-up bolded) | decisions(non-obvious only) | blockers
+  format: working-dir(absolute path inside repo e.g. .../redistricting-sim/spike/NNN-name/) | status | AC checklist(next-up bolded) | decisions(non-obvious only) | blockers
   resuming agent: read ticket → PROGRESS.md → jj log; continue from Next up
   keep under 30 lines; skip anything evident from ticket or code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,10 +85,7 @@ Format:
 
 ```markdown
 ## Working Directory
-`<absolute path to spike dir>`
-# Note: spikes run in jj workspaces created with `jj workspace add ../redistricting-sim-spike-NNN`.
-# The spike dir is therefore a sibling of the repo root, e.g.:
-# /Users/cgruber/Projects/github/cgruber/redistricting-sim-spike-001/spike/001-game-poc/
+`<absolute path to spike dir within the repo, e.g. /Users/cgruber/Projects/github/cgruber/redistricting-sim/spike/001-game-poc/>`
 
 ## Status: In Progress | Blocked: <reason> | Complete
 

--- a/thoughts/shared/tickets/SPIKE-001-game-tech-stack-poc.md
+++ b/thoughts/shared/tickets/SPIKE-001-game-tech-stack-poc.md
@@ -39,22 +39,21 @@ and play? It is not production code — correctness and polish are out of scope.
 `package.json`, `tsconfig.json`, and toolchain. Do not modify any files outside
 `spike/001-game-poc/`. Do not import from or depend on anything outside this directory.
 
-## jj Discipline (CRITICAL for parallel spike work)
+## jj Discipline
 
-This spike runs in parallel with SPIKE-002 (build system). To avoid conflicts:
+Work directly in the main repo checkout. All spike files live under `spike/001-game-poc/`
+inside the repo — do not create sibling directories or jj workspaces.
 
-1. Before starting, confirm the working copy (@) is on a fresh change descended from
-   main: `jj log`
-2. Create a dedicated jj workspace for this spike:
-   `jj workspace add ../redistricting-sim-spike-001`
-   Work exclusively in that workspace directory.
-3. All commits in this spike's change stack touch only `spike/001-game-poc/**`.
-4. Create bookmark: `jj bookmark create spike/001-game-poc -r @`
-5. Push and open PR only when **all acceptance criteria are met and `SPIKE-REPORT.md` is written**.
+1. Before starting: `jj log` — confirm `@` is a fresh empty change descended from main.
+   If not, run `jj new main` to start one.
+2. All commits touch only `spike/001-game-poc/**` — no other repo files.
+3. Create a bookmark before your first push:
+   `jj bookmark create spike/001-game-poc -r @`
+4. Push and open PR only when **all acceptance criteria are met and `SPIKE-REPORT.md` is written**.
 
 **Commit workflow during the spike:** commit after each logical chunk; run `npm test`
-before each commit; squash small fixes into the relevant commit freely. No PR during
-active execution — one PR at completion covers the whole spike.
+before each commit; squash small fixes freely. No PR during active execution — one PR
+at completion covers the whole spike.
 
 ## Map Generation
 

--- a/thoughts/shared/tickets/SPIKE-002-harmonized-bazel-build-poc.md
+++ b/thoughts/shared/tickets/SPIKE-002-harmonized-bazel-build-poc.md
@@ -78,18 +78,17 @@ at `spike/002-build-poc/MODULE.bazel` and run all Bazel commands from within tha
 directory (`cd spike/002-build-poc && bazel build //...`). This keeps the spike
 fully self-contained and avoids touching the repo root.
 
-## jj Discipline (CRITICAL for parallel spike work)
+## jj Discipline
 
-This spike runs in parallel with SPIKE-001 (game tech stack). To avoid conflicts:
+Work directly in the main repo checkout. All spike files live under `spike/002-build-poc/`
+inside the repo — do not create sibling directories or jj workspaces.
 
-1. Before starting, confirm the working copy (@) is on a fresh change descended from
-   main: `jj log`
-2. Create a dedicated jj workspace for this spike:
-   `jj workspace add ../redistricting-sim-spike-002`
-   Work exclusively in that workspace directory.
-3. All commits in this spike's change stack touch only `spike/002-build-poc/**`.
-4. Create bookmark: `jj bookmark create spike/002-build-poc -r @`
-5. Push and open PR only when **all acceptance criteria are met and `SPIKE-REPORT.md` is written**.
+1. Before starting: `jj log` — confirm `@` is a fresh empty change descended from main.
+   If not, run `jj new main` to start one.
+2. All commits touch only `spike/002-build-poc/**` — no other repo files.
+3. Create a bookmark before your first push:
+   `jj bookmark create spike/002-build-poc -r @`
+4. Push and open PR only when **all acceptance criteria are met and `SPIKE-REPORT.md` is written**.
 
 **Commit workflow during the spike:** commit after each logical chunk; run
 `bazel test //...` (or fallback equivalent) before each commit; squash small fixes


### PR DESCRIPTION
## Summary

Removes jj workspace instructions from both spike tickets; spikes work directly in the
main repo checkout. Fixes the PROGRESS.md working directory example in AGENTS.md to show
a path inside the repo (not a sibling worktree path).

- SPIKE-001 jj Discipline: rewritten — no `jj workspace add`, start with `jj new main` if needed, work at `spike/001-game-poc/` in the repo
- SPIKE-002 jj Discipline: same treatment for `spike/002-build-poc/`
- AGENTS.md PROGRESS.md template: working directory example now shows `.../redistricting-sim/spike/001-game-poc/`
- AGENTS.compressed.md: SPIKE ISOLATION updated to explicitly say "no jj workspaces"; working-dir format updated to match

## Validation performed

- [ ] N/A — documentation only
