### PR TITLE
plan: Sprint 1 tickets — scenario types, loader, content, renderer, integration

### DIFF
--- a/thoughts/shared/tickets/GAME-001-scenario-typescript-types.md
+++ b/thoughts/shared/tickets/GAME-001-scenario-typescript-types.md
@@ -1,0 +1,50 @@
+---
+id: GAME-001
+title: Define scenario TypeScript types from spec
+area: game, core, types
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Implement all TypeScript types from the scenario data format spec in the game
+source tree. These are the canonical data types for the entire game — the loader,
+simulation engine, renderer, and store all build on them.
+
+## Current State
+
+The spike (`game/web/src/model/types.ts`) has its own simplified types:
+hardcoded `PartyKey = "R" | "D" | "L" | "G" | "I"`, a flat `Precinct` with
+a `partyShare: PartyShare` field, and no demographic group model. These are
+spike-grade and must be superseded by spec-grade types for the real implementation.
+
+Spike types should be left in place for now — the procedural generator still
+uses them and the spike renderer depends on them. New types go in new files;
+the two type systems coexist until the GAME-005 integration replaces the generator.
+
+## Goals / Acceptance Criteria
+
+- [ ] New file(s) under `game/web/src/model/` (e.g. `scenario.ts`) defining:
+  - Opaque string branded types: `ScenarioId`, `PartyId`, `DistrictId`,
+    `PrecinctId`, `GroupId`, `EventId`, `CriterionId`, `RegionId`
+  - `Scenario` top-level interface (all fields from spec, including `default_district_id?`)
+  - `RegionSpec`, `GeometrySpec` (discriminated union hex_axial | custom), `Party`,
+    `District`, `Precinct`, `HexAxialPosition`, `CartesianPosition`
+  - `DemographicGroup` (including `name?` and `dimensions?`), `GroupSchema`,
+    `EligibilityRule`
+  - `DemographicEvent` (discriminated union: turnout_shift | vote_share_shift |
+    population_shift), `GroupFilter`, `PrecinctFilter`
+  - `ScenarioRules` (contiguity: "required" | "preferred" | "allowed")
+  - `SuccessCriterion`, `Criterion` (full discriminated union from spec including
+    `district_count` and `min_eligible_share`), `CompareOp`
+  - `Narrative`, `Slide`
+  - `StateContext`, `RegionResult`
+- [ ] No hardcoded party keys; `PartyId` is a plain `string` branded type
+- [ ] Strict TypeScript compiles cleanly (`tsc --noEmit`)
+- [ ] Existing spike types (`game/web/src/model/types.ts`) untouched
+
+## References
+
+- Spec: `thoughts/shared/decisions/2026-04-24-scenario-data-format.md`
+- Spike types: `game/web/src/model/types.ts` (to understand what exists)

--- a/thoughts/shared/tickets/GAME-002-scenario-loader-validator.md
+++ b/thoughts/shared/tickets/GAME-002-scenario-loader-validator.md
@@ -1,0 +1,48 @@
+---
+id: GAME-002
+title: Scenario JSON loader and validator
+area: game, core, data
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Implement a `loadScenario` function that parses raw JSON into a typed `Scenario`
+and validates all spec invariants. This is the boundary between the file system
+and the game engine — everything downstream can trust the result is valid.
+
+## Current State
+
+No loader exists. The spike uses a procedural generator (`game/web/src/model/generator.ts`)
+to create precincts at runtime. The loader replaces that data source.
+
+## Goals / Acceptance Criteria
+
+- [ ] `loadScenario(json: unknown): Scenario` function in `game/web/src/model/`
+- [ ] Rejects unknown `format_version`; throws a descriptive error
+- [ ] Validates all 13 invariants from the spec:
+  - All `PartyId` refs in `vote_shares`, events, criteria exist in `scenario.parties`
+  - All `DistrictId` refs in `initial_district_id` exist in `scenario.districts`
+  - All `GroupId` refs in events/criteria exist in ≥1 precinct's `demographic_groups`
+  - Every context precinct (`editable: false`) has a non-null `initial_district_id`
+  - `sum(population_shares) == 1.0` per precinct (±ε)
+  - `sum(vote_shares) == 1.0` per group (±ε); all parties present
+  - If `group_schema` declared: completeness constraint holds
+  - hex_axial: no `neighbors` field on precincts
+  - custom geometry: `neighbors` present and symmetric
+  - custom geometry: all `PrecinctId` values in `neighbors[]` exist in `scenario.precincts`
+  - `districts.length ≥ 2`
+  - All ids unique within scenario
+  - `precincts.length ≥ 1`
+- [ ] `auto-fill` behaviour: editable precincts with absent/null `initial_district_id`
+  are resolved to `default_district_id` (if set) or `districts[0]` at load time;
+  returned `Scenario` always has explicit `initial_district_id` on editable precincts
+- [ ] Error messages identify which invariant failed and where (e.g. precinct id)
+- [ ] Unit tests: happy path + one test per invariant violation
+- [ ] Depends on: GAME-001
+
+## References
+
+- Spec invariants: `thoughts/shared/decisions/2026-04-24-scenario-data-format.md` §Validation Invariants
+- Types: GAME-001

