### PR TITLE
plan: add GAME-006 (scenario compression) and GAME-007 (player persistence)

### DIFF
--- a/thoughts/shared/tickets/GAME-006-scenario-compression.md
+++ b/thoughts/shared/tickets/GAME-006-scenario-compression.md
@@ -1,0 +1,60 @@
+---
+id: GAME-006
+title: Compressed scenario format and efficient delivery
+area: game, build
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Reduce scenario download size. Two concerns addressed together: (1) HTTP-level
+compression for bundled v1 scenarios served with the app; (2) a defined portable
+compressed file format for future downloadable/community scenarios.
+
+## Current State
+
+Scenarios are plain JSON. No compression strategy defined. For v1, scenarios will
+be bundled as static assets. Community/downloadable scenarios are post-v1 but the
+format decision should be made before the loader is finalised.
+
+## Goals / Acceptance Criteria
+
+**Part A — HTTP delivery (v1 bundled scenarios):**
+- [ ] Vite build configured to emit scenarios with gzip (`.gz`) or brotli (`.br`)
+  pre-compressed alongside the originals, OR confirm that the v1 host (Vite dev
+  server + production serve target) serves static JSON with `Content-Encoding: gzip`
+  automatically
+- [ ] Decision documented: either "HTTP compression is sufficient; no format change"
+  or "explicit `.scenarioz` format adopted" — with rationale
+- [ ] If HTTP compression is confirmed sufficient for v1: this AC closes Part A;
+  no loader changes needed
+
+**Part B — Portable compressed format (for future downloadable scenarios):**
+- [ ] Define a compressed scenario file format: a gzip-compressed JSON file,
+  file extension `.scenarioz` (or `.scenario.gz`; decide and document)
+- [ ] `loadScenario` (GAME-002) extended to accept a `Uint8Array` (compressed) in
+  addition to parsed JSON, using the browser's `DecompressionStream` API
+  (no third-party dependency required for gzip in modern browsers)
+- [ ] Format version and magic-bytes convention documented in the scenario spec
+  (`thoughts/shared/decisions/2026-04-24-scenario-data-format.md`) as a note
+- [ ] Format decision documented in the scenario spec as a note
+
+**Sprint placement**: after GAME-002; before any community scenario work.
+Can be deferred to Sprint 3–4 if HTTP compression satisfies v1 delivery needs.
+
+## Notes
+
+- Browser `DecompressionStream` (gzip) is available in all modern browsers
+  (Chrome 80+, Firefox 113+, Safari 16.4+). No polyfill needed for desktop-first v1.
+- If scenarios stay under ~50 KB uncompressed, plain JSON + HTTP gzip is likely
+  sufficient for v1 and Part B can be deferred to whenever community scenarios land.
+- Community scenario sharing (post-v1) will use the `.scenarioz` format defined here.
+- Avoid MessagePack, CBOR, or other binary formats — JSON is human-readable and
+  debuggable; gzip compression ratios on JSON are already very good (~70–80%).
+
+## References
+
+- Spec: `thoughts/shared/decisions/2026-04-24-scenario-data-format.md`
+- Loader ticket: GAME-002
+- Game vision §V1_SCOPE (scenarios bundled; community sharing post-v1)

