### PR TITLE
sprint1(CI-002): Playwright behavioral test harness phase 1

### DIFF
--- a/game/package.json
+++ b/game/package.json
@@ -5,10 +5,11 @@
   "description": "Redistricting simulator — educational browser game",
   "dependencies": {
     "d3": "^7.9.0",
-    "zustand": "^5.0.3",
-    "zundo": "^2.3.0"
+    "zundo": "^2.3.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/d3": "^7.4.3"
   },
   "pnpm": {

--- a/game/pnpm-lock.yaml
+++ b/game/pnpm-lock.yaml
@@ -18,11 +18,19 @@ importers:
         specifier: ^5.0.3
         version: 5.0.12
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
 
 packages:
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -254,6 +262,11 @@ packages:
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -261,6 +274,16 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -295,6 +318,10 @@ packages:
         optional: true
 
 snapshots:
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -573,11 +600,22 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.3
 
+  fsevents@2.3.2:
+    optional: true
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
   internmap@2.0.3: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   robust-predicates@3.0.3: {}
 

--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 ts_config(
     name = "tsconfig",
@@ -8,6 +9,8 @@ ts_config(
 )
 
 # Type-check target: verifies TypeScript types without producing runtime output.
+# Note: src/model/ is a separate Bazel package (owns BUILD.bazel); glob does not
+# cross package boundaries, so model targets are listed explicitly as deps.
 ts_project(
     name = "app_typecheck_lib",
     srcs = glob(["src/**/*.ts"]),
@@ -17,6 +20,10 @@ ts_project(
         "//:node_modules/@types/d3",
         "//:node_modules/zustand",
         "//:node_modules/zundo",
+        "//web/src/model:loader_lib",
+        "//web/src/model:model_lib",
+        "//web/src/model:types_lib",
+        "//web/src/model:generator_lib",
     ],
 )
 
@@ -28,6 +35,8 @@ build_test(
 )
 
 # esbuild bundles TypeScript + npm deps into a single browser-ready JS file.
+# Note: src/model/ is a separate Bazel package; model sources are provided via
+# deps on //web/src/model targets.
 esbuild(
     name = "app",
     srcs = glob(["src/**/*.ts"]),
@@ -36,6 +45,10 @@ esbuild(
         "//:node_modules/d3",
         "//:node_modules/zustand",
         "//:node_modules/zundo",
+        "//web/src/model:loader_lib",
+        "//web/src/model:model_lib",
+        "//web/src/model:types_lib",
+        "//web/src/model:generator_lib",
     ],
     output = "bundle.js",
     format = "esm",
@@ -49,5 +62,34 @@ esbuild(
 filegroup(
     name = "html",
     srcs = ["index.html"],
+    visibility = ["//visibility:public"],
+)
+
+# Playwright behavioral (e2e) smoke test — CI-002 Phase 1.
+#
+# Assembles Bazel-built artifacts into a temp dir, starts python3 http.server
+# on port 58173, and runs npx playwright test against it.
+#
+# local = True: Playwright requires host npx and a Chromium browser binary
+# (installed once via `npx playwright install chromium`). The test cannot run
+# inside the Bazel sandbox.
+#
+# One-time setup outside Bazel:
+#   cd game && npx playwright install chromium
+sh_test(
+    name = "e2e_test",
+    srcs = ["e2e_test.sh"],
+    data = [
+        ":app",
+        ":html",
+        "//rust:wasm_calc_bindgen",
+        "playwright.config.ts",
+        "e2e/smoke.spec.ts",
+    ],
+    local = True,
+    tags = [
+        "no-sandbox",
+        "e2e",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/game/web/e2e/smoke.spec.ts
+++ b/game/web/e2e/smoke.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Smoke test — Phase 1 (CI-002).
+ *
+ * Verifies that the spike app loads and the hex map SVG renders with at least
+ * one hex precinct path. This is the regression baseline for sprint demos.
+ *
+ * Note: The app loads WASM asynchronously before injecting bundle.js.
+ * We wait for #map-svg to contain child elements rather than a fixed delay.
+ */
+test("app loads and renders hex map", async ({ page }) => {
+  const consoleErrors: string[] = [];
+
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+
+  page.on("pageerror", (err) => {
+    consoleErrors.push(`[pageerror] ${err.message}`);
+  });
+
+  await page.goto("/");
+
+  // Wait for the SVG to be present (it is static in the HTML)
+  const svg = page.locator("#map-svg");
+  await expect(svg).toBeVisible();
+
+  // Wait for at least one hex path to appear — the renderer populates these
+  // after the store initialises with generated precinct data.
+  const hexPath = svg.locator("path.hex").first();
+  await expect(hexPath).toBeVisible({ timeout: 10_000 });
+
+  // Confirm multiple hex cells rendered (not just 1 — sanity check)
+  const hexCount = await svg.locator("path.hex").count();
+  expect(hexCount).toBeGreaterThan(1);
+
+  // No uncaught console errors during load
+  expect(consoleErrors).toHaveLength(0);
+});

--- a/game/web/e2e_test.sh
+++ b/game/web/e2e_test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# e2e_test.sh — Bazel sh_test wrapper for Playwright behavioral tests.
+#
+# This script:
+#   1. Assembles Bazel-built artifacts (bundle.js, WASM files, index.html)
+#      into a temp directory using Bazel runfiles.
+#   2. Starts python3 -m http.server on port 58173.
+#   3. Runs npx playwright test against that server.
+#   4. Kills the server on exit (pass or fail).
+#
+# Port 58173 is distinct from the dev serve port (58080) to avoid conflicts.
+# There is no Vite dev server in this project — the app is statically served.
+#
+# Runfiles layout (module name "redistricting_sim" from MODULE.bazel):
+#   $RUNFILES_DIR/redistricting_sim/web/bundle.js
+#   $RUNFILES_DIR/redistricting_sim/web/index.html
+#   $RUNFILES_DIR/redistricting_sim/rust/wasm_calc_bindgen/wasm_calc_bindgen.js
+#   $RUNFILES_DIR/redistricting_sim/rust/wasm_calc_bindgen/wasm_calc_bindgen_bg.wasm
+
+set -euo pipefail
+
+# ── Runfiles resolution ───────────────────────────────────────────────────────
+# Bazel test runner sets RUNFILES_DIR. java_binary shell wrapper sets
+# JAVA_RUNFILES. Check both for robustness (per project convention).
+RUNFILES="${RUNFILES_DIR:-${JAVA_RUNFILES:-}}"
+if [[ -z "${RUNFILES}" ]]; then
+  echo "ERROR: neither RUNFILES_DIR nor JAVA_RUNFILES is set" >&2
+  exit 1
+fi
+
+MODULE="redistricting_sim"
+WEB_BUNDLE="${RUNFILES}/${MODULE}/web/bundle.js"
+WEB_HTML="${RUNFILES}/${MODULE}/web/index.html"
+WASM_JS="${RUNFILES}/${MODULE}/rust/wasm_calc_bindgen/wasm_calc_bindgen.js"
+WASM_BG="${RUNFILES}/${MODULE}/rust/wasm_calc_bindgen/wasm_calc_bindgen_bg.wasm"
+
+# ── Verify all required artifacts exist ──────────────────────────────────────
+for f in "${WEB_BUNDLE}" "${WEB_HTML}" "${WASM_JS}" "${WASM_BG}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "ERROR: required artifact not found: ${f}" >&2
+    echo "  RUNFILES_DIR=${RUNFILES_DIR:-<unset>}" >&2
+    echo "  JAVA_RUNFILES=${JAVA_RUNFILES:-<unset>}" >&2
+    exit 1
+  fi
+done
+
+# ── Assemble serve directory ──────────────────────────────────────────────────
+SERVE_DIR="$(mktemp -d)"
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${SERVE_DIR}"
+}
+trap cleanup EXIT
+
+cp "${WEB_HTML}"   "${SERVE_DIR}/index.html"
+cp "${WEB_BUNDLE}" "${SERVE_DIR}/bundle.js"
+cp "${WASM_JS}"    "${SERVE_DIR}/wasm_calc_bindgen.js"
+cp "${WASM_BG}"    "${SERVE_DIR}/wasm_calc_bindgen_bg.wasm"
+
+# ── Start HTTP server ─────────────────────────────────────────────────────────
+PORT=58173
+python3 -m http.server "${PORT}" --directory "${SERVE_DIR}" >/dev/null 2>&1 &
+SERVER_PID=$!
+
+# Wait for the server to be ready (up to 10 seconds)
+SERVER_READY=0
+for i in $(seq 1 20); do
+  if python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/')" 2>/dev/null; then
+    SERVER_READY=1
+    break
+  fi
+  sleep 0.5
+done
+if [[ "${SERVER_READY}" -eq 0 ]]; then
+  echo "ERROR: HTTP server on port ${PORT} did not become ready after 10 seconds" >&2
+  exit 1
+fi
+
+# ── Resolve workspace root (for playwright.config.ts) ────────────────────────
+# Playwright config is at game/web/playwright.config.ts.
+# BUILD_WORKSPACE_DIRECTORY is set when running via `bazel run`, but for
+# `bazel test` we need to find the workspace root another way.
+# The script lives at game/web/e2e_test.sh; under runfiles it's at:
+#   $RUNFILES/redistricting_sim/web/e2e_test.sh
+# The workspace root (game/) is the parent of web/ in the source tree.
+# We resolve it relative to the script's real location in the source tree,
+# falling back to BUILD_WORKSPACE_DIRECTORY if set.
+WORKSPACE_DIR="${BUILD_WORKSPACE_DIRECTORY:-}"
+if [[ -z "${WORKSPACE_DIR}" ]]; then
+  # Derive from script path: the script is in $WORKSPACE/web/, so go two levels
+  # up from its runfiles location to get the workspace root.
+  # Note: use cd+pwd -P instead of readlink -f (macOS BSD readlink lacks -f).
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  WORKSPACE_DIR="$(dirname "${SCRIPT_DIR}")"
+fi
+
+PLAYWRIGHT_CONFIG="${WORKSPACE_DIR}/web/playwright.config.ts"
+if [[ ! -f "${PLAYWRIGHT_CONFIG}" ]]; then
+  echo "ERROR: playwright.config.ts not found at ${PLAYWRIGHT_CONFIG}" >&2
+  exit 1
+fi
+
+# ── Run Playwright ────────────────────────────────────────────────────────────
+# npx resolves playwright from the node_modules in the workspace root (game/).
+cd "${WORKSPACE_DIR}"
+npx playwright test --config "web/playwright.config.ts"
+exit $?

--- a/game/web/playwright.config.ts
+++ b/game/web/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for behavioral (e2e) tests.
+ *
+ * The test server is started by e2e_test.sh (the Bazel sh_test wrapper), which
+ * assembles Bazel-built artifacts into a temp directory and starts python3 -m
+ * http.server on port 58173. This config just points at that port.
+ *
+ * There is no Vite dev server in this project — the app is esbuild-bundled via
+ * Bazel and served statically.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 10_000,
+  retries: 0,
+  reporter: [["list"], ["html", { outputFolder: "test-results/html", open: "never" }]],
+  outputDir: "test-results/artifacts",
+
+  use: {
+    baseURL: "http://localhost:58173",
+    // Collect trace on any test failure (on-first-retry is dead config with retries:0)
+    trace: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Adds the Playwright behavioral test harness (CI-002 Phase 1). Agents and CI can now run `bazel test //web:e2e_test` to get a pass/fail signal from a real browser.

- `game/web/playwright.config.ts` — Chromium only, port 58173, python3 http.server (app is esbuild-bundled statically, no Vite dev server)
- `game/web/e2e/smoke.spec.ts` — verifies `#map-svg` present, at least one `path.hex` element, no console errors on load
- `game/web/e2e_test.sh` — Bazel `sh_test` wrapper: assembles artifacts to tempdir, starts http.server, runs `npx playwright test`, traps EXIT to kill server
- `game/web/BUILD.bazel` — `sh_test` e2e target added; explicit deps on all `//web/src/model` targets including `types_lib` + `generator_lib` (created by GAME-002, see #35)
- `game/package.json` / `game/pnpm-lock.yaml` — `@playwright/test` added as devDependency

**One-time setup before first run** (outside Bazel — browser binaries can't be in the sandbox):
```
cd game && node_modules/.bin/playwright install chromium
```

**Note:** `game/web/src/model/BUILD.bazel` (owned by GAME-002, see #35) must be present for this PR's `//web:app` target to build cleanly. Both PRs are safe to merge independently; the second merge resolves the dep.

see #32 (CI-002 ticket will remain open until Phase 2 is complete after GAME-005)

## Test plan

- [x] `bazel build //web/...` passes
- [x] `bazel test //web/... --test_tag_filters=-e2e` passes
- [ ] `npx playwright install chromium` then `bazel test //web:e2e_test` passes against spike app
- [ ] Smoke test fails if `#map-svg` is removed (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
