### PR TITLE
docs: demographic group model + voter eligibility ADR; LEGAL-001

### DIFF
--- a/thoughts/shared/decisions/2026-04-24-demographic-group-model.compressed.md
+++ b/thoughts/shared/decisions/2026-04-24-demographic-group-model.compressed.md
@@ -1,0 +1,61 @@
+<!--COMPRESSED v1; source:2026-04-24-demographic-group-model.md-->
+§META
+date:2026-04-24 status:accepted
+topic:demographic group model + voter eligibility architecture
+
+§ABBREV
+pc=precinct grp=group grps=groups ET=election-type
+VRA=Voting Rights Act CVAP=citizen-voting-age-population
+v1=version 1
+
+§DECISIONS
+
+1. $grps = named flat simulation units (not dimensional matrices)
+  $grp fields: id(string) | population_share(float) | vote_shares:Map<PartyId,float> | turnout_rate(float)
+  vote_shares REQUIRED for ALL $grps incl. ineligible (see §7)
+  no fixed demographic vocabulary at engine level; $grp id = opaque scenario-defined string
+
+2. Scenario-level dimensional schema + completeness constraint (optional)
+  declare: scenario.group_schema.dimensions: Map<DimName, DimValue[]>
+  completeness constraint (if schema declared):
+    every $grp must declare a value for every declared dimension
+    every combination of dim values must exist in every $pc (zero population_share ok)
+  enforces: filter coherence + neutral treatment by construction
+    race-only scenario with no citizenship dim → citizenship never implies eligibility variation
+
+3. Voter eligibility = derived from scenario eligibility_rules; NOT a $grp field
+  declare: scenario.group_schema.eligibility_rules: [{dimension, value, voter_eligible: false}]
+  engine derives: voter_eligible($grp) = conjunction of its dim-value eligibility annotations
+  no eligibility rules + no schema → all $grps 100% voter-eligible; field doesn't exist in data
+
+4. Engine has NO dimension vocabulary
+  dim names+values = open strings; engine doesn't know race is protected class
+  no restriction on which dims may carry eligibility_rules
+    → historical suppression scenarios valid (e.g. race: Black, voter_eligible: false)
+    → counterfactual scenarios valid (e.g. age: under_18, voter_eligible: false)
+  content guidance OUT OF SCOPE for engine
+  rationale: restricting engine would prevent legitimate uses + be circumventable; encodes authors' views
+
+5. vote_shares required for ineligible $grps
+  reasons: display rollup (population filters) | counterfactual analysis | data integrity | uniform validation
+  authoring tools supply regional defaults to reduce burden
+
+6. Content guidance lives in authoring tool (post-$v1); NOT in engine
+  tool MAY: warn on eligibility rules for non-standard dims | show informational text | pre-populate dim pickers
+  tool guidance = advisory not prohibitive; scenario author can proceed past warnings
+  engine takes no position
+
+7. Voter weight formula
+  voter_weight($grp) = population_share × voter_eligible($grp,rules) × turnout_rate
+  $CVAP-equivalent: use citizenship dim if present; else full population
+
+§CONSEQUENCES
+Scenario format: $grps=flat named list; schema optional; if present→completeness applies
+Sim API: engine derives eligibility from eligibility_rules; no voter_eligible field on $grp
+$VRA: $CVAP denominator if citizenship dim present; else full population
+Authoring tool: content guidance responsibility; engine neutral
+Legal/disclaimer: deferred → LEGAL-001
+
+§REFS
+Election sim ADR: thoughts/shared/decisions/2026-04-24-election-simulation-architecture.md
+Legal ticket: thoughts/shared/tickets/LEGAL-001-content-presentation-risks.md

