### PR TITLE
Add kotlin tools to critique/response agent prompts in pr-review-cycle

### DIFF
--- a/thoughts/shared/tickets/AGENT-002-pr-review-cycle-kotlin-tools.md
+++ b/thoughts/shared/tickets/AGENT-002-pr-review-cycle-kotlin-tools.md
@@ -1,0 +1,40 @@
+---
+id: AGENT-002
+title: Add kotlin tools reference to pr-review-cycle critique/response agent prompts
+area: agentic workflow, tooling
+status: open
+created: 2026-04-23
+---
+
+## Summary
+
+Critique and response agents consistently use raw `gh api` calls instead of the
+established kotlin scripts in `/opt/geekinasuit/agents/tools/`. The scripts exist
+precisely to make these operations reliable and consistent. Two places need updating:
+
+1. **This repo's** `thoughts/shared/workflows/pr-review-cycle.md` — done (PR #9)
+2. **The infra repo's** `/opt/geekinasuit/agents/internal/workflows/pr-review-cycle.md`
+   — tracked by this ticket; requires a PR to `geekinasuit/infra`
+
+## Current State
+
+The infra repo's `pr-review-cycle.md` (§STEP3 critique prompt) currently instructs:
+> "Use `gh api` to post comments."
+
+And §STEP7 uses raw GraphQL `gh api graphql` calls for thread resolution instead of
+`gh-pr-threads.main.kts`.
+
+## Goals / Acceptance Criteria
+
+- [ ] `pr-review-cycle.md` in `geekinasuit/infra` updated to include a "Available tools"
+      preamble in the §STEP3 critique prompt and §STEP4 response prompt, listing:
+      - `gh-pr-comment.main.kts` for inline comments and thread replies (body from file only)
+      - `gh-pr-threads.main.kts` for listing and resolving threads
+- [ ] §STEP7 updated to use `gh-pr-threads.main.kts` instead of raw graphql
+- [ ] `pr-review-cycle.compressed.md` in `geekinasuit/infra` updated to match
+
+## References
+
+- This repo's updated workflow: `thoughts/shared/workflows/pr-review-cycle.md`
+- Tool catalog: `/opt/geekinasuit/agents/internal/TOOLS.compressed.md`
+- Infra repo: `/Users/cgruber/Projects/github/geekinasuit/infra`

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -37,6 +37,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `SPIKE-001-game-tech-stack-poc.md` | frontend, game | TypeScript + SVG/D3 + Zustand game prototype in `spike/001-game-poc/` (independent source root) |
 | `SPIKE-002-harmonized-bazel-build-poc.md` | build | Bazel + rules_ts + Rust→WASM hello-world in `spike/002-build-poc/` (independent source root) |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
+| `AGENT-002-pr-review-cycle-kotlin-tools.md` | agentic workflow | Update infra repo pr-review-cycle to use kotlin scripts in critique/response agent prompts instead of raw gh api |
 
 ---
 

