### PR TITLE
decisions+vision: election simulation architecture; resolve §OPEN 7+8

### DIFF
--- a/thoughts/shared/decisions/2026-04-24-election-simulation-architecture.compressed.md
+++ b/thoughts/shared/decisions/2026-04-24-election-simulation-architecture.compressed.md
@@ -1,0 +1,58 @@
+<!--COMPRESSED v1; source:2026-04-24-election-simulation-architecture.md-->
+§META
+date:2026-04-24 status:accepted
+topic:election-simulation-architecture — demographic events, N-party shares, drift
+
+§CONTEXT
+Post-research design discussion; decisions beyond what research doc covers.
+Owner value: structurally suppressed viewpoints (3rd parties, minority coalitions)
+must be representable even if FPTP prevents wins → drives demographic-event model
+and N-party shares. Educational/neutral stance unchanged.
+
+§DECISIONS
+
+1. Deterministic core; variance as designed events
+  v1: fixed precinct partisanship+turnout; exact outcomes; tight causal loop
+  Variance: explicit designed scenario events only — not ambient noise
+  Each event → deterministic outcome (same map+event = same result every time)
+  Ensemble comparison (map vs. distribution of random valid maps): v2, read-only layer
+
+2. Waves = demographic events, not partisan labels
+  Partisan consequence always DERIVED from demographic event, never assumed
+  Event types:
+    turnout_shift:    {group, magnitude}          // +0.15 for Black voters
+    vote_share_shift: {group, party, delta}        // -0.08 white women → Party A
+    population_shift: {precinct_filter, group, delta}
+  Enables: surge in Black turnout | Latino Party A drop | young voter mobilization
+  Generalises to any demographic dimension; no two-party binary encoded in wave mechanics
+
+3. N-party vote shares
+  vote_shares: Map<PartyId, float> summing to 1.0 per group; plurality-wins over map
+  v1: 2 parties in scenarios; architecture supports N
+  Enables: 3rd-party spoiler effects visible without 3rd-party wins
+  No hardcoded "Party A / Party B" in simulation logic; PartyId=string; parties per-scenario
+
+4. Precinct demographics = mutable scenario state
+  Baseline demographic config per scenario; events = diffs applied to config
+  Simulation always recomputes from current state
+  Within-scenario wave: transient diff | inter-scenario drift: permanent new baseline
+
+5. Demographic drift as inter-scenario transition (not a scenario)
+  Between scenarios: animated curtain showing regional change over time
+  Teaches: why redistricting happens; gerrymandered maps become obsolete
+  Light implementation: 10s animation + narrative paragraph
+  Distinct from Scenario 11 (After the Boom) which is a full playable level
+
+6. Scenario format must include first-class demographic events
+  events[] array alongside success criteria; in data not code
+  Prerequisite for evaluation engine build
+
+§CONSEQUENCES
+Scenario format: needs baseline_demographics + events[] BEFORE evaluation engine starts
+Simulation API: (scenarioState, events[]) → ElectionResult; pure function; no v1 randomness
+Party model: PartyId=string; parties defined per-scenario; no enum
+GATE: do not build evaluation engine until scenario data format spec written+reviewed
+
+§REFS
+Research: thoughts/shared/research/2026-04-24-election-simulation-and-evaluation-metrics.md
+Game vision: thoughts/shared/vision/game-vision.compressed.md