--- a/thoughts/shared/decisions/2026-04-24-demographic-group-model.md
+++ b/thoughts/shared/decisions/2026-04-24-demographic-group-model.md
@@ -1,0 +1,184 @@
+---
+date: 2026-04-24
+status: accepted
+---
+
+# ADR: Demographic Group Model and Voter Eligibility Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+During design discussion of the election simulation architecture, a need emerged to
+model demographic subpopulations with sufficient fidelity to support:
+
+- Bloc voting analysis and VRA compliance checks
+- Turnout variation across demographic groups
+- Voter eligibility distinctions (citizenship, age) without implying that any demographic
+  dimension is inherently eligibility-restricting
+- Educational display of population vs. voter-eligible population
+- Counterfactual analysis ("what if this group could vote?")
+- Future scenario extensibility without mandating a fixed demographic vocabulary
+
+This ADR records the resulting design decisions for the demographic group model and
+the voter eligibility architecture.
+
+## Decisions
+
+### 1. Groups are named flat simulation units
+
+Each precinct's demographic data is a set of named groups. A group represents a
+population segment that votes coherently — it is the atomic unit for simulation
+purposes. Groups are not derived from a fixed dimensional vocabulary; they are
+named strings defined by the scenario.
+
+```
+group: {
+  id: GroupId            // opaque string; scenario-defined
+  population_share: float  // fraction of precinct total population [0, 1]
+  vote_shares: Map<PartyId, float>  // required for ALL groups, including ineligible
+  turnout_rate: float    // fraction of eligible group that votes [0, 1]
+}
+```
+
+This model handles: race × partisanship, age × turnout, citizenship × eligibility,
+or any other combination the scenario designer needs. It avoids pre-committing to
+any demographic vocabulary at the engine level.
+
+### 2. Scenario-level dimensional schema with completeness constraint
+
+A scenario may optionally declare a dimensional schema describing the axes along
+which its groups are defined:
+
+```
+scenario.group_schema:
+  dimensions:
+    race: [White, Latino, Black]
+    citizenship: [citizen, non_citizen]
+```
+
+If a dimensional schema is declared, the completeness constraint applies:
+
+- Every group must declare a value for every declared dimension
+- Every combination of dimension values must exist as a group in every precinct,
+  even if that combination has `population_share: 0`
+
+This constraint ensures filter coherence in the UI (filtering by any dimension
+value always covers the full population) and enforces neutral treatment by
+construction — if citizenship is modeled, it must be modeled for all groups.
+A race-only scenario with no citizenship dimension never implies that race
+affects voter eligibility.
+
+### 3. Voter eligibility is derived from scenario-level eligibility rules
+
+Voter eligibility is NOT a field on groups. It is derived by the engine from
+eligibility rules declared in the scenario schema:
+
+```
+scenario.group_schema:
+  eligibility_rules:
+    - { dimension: citizenship, value: non_citizen, voter_eligible: false }
+    - { dimension: age, value: under_18, voter_eligible: false }
+```
+
+A group's voter eligibility is the conjunction of its dimension values' eligibility
+annotations. Groups with no eligibility-restricting dimension values are fully
+voter-eligible by default.
+
+Scenarios that declare no dimensional schema and no eligibility rules treat all
+groups as fully voter-eligible. The concept of voter eligibility simply does not
+appear in such scenarios' data — no field, no default, no implication.
+
+### 4. The engine has no dimension vocabulary
+
+Dimension names and values are open strings. The engine does not know that `race`
+is a legally protected class, that `citizenship` has specific legal meaning in the
+US, or that `hive_affiliation` is science fiction. The engine runs the simulation
+faithfully regardless of what the dimensions mean.
+
+The eligibility rules system does not restrict which dimensions may carry eligibility
+annotations. A scenario may declare `race: Black, voter_eligible: false` — modeling
+historical voter suppression or a dystopian scenario. The engine executes it without
+comment. Content guidance (warnings, disclaimers, editorial policy) is out of scope
+for the simulation engine.
+
+This decision is deliberate. The game's educational value depends on the simulator
+being an honest model. Restricting what the engine can represent would:
+- Prevent legitimate historical suppression scenarios
+- Prevent counterfactual analysis (e.g., "what if permanent residents could vote?")
+- Be circumventable by anyone using different dimension names
+- Encode the engine's authors' political/legal views into what is supposed to be a
+  neutral simulation substrate
+
+### 5. Vote shares required for all groups, including ineligible ones
+
+Ineligible groups (e.g., `citizenship: non_citizen`, `age: under_18`) still require
+vote shares in the scenario data. Rationale:
+
+- **Display rollup**: when the UI shows population without an eligibility filter,
+  ineligible groups contribute to demographic display correctly
+- **Counterfactual analysis**: "what would happen if this group could vote?" requires
+  the vote share data to be present
+- **Data integrity**: requiring vote shares for ineligible groups forces scenario
+  authors to confront what they're claiming about those groups' political preferences
+- **Consistency**: uniform data requirements make scenario data easier to validate
+  and audit
+
+Authoring tools will provide sensible defaults for ineligible-group vote shares
+(e.g., inherit from a regional baseline) to reduce authoring burden.
+
+### 6. Content guidance lives in the authoring tool, not the engine
+
+The game's scenario authoring tool (post-v1) is the appropriate place for content
+guidance. The tool can:
+
+- Surface warnings when eligibility rules are applied to dimensions that are not
+  factual eligibility criteria (age, citizenship, registration status)
+- Provide informational text about legal/ethical considerations
+- Display pre-populated dimension pickers with common demographic categories
+
+The tool may special-case specific dimension names it recognizes. This is
+the tool's business — not the engine's. The tool's guidance is advisory, not
+prohibitive; scenario authors can proceed past any warning.
+
+### 7. Voter weight calculation
+
+The engine derives voter weight per group as:
+
+```
+voter_weight(group) =
+  population_share
+  × voter_eligible(group, eligibility_rules)   // 1.0 or 0.0
+  × turnout_rate
+```
+
+For VRA analysis, the engine can also compute CVAP-equivalent denominators using
+the citizenship dimension if present. No special field is needed — citizenship-based
+eligibility rules already encode the information.
+
+## Consequences
+
+**Scenario data format**: Groups are a flat named list. Dimensional schema is
+optional. If present, completeness constraint applies: all dimension-value
+combinations must exist in every precinct (zero population allowed).
+
+**Election simulation API**: Engine derives voter eligibility from scenario's
+`eligibility_rules`. Groups have no `voter_eligible` field.
+
+**VRA risk calculation**: Uses CVAP-equivalent denominator if citizenship dimension
+is present; falls back to full population if not. See election simulation ADR for
+VRA risk threshold definition.
+
+**Authoring tool (post-v1)**: Content guidance for eligibility rules is the tool's
+responsibility. The engine takes no position.
+
+**Legal/disclaimer research**: A separate inquiry is needed into whether omitting
+warnings for unrecognized dimension names that carry eligibility restrictions could
+constitute accidental endorsement of discriminatory practices. See LEGAL-001.
+
+## References
+
+Election simulation ADR: `thoughts/shared/decisions/2026-04-24-election-simulation-architecture.md`
+Legal/disclaimer research ticket: `thoughts/shared/tickets/LEGAL-001-content-presentation-risks.md`

