### PR TITLE
tickets: resolve GAME-001, GAME-002, GAME-004; mark CI-002 Phase 1 done

### DIFF
--- a/thoughts/shared/tickets/CI-002-playwright-behavioral-tests.md
+++ b/thoughts/shared/tickets/CI-002-playwright-behavioral-tests.md
@@ -26,14 +26,14 @@ TypeScript typechecks. Smoke-testing the app is manual.
 ## Goals / Acceptance Criteria
 
 **Phase 1 — Framework (Sprint 1, parallel with GAME-002–005):**
-- [ ] Playwright added to `game/web/` workspace (npm dev-dependency)
-- [ ] Bazel target `//web:e2e_test` (or equivalent) that:
-  - Starts the Vite dev server (or uses a pre-built static bundle)
+- [x] Playwright added to `game/web/` workspace (npm dev-dependency)
+- [x] Bazel target `//web:e2e_test` (or equivalent) that:
+  - Uses esbuild static bundle served via python3 http.server (no Vite dev server; esbuild is CI-friendly)
   - Runs the Playwright test suite
   - Tears down cleanly; passes in CI
-- [ ] Smoke test: app loads; `#map-svg` is present and contains at least one
+- [x] Smoke test: app loads; `#map-svg` is present and contains at least one
   `path.hex` element; no console errors on load
-- [ ] `bazel test //web/...` includes the e2e target and passes
+- [x] `bazel test //web/...` includes the e2e target and passes
 
 **Phase 2 — Sprint 1 demo behavioral tests (immediately after GAME-005 merges):**
 - [ ] Scenario load: `tutorial-001.json` loaded; precinct count in SVG matches

--- a/thoughts/shared/tickets/GAME-001-scenario-typescript-types.md
+++ b/thoughts/shared/tickets/GAME-001-scenario-typescript-types.md
@@ -2,7 +2,7 @@
 id: GAME-001
 title: Define scenario TypeScript types from spec
 area: game, core, types
-status: open
+status: resolved
 created: 2026-04-25
 github_issue: 31
 ---

--- a/thoughts/shared/tickets/GAME-002-scenario-loader-validator.md
+++ b/thoughts/shared/tickets/GAME-002-scenario-loader-validator.md
@@ -2,7 +2,7 @@
 id: GAME-002
 title: Scenario JSON loader and validator
 area: game, core, data
-status: open
+status: resolved
 created: 2026-04-25
 ---
 
@@ -19,9 +19,9 @@ to create precincts at runtime. The loader replaces that data source.
 
 ## Goals / Acceptance Criteria
 
-- [ ] `loadScenario(json: unknown): Scenario` function in `game/web/src/model/`
-- [ ] Rejects unknown `format_version`; throws a descriptive error
-- [ ] Validates all 13 invariants from the spec:
+- [x] `loadScenario(json: unknown): Scenario` function in `game/web/src/model/`
+- [x] Rejects unknown `format_version`; throws a descriptive error
+- [x] Validates all 13 invariants from the spec:
   - All `PartyId` refs in `vote_shares`, events, criteria exist in `scenario.parties`
   - All `DistrictId` refs in `initial_district_id` exist in `scenario.districts`
   - All `GroupId` refs in events/criteria exist in ≥1 precinct's `demographic_groups`
@@ -35,12 +35,12 @@ to create precincts at runtime. The loader replaces that data source.
   - `districts.length ≥ 2`
   - All ids unique within scenario
   - `precincts.length ≥ 1`
-- [ ] `auto-fill` behaviour: editable precincts with absent/null `initial_district_id`
+- [x] `auto-fill` behaviour: editable precincts with absent/null `initial_district_id`
   are resolved to `default_district_id` (if set) or `districts[0]` at load time;
   returned `Scenario` always has explicit `initial_district_id` on editable precincts
-- [ ] Error messages identify which invariant failed and where (e.g. precinct id)
-- [ ] Unit tests: happy path + one test per invariant violation
-- [ ] Depends on: GAME-001
+- [x] Error messages identify which invariant failed and where (e.g. precinct id)
+- [x] Unit tests: happy path + one test per invariant violation
+- [x] Depends on: GAME-001
 
 ## References
 

--- a/thoughts/shared/tickets/GAME-004-map-renderer-interface.md
+++ b/thoughts/shared/tickets/GAME-004-map-renderer-interface.md
@@ -2,7 +2,7 @@
 id: GAME-004
 title: Extract MapRenderer interface from spike renderer
 area: game, rendering
-status: open
+status: resolved
 created: 2026-04-25
 github_issue: 32
 ---

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -38,10 +38,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
-| `GAME-001-scenario-typescript-types.md` | game, core | Define TypeScript types from scenario data format spec; replaces spike-grade types |
-| `GAME-002-scenario-loader-validator.md` | game, core | Scenario JSON loader + all 13 spec validation invariants; unit tested |
 | `GAME-003-tutorial-scenario-content.md` | game, content | Author tutorial scenario JSON (sketch proposal first, then full data file) |
-| `GAME-004-map-renderer-interface.md` | game, rendering | Extract MapRenderer interface; rename concrete class to SvgMapRenderer |
 | `GAME-005-render-scenario-from-json.md` | game, rendering | Sprint 1 demo: wire loader + scenario into renderer; replace procedural generator |
 | `GAME-006-scenario-compression.md` | game, build | Compressed scenario delivery: HTTP gzip for bundled; `.scenarioz` format for future downloads |
 | `GAME-007-player-progress-persistence.md` | game, storage | Save/resume in-progress scenario + completion tracking; "Continue" menu; localStorage |
@@ -57,6 +54,9 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | Summary | Resolution |
 |---|---|
+| GAME-001: Define scenario TypeScript types from spec | All AC met; branded types + full Scenario interface; merged PR #33 |
+| GAME-002: Scenario JSON loader and validator | All AC met; loadScenario + all 13 invariants + 33 unit tests; merged PR #34 |
+| GAME-004: Extract MapRenderer interface | All AC met; MapRenderer interface + SvgMapRenderer rename; merged PR #33 |
 | AGENT-002: Add kotlin tools to pr-review-cycle critique/response prompts | Infra workflow already updated; local override deleted — infra workflow is canonical |
 | BUILD-002: Integrate spikes into game/ Bazel workspace | Unified game/ workspace: TypeScript+D3+Zustand+Rust/WASM; all AC met; bazel build/test/run verified; merged PR #16 |
 | SPIKE-001: Game tech stack PoC | TypeScript+Vite+D3.js+Zustand hex-grid prototype complete; all AC met; SPIKE-REPORT.md written; go recommendation — merged PR #11 |


### PR DESCRIPTION
Resolves ticket files for GAME-001, GAME-002, GAME-004 (all merged in #33–#35).
Marks CI-002 Phase 1 AC as done; Phase 2 remains open.

## Summary

- GAME-001, GAME-002, GAME-004: status → resolved; AC checkboxes filled
- TICKETS.md: moved three tickets to Resolved with PR references
- CI-002: Phase 1 checkboxes filled; Phase 2 (after GAME-005) stays open

## Test plan

- [x] N/A — documentation only; no code changes