--- a/thoughts/shared/workflows/pr-review-cycle.compressed.md
+++ b/thoughts/shared/workflows/pr-review-cycle.compressed.md
@@ -1,0 +1,77 @@
+<!--COMPRESSED v1; source:pr-review-cycle.md-->
+§META
+name:pr-review-cycle scope:redistricting-sim version:2
+
+§ABBREV
+tools=/opt/geekinasuit/agents/tools
+owner=cgruber repo=redistricting-sim
+A=prose/metadata B=config C=secrets D=new-feature/infra
+
+§OVERVIEW
+All changes via branch+PR; no direct push to main.
+A(prose,tickets,AGENTS.md,workflow-docs) B(manifests,config) C(*.sops.yaml,keys,tokens) D(new-svc,new-pipeline)
+multi-category→apply highest bar
+
+§STEP0
+kotlin $tools/gh-pr-diff-summary.main.kts -- --pr <N> --owner $owner --repo $repo
+→ highest category + required validation; pass output into critique agent prompt
+
+§STEP1
+A: none
+B: dry-run validation where applicable
+C: sops decrypt+verify [NEVER commit without verify]
+D: document in PR body: affected services, deployment sequence, rollback, downtime
+
+§STEP2
+jj bookmark set <name> -r @- → jj git push -b <name>
+Write PR body → /tmp/$repo-<branch>-pr-body.md (Write tool; no heredoc)
+kotlin $tools/gh-pr-create.main.kts -- --title "..." --body-file /tmp/... --owner $owner --repo $repo
+Keywords: N/A(skip) POST-MERGE(skip) OPTIONAL(skip unless checked) — unchecked w/o keyword→blocks CI check
+
+§STEP3
+critique agent(foreground; wait before step4)
+pass diff-summary output + category into prompt
+
+Standard critique preamble (include in every critique prompt):
+  Available tools — use these NOT raw gh api:
+    gh-pr-comment: post inline comment or thread reply (body from file only)
+      kotlin $tools/gh-pr-comment.main.kts -- --pr N --owner $owner --repo $repo --body-file F [--path P --line N | --reply-to ID]
+    gh-pr-threads: list or resolve threads
+      kotlin $tools/gh-pr-threads.main.kts -- --pr N --owner $owner --repo $repo [--resolve]
+    always Write reply/comment body to /tmp file first; never inline
+
+Step 0: scope check → gh pr diff N --repo $owner/$repo; SCOPE MISMATCH→stop+report
+Step 1(A): prose correctness+token efficiency+internal consistency
+Step 1(B/C/D): safety/secrets/correctness/blast-radius
+SCOPE MISMATCH→stop+fix+re-run §STEP3; LGTM→skip to §STEP6
+
+§STEP4
+response agent(after critique; foreground):
+  tools: gh-pr-comment(--reply-to only; no new inline threads), gh-pr-threads; body from file
+  Read PR+all open threads; fix or explain no-change; reply via gh-pr-comment --reply-to; no push; report changes+reasons
+
+§STEP5
+changes made→re-validate(§STEP1 affected files)→push→re-run §STEP3 | no changes→§STEP6
+
+§STEP6
+pause if: judgment flagged | validation fails | conflicting comments | cat-D(always)
+
+§STEP7
+every thread→reply before resolving [no reply = unreadable history]
+reply: Fixed(<what>) | No change/won't fix(<why>)
+kotlin $tools/gh-pr-threads.main.kts -- --pr N --owner $owner --repo $repo           # list unresolved
+kotlin $tools/gh-pr-threads.main.kts -- --pr N --owner $owner --repo $repo --resolve  # resolve all
+
+§STEP8
+kotlin $tools/gh-pr-status.main.kts -- --pr N --owner $owner --repo $repo
+gh pr merge N --repo $owner/$repo --squash
+never --auto | --admin | --merge; CI must pass; textual-A exception: infra failures only, non-blocking
+
+§STEP9
+jj git fetch; jj bookmark set main -r main@origin
+jj rebase -b <next> -d main; jj abandon <change-id>; jj bookmark delete <name>; jj git push --deleted
+
+§NOTES
+stacked PRs: wait for parent merge before pushing child
+never unchecked boxes in review comments — prose only (task-list-completed scans all comments)
+tmp files: unique names → repo+branch+purpose; never generic /tmp/pr-body.md

--- a/thoughts/shared/workflows/pr-review-cycle.md
+++ b/thoughts/shared/workflows/pr-review-cycle.md
@@ -1,141 +1,178 @@
 # PR Review Cycle Workflow
 
 Standard process for taking a local bookmark through review and merge.
+Kotlin scripts live at `/opt/geekinasuit/agents/tools/`. Run any script with
+`kotlin <script> -- --help` for authoritative flag reference.
+
+---
 
 ## Steps
 
