### PR TITLE
plan: sprint roadmap v1 (checkpoints S1-S7)

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -1,0 +1,91 @@
+<!--COMPRESSED v1; source:2026-04-25-sprint-roadmap.md-->
+§META
+date:2026-04-25 status:active type:sprint-roadmap
+LIVING DOC — update at sprint start (fill tickets) + after demo (outcomes, re-evaluate next)
+
+§ABBREV
+sp=sprint S1=Sprint1 … S7=Sprint7
+pc=precinct dist=district ET=election-type
+v1=version 1
+
+§CADENCE
+checkpoint-based NOT time-boxed; $sp done when demo target met
+current $sp: tickets planned in detail before work; future $sps: sketched until prior $sp closes
+
+§V1_GOAL
+playable browser game; 8-12 scenarios; gerrymandering mechanics
+single-player desktop-first fictional-regions FPTP-only local-storage no-user-accounts
+see game-vision.compressed.md for full scope
+
+§SPRINT_OVERVIEW
+| $sp | goal | demo | status |
+|-----|------|------|--------|
+| S1 | load+display real scenario | tutorial JSON→hex map; player paints $dists | planned |
+| S2 | edit map + live feedback | live pop-balance, contiguity, $pc tooltip | backlog |
+| S3 | test the map | Test→per-criterion pass/fail; real sim engine | backlog |
+| S4 | one complete playable scenario | tutorial: intro→edit→test→pass/fail→retry | backlog |
+| S5 | more criteria + scenarios 2-4 | events; majority_minority/gap criteria; 4 playable | backlog |
+| S6 | game infra + scenarios 5-7 | $sp-select, unlock, persist (Continue); 7 playable | backlog |
+| S7 | complete $v1 | all 8-12 scenarios; achievements; test anim; about; shippable | backlog |
+
+§SPRINT1
+goal: app renders tutorial-001.json; player paints+undoes; no sim/game-loop yet
+tickets (dependency order):
+  GAME-001 scenario TS types          [no deps; start here]
+  GAME-004 MapRenderer interface      [no deps; parallel w/ GAME-001]
+  GAME-002 scenario loader+validator  [needs GAME-001]
+  GAME-003 tutorial scenario content  [needs GAME-001+002; sketch proposal FIRST]
+  GAME-005 sprint1 integration        [needs all above; this IS the demo]
+GAME-001 ∥ GAME-004 → GAME-002 → GAME-003(Phase2) → GAME-005
+  note: GAME-003 Phase1(sketch) can start alongside GAME-002
+
+§SPRINT2 (backlog; ticket on sprint-plan before S2 starts)
+live pop-balance per $dist | contiguity validation+highlight | $pc hover tooltip |
+county border overlay toggle | brush size controls | reset-to-initial
+
+§SPRINT3 (backlog)
+real sim engine: group model(pop_share×voter_eligible×turnout×vote_shares); events applied
+criterion evaluators: population_balance | seat_count | district_count
+basic Test sequence UI (placeholder anim; real anim=S7)
+GAME-006 (scenario compression): evaluate+resolve or defer
+
+§SPRINT4 (backlog)
+scenario intro slides UI | success screen | failure+feedback screen | retry loop
+Canvas+SVG hybrid: assess threshold; defer if all scenarios ≤800 $pcs
+
+§SPRINT5 (backlog)
+criterion evaluators: majority_minority(min_eligible_share) | efficiency_gap |
+  mean_median | compactness | safe_seats | competitive_seats
+scenarios 2(Gov Win) 3(Packing) 4(Cracking) authored+playable
+scenario-to-scenario transition (unlock display; no persist yet)
+
+§SPRINT6 (backlog)
+scenario select screen | sequential unlock | main menu
+GAME-007 player persistence: in-progress save/resume; completion tracking; Continue menu
+scenarios 5(VRA) 6(Harden) 7(Reform Map)
+
+§SPRINT7 (backlog)
+scenarios 8(Both Sides) 9(Cats+Dogs) + design-gap scenarios
+Test sequence animation (governor/legislature/lobby icons)
+achievement/star UX (pending DESIGN-001 research)
+About page
+perf pass: confirm ≤800 $pcs pure SVG | Canvas+SVG hybrid if exceeded
+GAME-006 if not done in S3
+
+§BACKLOG (not sprint-assigned)
+GAME-006  scenario compression          S3 or S7
+GAME-007  player progress persistence   S6
+CI-001    GH Action ticket-close sync   any (low priority)
+LEGAL-001 content presentation risk     before public release
+DIST-001  Steam deployment research     before distribution decision
+DESIGN-001 achievement/star ergonomics  before S7 UX work
+
+§BLOCKING_OPEN_QUESTIONS
+OQ4 narrative asset resolution (Slide.image) → blocks S4 intro slides
+OQ9 StateContext redesign → blocks S5/S6 state-level view infra
+DESIGN-001 star/achievement UX → blocks S7
+
+§REFS
+vision: thoughts/shared/vision/game-vision.compressed.md
+tickets: thoughts/shared/tickets/TICKETS.md
+scenario spec: thoughts/shared/decisions/2026-04-24-scenario-data-format.compressed.md

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -1,0 +1,210 @@
+---
+date: 2026-04-25
+status: active
+type: sprint-roadmap
+---
+
+# Sprint Roadmap — Redistricting Simulator v1
+
+## About This Document
+
+Living document. Updated at the start of each sprint (tickets filled in) and
+after each sprint demo (outcomes noted, next sprint re-evaluated). Sprints are
+**checkpoint-based, not time-boxed** — velocity is unknown; a sprint is done when
+its demo target is met, not when a clock runs out.
+
+Tickets for the *current* sprint are planned in detail before work begins.
+Future sprint tickets are sketched; they are sprint-planned in full when the
+previous sprint closes. This keeps the roadmap honest about what we know vs.
+what we're projecting.
+
+---
+
+## v1 Goal
+
+A playable browser game with 8–12 scenarios teaching gerrymandering mechanics.
+Single player, desktop-first, fictional regions, FPTP only. Local progress
+storage; no user accounts; no server game state.
+
+See `thoughts/shared/vision/game-vision.compressed.md` for full scope.
+
+---
+
+## Sprint Overview
+
+| Sprint | Goal | Demo target | Status |
+|---|---|---|---|
+| 1 | Load and display a real scenario | Tutorial map renders from JSON; player can paint districts | planned |
+| 2 | Edit the map + live feedback | Live population balance, contiguity indicators, precinct tooltip | backlog |
+| 3 | Test the map | Hit Test → per-criterion pass/fail; real simulation engine | backlog |
+| 4 | One complete playable scenario | Tutorial scenario: intro → edit → test → pass/fail → retry | backlog |
+| 5 | More criteria + scenarios 2–4 | Demographic events; majority_minority/efficiency_gap criteria; 4 playable | backlog |
+| 6 | Game infrastructure + scenarios 5–7 | Scenario select, unlock, persistence ("Continue"); 7 playable | backlog |
+| 7 | Complete v1 | All 8–12 scenarios; achievements UX; test animation; about page; shippable | backlog |
+
+---
+
+## Sprint 1 — Load and Display a Real Scenario
+
+**Goal**: The app renders a real scenario from a JSON file. The player can see
+the hex map, paint districts, undo/redo, and toggle the partisan lean view.
+No simulation or game loop yet.
+
+**Demo**: Open browser via `serve.sh`. Tutorial scenario loads, hex map visible,
+precincts rendered at correct positions. Player can paint districts and undo.
+
+**Tickets** (execute in dependency order):
+
+| Ticket | Title | Notes |
+|---|---|---|
+| GAME-001 | Scenario TypeScript types | No dependencies; do first |
+| GAME-004 | MapRenderer interface extraction | No dependencies; parallel with GAME-001 |
+| GAME-002 | Scenario JSON loader + validator | Depends on GAME-001 |
+| GAME-003 | Tutorial scenario content | Depends on GAME-001 (types), GAME-002 (validator); sketch proposal first |
+| GAME-005 | Sprint 1 integration | Depends on all above; this is the demo |
+
+**GAME-001 and GAME-004 can proceed in parallel.** Once GAME-001 is done,
+GAME-002 begins. GAME-003 Phase 1 (the written sketch) can also start once
+GAME-001 is done — it does not need the validator. GAME-003 Phase 2 (full JSON
+authoring) requires GAME-002 to be complete (so the scenario can be validated).
+GAME-005 is last.
+
+DAG: `GAME-001 ∥ GAME-004 → GAME-002 → GAME-003 (Phase 2) → GAME-005`
+Note: GAME-003 Phase 1 (sketch) can start alongside GAME-002.
+
+---
+
+## Sprint 2 — Edit the Map + Live Feedback
+
+**Goal**: The editing experience is complete. The player gets real-time feedback
+on map validity without running the full simulation.
+
+**Planned scope** (tickets to be created at sprint planning):
+- Live population balance per district (% deviation from target shown per district)
+- Contiguity validation — highlight non-contiguous district segments
+- Precinct tooltip on hover (population, demographic summary, current district)
+- County border overlay toggle (wires up `setCountyBordersVisible` from GAME-004)
+- Brush size controls (already partially in spike; needs scenario-aware refinement)
+- Reset to initial state button
+
+**Not yet ticketed** — sprint plan written before Sprint 2 begins.
+
+---
+
+## Sprint 3 — Test the Map
+
+**Goal**: The player can run Test and see which success criteria pass or fail.
+Introduces the real simulation engine (demographic group model, events).
+
+**Planned scope**:
+- Election simulation engine replacing spike's simplified version
+  - Group model: `population_share × voter_eligible × turnout_rate × vote_shares`
+  - Demographic events applied before simulation
+  - Pure function; fully unit-testable
+- Criterion evaluators: `population_balance`, `seat_count`, `district_count`
+  (the types present in tutorial scenario — enough for Sprint 3 demo)
+- Basic Test sequence UI: per-criterion pass/fail list (placeholder animation;
+  real governor/legislature animation is Sprint 7)
+- Scenario compression (GAME-006) evaluated and addressed this sprint or deferred
+
+**Not yet ticketed.**
+
+---
+
+## Sprint 4 — One Complete Playable Scenario
+
+**Goal**: The tutorial scenario is fully playable end-to-end. The game loop is
+complete for one scenario.
+
+**Planned scope**:
+- Scenario intro slides UI (character framing, narrative context)
+- Success screen (required criteria all passed; optional criteria status)
+- Failure/feedback screen (which criteria failed; return to editing)
+- Retry loop
+- MapRenderer interface: confirm Canvas+SVG hybrid threshold is not yet hit;
+  defer Canvas implementation if all scenarios stay ≤ 800 precincts
+
+**Not yet ticketed.**
+
+---
+
+## Sprint 5 — More Criteria + Scenarios 2–4
+
+**Goal**: Four scenarios are playable. All common criterion types implemented.
+
+**Planned scope**:
+- Additional criterion evaluators: `majority_minority` (uses `min_eligible_share`
+  and eligibility_rules), `efficiency_gap`, `mean_median`, `compactness`,
+  `safe_seats`, `competitive_seats`
+- Scenarios 2 (Give the Governor a Win), 3 (The Packing Problem),
+  4 (Cracking the Opposition) — authored as JSON
+- Scenario-to-scenario transition (completing one shows the next is unlocked;
+  no persist yet — that's Sprint 6)
+
+**Not yet ticketed.**
+
+---
+
+## Sprint 6 — Game Infrastructure + Scenarios 5–7
+
+**Goal**: The game feels like a real game. Progression, persistence, scenario
+select screen. Seven scenarios playable.
+
+**Planned scope**:
+- Scenario select screen (completed / next unlocked / locked visible)
+- Sequential unlock: completing scenario N unlocks N+1
+- Player progress persistence (GAME-007): in-progress session save/resume,
+  completion tracking, "Continue" from main menu
+- Main menu screen
+- Scenarios 5 (A Voice for the Valley), 6 (Harden the Map), 7 (The Reform Map)
+
+**Known tickets**: GAME-007. Remainder TBD.
+
+---
+
+## Sprint 7 — Complete v1
+
+**Goal**: Shippable v1. All scenarios, polish, about page.
+
+**Planned scope**:
+- Remaining scenarios: 8 (Both Sides Unhappy), 9 (Cats vs. Dogs), plus
+  any additional scenarios needed to fill the design gap (see vision §SCENARIOS
+  note about needing 1+ scenarios complicating the reform narrative)
+- Test sequence animation (governor/legislature/lobby icons — see vision §TEST)
+- Achievement/optional criteria UX (star display or equivalent; see DESIGN-001)
+- About page
+- Performance pass: confirm all scenarios ≤ 800 precincts (pure SVG) or
+  implement Canvas+SVG hybrid if needed
+- Scenario compression (GAME-006) confirmed/implemented if not done in Sprint 3
+
+**Known tickets**: GAME-006 (if not Sprint 3), DESIGN-001 (research informs UX).
+Remainder TBD.
+
+---
+
+## Backlog (not yet sprint-assigned)
+
+These tickets exist but are not assigned to a sprint. They will be slotted in
+at sprint planning for the appropriate sprint.
+
+| Ticket | Area | Sprint target |
+|---|---|---|
+| GAME-006 | Scenario compression | Sprint 3 or 7 |
+| GAME-007 | Player progress persistence | Sprint 6 |
+| CI-001 | GitHub Action ticket-close sync | Any (infrastructure; low priority) |
+| LEGAL-001 | Content presentation risk research | Before any public release |
+| DIST-001 | Steam deployment research | Before distribution decision |
+| DESIGN-001 | Achievement/star system ergonomics | Before Sprint 7 UX work |
+
+---
+
+## Open Spec Questions That Will Block Implementation
+
+These open questions from the scenario data format spec need resolution before
+the relevant sprint begins. Flagged here so they don't get lost.
+
+| Question | Blocks | ADR/spec reference |
+|---|---|---|
+| OQ4: Narrative asset resolution strategy (Slide.image path vs. key) | Sprint 4 (intro slides) | scenario-data-format.md OQ4 |
+| OQ9: StateContext redesign | Sprint 5/6 (state-level view infrastructure) | scenario-data-format.md OQ9 |
+| DESIGN-001: Star/achievement UX | Sprint 7 | DESIGN-001 ticket |


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- Sprint roadmap document covering v1 checkpoints Sprint 1–7
- Sprint 1 fully detailed (tickets, dependency order, demo target)
- Sprints 2–7 sketched with planned scope; tickets to be created at each sprint planning
- Backlog section maps known tickets to target sprints
- Blocking open questions (OQ4, OQ9, DESIGN-001) flagged with the sprints they will block
- Both .md and .compressed.md forms

## Validation performed
- N/A — planning doc only

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A

## Rollback
- Revert commit; no side effects