--- a/thoughts/shared/tickets/GAME-003-tutorial-scenario-content.md
+++ b/thoughts/shared/tickets/GAME-003-tutorial-scenario-content.md
@@ -1,0 +1,67 @@
+---
+id: GAME-003
+title: Author tutorial scenario JSON (scenario 1)
+area: game, content
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Create the first playable scenario: the tutorial. This is the primary demo target
+for Sprint 1 and the scenario players experience first. It must teach basic
+redistricting mechanics without assuming prior knowledge.
+
+The implementing agent must produce a written **sketch/proposal** before authoring
+the full JSON. The proposal should be reviewed before the full data is written,
+since the fictional world choices affect all future scenarios.
+
+## Current State
+
+No scenario files exist. The fictional world (state name, region, parties, characters)
+has not been decided. These decisions are intentionally left to the authoring agent —
+the game vision provides design constraints but not specific creative choices.
+
+## Goals / Acceptance Criteria
+
+**Phase 1 — Proposal (produce first, before Phase 2):**
+- [ ] Written sketch covering:
+  - Fictional state name and region/county name
+  - Two fictional party names and abbreviations (not Red/Blue — something more fun)
+  - Player character: name, role, motivation (low-stakes, tutorial framing)
+  - Intro slide text (1–2 slides)
+  - Objective text shown on map screen
+  - Map shape: ~30 hex precincts in axial coordinates, rough layout sketch
+  - District count (2) and rough intended split
+  - Success criteria (at minimum: `district_count` + `population_balance`)
+  - Lesson taught: how redistricting works; no partisan angle
+
+**Phase 2 — Full JSON authoring (after proposal reviewed):**
+- [ ] Valid scenario JSON file at `game/scenarios/tutorial-001.json`
+- [ ] Passes `loadScenario()` validator (GAME-002) with no errors
+- [ ] `format_version: "1"`; `election_type: "state_house"`
+- [ ] ~30 hex precincts in axial coordinates; all editable; no context precincts needed
+- [ ] Demographic groups: at minimum 2 groups per precinct; `vote_shares` sum to 1.0
+  for all parties; `population_share` sum to 1.0 per precinct
+- [ ] Both districts populated plausibly when auto-fill applied (not all precincts
+  in one corner)
+- [ ] `initial_district_id: null` on all precincts (player draws from scratch)
+- [ ] No events (tutorial is baseline only)
+- [ ] 2 required success criteria: `district_count` + `population_balance`
+- [ ] Optional criterion: at least 1 (e.g. rough partisan balance or compactness)
+- [ ] Narrative: character framing, 1–2 intro slides, map objective text
+
+## Design Constraints (from game vision)
+
+- Fictional parties — NOT "Red Party" / "Blue Party" as defaults; pick something
+  with personality (see §SCENARIOS — "Cats vs Dogs" is a later scenario, so avoid
+  animal parties here; use something civic-flavored)
+- Tutorial lesson: redistricting exists; you draw lines; lines affect outcomes
+- No partisan gotcha in tutorial — success should be achievable many ways
+- Character should have low-stakes, relatable motivation ("just trying to do the job")
+
+## References
+
+- Game vision: `thoughts/shared/vision/game-vision.compressed.md` §SCENARIOS, §SCENARIO_INTRO, §LOOP
+- Spec: `thoughts/shared/decisions/2026-04-24-scenario-data-format.md`
+- Loader (validates the result): GAME-002

