### PR TITLE
docs: scenario format spec updates, ADR cross-refs, new tickets

### DIFF
--- a/thoughts/shared/decisions/2026-04-24-election-simulation-architecture.compressed.md
+++ b/thoughts/shared/decisions/2026-04-24-election-simulation-architecture.compressed.md
@@ -15,7 +15,7 @@ and N-party shares. Educational/neutral stance unchanged.
   v1: fixed precinct partisanship+turnout; exact outcomes; tight causal loop
   Variance: explicit designed scenario events only — not ambient noise
   Each event → deterministic outcome (same map+event = same result every time)
-  Ensemble comparison (map vs. distribution of random valid maps): v2, read-only layer
+  Ensemble comparison (map vs. distribution of random valid maps): v2, read-only layer; runs against same deterministic core (see scenario-data-format spec Purpose section)
 
 2. Waves = demographic events, not partisan labels
   Partisan consequence always DERIVED from demographic event, never assumed

--- a/thoughts/shared/decisions/2026-04-24-election-simulation-architecture.md
+++ b/thoughts/shared/decisions/2026-04-24-election-simulation-architecture.md
@@ -41,7 +41,9 @@ lesson from being obscured by luck.
 
 Ensemble comparison (showing a player's map against a distribution of randomly drawn
 valid maps) is deferred to v2 as a read-only analysis layer — it does not affect
-gameplay or success criteria.
+gameplay or success criteria. This planned v2 layer runs against the same deterministic
+simulation core; it is a separate analytical mode, not a different engine. (Cross-
+reference: the scenario data format spec notes this in its Purpose section.)
 
 ### 2. Waves expressed as demographic events, not partisan labels
 

--- a/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.compressed.md
+++ b/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.compressed.md
@@ -59,7 +59,7 @@ pc=precinct dist=district ET=election-type
   Random map gen(v2): generating county-like $pc groupings = secondary v2 goal; not v1
 
 §CONSEQUENCES
-Scenario format: neighboring_context_precincts[] first-class field; $pc.county_id metadata field
+Scenario format: ~~neighboring_context_precincts[] first-class field~~ superseded: merged into single precincts[] distinguished by editable:bool (see scenario data format spec); $pc.county_id metadata field
 Simulation API: simulate(allPrecincts, assignments, electionType) → ElectionResult
 District assignment: pc.assignments: Map<ElectionType, DistrictId> (not single ID)
 Rendering: MapRenderer interface; SVG+Canvas as implementations; county border overlay layer

--- a/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.md
+++ b/thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.md
@@ -132,8 +132,11 @@ rendering mode, not refactoring the data model.
 
 ## Consequences
 
-**Scenario data format**: Must include `neighboring_context_precincts[]` alongside the
-editable precinct set. Context precincts participate in simulation but are not editable.
+**Scenario data format**: ~~Must include `neighboring_context_precincts[]` alongside the
+editable precinct set.~~ *Superseded by the scenario data format spec*: editable and
+context precincts are merged into a single `precincts[]` array distinguished by
+`editable: boolean`. The semantic distinction is preserved; the data shape is simpler.
+Context precincts participate in simulation but are not editable.
 
 **Simulation API**: Operates on the full set of precincts (editable + context). The
 election type is a required parameter. `simulate(allPrecincts, assignments, electionType)`

--- a/thoughts/shared/decisions/2026-04-24-scenario-data-format.compressed.md
+++ b/thoughts/shared/decisions/2026-04-24-scenario-data-format.compressed.md
@@ -12,6 +12,7 @@ v1=version 1
 Self-contained per-scenario JSON doc; no runtime external lookups
 Serves: pre-built authoring | sim engine | future player/community scenarios
 Deterministic: same file + same map → same sim result
+  v2 planned: ensemble/Monte Carlo comparison runs as separate analytical layer against same deterministic sim (see election-simulation ADR Decision 1)
 format_version:"1" required; parser rejects unknown versions
 
 §TOP_LEVEL Scenario