-### 1. Pre-push verification
-- Run full test suite locally: `bazel test //...`
-- Fix any failures before pushing (saves CI resources)
-
-### 2. Push and open PR
-
-> **Note**: This repo runs the `stilliard/github-task-list-completed` GitHub App. It scans
-> **every** body for unchecked checkboxes: the PR description, all PR comments, all review
-> submissions, and all inline review comments. Any unchecked `- [ ]` blocks the check.
->
-> - Check boxes immediately after verifying (`- [x]`), or mark inapplicable ones with `N/A`,
->   `POST-MERGE`, or `OPTIONAL` (all caps, inline) to exclude them.
-> - **Never put unchecked checkboxes in review comments** — use prose instead.
-- After `jj commit`, the new commit sits at `@-` (the empty working copy is `@`). Set bookmark to that commit: `jj bookmark set <name> -r @-`
-- Push: `jj git push -b <name>`
-- If no PR exists: `gh pr create --repo geekinasuit/polyglot --title "..." --body "$(cat <<'EOF' ... EOF)"`
-
-### 3. Critique agent (foreground — wait for completion)
-
-Run the critique agent **first and wait for it to finish** before launching the response agent.
-The response agent needs the critique agent's posted comments to exist on GitHub before it runs;
-running them in parallel means the response agent sees an empty comment list.
-
-**Critique agent** (subagent_type: general-purpose):
-> "You are a code reviewer. Review PR #N at https://github.com/geekinasuit/polyglot/pull/N.
->
-> **Step 0 — Scope check (do this first, before any inline review):**
-> Compare the PR title and description against the actual diff (`gh pr diff <N>`).
-> Check whether the diff contains changes that are NOT described — files modified, added, or
-> deleted that have no relationship to the stated purpose of the PR. This can happen when a
-> branch is based on another in-flight branch and a squash merge captures ancestor changes
-> unintentionally. If you find out-of-scope changes, post a single top-level PR comment
-> (not an inline comment) flagging the discrepancy and listing the unexpected files/hunks.
-> **Stop and report 'SCOPE MISMATCH' to the caller** — do not proceed with inline review
-> until the scope issue is resolved.
->
-> **Step 1 — Inline review (only if scope check passes):**
-> Read every changed file. Post inline review comments on GitHub for any real issues (bugs,
-> security, correctness, style violations, misleading names). Do NOT post praise or nitpicks.
-> Use `gh api` to post comments. If there are no issues, output 'LGTM - no issues found' and
-> do nothing."
-
-If the critique agent reports **SCOPE MISMATCH**, stop. Notify the PR author to rebase or
-re-target the branch so the diff matches the stated purpose, then re-run from Step 3 once
-the scope is corrected. Do not proceed with the response agent until the scope check passes.
-
-If the critique agent reports LGTM, skip to Step 8.
-
-### 4. Response agent (after critique agent completes)
-
-**Response agent** (subagent_type: general-purpose):
-> "Read PR #N at https://github.com/geekinasuit/polyglot/pull/N. Collect all open review
-> comments (from the critique agent AND any AI/human reviewers). For each comment, either
-> propose a concrete code fix or explain why no change is needed. Apply fixes directly to
-> the files. Do NOT push — report back what was changed and what was left as-is with reasons."
-
-### 5. Evaluate responses
-- If response agent made changes: run `bazel test //...`, then push, then re-run from Step 3
-- If no changes needed (all LGTM): proceed to Step 6
-
-### 6. Pause for human input if:
-- Response agent flagged any comment as requiring design/product judgment
-- Tests fail after applying fixes
-- Conflicting review comments
-
-### 7. Resolve all review threads
-
-After replying to every comment, resolve each thread — replies alone do not unblock merge:
+### Step 0 — Classify the PR
 
 ```bash
-# Find unresolved thread IDs
-gh api graphql -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:50){nodes{id isResolved}}}}}' \
-  -f owner=geekinasuit -f repo=polyglot -F pr=<N> \
-  --jq '.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)|.id'
-
-# Resolve each one
-gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' \
-  -f t=<thread_id>
+kotlin /opt/geekinasuit/agents/tools/gh-pr-diff-summary.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim
 ```
 
-### 8. Merge
+Outputs the highest category (A/B/C/D) and required validation. Categories:
+- **A** — prose/metadata (`.md`, tickets, AGENTS files): no build validation required
+- **B** — config/manifests: dry-run validation where possible
+- **C** — secrets: decrypt-verify before commit
+- **D** — new feature/infra: document deployment, rollback, downtime in PR body
 
-When all checks pass:
+Multi-category PRs apply the highest bar.
+
+### Step 1 — Pre-push verification
+
+- Category A: none required
+- Category B: validate with dry-run (kubectl, etc.) if applicable
+- Category C: `sops decrypt` and verify — never commit unverified
+- Category D: document affected services, deployment sequence, rollback plan in PR body
+
+Run the spike's test suite if touching spike code (`npm test`, `bazel test //...`).
+
+### Step 2 — Push and open PR
+
+After `jj commit`, set bookmark and push:
+```bash
+jj bookmark set <name> -r @-
+jj git push -b <name>
 ```
-gh pr merge <N> --repo geekinasuit/polyglot --squash --auto
+
+Write PR body to a temp file (never inline — see NOINLINE rule in AGENTS.md):
+```bash
+# Write body to /tmp/redistricting-sim-<branch>-pr-body.md
+kotlin /opt/geekinasuit/agents/tools/gh-pr-create.main.kts -- \
+  --title "..." --body-file /tmp/redistricting-sim-<branch>-pr-body.md \
+  --owner cgruber --repo redistricting-sim
 ```
 