--- a/thoughts/shared/tickets/GAME-004-map-renderer-interface.md
+++ b/thoughts/shared/tickets/GAME-004-map-renderer-interface.md
@@ -1,0 +1,45 @@
+---
+id: GAME-004
+title: Extract MapRenderer interface from spike renderer
+area: game, rendering
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+The map geography ADR requires a `MapRenderer` interface from v1, with
+`SvgMapRenderer` as the first implementation. The spike has a single concrete
+`MapRenderer` class. Extract the interface so game logic never imports a concrete
+renderer, enabling the Canvas+SVG hybrid swap later without refactoring callers.
+
+## Current State
+
+`game/web/src/render/mapRenderer.ts` contains a concrete `MapRenderer` class.
+`game/web/src/main.ts` instantiates it directly. No interface exists.
+
+## Goals / Acceptance Criteria
+
+- [ ] `MapRenderer` defined as a TypeScript interface in
+  `game/web/src/render/mapRenderer.ts` (or a new `types.ts` in that dir)
+  - `render(): void`
+  - `setViewMode(mode: ViewMode): void`
+  - `setCountyBordersVisible(visible: boolean): void`
+    (county border overlay is an independent toggleable layer per the map geography ADR;
+    interface must include it from v1 even if the toggle is a no-op in SvgMapRenderer
+    until county_id data is present)
+  - Anything else currently called on the concrete class from `main.ts`
+- [ ] Rename concrete class to `SvgMapRenderer implements MapRenderer`
+- [ ] `main.ts` typed against `MapRenderer` (the interface), not `SvgMapRenderer`
+  - Construction site (`new SvgMapRenderer(...)`) is the one allowed concrete reference
+- [ ] `ViewMode` type exported (`"districts" | "lean"` from spike, expandable later)
+- [ ] All existing spike functionality continues to work (paint, undo/redo, view toggle,
+  district buttons, results panel, WASM diagnostic)
+- [ ] `bazel build //game/web/...` and `bazel test //game/web/...` pass (if tests exist)
+
+## References
+
+- ADR: `thoughts/shared/decisions/2026-04-24-map-geography-and-rendering-architecture.md`
+  §Decision 6 (renderer-agnostic model, interface boundary from v1)
+- Spike renderer: `game/web/src/render/mapRenderer.ts`
+- Spike entry: `game/web/src/main.ts`