@@ -26,6 +27,7 @@ parties         Party[]          min 2; fictional names
 districts       District[]       defines target $dist set; count = num to draw
 precincts       Precinct[]       editable + context $pcs
 group_schema?   GroupSchema      optional dimensional schema
+default_district_id? DistId       auto-fill target for unassigned editable $pcs; default districts[0]
 events          DemographicEvent[]  fire at evaluation time
 rules           ScenarioRules
 success_criteria SuccessCriterion[]
@@ -58,7 +60,7 @@ tags?             string[]       for event PrecinctFilter
 ```
 
 §DEMOGRAPHIC_GROUPS
-$grp fields: id | population_share[0,1] | vote_shares:Map<$PartyId,float>(sum=1.0; ALL parties)
+$grp fields: id | name?(string,UI display label) | population_share[0,1] | vote_shares:Map<$PartyId,float>(sum=1.0; ALL parties)
   | turnout_rate[0,1] | dimensions?:Map<DimName,DimValue>(required if group_schema declared)
 voter_eligible: NOT on $grp — derived from group_schema.eligibility_rules
 voter_weight = total_population × population_share × voter_eligible × turnout_rate
@@ -78,6 +80,10 @@ population_shift: id | precinct_filter | group_filter | delta(renormalized after
 GroupFilter: {group_ids:$GroupId[]} | {dimension,value}(requires schema)
 PrecinctFilter: {precinct_ids:$PcId[]} | {tags:string[]}(ALL tags) | {editable_only:true}
 
+§RULES_VS_CRITERIA
+rules=hard validity constraints; illegal map→Test blocked
+criteria=grading rubric; required→must pass to complete; optional→achievements/stars
+
 §RULES
 population_tolerance: float  ±fraction from ideal (congressional~0.001; state-leg~0.05)
 contiguity: "required"|"preferred"|"allowed"
@@ -87,14 +93,15 @@ compactness_threshold?: float  min Fraction Kept; absent=not enforced (still eva
 §CRITERIA SuccessCriterion: id | required:bool | description | criterion
 ```
 seat_count:        party | operator(lt|lte|eq|gte|gt) | count
-majority_minority: group_filter | min_cvap_share | min_districts
-                   (uses CVAP if citizenship dim present; else VAP)
+majority_minority: group_filter | min_eligible_share | min_districts
+                   (uses voter-eligible pop; eligibility_rules define the denominator)
 efficiency_gap:    operator | threshold
 mean_median:       party | operator | threshold
 compactness:       operator | threshold  (Fraction Kept metric)
 safe_seats:        party | margin | min_count
 competitive_seats: margin | min_count
 population_balance: (no params; display hook for Test sequence)
