### PR TITLE
docs: map geography + rendering architecture decisions

### DIFF
--- a/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.compressed.md
+++ b/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.compressed.md
@@ -1,0 +1,62 @@
+<!--COMPRESSED v1; source:2026-04-24-map-geography-and-rendering-architecture.md-->
+§META
+date:2026-04-24 status:accepted
+topic:map geography model + rendering architecture
+
+§ABBREV
+pc=precinct dist=district ET=election-type
+
+§DECISIONS
+
+1. Scenario region not county
+  Playfield = scenario-defined set of $pcs; not constrained to admin county boundaries
+  County boundary changes: explicitly OUT OF SCOPE (rare IRL; lesson covered by other mechanics)
+
+2. Neighboring context $pcs
+  Scenario includes editable $pcs + read-only context $pcs that complete cross-boundary $dists
+  Context $pcs: participate in population balance; visible in state view; not editable
+  First-class in scenario data format; simulation operates on full set (editable+context)
+
+3. One $ET per scenario
+  Congressional/state-senate/state-house = completely separate maps; editing one ≠ changes others
+  Scenario always has one $ET; multiple $ETs as read-only overlay views only (educational point)
+
+4. Pannable viewport
+  Player pans (right-click-drag|arrows); $pcs scroll in/out of view
+  Simulation = always statewide; viewport constrains visible+editable, not simulated
+  Scope enforcement = scoring not hard boundary; visual "focus zone" hint; no wall
+
+5. Panning perf: CSS transform smooth; interaction is constraint
+  CSS transform on SVG = 60fps pan regardless of node count (browser composites layer)
+  Interaction (hover/click/paint) degrades at >~1,000 SVG DOM nodes (off-screen still hit-tested)
+  ≤800 total $pcs (editable+context): pure SVG viable
+  >800–1,000 total $pcs: Canvas+SVG hybrid required
+
+6. Renderer-agnostic model + Canvas+SVG hybrid target
+  Simulation/data/scenario = renderer-agnostic; no SVG/Canvas imports outside rendering layer
+  Target architecture:
+    Canvas layer: hex grid background; pan=redraw with offset; fast at any count; no DOM nodes
+    SVG overlay: interactive elements for current viewport only; small node count; D3 interactivity
+  v1: pure SVG if ≤800 $pcs; Canvas+SVG when scenarios exceed threshold
+  CRITICAL: MapRenderer = interface; SvgMapRenderer/CanvasMapRenderer = implementations
+    do NOT hardwire rendering to SVG-only; interface boundary must exist from v1
+
+7. Geographic hierarchy in data model (from v1)
+  State → Region(scenario playfield) → Precinct
+  Even if state-level view is v2, hierarchy in data model from day 1
+  State result = sum(all_region_results); most regions pre-computed; player's region live
+
+8. State-level view = explicit v2
+  Zoomed-out view showing edited region in state context = v2
+  Data model + rendering interface must not preclude it; adding it = new rendering mode, not refactor
+
+§CONSEQUENCES
+Scenario format: neighboring_context_precincts[] first-class field
+Simulation API: simulate(allPrecincts, assignments, electionType) → ElectionResult
+District assignment: pc.assignments: Map<ElectionType, DistrictId> (not single ID)
+Rendering: MapRenderer interface; SVG+Canvas as implementations
+NOT modeled: county boundary changes; multi-type simultaneous editing
+
+§REFS
+Research: thoughts/shared/research/2026-04-24-precinct-count-calibration.md
+Simulation ADR: thoughts/shared/decisions/2026-04-24-election-simulation-architecture.md