--- a/thoughts/shared/decisions/2026-04-24-election-simulation-architecture.md
+++ b/thoughts/shared/decisions/2026-04-24-election-simulation-architecture.md
@@ -1,0 +1,141 @@
+---
+date: 2026-04-24
+status: accepted
+---
+
+# ADR: Election Simulation Architecture — Demographic Events, N-Party Shares, Drift
+
+## Status
+
+Accepted
+
+## Context
+
+During review of the election simulation research (see
+`thoughts/shared/research/2026-04-24-election-simulation-and-evaluation-metrics.md`),
+a design discussion surfaced several architectural decisions that go beyond what the
+research document covers. These decisions affect the scenario data format, the election
+simulation engine, and the scenario sequencing model. They are recorded here before
+implementation begins.
+
+The project owner has an anarchist perspective on electoral systems and a particular
+concern that structurally suppressed viewpoints (3rd parties, minority coalitions) be
+representable in the model even if FPTP structurally prevents them from winning. This
+is a design value, not advocacy — the game is educational and neutral. It informs the
+decision to use demographic events rather than partisan labels, and to support N-party
+vote shares from the start.
+
+## Decisions
+
+### 1. Deterministic core; variance as designed scenario events
+
+The election simulation is deterministic for all v1 scenarios. Fixed precinct
+partisanship + fixed turnout + exact outcomes. This preserves the tight causal loop
+required for teaching structural effects: "you drew it this way, you got this outcome."
+
+Variance (waves, shocks) is introduced only as explicit, designed scenario events —
+not as ambient noise on every simulation run. A scenario event produces a deterministic
+outcome given its parameters. The player sees the same result each time they try the
+same map under the same event. This makes success criteria clean and prevents the
+lesson from being obscured by luck.
+
+Ensemble comparison (showing a player's map against a distribution of randomly drawn
+valid maps) is deferred to v2 as a read-only analysis layer — it does not affect
+gameplay or success criteria.
+
+### 2. Waves expressed as demographic events, not partisan labels
+
+Scenario events (waves, shocks, mobilizations) are expressed as changes to demographic
+parameters — not as "red wave" or "blue wave." The partisan electoral consequence is
+always *derived* from the demographic event, never assumed.
+
+Three event types:
+
+```
+{ type: "turnout_shift",    group: GroupId, magnitude: float }   // e.g. +0.15 for Black voters
+{ type: "vote_share_shift", group: GroupId, party: PartyId, delta: float }  // e.g. -0.08 for white women → Party A
+{ type: "population_shift", precinct_filter: Filter, group: GroupId, delta: float }  // demographic composition change
+```
+
+`magnitude` and `delta` apply to the group's baseline value for this scenario.
+`precinct_filter` can target a region (e.g., urban precincts only).
+
+This approach:
+- Avoids encoding a two-party binary into wave mechanics
+- Allows events like "surge in Black voter turnout," "drop in Latino Party A support,"
+  "young voter mobilization" to be expressed directly
+- Makes the connection between demographic groups and electoral outcomes legible to players
+- Generalizes to any demographic dimension without special-casing parties
+
+### 3. N-party vote shares from the start
+
+Vote shares per demographic group are not constrained to two parties. Each group has a
+`vote_shares` map of `PartyId → float`, summing to 1.0. The election simulation uses
+plurality-wins (FPTP) across however many parties are defined.
+
+In v1, all scenarios use two parties. But the architecture supports N parties, enabling:
+- 3rd-party spoiler effects (Party A loses 12 points of young voters to Party C; Party C
+  wins nothing but Party A loses previously safe districts)
+- Independent candidates eating into a coalition
+- Future scenarios exploring the spoiler effect and FPTP's structural suppression of
+  third parties — without requiring 3rd party wins, just making the effect visible
+
+This is a design value: structurally suppressed viewpoints should be representable in
+the model, even if FPTP prevents them from winning seats. The partisan outcome is
+derived from the data, not assumed.
+
+### 4. Precinct demographic data is mutable scenario state
+
+Precinct demographics are not baked-in constants. Each scenario has a baseline
+demographic configuration. Scenario events are *diffs* applied to that configuration.
+The election simulation always recomputes from the current demographic state.
+
+This means:
+- Waves within a scenario change the demographic state for that simulation run
+- Demographic drift between scenarios is a permanent transition to a new baseline
+- The same scenario logic works for both — the difference is persistence
+
+### 5. Demographic drift as inter-scenario transition
+
+Demographic change between scenarios is represented as a visual/narrative transition
+(not a separate playable scenario). Between scenarios, the player sees: "10 years have
+passed. Here's what changed in the region." The filters animate to show shifts in
+partisan lean, demographic composition, etc. Then the player is handed the new
+baseline to draw districts for.
+
+This teaches:
+- Why redistricting happens (census/demographic change triggers mandatory redraw)
+- That a "good" gerrymander can become obsolete as populations shift
+- The connection between demographic change and electoral outcome
+
+The transition is a curtain between acts, not a level. It can be as light as a
+10-second animation with a paragraph of narrative context. Scenario 11 ("After the
+Boom") in the vision is a full playable scenario about this; the transition mechanism
+is a lighter version used between any two scenarios where the region has changed.
+
+### 6. Scenario data format must include first-class demographic events
+
+The scenario data format (to be defined before the evaluation engine is built) must
+treat demographic events as first-class objects alongside success criteria, not as
+scenario-specific code. This enables:
+- Pre-built scenario events to be defined in data
+- Future player-authored scenarios (post-v1) to include their own demographic events
+- Consistent evaluation engine that operates on events without special cases
+
+## Consequences
+
+**Scenario data format**: Must include a `baseline_demographics` configuration and
+an `events[]` array before the evaluation engine is built. This is the gate before
+implementation of the simulation layer.
+
+**Election simulation API**: Takes `(scenarioState, events[])` → `ElectionResult`.
+The simulation function is pure: same inputs → same outputs. Events modify state
+before passing to simulation; the simulation itself has no randomness in v1.
+
+**Party model**: `PartyId` is a string, not an enum. Parties are defined per-scenario.
+Vote shares are `Map<PartyId, float>`. The plurality-wins rule operates over the map.
+No hardcoded "Party A / Party B" anywhere in simulation logic.
+
+**Architectural flag for evaluation engine**: Do not begin building the evaluation
+engine until the scenario data format spec is written and reviewed. The format decision
+is the dependency.

--- a/thoughts/shared/vision/game-vision.compressed.md
+++ b/thoughts/shared/vision/game-vision.compressed.md
@@ -183,10 +183,17 @@ OUT: player-facing Custom Level UI + community sharing(post-$v1) |
 4. Mobile: deferred; may be different interaction model on same data; may not happen; no decision needed
 5. Fictional region names+geographies: GES+VDA creative decision per scenario
 6. [RESOLVED] Tech stack: TypeScript+Vite+D3.js+Zustand (SPIKE-001) + Bazel 9.1+bzlmod+rules_rust+aspect_rules_ts (SPIKE-002); Rust→WASM via wasm-bindgen; open: switch to web target+proper .d.ts import for production; next: BUILD ticket to integrate spikes into single Bazel graph
-7. Precinct count calibration: target ~hundreds; DR to research real sub-state regions+precinct
-   counts to inform GES+ARCH rendering+perf targets
-8. $VRA/bloc voting model: simplified — demographic group vote-share % per $pc; district outcome
-   aggregated from breakdown; GES+DR to validate educational soundness; generalises to any demographic
+7. [RESOLVED] Precinct count: 300 nominal (250–350); parameterized (tutorial@150↔hard@500)
+   Travis County TX anchor; SVG safe ≤1,000 elements; Canvas crossover 1,000–2,000
+   see research/2026-04-24-precinct-count-calibration.md
+8. [RESOLVED] $VRA/bloc voting model + simulation architecture:
+   vote_shares:Map<PartyId,float> per group (N-party); district=population-weighted avg
+   waves=demographic events(turnout_shift|vote_share_shift|population_shift) not partisan labels
+   partisan outcome always derived; deterministic core; waves=designed scenario events not noise
+   demographic drift between scenarios=animated transition (not a level)
+   scenario format must include events[] first-class alongside success criteria
+   $VRA risk: minority $VAP ≥30% but <50% AND preferred-cand loses
+   see decisions/2026-04-24-election-simulation-architecture.md + research docs
 9. Historical/inspired scenarios: post-$v1; fictional pop data on inspired maps; DR required
 10. About page content: deferred until page exists; convey intent+non-partisan framing
 

--- a/thoughts/shared/vision/game-vision.md
+++ b/thoughts/shared/vision/game-vision.md
@@ -459,17 +459,24 @@ static data once published; no per-session server compute needed.
    `.d.ts` import for production). Integration of spike prototypes into a single Bazel build graph
    is the next immediate BUILD ticket.
 