--- a/thoughts/shared/tickets/LEGAL-001-content-presentation-risks.md
+++ b/thoughts/shared/tickets/LEGAL-001-content-presentation-risks.md
@@ -1,0 +1,56 @@
+---
+id: LEGAL-001
+title: Content presentation legal risk research
+area: legal, content, presentation
+status: open
+created: 2026-04-24
+---
+
+## Summary
+
+The demographic group model (see ADR `decisions/2026-04-24-demographic-group-model.md`)
+deliberately gives the simulation engine no vocabulary for demographic dimensions and
+no restriction on which dimensions may carry voter eligibility restrictions. Content
+guidance is delegated to the authoring tool, which can warn on specific recognized
+dimension names.
+
+This raises a legal and reputational question that requires domain expertise:
+
+> Does the game's failure to warn — or inability to warn — when an unrecognized
+> dimension name is used to restrict voter eligibility constitute accidental
+> endorsement of discriminatory practices? Does partial warning coverage (known
+> dimensions warned; unknown dimensions silent) create worse liability than either
+> warning on everything or warning on nothing?
+
+## Current State
+
+Not researched. Decision deferred at time of ADR authoring.
+
+## Goals / Acceptance Criteria
+
+- [ ] Consult with a lawyer or legal advisor familiar with educational software,
+      election law, and content liability
+- [ ] Determine whether blanket disclaimer language ("this simulator may be used
+      to model illegal or hypothetical scenarios; the game does not endorse any
+      depicted restriction of voting rights") is sufficient
+- [ ] Determine whether partial-coverage warnings (known bad dimensions) create
+      greater liability than blanket disclaimers
+- [ ] Determine whether open-source status affects liability exposure
+- [ ] Produce a recommendation: blanket disclaimer only / partial warnings + disclaimer /
+      full vocabulary required / other
+- [ ] If recommendation requires engine changes, open a follow-up implementation ticket
+
+## Context
+
+- The authoring tool (post-v1) will warn on recognized dimension names when used with
+  eligibility restrictions (e.g., `race`, `gender`, `religion`)
+- Unrecognized dimension names (e.g., `hive_affiliation`, or `ethnicity` spelled
+  differently) receive no special treatment
+- The game's own pre-built scenarios do not use eligibility restrictions on legally
+  protected classes
+- The project is open-source; hardcoded vocabulary restrictions are circumventable
+
+## References
+
+- ADR: `thoughts/shared/decisions/2026-04-24-demographic-group-model.md`
+- Game vision: `thoughts/shared/vision/game-vision.md` (§Political Neutrality and Framing)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -27,6 +27,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `OPT-NNN` | Performance optimization |
 | `AGENT-NNN` | Agentic workflow and agent tooling changes |
 | `SPIKE-NNN` | Time-boxed proof-of-concept investigations |
+| `LEGAL-NNN` | Legal, content liability, and compliance research |
 
 ---
 
@@ -36,6 +37,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 |---|---|---|
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `AGENT-002-pr-review-cycle-kotlin-tools.md` | agentic workflow | Update infra repo pr-review-cycle to use kotlin scripts in critique/response agent prompts instead of raw gh api |
+| `LEGAL-001-content-presentation-risks.md` | legal, content | Research legal risk from partial/no eligibility-restriction warnings in sim authoring tool |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [ ] N/A

## Summary

ADR and ticket recording the demographic group model and voter eligibility architecture, emerging from design discussion on demographic dimensionality, CVAP/VAP distinction, and content neutrality.

Key decisions:
- **Flat named groups**: simulation unit is a named group with `population_share`, `vote_shares` (required for all groups including ineligible), and `turnout_rate`; no fixed engine vocabulary
- **Optional dimensional schema**: scenarios may declare dimensions with a completeness constraint — if citizenship is modeled, it must be modeled for all groups (enforces neutrality by construction)
- **Voter eligibility via rules**: eligibility is a scenario-level annotation on dimension values, not a field on groups; scenarios with no eligibility rules treat all groups as fully voter-eligible
- **Engine has no vocabulary**: no restriction on which dimensions may carry eligibility rules; historical suppression and counterfactual scenarios are valid; content guidance is the authoring tool's concern (post-v1)
- **LEGAL-001**: research ticket for whether partial warning coverage on eligibility restrictions creates greater liability than a blanket disclaimer

## Validation performed
- [ ] N/A — documentation and ticket only; no code changes

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see LEGAL-001 (opened in this PR)

## Rollback
- N/A — documentation only