-> **IMPORTANT — CI failures before merge**: If any check is failing, **stop and report to the
-> user regardless of any merge permission already granted**. Permission to merge (i.e. permission
-> to proceed without further human review) is NOT permission to merge through failing CI.
->
-> **Exception — purely textual, non-load-bearing PRs**: A PR may be merged through *infra*
-> CI failures if and only if *every* changed file meets all of these criteria:
-> 1. It has a purely prose file extension (`.md`, `.txt`) **or** is a well-known prose file
->    by name/path (e.g. files under `thoughts/`, `AGENTS.md`, `README`, `LICENSE`). A file
->    under `thoughts/` that has a non-prose extension (e.g. `.sh`, `.yaml`) does **not**
->    qualify on path alone.
-> 2. It is **not** referenced by any Bazel target (not test data, not website source, not
->    generated into any build output)
-> 3. It is **not** a CI/build config file (`.github/`, `.buildkite/`, `.bazelrc`, `MODULE.bazel`,
->    `BUILD.bazel`, `*.bzl`, `Makefile`, etc.)
->
-> When this exception applies, **infra failures only** may be treated as non-blocking. Still
-> classify the failure (infra vs. real) and note it in your report to the user. Real
-> build/test failures (e.g. a markdown-lint or link-checker step actually failing on changed
-> content) are blockers even for textual PRs and must be reported and addressed.
->
-> For all other PRs, every failing check is a blocker until the user explicitly addresses it:
->
-> - **Infra failures** (e.g. Docker image not found, agent offline): report to the user so they
->   can investigate and mitigate — do not merge until they confirm the infra issue is understood
->   and accepted for this specific PR.
-> - **Actual build/test failures**: must be diagnosed and fixed before merging.
->
-> Describe which checks passed and which failed, classify each failure as infra vs. real, and
-> ask the user how to proceed. Do not use `--admin` or any other bypass flag without explicit
-> one-time permission for that specific PR.
+PR body required sections: Summary, Validation performed, Tickets addressed.
+Mark inapplicable checkboxes with `N/A`, `POST-MERGE`, or `OPTIONAL` (all caps, inline)
+— unchecked boxes without these keywords block the task-list-completed CI check.
 
-### 9. Fetch and rebase after every merge
+### Step 3 — Critique agent (foreground — wait for completion)
 