--- a/thoughts/shared/tickets/GAME-007-player-progress-persistence.md
+++ b/thoughts/shared/tickets/GAME-007-player-progress-persistence.md
@@ -1,0 +1,73 @@
+---
+id: GAME-007
+title: Player progress persistence — save/resume game state
+area: game, storage
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Players can save their current game state and return to it later. Two distinct
+persistence concerns are handled here: (1) in-progress scenario resume ("Continue"
+from the main menu); (2) scenario completion tracking (which scenarios are done,
+which optional criteria were achieved). Both use local browser storage — no user
+accounts, no server game state.
+
+## Current State
+
+No persistence exists. The game resets on page reload. The game vision calls out
+`local browser storage (IndexedDB/localStorage)` as the v1 mechanism, with no
+user accounts.
+
+## Goals / Acceptance Criteria
+
+**In-progress scenario save/resume:**
+- [ ] When the player is in an active scenario, their current district assignment
+  map is saved to storage on every meaningful state change (debounced; not on
+  every single paint stroke)
+- [ ] On returning to the game (page load / "Continue" from menu), the player
+  can resume from their last assignment state for the most recent in-progress scenario
+- [ ] "Continue" is shown on the main menu only when an in-progress scenario exists
+- [ ] Resuming correctly restores: assignment map, active scenario, active district
+- [ ] Clearing an in-progress save (e.g. after completing the scenario) removes it
+
+**Scenario completion tracking:**
+- [ ] When a player completes a scenario (all required criteria pass), completion
+  is recorded: scenario id, required criteria all passed, which optional criteria
+  passed (for achievement/star display)
+- [ ] Completed scenarios are shown as completed in the scenario select screen
+  (Sprint 6), with achievement status
+- [ ] Sequential unlock: completing scenario N unlocks scenario N+1
+- [ ] Completion state survives page reload
+
+**Storage:**
+- [ ] Use `localStorage` for simplicity if data volume is small (assignment maps
+  for ~300 precincts per scenario compress well as a JSON object); fall back to
+  IndexedDB if localStorage quota becomes a concern
+- [ ] Storage key prefix namespaced to avoid collisions (e.g. `redistricting-sim/`)
+- [ ] Graceful degradation if storage is unavailable (private browsing quotas):
+  game works; progress just isn't saved; user informed via a one-time notice
+
+**Sprint placement**: Sprint 6 (game infrastructure), alongside scenario select
+and unlock system. The "Continue" menu item is part of the same sprint.
+
+## Notes
+
+- Assignment map is `Map<PrecinctId, DistrictId>` — serialises to a plain object
+  for JSON storage. ~300 entries × ~20 bytes each ≈ 6 KB uncompressed per scenario;
+  localStorage quota (5–10 MB) is not a concern for v1.
+- Only one in-progress scenario at a time (player can only be mid-one-scenario).
+  If they start a new scenario, the old in-progress state is discarded (or prompt
+  to confirm abandonment — UX decision at implementation time).
+- Completion records are small (scenario id + boolean array) and accumulate across
+  all scenarios; easily within localStorage quota.
+
+## References
+
+- Game vision: `thoughts/shared/vision/game-vision.compressed.md`
+  §MENU (Continue item), §PROGRESSION (unlock), §V1_SCOPE (localStorage)
+- Scenario data format: `thoughts/shared/decisions/2026-04-24-scenario-data-format.md`
+  (PrecinctId, DistrictId types used in assignment map)
+- Related: DESIGN-001 (achievement/star system — optional criteria completion
+  is part of the state saved here)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -43,6 +43,8 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `GAME-003-tutorial-scenario-content.md` | game, content | Author tutorial scenario JSON (sketch proposal first, then full data file) |
 | `GAME-004-map-renderer-interface.md` | game, rendering | Extract MapRenderer interface; rename concrete class to SvgMapRenderer |
 | `GAME-005-render-scenario-from-json.md` | game, rendering | Sprint 1 demo: wire loader + scenario into renderer; replace procedural generator |
+| `GAME-006-scenario-compression.md` | game, build | Compressed scenario delivery: HTTP gzip for bundled; `.scenarioz` format for future downloads |
+| `GAME-007-player-progress-persistence.md` | game, storage | Save/resume in-progress scenario + completion tracking; "Continue" menu; localStorage |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `LEGAL-001-content-presentation-risks.md` | legal, content | Research legal risk from partial/no eligibility-restriction warnings in sim authoring tool |
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- GAME-006: Compressed scenario format — HTTP gzip/brotli for bundled v1 scenarios; defines `.scenarioz` portable compressed format for future downloadable/community scenarios; loader extended to decompress via browser `DecompressionStream` API
- GAME-007: Player progress persistence — in-progress scenario save/resume ("Continue" menu item) + scenario completion tracking; localStorage-backed; Sprint 6 placement

Both tickets are v1 requirements but not Sprint 1 work. Added to backlog.

## Validation performed
- N/A — planning/tickets only

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- Creates GAME-006, GAME-007

## Rollback
- Revert commit; no side effects