--- a/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.md
+++ b/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.md
@@ -1,0 +1,150 @@
+---
+date: 2026-04-24
+status: accepted
+---
+
+# ADR: Map Geography Model and Rendering Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+Review of the precinct count calibration research surfaced several interconnected
+design decisions about the geographic model, editing scope, and rendering strategy.
+These were resolved through design discussion and are recorded here before
+implementation begins.
+
+## Decisions
+
+### 1. Scenario region, not county, as the canonical playfield
+
+The editable playfield is a **scenario region** — a set of precincts defined by the
+scenario, not by administrative county boundaries. The scenario designer picks a
+coherent region that makes the pedagogical point. This region will typically be
+roughly county-sized (~300 precincts) but is not constrained to county lines.
+
+County boundary changes are explicitly out of scope — they are extremely rare in the
+US and the lesson (demographic/political change producing different outcomes) is better
+taught through redistricting and population shift. Do not model county boundary changes.
+
+### 2. Neighboring context precincts
+
+A scenario includes both the editable region and read-only neighboring precincts that:
+- Complete districts that extend beyond the editing boundary
+- Participate in population balance calculations (so district population math is correct
+  even when a district crosses the editing boundary)
+- Are visible in the state-level view
+- Are not editable by the player
+
+Neighboring context precincts are first-class objects in the scenario data format —
+not a rendering hack. The simulation always operates on the full district including
+context precincts.
+
+### 3. One election type per scenario
+
+Congressional, state senate, and state house districts are entirely separate maps
+drawn independently. A single precinct simultaneously belongs to a congressional
+district, a state senate district, and a state house district — but these assignments
+are unrelated to each other.
+
+A scenario is therefore always about one specific election type. Redrawing congressional
+districts does not affect state senate or house boundaries. A player cannot "redraw the
+map" in a type-agnostic way.
+
+Multiple election types may be shown as **read-only overlay views** on the same precinct
+map — "here is how these same precincts are carved up differently for each election type"
+— which is itself an educational point. But editing one type never changes another.
+
+### 4. Pannable viewport: the editing window is mobile
+
+The editing/rendering window is a viewport the player can pan (right-click-drag or
+arrow keys). Precincts scroll in and out of view as the player pans. The state-wide
+simulation always covers all precincts; the viewport constrains what is visible and
+editable, not what is simulated.
+
+Scenario scope is enforced by **scoring, not by hard boundaries**. The player can pan
+freely and assign any precinct; the scenario grades them based on outcomes for the
+election type and objectives defined in the scenario. A visual "focus zone" hint
+indicates where the interesting action is without walling off the rest of the map.
+
+### 5. Panning performance: CSS transform is smooth; interaction is the constraint
+
+CSS transform panning (applying a CSS translate to the SVG container) is smooth at
+60fps regardless of DOM node count — the browser composites the layer without
+re-rendering. This is the panning implementation for SVG.
+
+The binding constraint is **interaction performance** (hover, click, drag-to-paint),
+not pan animation. Interaction degrades noticeably above ~1,000 SVG DOM nodes because
+every off-screen node still participates in event hit-testing.
+
+Implications:
+- Scenarios with ≤800 total precincts (editable + context): pure SVG is viable
+- Scenarios with >800–1,000 total precincts: Canvas+SVG hybrid is required
+
+### 6. Rendering architecture: renderer-agnostic model with Canvas+SVG hybrid target
+
+The simulation, data model, and scenario logic are **renderer-agnostic**. They do not
+know about SVG or Canvas. The rendering strategy is a parameter of the map component.
+
+The target rendering architecture for the pannable map:
+
+- **Canvas layer**: draws the hex grid background for the current viewport each frame.
+  Pan = redraw with a new offset. Fast at any precinct count; no DOM nodes.
+- **SVG overlay**: sits on top of Canvas; contains only interactive elements for the
+  current viewport (selected cells, district boundaries, hover state). Small node count;
+  full D3 interactivity.
+
+This is the pattern used by Leaflet/MapboxGL and handles arbitrary scale smoothly.
+
+For v1, if the total scenario precinct count (editable + context) stays under ~800,
+pure SVG is acceptable and simpler to implement. The Canvas+SVG hybrid should be
+introduced when scenarios exceed that threshold — not before, not never.
+
+The critical constraint: **do not hardwire the rendering to SVG-only**. The interface
+boundary between the data/simulation layer and the rendering layer must exist from v1,
+even if only one rendering strategy is implemented initially.
+
+### 7. Geographic hierarchy in the data model
+
+Every precinct knows what region it belongs to and what state that region is in.
+The hierarchy is in the data model from v1 even if the state-level view is v2.
+
+```
+State
+ └─ Region (scenario playfield; roughly county-sized; not admin-boundary-constrained)
+     └─ Precinct (atomic unit; not subdivided)
+```
+
+State-level aggregation is: `state_result = sum(all_region_results)` where most regions
+are pre-computed constants for the scenario and the player's region is live.
+
+### 8. State-level view is explicit v2
+
+The zoomed-out view showing the player's edited region in state context, with full
+state electoral consequences visible, is a v2 feature. v1 plays within the scenario
+region; the state-level view is deferred.
+
+However, the data model (geographic hierarchy) and rendering interface (renderer-agnostic)
+must not preclude it. Adding the state-level view in v2 should require adding a new
+rendering mode, not refactoring the data model.
+
+## Consequences
+
+**Scenario data format**: Must include `neighboring_context_precincts[]` alongside the
+editable precinct set. Context precincts participate in simulation but are not editable.
+
+**Simulation API**: Operates on the full set of precincts (editable + context). The
+election type is a required parameter. `simulate(allPrecincts, assignments, electionType)`
+→ `ElectionResult`.
+
+**District assignment model**: Each precinct has `assignments: Map<ElectionType, DistrictId>`.
+Not a single district ID. The active election type for a scenario determines which
+assignment layer is being edited.
+
+**Rendering interface**: `MapRenderer` is an interface/protocol. `SvgMapRenderer` and
+`CanvasMapRenderer` are implementations. The scenario/game logic calls the interface;
+it does not import SVG or Canvas specifics.
+
+**Do not model**: county boundary changes; multi-type simultaneous editing.

