### PR TITLE
Bookkeeping: resolve SPIKE-001/002 tickets; add BUILD-002; update game vision

### DIFF
--- a/thoughts/shared/tickets/BUILD-002-integrate-spikes-into-bazel.md
+++ b/thoughts/shared/tickets/BUILD-002-integrate-spikes-into-bazel.md
@@ -1,0 +1,124 @@
+---
+id: BUILD-002
+title: Integrate spike prototypes into a single Bazel build graph
+area: build, tooling, architecture
+status: open
+created: 2026-04-24
+---
+
+## Summary
+
+Merge the SPIKE-001 game prototype (TypeScript/Vite/D3/Zustand) and SPIKE-002 Bazel PoC
+(rules_rust + rules_ts + Rust→WASM) into a single, unified source root under `game/` with
+a single `bazel build //...` that produces the game. This is the first production-quality
+build step — it establishes the `game/` directory as the canonical source root for all
+subsequent game development.
+
+## Goals / Acceptance Criteria
+
+- [ ] `game/` directory created as a new Bazel workspace (`game/MODULE.bazel`) descended
+      from the SPIKE-002 build patterns (no WORKSPACE file; bzlmod only)
+- [ ] TypeScript source migrated from `spike/001-game-poc/src/` into `game/web/src/`
+      compiled by `ts_project` (aspect_rules_ts 3.x); `bazel build //web/...` succeeds
+- [ ] Rust `calc` library and WASM binding migrated from `spike/002-build-poc/rust/` into
+      `game/rust/`; `bazel build //rust/...` succeeds
+- [ ] TypeScript calls Rust/WASM function at runtime (end-to-end integration verified in
+      browser; not just build-time type-check)
+- [ ] `bazel test //...` passes all migrated tests (Rust unit tests + TypeScript type-check)
+- [ ] `bazel run //:serve` (or equivalent) serves the game locally; hex map renders; election
+      simulation runs; WASM add function called from TypeScript
+- [ ] WASM type import pattern resolved: either document the `no-modules` ambient-declare
+      approach as the v1 standard, OR prove the `web` target + generated `.d.ts` import
+      pattern works end-to-end (see SPIKE-002-REPORT open question #2)
+- [ ] `game/` is hermetic: all tools come from Bazel-managed toolchains (document any host
+      tool dependencies found, per SPIKE-002 hermeticity assessment baseline)
+- [ ] `game/WORKSPACE_NOTES.md` (or equivalent) documents any version overrides, hermeticity
+      gaps, and setup steps needed for a fresh checkout
+
+## Out of Scope
+
+- Vite dev server (replaced by Bazel serve target; Vite config can be removed or kept for
+  local dev if it doesn't complicate the build graph)
+- New game features or scenarios (this ticket is build-only)
+- Production bundling / minification
+- CI integration (separate CI ticket)
+- Mobile targets
+- Removing the `spike/` directories (they stay as historical reference)
+
+## Background
+
+SPIKE-001 (`spike/001-game-poc/`) proved the TypeScript + D3.js + Zustand game mechanics:
+hex-grid map generation, SVG rendering, election simulation, boundary editing, undo/redo.
+Stack validated; go recommendation given.
+
+SPIKE-002 (`spike/002-build-poc/`) proved the Bazel build: TypeScript compiled by rules_ts,
+Rust compiled to WASM via rules_rust_wasm_bindgen, TypeScript calling WASM at runtime.
+Go recommendation given. Key configuration decisions documented in SPIKE-002 SPIKE-REPORT.md.
+
+This ticket brings them together. The spike source roots (`spike/001-game-poc/` and
+`spike/002-build-poc/`) are read-only references — do not modify them.
+
+## Key Build Decisions Inherited from SPIKE-002
+
+- Bazel 9.1.0 + bzlmod (no WORKSPACE); run all Bazel commands from `game/`
+- `rules_rust 0.70.0` + `rules_rust_wasm_bindgen 0.70.0`
+- `aspect_rules_ts 3.8.8` + `aspect_rules_js 2.9.2` + `rules_nodejs 6.7.4` (explicit, fixes CcInfo on Bazel 9.x)
+- `rules_shell 0.6.1` for `sh_binary`
+- `platforms 1.0.0` for `@platforms//cpu:wasm32`
+- `.bazelrc` must include: `common --@aspect_rules_ts//ts:default_to_tsc_transpiler`
+- `tsconfig.json` must NOT have `outDir` or `rootDir` (ts_project manages via CLI flags)
+- TypeScript version: 5.6.2 (fetched by `rules_ts_ext.deps(ts_version = "5.6.2")`)
+- Rust edition: 2021; `versions = ["1.85.0"]`; `extra_target_triples = ["wasm32-unknown-unknown"]`
+
+## WASM Type Import Open Question
+
+SPIKE-002 used `target = "no-modules"` with an ambient TypeScript declaration:
+```ts
+declare const wasm_bindgen: { add(a: number, b: number): number; };
+```
+
+For production the preferred path is `target = "web"` (ES modules) which generates proper
+`.d.ts` + `.js` files importable by TypeScript. The pattern for making Bazel-generated `.d.ts`
+available as `deps` in `ts_project` is not yet confirmed.
+
+**Decision options for this ticket:**
+1. Confirm `no-modules` + ambient declare as v1 standard (simpler; unblocks integration now;
+   known limitation documented)
+2. Prove the `web` target + generated `.d.ts` import pattern (better long-term; more work now)
+
+Recommendation: attempt (2) first; fall back to (1) with documented rationale if (2)
+requires ongoing-friction workarounds (per SPIKE-002 fallback policy).
+
+## Working Directory
+
+`game/` — new, independent source root. Treat it like SPIKE-002 treated `spike/002-build-poc/`:
+Bazel workspace rooted at `game/MODULE.bazel`, all Bazel commands run from `game/`.
+
+## jj Discipline
+
+Work directly in main repo checkout. All files in `game/**` only.
+
+1. Before starting: `jj log` — confirm `@` is a fresh empty change descended from main.
+   If not: `jj new main`.
+2. Create bookmark before first push: `jj bookmark create build/game-bazel-integration -r @`
+3. Commit after each logical chunk; run `bazel test //...` before each commit.
+4. PR when all acceptance criteria met and `game/BUILD-NOTES.md` written.
+
+## Definition of Done
+
+1. All acceptance criteria above are checked.
+2. `game/BUILD-NOTES.md` written covering:
+   - Final MODULE.bazel dependency versions and any version overrides
+   - Hermeticity assessment (what's hermetic, what requires host tools)
+   - WASM type import decision and rationale
+   - How to run: build, test, serve from a fresh checkout
+3. `PROGRESS.md` updated to `Status: Complete` in the working branch.
+4. PR opened, critiqued, and merged to main.
+
+## References
+
+- `spike/002-build-poc/SPIKE-REPORT.md` — build configuration decisions + open questions
+- `spike/001-game-poc/SPIKE-REPORT.md` — game stack decisions
+- `spike/002-build-poc/MODULE.bazel` — reference MODULE.bazel
+- `spike/002-build-poc/rust/BUILD.bazel` — reference rust targets
+- `spike/002-build-poc/web/BUILD.bazel` — reference web targets

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -34,6 +34,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
+| `BUILD-002-integrate-spikes-into-bazel.md` | build, tooling | Integrate spike/001 game prototype + spike/002 Bazel build into a single `game/` Bazel workspace |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `AGENT-002-pr-review-cycle-kotlin-tools.md` | agentic workflow | Update infra repo pr-review-cycle to use kotlin scripts in critique/response agent prompts instead of raw gh api |
 
@@ -43,8 +44,8 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | Summary | Resolution |
 |---|---|
-| SPIKE-001: Game tech stack PoC | TypeScript+Vite+D3.js+Zustand hex-grid prototype complete; all AC met; SPIKE-REPORT.md written |
-| SPIKE-002: Harmonized Bazel build PoC | Bazel 9.1.0+bzlmod+rules_rust+rules_ts TypeScript+Rust/WASM build complete; all AC met; SPIKE-REPORT.md written; Go recommendation |
+| SPIKE-001: Game tech stack PoC | TypeScript+Vite+D3.js+Zustand hex-grid prototype complete; all AC met; SPIKE-REPORT.md written; go recommendation — merged PR #11 |
+| SPIKE-002: Harmonized Bazel build PoC | Bazel 9.1+bzlmod+rules_rust+rules_ts TypeScript+Rust/WASM build complete; all AC met; SPIKE-REPORT.md written; go recommendation — merged PR #13 |
 | AGENT-001: $abr convention in compressed docs | Applied $-prefix to all §ABBREV key references in game-vision.compressed.md and agent-team-design.compressed.md; merged PR #2 |
 | KT-001, KT-003, KT-004: Kotlin gRPC service work | Superseded — Kotlin service removed from repo; game will be a TypeScript browser app |
 | BUILD-001: grpc-kotlin bzlmod migration | Superseded — Kotlin and Bazel removed; build system being re-evaluated via SPIKE-002 |

--- a/thoughts/shared/vision/game-vision.compressed.md
+++ b/thoughts/shared/vision/game-vision.compressed.md
@@ -182,7 +182,7 @@ OUT: player-facing Custom Level UI + community sharing(post-$v1) |
 3. [RESOLVED] Precinct naming: "precinct" confirmed
 4. Mobile: deferred; may be different interaction model on same data; may not happen; no decision needed
 5. Fictional region names+geographies: GES+VDA creative decision per scenario
-6. Tech stack: unresolved → separate GES+ARCH session
+6. [RESOLVED] Tech stack: TypeScript+Vite+D3.js+Zustand (SPIKE-001) + Bazel 9.1+bzlmod+rules_rust+aspect_rules_ts (SPIKE-002); Rust→WASM via wasm-bindgen; open: switch to web target+proper .d.ts import for production; next: BUILD ticket to integrate spikes into single Bazel graph
 7. Precinct count calibration: target ~hundreds; DR to research real sub-state regions+precinct
    counts to inform GES+ARCH rendering+perf targets
 8. $VRA/bloc voting model: simplified — demographic group vote-share % per $pc; district outcome

--- a/thoughts/shared/vision/game-vision.md
+++ b/thoughts/shared/vision/game-vision.md
@@ -452,8 +452,12 @@ static data once published; no per-session server compute needed.
 5. **Scenario fictional region names and geographies** — placeholder. GES + Visual Designer
    creative decision informed by educational goals per scenario.
 
-6. **Tech stack** — unresolved (separate session with GES + Architect). Affects: how
-   simulation runs, map rendering approach, save system, mobile.
+6. ~~**Tech stack**~~ — **Resolved.** TypeScript + Vite + D3.js + Zustand (browser game;
+   validated by SPIKE-001). Build system: Bazel 9.1 + bzlmod + rules_rust + aspect_rules_ts
+   (validated by SPIKE-002; go recommendation). Rust → WASM for compute kernel (optional
+   per-scenario; wasm-bindgen no-modules for v1; open question: switch to `web` target + proper
+   `.d.ts` import for production). Integration of spike prototypes into a single Bazel build graph
+   is the next immediate BUILD ticket.
 
 7. **Precinct count calibration** — target is "hundreds" (visually small, fat-pixel
    aesthetic). Domain Reviewer should research real sub-state regions, their precinct


### PR DESCRIPTION
## Prerequisites
- [x] N/A — base PR (targets main); SPIKE-001 (#11) and SPIKE-002 (#13) already merged

## Summary
- Moves SPIKE-001 and SPIKE-002 from Open to Resolved in TICKETS.md (with PR numbers)
- Creates BUILD-002 ticket: integrate spike prototypes into a single `game/` Bazel workspace
- Marks game-vision.md §Open item 6 (tech stack) as Resolved with stack decisions and open questions documented

## Validation performed
- [ ] N/A — prose/tickets only; no code, no infrastructure

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- Resolves SPIKE-001 ticket (thoughts/shared/tickets/SPIKE-001-game-tech-stack-poc.md)
- Resolves SPIKE-002 ticket (thoughts/shared/tickets/SPIKE-002-harmonized-bazel-build-poc.md)
- Creates BUILD-002 ticket (thoughts/shared/tickets/BUILD-002-integrate-spikes-into-bazel.md)

## Rollback
- N/A — docs/tickets only