--- a/thoughts/shared/tickets/GAME-005-render-scenario-from-json.md
+++ b/thoughts/shared/tickets/GAME-005-render-scenario-from-json.md
@@ -1,0 +1,69 @@
+---
+id: GAME-005
+title: Sprint 1 integration — render scenario from JSON
+area: game, rendering, integration
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Wire the scenario loader (GAME-002) and tutorial scenario JSON (GAME-003) into
+the renderer (GAME-004). Replace the procedural generator as the data source.
+At the end of this ticket, the app renders a real scenario and the player can
+paint districts.
+
+This is the Sprint 1 demo milestone.
+
+## Current State
+
+The app loads precincts from the procedural generator (`generator.ts`). The
+renderer, store, and simulation all use spike-grade types. The goal is to
+swap the data source without breaking the rendering and editing experience.
+
+## Goals / Acceptance Criteria
+
+- [ ] App loads `tutorial-001.json` at startup (hardcoded path / static import for now;
+  scenario picker is a later sprint)
+- [ ] Scenario passed through `loadScenario()` before use; validation errors surface
+  clearly in the browser console (no silent failures)
+- [ ] Precincts rendered at correct hex positions from `scenario.precincts[*].position`
+- [ ] Initial district assignments from `initial_district_id` applied (or auto-fill
+  if null) before first render
+- [ ] District color overlay rendered; district boundaries drawn between adjacent
+  precincts in different districts
+- [ ] Paint/brush interaction works: stroking assigns precincts to active district
+- [ ] Undo/redo works
+- [ ] View mode toggle works (districts ↔ partisan lean)
+  - Partisan lean derived from scenario's demographic groups + vote_shares
+    (population-weighted average across groups for now — full group model is Sprint 3)
+- [ ] Viewport panning works (CSS transform; existing spike behaviour)
+- [ ] Spike types (`types.ts`, `generator.ts`) and spike entry point left in place
+  but no longer the primary data path; they can be deleted in a follow-up
+- [ ] `bazel build //game/web/...` passes; app serves and renders correctly
+
+**Sprint 1 demo**: open browser via `serve.sh`, see tutorial scenario map, paint
+districts, undo/redo, toggle view mode. No simulation, no test sequence yet.
+
+## Notes
+
+- The Zustand store's `GameState` will need to accommodate `Scenario` types rather
+  than spike types. Decide whether to update the store types in this ticket or keep
+  a thin adapter layer — whichever produces less churn for Sprint 2.
+- The spike simulation (`election.ts`) does not need to be replaced this sprint;
+  it can continue to run against adapted types if the mapping is simple, or be
+  temporarily disabled. Simulation replacement is Sprint 3.
+
+## Dependencies
+
+- GAME-001 (types)
+- GAME-002 (loader)
+- GAME-003 (tutorial scenario JSON)
+- GAME-004 (MapRenderer interface)
+
+## References
+
+- Spike entry: `game/web/src/main.ts`
+- Spike store: `game/web/src/store/gameStore.ts`
+- Spike renderer: `game/web/src/render/mapRenderer.ts`
+- Spike generator: `game/web/src/model/generator.ts`

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -30,6 +30,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `LEGAL-NNN` | Legal, content liability, and compliance research |
 | `DIST-NNN` | Distribution, deployment, and platform research |
 | `DESIGN-NNN` | Game design, UX, and ergonomics research |
+| `GAME-NNN` | Game implementation work (rendering, simulation, content, game loop) |
 
 ---
 
@@ -37,6 +38,11 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
+| `GAME-001-scenario-typescript-types.md` | game, core | Define TypeScript types from scenario data format spec; replaces spike-grade types |
+| `GAME-002-scenario-loader-validator.md` | game, core | Scenario JSON loader + all 13 spec validation invariants; unit tested |
+| `GAME-003-tutorial-scenario-content.md` | game, content | Author tutorial scenario JSON (sketch proposal first, then full data file) |
+| `GAME-004-map-renderer-interface.md` | game, rendering | Extract MapRenderer interface; rename concrete class to SvgMapRenderer |
+| `GAME-005-render-scenario-from-json.md` | game, rendering | Sprint 1 demo: wire loader + scenario into renderer; replace procedural generator |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `LEGAL-001-content-presentation-risks.md` | legal, content | Research legal risk from partial/no eligibility-restriction warnings in sim authoring tool |
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- Sprint 1 ticket set: 5 tickets covering the first demonstrable checkpoint ("load and display a real scenario")
- Added GAME-NNN ticket category to TICKETS.md
- GAME-001: scenario TypeScript types (from spec)
- GAME-002: scenario JSON loader + 13-invariant validator
- GAME-003: tutorial scenario content (sketch proposal → full JSON)
- GAME-004: MapRenderer interface extraction (SvgMapRenderer as first impl)
- GAME-005: Sprint 1 integration — render scenario from JSON, replace procedural generator

Sprint 1 demo target: browser opens, tutorial scenario renders from JSON, player can paint districts, undo/redo works.

## Validation performed
- N/A — planning/tickets only

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- Creates GAME-001 through GAME-005

## Rollback
- Revert commit; no side effects