--- a/thoughts/shared/vision/game-vision.compressed.md
+++ b/thoughts/shared/vision/game-vision.compressed.md
@@ -1,12 +1,13 @@
 <!--COMPRESSED v1; source:game-vision.md-->
 §META
-type:vision status:draft created:2026-04-23 authors:cgruber+claude last_updated:2026-04-23
+type:vision status:draft created:2026-04-23 authors:cgruber+claude last_updated:2026-04-24
 LIVING DOC — updated each sprint after demo; direction changes reviewed with user before acting
 
 §ABBREV
-pc=precinct seg=segment dist=district
+pc=precinct seg=segment dist=district ET=election-type DistId=DistrictId
+MapRend=MapRenderer SvgMapRend=SvgMapRenderer CanvasMapRend=CanvasMapRenderer
 FPTP=first-past-the-post VRA=Voting Rights Act
-v1=version 1 scope
+v1=version 1 scope v2=version 2
 
 §GOAL
 Primary: players understand viscerally that same population+votes → wildly different outcomes
@@ -74,14 +75,21 @@ Cats and Dogs(complete cats-vs-dogs scenario)
 Replay motivation: achievements + optional criteria + completionism
 
 §MAP_MECHANICS
-Playfield: fictional sub-state region(county/metro/similar) — ONE region per scenario
-  scope: NOT whole state; not multi-state; "zoom out" deferred(may be relevant for electoral-system
-  comparisons later; explicitly not $v1 or near-term)
-Precincts($pc): atomic geographic unit; not subdivisible; target ~hundreds; visually small
-  ("fat pixels whose edges you push around"); exact count → calibrate against real regions(see §OPEN)
+Playfield: fictional scenario region — ONE region per scenario; NOT county-bound (scenario-defined)
+  geography: State→Region→Precinct (hierarchy in data model from $v1; state view=$v2)
+  context $pcs: neighboring read-only $pcs completing cross-boundary $dists; participate in sim; not editable
+  one $ET per scenario: congressional|state-senate|state-house = separate maps; editing one ≠ changes others
+  county boundary changes: EXPLICITLY OUT OF SCOPE (rare IRL; lesson→redistricting+demographic shift)
+Viewport: pannable (right-click-drag|arrows); $pcs scroll in/out; simulation=always statewide
+  panning: CSS transform→60fps smooth regardless of node count; interaction degrades >~1,000 SVG nodes
+  rendering: $MapRend=interface; $SvgMapRend|$CanvasMapRend=implementations; Canvas+SVG hybrid at >800 $pcs
+  state-level view=$v2: data model+rendering interface must not preclude it
+Precincts($pc): atomic geographic unit; not subdivisible; target 300 nominal(250–350); parameterized
+  (tutorial@150↔hard@500); visually small ("fat pixels whose edges you push around")
 $pc metadata: population(total+density) | demographic breakdown(race,partisan,gender,religion) |
   last election result(votes by party, turnout) | scenario-specific data
 $dist = grouping of $pcs; boundary = edges between adjacent $pcs in different $dists
+  $pc.assignments:Map<$ET,$DistId> (not single ID)
 $seg = contiguous blob of $pcs within a $dist; $dist may have multiple $segs(non-contiguous)
   non-contiguous: DISABLED by default; enabled only when scenario permits
 
