### PR TITLE
docs: county borders as rendering overlay (flavor, not mechanics)

### DIFF
--- a/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.compressed.md
+++ b/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.compressed.md
@@ -50,12 +50,20 @@ pc=precinct dist=district ET=election-type
   Zoomed-out view showing edited region in state context = v2
   Data model + rendering interface must not preclude it; adding it = new rendering mode, not refactor
 
+9. County borders as rendering overlay (flavor; not mechanics)
+  County borders drawn as visual overlay for realism; mechanically inert
+  No sim/scoring/assignment logic depends on county membership
+  $pc.county_id: metadata only; renderer uses it to draw county border layer
+  Rendering: county border overlay = independent toggleable layer alongside $dist boundary overlay
+  NOT modeled as game mechanic; county boundary changes remain OUT OF SCOPE
+  Random map gen(v2): generating county-like $pc groupings = secondary v2 goal; not v1
+
 §CONSEQUENCES
-Scenario format: neighboring_context_precincts[] first-class field
+Scenario format: neighboring_context_precincts[] first-class field; $pc.county_id metadata field
 Simulation API: simulate(allPrecincts, assignments, electionType) → ElectionResult
 District assignment: pc.assignments: Map<ElectionType, DistrictId> (not single ID)
-Rendering: MapRenderer interface; SVG+Canvas as implementations
-NOT modeled: county boundary changes; multi-type simultaneous editing
+Rendering: MapRenderer interface; SVG+Canvas as implementations; county border overlay layer
+NOT modeled: county boundary changes; multi-type simultaneous editing; county game mechanics
 
 §REFS
 Research: thoughts/shared/research/2026-04-24-precinct-count-calibration.md

--- a/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.md
+++ b/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.md
@@ -148,3 +148,25 @@ assignment layer is being edited.
 it does not import SVG or Canvas specifics.
 
 **Do not model**: county boundary changes; multi-type simultaneous editing.
+
+### 9. County borders as rendering overlay (flavor, not mechanics)
+
+County borders are drawn as a visual overlay for realism and geographic orientation.
+They are mechanically inert — no game logic, simulation, scoring, or district
+assignment depends on county membership. A precinct's county is metadata for display
+only.
+
+The rendering interface must support a county border overlay layer alongside the
+existing district boundary overlay. These are independent visual layers; the player
+can toggle each.
+
+County membership is a precinct-level attribute in the data model (`precinct.county_id`)
+so the renderer can draw county borders without any additional data structure. No
+county-level aggregation or simulation is needed.
+
+**Random map generation** (post-v1 / v2): when procedurally generating fictional
+regions, generating county-like groupings of precincts is a secondary v2 goal —
+adds realism without affecting simulation correctness. Not a v1 requirement.
+
+**Explicitly not modeled**: county boundary changes (confirmed out of scope in
+decision 1 above); county as an administrative unit with any game-mechanical effect.

--- a/thoughts/shared/vision/game-vision.compressed.md
+++ b/thoughts/shared/vision/game-vision.compressed.md
@@ -95,6 +95,8 @@ $seg = contiguous blob of $pcs within a $dist; $dist may have multiple $segs(non
 
 View filters(color overlay; always show $dist boundaries on top):
   population density | partisan lean | any demographic dimension | district assignment
+County borders: separate toggleable overlay; flavor+orientation only; no game mechanic
+  $pc.county_id metadata; no effect on scoring/sim/$dist validity; random-gen county groups=$v2
 Hover: tooltip with all $pc metadata; pin for comparison
 
 Editing:
@@ -211,7 +213,7 @@ OUT: player-facing Custom Level UI + community sharing(post-$v1) |
 11. [RESOLVED] Map geography+rendering: scenario region(not county-bound) | State→Region→Precinct hierarchy |
     neighboring context $pcs first-class | one $ET/scenario | $pc.assignments:Map<$ET,$DistId> |
     pannable viewport; scoring not walls | $MapRend interface from $v1; Canvas+SVG hybrid >800 $pcs |
-    state-level view=$v2; county boundary changes=out of scope
+    state-level view=$v2; county boundary changes=out of scope | county borders=overlay only($pc.county_id metadata); random-gen county groups=$v2
     see decisions/2026-04-24-map-geography-and-rendering-architecture.md
 
 §REFS

--- a/thoughts/shared/vision/game-vision.md
+++ b/thoughts/shared/vision/game-vision.md
@@ -253,7 +253,11 @@ Hovering a precinct shows a tooltip with all metadata. Players can keep a precin
 pinned for comparison while browsing.
 
 District boundary lines are always overlaid on top of whichever color dimension is
-active.
+active. County borders are also shown as a separate toggleable overlay — for geographic
+orientation and realism, not as a game mechanic. County membership has no effect on
+scoring, simulation, or district validity (`precinct.county_id` is display metadata only).
+Random map generation (v2) will aim to produce county-like groupings of precincts for
+added realism, but this is a secondary v2 goal with no v1 requirement.
 
 ### Editing Boundaries
 
@@ -526,3 +530,4 @@ static data once published; no per-session server compute needed.
     - Pannable viewport; scenario scope enforced by scoring not hard walls
     - `MapRenderer` interface from v1; Canvas+SVG hybrid when >800 total precincts
     - State-level view is explicit v2; county boundary changes out of scope entirely
+    - County borders rendered as toggleable overlay (`precinct.county_id` metadata); no game mechanic; random-gen county groupings = v2 secondary goal


### PR DESCRIPTION
## Prerequisites
- [ ] N/A

## Summary

Addendum to the map geography ADR and vision doc: county borders are drawn as a visual overlay for realism/orientation, not as a game mechanic.

- `pc.county_id` is a metadata field used only by the renderer to draw county border lines
- County border overlay is an independent toggleable layer alongside district boundaries
- No simulation, scoring, or district validity logic depends on county membership
- County boundary changes remain explicitly out of scope
- Random map generation: generating county-like precinct groupings is a secondary v2 goal

## Validation performed
- [ ] N/A — documentation only

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A

## Rollback
- N/A