+district_count:    (no params; all districts[] non-empty+assigned; constitutional seat count)
 ```
 
 §NARRATIVE
@@ -108,8 +115,8 @@ state_name | total_districts | other_region_results:Map<RegionId,{district_count
 live region results + sum(other) = statewide totals
 
 §UNASSIGNED_PCS
-absent/null initial_district_id → auto-assign to districts[0] (editable $pcs only; context $pcs must have non-null)
-partial assignments ok: unassigned $pcs → districts[0]
+absent/null initial_district_id → auto-assign to default_district_id (if set) else districts[0] (editable $pcs only)
+partial assignments ok: unassigned $pcs → default_district_id (if set) else districts[0]
 scenario wanting blank start: set all initial_district_id:null; narrative explains
 initial assignments = starting point for player session state; simulate() receives CURRENT assignment map
 runtime maintains assignment state separately; initial_district_id read once at scenario load
@@ -124,16 +131,17 @@ runtime maintains assignment state separately; initial_district_id read once at 
 7. If group_schema: ∀$pc has one $grp per dim-value combo; ∀$grp has value for every dim
 8. hex_axial→no neighbors field; custom→neighbors present+symmetric
 9. custom geometry: all $PcId values in neighbors[] must exist in scenario.precincts
-10. districts.length ≥ 2
+10. districts.length ≥ 2 (scenario definition constraint; not player starting state)
 11. All ids (EventId,CriterionId,PcId,DistId,GroupId,$PartyId) unique within scenario
+12. precincts.length ≥ 1
 
 §OPEN
-1. majority_minority criterion: infer CVAP from schema presence, or explicit measure field?
+1. [RESOLVED] CVAP/VAP: majority_minority uses voter-eligible pop; eligibility_rules are the mechanism; no explicit measure field needed
 2. [RESOLVED] Event ordering: sequential (declaration order); overlapping shifts produce order-dependent results by design; document in authoring guidance
-3. [RESOLVED] state_context in v1: included for forward compat; v1 renderer may ignore; no breaking change when v2 state-level view implemented
+3. [RESOLVED] state_context in v1: included for forward compat; v1 renderer may ignore; no breaking change when v2 state-level view implemented; see OQ9
 4. Narrative asset refs: relative path vs. asset key? Decide before pre-built authoring
-5. Partial auto-fill target: always districts[0], or configurable default_district_id?
-6. Format migration: no strategy yet; defer until v2 format requirement exists
+5. [RESOLVED] auto-fill: added default_district_id? to scenario; falls back to districts[0]
+6. [RESOLVED-PARTIAL] format_version:1 in spec; migration strategy deferred to v2 requirement
 7. Context $pc non-editability = pedagogical simplification: real redistricting may require
    cross-boundary $pc adjustments for population balance; spec locks context $pcs as read-only
    ok for v1: (a) editable:false is per-$pc so scenario can override; (b) early scenarios simplified
@@ -141,3 +149,5 @@ runtime maintains assignment state separately; initial_district_id read once at 
 8. Editor tools for blank-start: brush alone is poor for ~300 unassigned $pcs from scratch
    needed: flood-fill from seed | lasso+assign | generate valid starting partition
    UI/editor concern not format concern; track separately when approaching editor build
+9. StateContext redesign: total_districts volatile; RegionResult concept unclear; redesign before $v1 impl; proposed: other_region_seat_totals:Record<PartyId,int>+state_total_districts:int
+10. Achievement/star system: OQ; required:false criteria enable it; game ergonomics research needed before format extension; see DESIGN-001

--- a/thoughts/shared/decisions/2026-04-24-scenario-data-format.md
+++ b/thoughts/shared/decisions/2026-04-24-scenario-data-format.md
@@ -21,7 +21,10 @@ Defines the canonical data format for a redistricting scenario. The format serve
 
 All data is self-contained in one document per scenario. No external lookups at
 runtime. A scenario file is deterministic: given the same file and the same player
-map, the simulation always produces the same result.
+map, the simulation always produces the same result. (Planned v2: ensemble/
+Monte Carlo comparison — showing where a player's map falls in a distribution
+of randomly-drawn valid maps — runs as a separate analytical layer against the
+same deterministic simulation. See the election simulation ADR, Decision 1.)
 
 ## Conventions
 
@@ -56,6 +59,8 @@ interface Scenario {
   precincts:      Precinct[]          // editable + context precincts
 
   group_schema?:  GroupSchema         // optional dimensional schema (see Demographic Groups)
+  default_district_id?: DistrictId     // auto-fill target for unassigned editable precincts
+                                       // defaults to districts[0] if absent
 
   events:         DemographicEvent[]  // fires at evaluation time
   rules:          ScenarioRules
@@ -191,6 +196,7 @@ renderer distinguishes them visually.
 ```typescript
 interface DemographicGroup {
   id:               GroupId         // opaque string; unique within precinct
+  name?:            string          // display label shown in UI (e.g., "Latino voters")
   population_share: number          // fraction of precinct total_population [0, 1]
   vote_shares:      Record<PartyId, number>  // must sum to 1.0; all parties present
   turnout_rate:     number          // fraction of eligible pop that votes [0, 1]
@@ -295,6 +301,17 @@ The simulation sees the post-event demographic state.
 
 ### `ScenarioRules`
 
+**Rules vs. success criteria — the distinction:**
+Rules are hard validity constraints. A map that violates a rule is *illegal* — the
+player cannot submit it and the Test sequence will not run to completion. Rules define
+the boundaries of what counts as a valid redistricting plan (e.g., districts must be
+roughly equal in population; districts must be contiguous). They are not negotiable.
+
+Success criteria are the scenario's *grading rubric*. A valid map is always testable;
+criteria determine whether it passes, partially passes (optional criteria), or fails.
+Required criteria must all pass to complete the scenario. Optional criteria add depth —
+players can replay to achieve them. See `SuccessCriterion` below.
+
 ```typescript
 interface ScenarioRules {
   population_tolerance:    number
@@ -324,9 +341,10 @@ interface SuccessCriterion {
 
 type Criterion =
   | { type: "seat_count";         party: PartyId; operator: CompareOp; count: number }
-  | { type: "majority_minority";  group_filter: GroupFilter; min_cvap_share: number;
+  | { type: "majority_minority";  group_filter: GroupFilter; min_eligible_share: number;
                                   min_districts: number }
-                                  // at least min_districts must have ≥ min_cvap_share CVAP
+                                  // at least min_districts must have ≥ min_eligible_share
+                                  // of voter-eligible population from the filtered groups
   | { type: "efficiency_gap";     operator: CompareOp; threshold: number }
   | { type: "mean_median";        party: PartyId; operator: CompareOp; threshold: number }
   | { type: "compactness";        operator: CompareOp; threshold: number }   // Fraction Kept
@@ -338,17 +356,30 @@ type Criterion =
                                   // all districts within rules.population_tolerance
                                   // (redundant if rules enforce it; included for
                                   //  explicit display in Test sequence)
+  | { type: "district_count" }
+                                  // all districts[].length districts are non-empty
+                                  // and fully assigned; no districts left unused.
+                                  // Captures the constitutional requirement that a
+                                  // state must draw exactly its apportioned seat count.
+                                  // Typically required:true in every scenario.
 
 type CompareOp = "lt" | "lte" | "eq" | "gte" | "gt"
 ```
 
-`majority_minority` uses CVAP if a citizenship dimension is present in
-`group_schema`; falls back to VAP otherwise. The criterion description should
-tell the player which is being evaluated.
+`majority_minority` evaluates voter-eligible population as defined by the scenario's
+`eligibility_rules`. If a citizenship dimension is present with non-citizen groups marked
+ineligible, this naturally computes a CVAP-equivalent denominator. If no eligibility rules
+are declared, all population is voter-eligible, so VAP = eligible population. The criterion
+does not need to know which measure is in use — it always operates on eligible population.
+The scenario description should tell the player what the threshold represents in context.
 
 ---
 
 ### `Narrative`
+
+> **Provisional**: this section captures the minimum required for v1. It will likely
+> evolve as front-end and visual design requirements are formalized. Changes should
+> be reviewed with front-end and design roles before first scenario authoring begins.
 
 ```typescript
 interface Narrative {
@@ -377,6 +408,12 @@ interface Slide {
 Pre-computed election results for all regions outside the player's scenario region.
 Used for state-level aggregation (displaying statewide seat totals as the player
 draws).
+
+> **Design concern** (see Open Question 9 below): the current shape has a conceptual
+> issue — `total_districts` includes the player's region, which makes it volatile, not
+> pre-computed. `RegionResult` may not map cleanly to the current data model where
+> Region is an editable view rather than a fixed entity. This section will be redesigned
+> before v1 implementation. It is a structural placeholder; v1 ignores it.
 
 ```typescript
 interface StateContext {
@@ -417,16 +454,20 @@ A scenario is valid if and only if:
    adjacency is symmetric (if A lists B as neighbor, B lists A).
 10. For `geometry.type == "custom"`: all `PrecinctId` values in `neighbors[]` must
     exist in `scenario.precincts`.
-11. `scenario.districts` has at least 2 entries.
+11. `scenario.districts` has at least 2 entries. (Note: this constrains the scenario
+    *definition*, not the player's starting state — the auto-fill behavior starting all
+    editable precincts in one district is intentional even when `districts.length > 1`.)
 12. Every `EventId`, `CriterionId`, `PrecinctId`, `DistrictId`, `GroupId`, `PartyId`
     is unique within the scenario.
+13. `scenario.precincts` is non-empty (`precincts.length ≥ 1`).
 
 ---
 
 ## Unassigned Precinct Handling
 
 When a scenario provides no `initial_district_id` on any precinct (or all are null),
-the game initializes all precincts to `districts[0]`. The player begins with one
+the game initializes all editable precincts to the `default_district_id` (if set on the
+scenario) or `districts[0]` if not. The player begins with one
 giant district and carves it into the required number. This avoids an error state
 and gives a natural starting point.
 
@@ -550,32 +591,30 @@ A minimal two-district, two-party scenario with one event and one required crite
 
 ## Open Questions
 
-1. **CVAP vs VAP in `majority_minority` criterion**: The criterion uses CVAP when
-   a citizenship dimension is present. Should the criterion explicitly declare
-   which measure to use (`measure: "cvap" | "vap"`) rather than inferring from
-   schema? More explicit; better for authoring validation.
+1. ~~**CVAP vs VAP in `majority_minority` criterion**~~: Resolved. The criterion uses
+   voter-eligible population as defined by `eligibility_rules`. If citizenship eligibility
+   rules are present, this naturally computes CVAP-equivalent denominators. No explicit
+   `measure` field needed — the eligibility rules model is the mechanism.
 
-2. ~~**Event ordering and interaction**~~: Resolved. Events are applied in
-   declaration order (sequential). Scenario authors must be aware that overlapping
-   population shifts may produce different results depending on order; this is by
-   design and should be documented in authoring guidance.
+2. ~~**Event ordering and interaction**~~: Resolved. Events are applied in declaration
+   order (sequential). Scenario authors must be aware that overlapping population shifts
+   may produce order-dependent results; document in authoring guidance.
 
-3. ~~**`state_context` in v1**~~: Resolved. `state_context` is included in the format
-   for forward compatibility; v1 renderer may ignore it. No breaking change needed
-   when v2 state-level view is implemented.
+3. ~~**`state_context` in v1**~~: Resolved. Included for forward compatibility; v1
+   renderer ignores it. See also Open Question 9.
 
 4. **Narrative asset references**: `Slide.image` references an asset. What is the
    asset resolution strategy? Relative path to a sibling assets directory? A
    named key in a shared asset bundle? Needs a decision before pre-built scenario
    authoring begins.
 
-5. **Partial initial assignment auto-fill**: The spec says unassigned precincts
-   auto-fill to `districts[0]`. Should the auto-fill target be configurable
-   (`default_district_id` on the scenario)? Or is `districts[0]` always correct?
+5. ~~**Partial initial assignment auto-fill**~~: Resolved. Added `default_district_id?`
+   to the top-level `Scenario` interface. Unassigned editable precincts auto-fill to
+   `default_district_id` if set, otherwise `districts[0]`.
 
-6. **Scenario versioning / migration**: No migration strategy defined. Format
-   version `"1"` is parsed or rejected. Future versions will need a migration path.
-   Defer until there is a v2 format requirement.
+6. ~~**Scenario versioning**~~: Partially resolved. `format_version: "1"` is in the
+   format; parser rejects unknown versions. Migration strategy deferred until a v2 format
+   requirement exists.
 
 7. **Context precinct non-editability as a pedagogical simplification**: In
    real-world redistricting, districts frequently cross county/region boundaries
@@ -588,10 +627,21 @@ A minimal two-district, two-party scenario with one event and one required crite
 
 8. **Editor tools for blank-start scenarios**: The brush/paint interaction is
    sufficient for reshaping an existing map but is a poor starting point for drawing
-   ~300 blank precincts from scratch. Editor needs additional tools before blank-start
-   scenarios are playable:
-   - Flood-fill from a seed precinct (expand greedily to district boundary)
-   - Lasso / region-select then assign
-   - Generate valid starting partition (randomize contiguous, population-balanced map)
-   These are UI/editor concerns, not format concerns. Track separately when
-   approaching editor implementation.
+   ~300 blank precincts from scratch. Editor needs: flood-fill from seed, lasso/region-
+   select, generate-valid-partition. UI/editor concern; track separately when approaching
+   editor implementation.
+
+9. **`StateContext` redesign**: The current `StateContext` shape is a placeholder with
+   known issues: `total_districts` "including this region" is volatile (changes as player
+   draws), and `RegionResult` does not map cleanly to the current data model where Region
+   is an editable view. This section needs redesign before v1 implementation. Proposed
+   direction: `other_region_seat_totals: Record<PartyId, number>` (pre-computed aggregate,
+   fixed) + `state_total_districts: number` (constitutional total, fixed). Player's region
+   contributes live; no per-region breakdown needed. v1 ignores this field, so the redesign
+   can happen before implementation without a breaking change.
+
+10. **Achievement / star-ranking system**: The `required: false` criteria field enables
+    optional objectives. A star-ranking system (e.g., 1 star = all required met; 2 stars =
+    required + some optional; 3 stars = all optional met) is architecturally supported by
+    the current spec but the UX design needs game ergonomics research before the format is
+    extended. See DESIGN-001.

--- a/thoughts/shared/tickets/DESIGN-001-achievement-star-system.md
+++ b/thoughts/shared/tickets/DESIGN-001-achievement-star-system.md
@@ -1,0 +1,42 @@
+---
+id: DESIGN-001
+title: Achievement / star-ranking system game ergonomics research
+area: design
+status: open
+created: 2026-04-24
+---
+
+## Summary
+
+The scenario data format supports `required: false` on `SuccessCriterion`, which
+architecturally enables optional objectives. Before the format is extended to support
+a formal star/achievement ranking system, game ergonomics research is needed to
+determine the right UX model.
+
+## Current State
+
+The spec supports optional criteria today. No star-ranking UX is defined. The
+scenario format has no ranking shape, weighting, or display contract for optional
+criteria beyond "they exist."
+
+## Goals / Acceptance Criteria
+
+- [ ] Research how comparable educational and puzzle games present multi-tier
+      success (stars, ranks, medals, etc.).
+- [ ] Evaluate candidate models:
+      - 3-tier stars: 1 star = all required; 2 stars = required + some optional;
+        3 stars = all optional
+      - N/M stars: 34/45 campaign stars, 1/1 per scenario, etc. (freeform)
+      - Per-criterion achievements: no aggregate rank, each optional criterion is
+        an independent badge
+- [ ] Determine whether star count should be fixed (always 3) or variable per
+      scenario (driven by optional criteria count).
+- [ ] Identify what format changes, if any, are needed to support the chosen model
+      (e.g., `weight`, `tier`, or `star_value` on `SuccessCriterion`).
+- [ ] Summarize recommendation with reasoning. No implementation required yet.
+
+## References
+
+- Scenario data format spec: `thoughts/shared/decisions/2026-04-24-scenario-data-format.md`
+  (Open Question 10; `SuccessCriterion.required`)
+- DIST-001: Steam deployment research (Steam achievements API may inform this)

--- a/thoughts/shared/tickets/DIST-001-steam-deployment-research.md
+++ b/thoughts/shared/tickets/DIST-001-steam-deployment-research.md
@@ -1,0 +1,38 @@
+---
+id: DIST-001
+title: Steam deployment research — educational free program and achievements
+area: distribution
+status: open
+created: 2026-04-24
+---
+
+## Summary
+
+Before committing to a distribution strategy, research Steam's options for
+educational/free games, including whether the Steam free-to-play / educational
+program is viable, what the achievements API looks like, and how Steam compares
+to a web-based distribution approach for this project's goals.
+
+## Current State
+
+No distribution decision has been made. The game is being built as a browser
+application (TypeScript + Vite). Steam is a possible deployment target but has
+not been evaluated.
+
+## Goals / Acceptance Criteria
+
+- [ ] Determine whether Steam's educational / free game program applies and what
+      its requirements are.
+- [ ] Understand the Steam achievements API: integration complexity, supported
+      platforms, any restrictions.
+- [ ] Evaluate web-first vs. Steam-first vs. both: what do educational games
+      typically choose, and what are the tradeoffs for discoverability, reach,
+      and maintenance cost?
+- [ ] Summarize recommendation with reasoning. No implementation required.
+
+## References
+
+- Game vision: `thoughts/shared/vision/game-vision.compressed.md`
+- Scenario data format: `thoughts/shared/decisions/2026-04-24-scenario-data-format.md`
+  (optional criteria / achievements system is related — see DESIGN-001)
+- DESIGN-001: Achievement/star system (game ergonomics side of same question)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -28,6 +28,8 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `AGENT-NNN` | Agentic workflow and agent tooling changes |
 | `SPIKE-NNN` | Time-boxed proof-of-concept investigations |
 | `LEGAL-NNN` | Legal, content liability, and compliance research |
+| `DIST-NNN` | Distribution, deployment, and platform research |
+| `DESIGN-NNN` | Game design, UX, and ergonomics research |
 
 ---
 
@@ -38,6 +40,8 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `AGENT-002-pr-review-cycle-kotlin-tools.md` | agentic workflow | Update infra repo pr-review-cycle to use kotlin scripts in critique/response agent prompts instead of raw gh api |
 | `LEGAL-001-content-presentation-risks.md` | legal, content | Research legal risk from partial/no eligibility-restriction warnings in sim authoring tool |
+| `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
+| `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary

Batch of spec updates following user review of the scenario data format spec (PR #24), plus related ADR cross-references and two new research tickets.

**Scenario data format spec** (`2026-04-24-scenario-data-format.md` + `.compressed.md`):
- Added Monte Carlo/ensemble v2 cross-reference to Purpose section (determinism note)
- Added `default_district_id?: DistrictId` to top-level `Scenario` interface (resolves OQ5)
- Added `name?: string` to `DemographicGroup` for UI display labels
- Added "Rules vs. success criteria" distinction blurb before `ScenarioRules`
- Renamed `min_cvap_share` → `min_eligible_share` in `majority_minority` criterion; updated prose to use eligibility_rules model (resolves OQ1)
- Added `district_count` criterion type (constitutional seat count requirement)
- Added "Provisional" note to `Narrative` section
- Added "Design concern" note to `StateContext` section (cross-ref to OQ9)
- Updated Unassigned Precinct Handling to reference `default_district_id`
- Clarified validation invariant 11 (scenario definition vs. player state)
- Added validation invariant 13: `precincts.length ≥ 1`
- Replaced Open Questions section: resolved OQ1/OQ5/OQ6; added OQ9 (StateContext redesign) and OQ10 (stars/achievement system)

**Election simulation ADR** (`2026-04-24-election-simulation-architecture.md` + `.compressed.md`):
- Added explicit cross-reference note to Decision 1 (ensemble = v2 analytical layer, same deterministic core)

**Map geography ADR** (`2026-04-24-map-geography-and-rendering-architecture.md` + `.compressed.md`):
- Added supersession note on `neighboring_context_precincts[]` consequence — merged into single `precincts[]` per scenario data format spec

**New tickets**:
- DIST-001: Steam deployment research (free/educational program, achievements API, web vs. Steam)
- DESIGN-001: Achievement/star system game ergonomics research
- Updated TICKETS.md with DIST and DESIGN ID categories + both new entries

## Validation performed
- N/A — prose/doc changes only; no code

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- Creates DIST-001 (open — research not yet done)
- Creates DESIGN-001 (open — research not yet done)

## Rollback
- Revert commit; no side effects