-**Always do this immediately after a merge**, before starting the next PR:
+Run the critique agent **first** and wait before launching the response agent.
+
 ```
+kotlin /opt/geekinasuit/agents/tools/gh-pr-diff-summary.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim
+```
+
+Include the diff-summary output in the critique agent's prompt. Standard critique prompt:
+
+---
+You are a code reviewer for the redistricting-sim project (cgruber/redistricting-sim).
+
+**Available tools** — use these instead of raw `gh api` calls:
+- `kotlin /opt/geekinasuit/agents/tools/gh-pr-comment.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim --body-file <f> --path <file> --line <N>` — post inline comment
+- `kotlin /opt/geekinasuit/agents/tools/gh-pr-comment.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim --body-file <f> --reply-to <id>` — reply to thread
+- `kotlin /opt/geekinasuit/agents/tools/gh-pr-threads.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim` — list unresolved threads
+- Always write comment bodies to a /tmp file first; never pass inline.
+
+**Step 0 — Scope check:**
+Get the diff: `gh pr diff <N> --repo cgruber/redistricting-sim`
+Verify the diff matches the PR description. Flag files changed that are unrelated to the
+stated purpose. If scope mismatch found: post a top-level comment and report SCOPE MISMATCH
+to the caller. Stop — do not proceed with inline review.
+
+**Step 1 — Inline review (only if scope check passes):**
+Category from diff-summary: [INSERT CATEGORY HERE]
+- Category A (prose): check prompt correctness, token efficiency, internal consistency
+- Category B/C/D (config/secrets/infra): check safety, secrets handling, blast radius
+
+Post inline comments only for real issues. No praise or nitpicks. If no issues: output
+LGTM and stop.
+---
+
+If critique reports **SCOPE MISMATCH**: stop and notify the user. Fix scope, then re-run Step 3.
+If critique reports **LGTM**: skip to Step 6.
+
+### Step 4 — Response agent (after critique completes)
+
+Standard response prompt:
+
+---
+You are responding to review comments on PR #<N> at cgruber/redistricting-sim.
+
+**Available tools** — use these instead of raw `gh api` calls:
+- `kotlin /opt/geekinasuit/agents/tools/gh-pr-threads.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim` — list unresolved threads
+- `kotlin /opt/geekinasuit/agents/tools/gh-pr-comment.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim --body-file <f> --reply-to <id>` — reply to a thread
+- Always write reply bodies to a /tmp file first; never pass inline.
+
+Read the PR and all open review threads. For each thread: either apply the fix directly to
+the file, or explain clearly why no change is needed. Do not push. Report what was changed
+and what was left as-is with reasons.
+---
+
+### Step 5 — Re-validate and re-critique
+
+If response agent made changes:
+- Re-run any required validation (Step 1) for affected files
+- Push: `jj git push -b <name>`
+- Re-run Step 3
+
+If no changes: proceed to Step 6.
+
+### Step 6 — Pause for human input if:
+
+- Response agent flagged a comment as requiring design/product judgment
+- Tests fail after applying fixes
+- Conflicting review comments
+- Category D change (always pause before merge)
+
+### Step 7 — Resolve all review threads
+
+Reply to every thread before resolving. Reply format:
+- Fixed: `Fixed — <what changed>`
+- No change: `No change — <why>`
+
+```bash
+# List unresolved threads
+kotlin /opt/geekinasuit/agents/tools/gh-pr-threads.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim
+
+# Resolve all threads (after replies are posted)
+kotlin /opt/geekinasuit/agents/tools/gh-pr-threads.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim --resolve
+```
+
+### Step 8 — Merge
+
+Check status first:
+```bash
+kotlin /opt/geekinasuit/agents/tools/gh-pr-status.main.kts -- --pr <N> --owner cgruber --repo redistricting-sim
+```
+
+When all checks pass and all threads are resolved:
+```bash
+gh pr merge <N> --repo cgruber/redistricting-sim --squash
+```
+
+Never use `--auto`, `--admin`, or `--merge`. Squash only (keeps linear history).
+
+**CI failures before merge:** stop and report to the user — do not merge through failing CI.
+
+Exception for purely textual PRs (category A only): infra-level CI failures (not build/test
+failures on changed content) may be treated as non-blocking if every changed file is prose
+only and not referenced by any build target. Classify the failure and note it in your
+report. Real failures are always blockers.
+
+### Step 9 — Clean up after merge
+
+```bash
 jj git fetch
 jj bookmark set main -r main@origin
-# Rebase each in-flight bookmark onto the new main (one per bookmark):
-jj rebase -b <next-bookmark> -d main
+jj rebase -b <next-bookmark> -d main   # for each in-flight bookmark
+jj abandon <change-id>                  # abandon the merged change
+jj bookmark delete <name>
+jj git push --deleted
 ```
 
-`jj rebase -d main` without `-b` only moves `@` (the working copy commit), not other
-in-flight bookmarks. Use `-b <bookmark>` for each bookmark that needs rebasing.
-jj will automatically abandon commits whose change IDs already exist on `main`
-(squash-merged bookmarks), preventing them from accumulating as stale divergent heads.
+---
 
 ## Notes
-- One PR at a time: wait for each merge before pushing the next bookmark that depends on it.
+
+- One PR at a time when PRs depend on each other — wait for merge before pushing a dependent branch.
+- Never put unchecked checkboxes in review comments — use prose instead (the task-list-completed
+  GitHub App scans all PR comments).
+- All temp files: use unique names including repo + branch + purpose to avoid collisions with
+  concurrent agents.


### PR DESCRIPTION
## Summary

- Rewrites `thoughts/shared/workflows/pr-review-cycle.md` to use kotlin scripts throughout instead of raw `gh api` calls
- Adds compressed companion `pr-review-cycle.compressed.md` (was missing)
- Adds AGENT-002 ticket tracking the same fix needed in the infra repo's internal workflow doc
- Updates TICKETS.md with AGENT-002

Key changes in the workflow doc:
- Step 0: adds `gh-pr-diff-summary` classification step (was missing entirely)
- Step 2: switches to `gh-pr-create.main.kts` (validates body sections before creating)
- Step 3 critique prompt: replaces "Use `gh api` to post comments" with explicit kotlin script preamble listing `gh-pr-comment.main.kts` and `gh-pr-threads.main.kts`
- Step 4 response prompt: same tools preamble
- Step 7: replaces raw GraphQL thread resolution with `gh-pr-threads.main.kts`
- Step 8: removes `--auto` flag; adds `gh-pr-status.main.kts` pre-merge check
- Fixes all `geekinasuit/polyglot` repo references to `cgruber/redistricting-sim`

## Validation performed

- [ ] N/A — workflow documentation only

## Tickets addressed

see AGENT-002