-7. **Precinct count calibration** — target is "hundreds" (visually small, fat-pixel
-   aesthetic). Domain Reviewer should research real sub-state regions, their precinct
-   counts, and how actual redistricting breaks down at that scale. Result informs
-   GES + ARCH on rendering and performance targets.
+7. **Precinct count calibration** — [RESOLVED] Target 300 nominal precincts (range
+   250–350); parameterized so scenarios can dial 150 (tutorial) to 500 (hard). Travis
+   County TX (247–287) is the real-world calibration anchor. SVG+D3 safe to ~1,000
+   elements; Canvas crossover at 1,000–2,000. See research doc
+   `thoughts/shared/research/2026-04-24-precinct-count-calibration.md`.
 
-8. **VRA / bloc voting simulation model** — simplified model: each demographic group
-   has a per-precinct vote-share percentage (e.g., "Latinos in this precinct vote
-   R 44%, D 38%, other 18%"); district outcome is aggregated from precinct-level
-   demographic breakdowns. GES + Domain Reviewer to validate that this simplification
-   is educationally sound and sufficient for the VRA scenario. The same model should
-   generalise to other demographic groups.
+8. **VRA / bloc voting simulation model** — [RESOLVED] Model validated and extended.
+   Key decisions (see ADR `thoughts/shared/decisions/2026-04-24-election-simulation-architecture.md`):
+   - Demographic data: `vote_shares: Map<PartyId, float>` per group (N-party, not 2-party);
+     district outcome = population-weighted average across groups and precincts.
+   - Waves/variance: expressed as demographic events (turnout_shift, vote_share_shift,
+     population_shift) per group — never as partisan labels. Partisan outcome derived.
+   - Deterministic core for v1; waves are designed scenario events, not ambient noise.
+   - Demographic drift between scenarios: animated inter-scenario transition (not a level).
+   - Scenario format must include first-class `events[]` alongside success criteria.
+   - VRA risk indicator: minority VAP ≥30% but <50% AND preferred candidate loses.
+   See also research docs `2026-04-24-election-simulation-and-evaluation-metrics.md`
+   and `2026-04-24-vra-and-bloc-voting-model.md`.
 
 9. **Historical / inspired scenarios** — later versions may use historically-inspired
    maps with fictional population data. Domain Reviewer required. Flag for v2.


### PR DESCRIPTION
## Prerequisites
- [ ] N/A

## Summary
- ADR recording design decisions from post-research discussion on election simulation architecture
- Game vision §OPEN 7 and §OPEN 8 marked resolved with full summaries

## Key decisions recorded

**N-party vote shares**: `vote_shares: Map<PartyId, float>` per demographic group; no hardcoded two-party binary; PartyId is a string defined per-scenario. Enables 3rd-party spoiler effects without requiring 3rd-party wins.

**Demographic-event waves**: Scenario events expressed as `turnout_shift`, `vote_share_shift`, or `population_shift` per demographic group — never as partisan labels. Partisan outcome is always derived, never assumed. Avoids encoding red/blue into wave mechanics.

**Deterministic core**: v1 simulation is deterministic. Variance introduced only as explicit designed scenario events (same map + event = same result). Ensemble comparison deferred to v2 as read-only analysis layer.

**Mutable precinct state**: Demographic config is baseline + event diffs, not constants. Enables both within-scenario waves (transient) and inter-scenario drift (permanent transition).

**Demographic drift as transition**: Animated inter-scenario curtain (not a playable level) showing regional demographic change over time. Teaches why redistricting happens.

**Scenario format gate**: Scenario data format must include `events[]` as first-class objects alongside success criteria. Gate: do not build evaluation engine until format spec is written and reviewed.

## Validation performed
- [ ] N/A — prose/decisions only

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A — design decisions, not a ticket

## Rollback
- N/A