@@ -169,10 +177,14 @@ IN: single-player | single sub-state region/scenario | $FPTP only | fictional re
   8-12 scenarios(partisan+demographic+neutral-rules) | desktop-first |
   progress: local browser storage(IndexedDB/localStorage); no user accounts; no server game state
   scenario data format(shared w/ pre-built authoring; player UI deferred)
+  rendering: $MapRend interface + $SvgMapRend impl; Canvas+SVG hybrid when >800 $pcs; CSS transform panning
 OUT: player-facing Custom Level UI + community sharing(post-$v1) |
-  alt electoral systems(STV,party-list) | real geodata | full-state/multi-state scope |
+  alt electoral systems(STV,party-list) | real geodata |
+  county boundary changes(out of scope entirely) |
+  state-level view(=$v2; data model+rendering interface must accommodate w/o refactor) |
+  full-state/multi-state editing scope |
   multiplayer | mobile-optimised editor(TBD; may be different model on same data) |
-  international comparisons(early v2) | user accounts/cross-device(v2 if justified) |
+  international comparisons(early $v2) | user accounts/cross-device($v2 if justified) |
   campaign/narrative mode(stretch; must not be precluded)
 
 §OPEN
@@ -196,7 +208,14 @@ OUT: player-facing Custom Level UI + community sharing(post-$v1) |
    see decisions/2026-04-24-election-simulation-architecture.md + research docs
 9. Historical/inspired scenarios: post-$v1; fictional pop data on inspired maps; DR required
 10. About page content: deferred until page exists; convey intent+non-partisan framing
+11. [RESOLVED] Map geography+rendering: scenario region(not county-bound) | State→Region→Precinct hierarchy |
+    neighboring context $pcs first-class | one $ET/scenario | $pc.assignments:Map<$ET,$DistId> |
+    pannable viewport; scoring not walls | $MapRend interface from $v1; Canvas+SVG hybrid >800 $pcs |
+    state-level view=$v2; county boundary changes=out of scope
+    see decisions/2026-04-24-map-geography-and-rendering-architecture.md
 
 §REFS
 team+workflow: thoughts/shared/research/2026-04-23-agent-team-and-workflow-design.compressed.md
 project purpose: README.md
+map geography+rendering ADR: thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.compressed.md
+election sim ADR: thoughts/shared/decisions/2026-04-24-election-simulation-architecture.compressed.md

--- a/thoughts/shared/vision/game-vision.md
+++ b/thoughts/shared/vision/game-vision.md
@@ -3,7 +3,7 @@ type: vision
 status: draft — awaiting review
 created: 2026-04-23
 authors: cgruber + claude
-last_updated: 2026-04-23
+last_updated: 2026-04-24
 ---
 
 # Redistricting Simulator — Game Vision
@@ -194,18 +194,38 @@ Achievement examples (not exhaustive):
 
 ### The Map
 
-The playfield is a fictional sub-state **region** — a county, metro area, or similar
-geographic unit — divided into **precincts**. Each scenario covers one such region.
-The game does not model whole states; redistricting at the state-legislature or
-congressional-district level happens within a single region boundary. "Zooming out" to
-full-state or multi-state scope is explicitly deferred — it may become relevant for
-electoral-system comparison scenarios but is not needed for v1 or the near term.
+The playfield is a fictional **scenario region** — a set of precincts defined by the
+scenario, not constrained to administrative county boundaries. Each scenario covers one
+such region. The region is roughly county-sized in feel (~300 precincts nominal) but
+may extend into neighboring areas as the scenario requires.
+
+**Geography model** (see ADR `decisions/2026-04-24-map-geography-and-rendering-architecture.md`):
+- Data hierarchy: State → Region → Precinct. The hierarchy exists in the data model
+  from v1 even though the state-level view is deferred to v2.
+- Each scenario includes an editable region plus read-only **neighboring context precincts**
+  that complete districts crossing the editing boundary. Context precincts participate in
+  population balance and simulation but are not editable.
+- **One election type per scenario.** Congressional, state senate, and state house are
+  entirely separate maps. Editing one type never changes another. Multiple types may be
+  shown as read-only overlay views for comparison.
+- County boundary changes are out of scope — the lesson is better taught through
+  redistricting and demographic shift.
+
+**Viewport and navigation**: The editing window is a pannable viewport. The player
+pans via right-click-drag or arrow keys; precincts scroll in and out of view. The
+state-wide simulation always covers all precincts; the viewport constrains what is
+visible and editable, not what is simulated. A visual focus-zone hint indicates where
+the interesting action is; scenario scoring (not a hard wall) enforces scope.
+
+**State-level view** (v2): a zoomed-out view showing the player's edited region in
+full state context with statewide electoral consequences. Data model and rendering
+interface are designed to accommodate it without refactoring.
 
 Precincts are the atomic unit of redistricting: small, fixed-boundary geographic cells
 (a stylised grid or organic shapes depending on the scenario's aesthetic). They cannot be
-subdivided. Target count is in the hundreds — visually small, like fat pixels whose edges
-the player pushes around. The exact count should be calibrated against real regional
-examples (see §Open Questions — precinct count research).
+subdivided. Target count: 300 nominal (250–350 range), parameterized per scenario
+(tutorial ~150; hard scenarios ~500). See research doc
+`research/2026-04-24-precinct-count-calibration.md`.
 
 Each precinct has metadata:
 - Population (total and density)
@@ -419,11 +439,23 @@ static data once published; no per-session server compute needed.
 - Scenario data format designed for authoring (pre-built scenarios use it; player-facing
   UI deferred to post-v1)
 
+**Rendering architecture (v1):**
+- Renderer-agnostic data/simulation layer; `MapRenderer` interface exists from v1 with
+  `SvgMapRenderer` as initial implementation
+- Pure SVG acceptable if total precincts (editable + context) stay ≤800; Canvas+SVG hybrid
+  required when scenarios exceed that threshold
+- CSS transform panning (smooth 60fps regardless of node count); Canvas layer for hex grid
+  background; SVG overlay for interactive elements only
+
 **Explicitly out of v1:**
 - Player-facing Custom Level UI and community scenario sharing (data format in v1; UI post-v1)
 - Alternative electoral systems (STV, party-list, etc.)
 - Real geographic data
-- Full-state or multi-state scope
+- County boundary changes (out of scope entirely — rare IRL; lesson taught via redistricting
+  and demographic shift)
+- State-level view showing edited region in statewide context (v2; data model and rendering
+  interface must accommodate it without refactoring)
+- Full-state or multi-state editing scope
 - Multiplayer
 - Mobile-optimised boundary drawing (TBD — may be a different interaction model on the
   same data; decision deferred)
@@ -484,3 +516,13 @@ static data once published; no per-session server compute needed.
 10. **About page content** — deferred. Deserves its own review when there is a page
     to look at. Should convey educational intent and non-partisan framing without
     making claims that require ongoing maintenance.
+
+11. ~~**Map geography model and rendering architecture**~~ — **Resolved.** Key decisions
+    (see ADR `thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.md`):
+    - Playfield is a *scenario region* (scenario-defined, not county-bounded)
+    - Geographic hierarchy: State → Region → Precinct in data model from v1
+    - Neighboring context precincts are first-class in scenario data
+    - One election type per scenario; `pc.assignments: Map<ElectionType, DistrictId>`
+    - Pannable viewport; scenario scope enforced by scoring not hard walls
+    - `MapRenderer` interface from v1; Canvas+SVG hybrid when >800 total precincts
+    - State-level view is explicit v2; county boundary changes out of scope entirely


### PR DESCRIPTION
## Prerequisites
- [ ] N/A

## Summary

ADR and vision updates recording the map geography model and rendering architecture decisions reached through design discussion.

Key decisions:
- **Scenario region, not county**: the editable playfield is scenario-defined, not constrained to administrative county boundaries
- **Geographic hierarchy**: State → Region → Precinct in data model from v1; state-level view is v2
- **Neighboring context precincts**: read-only precincts completing cross-boundary districts; first-class in scenario data; participate in simulation
- **One election type per scenario**: congressional/state senate/state house are entirely separate maps; `pc.assignments: Map<ElectionType, DistrictId>`
- **Pannable viewport**: CSS transform panning (smooth 60fps regardless of node count); interaction degrades at >~1,000 SVG DOM nodes; scope enforced by scoring not hard walls
- **MapRenderer interface from v1**: `SvgMapRenderer` / `CanvasMapRenderer` as implementations; Canvas+SVG hybrid required when total precincts exceed ~800
- **County boundary changes out of scope entirely**
- **State-level view = explicit v2** (data model and rendering interface must not preclude it)

## Validation performed
- [ ] N/A — documentation only; no code changes

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A (design decisions; no open ticket)

## Rollback
- N/A — documentation only
