### PR TITLE
sprint1(GAME-005): wire scenario loader into renderer

### DIFF
--- a/game/scenarios/BUILD.bazel
+++ b/game/scenarios/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "scenario_files",
+    srcs = glob(["*.json"]),
+    visibility = ["//visibility:public"],
+)

--- a/game/serve.sh
+++ b/game/serve.sh
@@ -18,5 +18,9 @@ cp "${BAZEL_BIN}/web/bundle.js" "${DIST}/"
 # HTML entry point (served from source)
 cp "${BUILD_WORKSPACE_DIRECTORY}/web/index.html" "${DIST}/"
 
+# Scenario JSON files (fetched at runtime; not bundled by esbuild)
+mkdir -p "${DIST}/scenarios"
+cp "${BUILD_WORKSPACE_DIRECTORY}/scenarios/"*.json "${DIST}/scenarios/"
+
 echo "Serving on http://localhost:58080 (Ctrl-C to stop)"
 cd "${DIST}" && python3 -m http.server 58080

--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -24,6 +24,7 @@ ts_project(
         "//web/src/model:model_lib",
         "//web/src/model:types_lib",
         "//web/src/model:generator_lib",
+        "//web/src/model:adapter_lib",
     ],
 )
 
@@ -49,6 +50,7 @@ esbuild(
         "//web/src/model:model_lib",
         "//web/src/model:types_lib",
         "//web/src/model:generator_lib",
+        "//web/src/model:adapter_lib",
     ],
     output = "bundle.js",
     format = "esm",
@@ -83,6 +85,7 @@ sh_test(
         ":app",
         ":html",
         "//rust:wasm_calc_bindgen",
+        "//scenarios:scenario_files",
         "playwright.config.ts",
         "e2e/smoke.spec.ts",
     ],

--- a/game/web/e2e_test.sh
+++ b/game/web/e2e_test.sh
@@ -11,11 +11,12 @@
 # Port 58173 is distinct from the dev serve port (58080) to avoid conflicts.
 # There is no Vite dev server in this project — the app is statically served.
 #
-# Runfiles layout (module name "redistricting_sim" from MODULE.bazel):
-#   $RUNFILES_DIR/redistricting_sim/web/bundle.js
-#   $RUNFILES_DIR/redistricting_sim/web/index.html
-#   $RUNFILES_DIR/redistricting_sim/rust/wasm_calc_bindgen/wasm_calc_bindgen.js
-#   $RUNFILES_DIR/redistricting_sim/rust/wasm_calc_bindgen/wasm_calc_bindgen_bg.wasm
+# Runfiles layout (module name "redistricting_sim" from MODULE.bazel).
+# Bazel ≥ 7 uses canonical name _main for the current repo; we try both.
+#   $RUNFILES_DIR/_main/web/bundle.js          (Bazel ≥ 7)
+#   $RUNFILES_DIR/redistricting_sim/web/bundle.js  (older Bazel)
+#   $RUNFILES_DIR/_main/scenarios/tutorial-001.json
+#   $RUNFILES_DIR/_main/rust/wasm_calc_bindgen/wasm_calc_bindgen.js
 
 set -euo pipefail
 
@@ -29,15 +30,27 @@ if [[ -z "${RUNFILES}" ]]; then
 fi
 
 MODULE="redistricting_sim"
-WEB_BUNDLE="${RUNFILES}/${MODULE}/web/bundle.js"
-WEB_HTML="${RUNFILES}/${MODULE}/web/index.html"
-WASM_JS="${RUNFILES}/${MODULE}/rust/wasm_calc_bindgen/wasm_calc_bindgen.js"
-WASM_BG="${RUNFILES}/${MODULE}/rust/wasm_calc_bindgen/wasm_calc_bindgen_bg.wasm"
+# Bazel ≥ 7 uses the canonical name (_main) for the current repo instead of
+# the module name (redistricting_sim). Check both; prefer the explicit name.
+if [[ -d "${RUNFILES}/${MODULE}" ]]; then
+  RUNFILES_MOD="${RUNFILES}/${MODULE}"
+elif [[ -d "${RUNFILES}/_main" ]]; then
+  RUNFILES_MOD="${RUNFILES}/_main"
+else
+  echo "ERROR: runfiles module dir not found (tried ${MODULE} and _main under ${RUNFILES})" >&2
+  exit 1
+fi
+WEB_BUNDLE="${RUNFILES_MOD}/web/bundle.js"
+WEB_HTML="${RUNFILES_MOD}/web/index.html"
+WASM_JS="${RUNFILES_MOD}/rust/wasm_calc_bindgen/wasm_calc_bindgen.js"
+WASM_BG="${RUNFILES_MOD}/rust/wasm_calc_bindgen/wasm_calc_bindgen_bg.wasm"
+SCENARIOS_DIR="${RUNFILES_MOD}/scenarios"
 
 # ── Verify all required artifacts exist ──────────────────────────────────────
 for f in "${WEB_BUNDLE}" "${WEB_HTML}" "${WASM_JS}" "${WASM_BG}"; do
   if [[ ! -f "${f}" ]]; then
     echo "ERROR: required artifact not found: ${f}" >&2
+    echo "  RUNFILES_MOD=${RUNFILES_MOD}" >&2
     echo "  RUNFILES_DIR=${RUNFILES_DIR:-<unset>}" >&2
     echo "  JAVA_RUNFILES=${JAVA_RUNFILES:-<unset>}" >&2
     exit 1
@@ -58,6 +71,12 @@ cp "${WEB_HTML}"   "${SERVE_DIR}/index.html"
 cp "${WEB_BUNDLE}" "${SERVE_DIR}/bundle.js"
 cp "${WASM_JS}"    "${SERVE_DIR}/wasm_calc_bindgen.js"
 cp "${WASM_BG}"    "${SERVE_DIR}/wasm_calc_bindgen_bg.wasm"
+
+# Scenario JSON files (fetched at runtime by the app)
+if [[ -d "${SCENARIOS_DIR}" ]]; then
+  mkdir -p "${SERVE_DIR}/scenarios"
+  cp "${SCENARIOS_DIR}/"*.json "${SERVE_DIR}/scenarios/"
+fi
 
 # ── Start HTTP server ─────────────────────────────────────────────────────────
 PORT=58173
@@ -103,7 +122,9 @@ if [[ ! -f "${PLAYWRIGHT_CONFIG}" ]]; then
 fi
 
 # ── Run Playwright ────────────────────────────────────────────────────────────
-# npx resolves playwright from the node_modules in the workspace root (game/).
+# Bazel test runner may strip the user's PATH (e.g. /opt/homebrew/bin absent).
+# Extend PATH with common node/npm locations so npx is accessible.
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
 cd "${WORKSPACE_DIR}"
 npx playwright test --config "web/playwright.config.ts"
 exit $?

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -1,7 +1,7 @@
 /**
  * Application entry point.
- * Wires together the Zustand store, D3 renderer, and DOM controls.
- * D3 owns the SVG DOM; Zustand owns state.
+ * Fetches tutorial-001.json, validates it through loadScenario(), builds the
+ * Zustand store, wires D3 renderer and DOM controls.
  *
  * The WASM kernel (Rust → wasm-bindgen no-modules) is loaded by index.html
  * before this bundle. The global wasm_bindgen object is declared below.
@@ -11,6 +11,8 @@
 // index.html initialises the WASM binary before this bundle executes.
 declare const wasm_bindgen: { add(a: number, b: number): number };
 
+import { loadScenario } from "./model/loader.js";
+import type { Scenario } from "./model/scenario.js";
 import {
 	type MapRenderer,
 	type ViewMode,
@@ -19,7 +21,7 @@ import {
 	renderLegend,
 	renderResults,
 } from "./render/mapRenderer.js";
-import { useGameStore, useTemporalStore } from "./store/gameStore.js";
+import { createGameStore } from "./store/gameStore.js";
 
 // ─── DOM refs ─────────────────────────────────────────────────────────────────
 
@@ -43,75 +45,6 @@ if (
 	throw new Error("Required DOM elements not found");
 }
 
-// ─── Renderer ─────────────────────────────────────────────────────────────────
-
-const store = useGameStore;
-
-const renderer: MapRenderer = new SvgMapRenderer(
-	svgEl,
-	() => store.getState(),
-	(ids, district) => store.getState().paintStroke(ids, district),
-	(id) => store.getState().setActiveDistrict(id),
-);
-
-// ─── Update cycle ─────────────────────────────────────────────────────────────
-
-function updateUI() {
-	const state = store.getState();
-	const temporal = useTemporalStore();
-	const { pastStates, futureStates } = temporal.getState();
-
-	renderer.render();
-
-	if (resultsEl !== null) {
-		renderResults(resultsEl, state);
-	}
-
-	if (legendEl !== null) {
-		renderLegend(legendEl, state.districtCount);
-	}
-
-	if (districtBtnsEl !== null) {
-		renderDistrictButtons(districtBtnsEl, state.districtCount, state.activeDistrict, (id) => {
-			store.getState().setActiveDistrict(id);
-		});
-	}
-
-	if (btnUndo !== null) {
-		btnUndo.disabled = pastStates.length === 0;
-	}
-	if (btnRedo !== null) {
-		btnRedo.disabled = futureStates.length === 0;
-	}
-}
-
-// ─── Undo / Redo buttons ─────────────────────────────────────────────────────
-
-btnUndo.addEventListener("click", () => {
-	useTemporalStore().getState().undo();
-});
-
-btnRedo.addEventListener("click", () => {
-	useTemporalStore().getState().redo();
-});
-
-let currentViewMode: ViewMode = "districts";
-btnViewToggle.addEventListener("click", () => {
-	currentViewMode = currentViewMode === "districts" ? "lean" : "districts";
-	renderer.setViewMode(currentViewMode);
-	btnViewToggle.textContent =
-		currentViewMode === "districts" ? "View: Partisan Lean" : "View: Districts";
-});
-
-// ─── Subscribe to state changes ───────────────────────────────────────────────
-
-store.subscribe(() => updateUI());
-useTemporalStore().subscribe(() => updateUI());
-
-// ─── Initial render ───────────────────────────────────────────────────────────
-
-updateUI();
-
 // ─── WASM kernel diagnostic ───────────────────────────────────────────────────
 // Verifies the Rust→WASM pipeline is wired end-to-end.
 // wasm_bindgen is initialised by index.html before this bundle runs.
@@ -120,3 +53,93 @@ const wasmEl = document.getElementById("wasm-status");
 if (wasmEl !== null) {
 	wasmEl.textContent = `WASM kernel: add(2, 3) = ${wasm_bindgen.add(2, 3)}`;
 }
+
+// ─── Async init ───────────────────────────────────────────────────────────────
+
+(async () => {
+	// ── Load scenario JSON ────────────────────────────────────────────────────
+	let json: unknown;
+	try {
+		const resp = await fetch("/scenarios/tutorial-001.json");
+		if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+		json = (await resp.json()) as unknown;
+	} catch (e) {
+		console.error("[GAME-005] Failed to fetch scenario:", e);
+		document.body.insertAdjacentHTML(
+			"afterbegin",
+			`<div style="color:#e94560;padding:1em;font-family:monospace">
+        Scenario load failed — check console for details.
+      </div>`,
+		);
+		return;
+	}
+
+	// ── Validate + parse ──────────────────────────────────────────────────────
+	let scenario: Scenario;
+	try {
+		scenario = loadScenario(json);
+	} catch (e) {
+		console.error("[GAME-005] Scenario validation failed:", e);
+		document.body.insertAdjacentHTML(
+			"afterbegin",
+			`<div style="color:#e94560;padding:1em;font-family:monospace">
+        Scenario validation failed — check console for details.
+      </div>`,
+		);
+		return;
+	}
+
+	// ── Build store from scenario ─────────────────────────────────────────────
+	const { store } = createGameStore(scenario);
+	const temporalStore = store.temporal;
+
+	// ── Create renderer ───────────────────────────────────────────────────────
+	const renderer: MapRenderer = new SvgMapRenderer(
+		svgEl!,
+		() => store.getState(),
+		(ids, district) => store.getState().paintStroke(ids, district),
+		(id) => store.getState().setActiveDistrict(id),
+	);
+
+	// ── Update cycle ──────────────────────────────────────────────────────────
+	function updateUI() {
+		const state = store.getState();
+		const { pastStates, futureStates } = temporalStore.getState();
+
+		renderer.render();
+
+		renderResults(resultsEl!, state);
+		renderLegend(legendEl!, state.districtCount);
+		renderDistrictButtons(districtBtnsEl!, state.districtCount, state.activeDistrict, (id) => {
+			store.getState().setActiveDistrict(id);
+		});
+
+		btnUndo!.disabled = pastStates.length === 0;
+		btnRedo!.disabled = futureStates.length === 0;
+	}
+
+	// ── Undo / Redo buttons ───────────────────────────────────────────────────
+	btnUndo!.addEventListener("click", () => {
+		temporalStore.getState().undo();
+	});
+
+	btnRedo!.addEventListener("click", () => {
+		temporalStore.getState().redo();
+	});
+
+	// ── View toggle ───────────────────────────────────────────────────────────
+	let currentViewMode: ViewMode = "districts";
+	btnViewToggle!.addEventListener("click", () => {
+		currentViewMode = currentViewMode === "districts" ? "lean" : "districts";
+		renderer.setViewMode(currentViewMode);
+		btnViewToggle!.textContent =
+			currentViewMode === "districts" ? "View: Partisan Lean" : "View: Districts";
+	});
+
+	// ── Subscribe to state changes ────────────────────────────────────────────
+	store.subscribe(() => updateUI());
+	temporalStore.subscribe(() => updateUI());
+
+	// ── Initial render ────────────────────────────────────────────────────────
+	updateUI();
+})();

--- a/game/web/src/model/BUILD.bazel
+++ b/game/web/src/model/BUILD.bazel
@@ -68,6 +68,17 @@ ts_project(
     visibility = ["//web:__pkg__", "//web/src/model:__pkg__"],
 )
 
+# ── adapter_lib: Scenario → spike internal types (GAME-005) ──────────────────
+
+ts_project(
+    name = "adapter_lib",
+    srcs = ["adapter.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [":model_lib", ":types_lib", ":generator_lib"],
+    visibility = ["//web:__pkg__", "//web/src/model:__pkg__"],
+)
+
 # ── loader_typecheck_test: type-check passes ──────────────────────────────────
 
 build_test(

--- a/game/web/src/model/adapter.ts
+++ b/game/web/src/model/adapter.ts
@@ -1,0 +1,97 @@
+/**
+ * Adapter: converts a loaded Scenario (spec types, GAME-001) to spike
+ * internal types (types.ts) for the Sprint 1 renderer and store.
+ *
+ * Strategy:
+ *  - Stable numeric IDs from array position (precincts[i].id = i)
+ *  - District IDs: 1-based integers (scenario.districts[i] → i+1)
+ *  - partyShare: population-weighted vote shares; ken→R, ryu→D; L/G/I=0
+ *  - neighbors: computed from hex axial positions via HEX_DIRECTIONS
+ *  - center: hexToPixel(q, r)
+ *  - initial assignments from loader-filled initial_district_id
+ *
+ * This is a Sprint 1 shortcut — Sprint 3 will replace spike types entirely.
+ */
+
+import type { Scenario } from "./scenario.js";
+import type { AssignmentMap, DistrictId, Precinct } from "./types.js";
+import { HEX_DIRECTIONS, hexToPixel } from "./generator.js";
+
+// vote_shares is Record<PartyId, number> with branded keys; cast to plain string map at runtime
+type VoteShareRecord = Record<string, number>;
+
+export function scenarioToSpike(scenario: Scenario): {
+	precincts: Precinct[];
+	assignments: AssignmentMap;
+	districtCount: number;
+} {
+	// Map scenario DistrictId (branded string) → spike DistrictId (1-based number)
+	const districtIndexMap = new Map<string, DistrictId>();
+	scenario.districts.forEach((d, i) => {
+		districtIndexMap.set(d.id, (i + 1) as DistrictId);
+	});
+
+	// Map axial position key → precinct array index (for neighbor lookup)
+	const posMap = new Map<string, number>();
+	scenario.precincts.forEach((pc, i) => {
+		const pos = pc.position;
+		if ("q" in pos) posMap.set(`${pos.q},${pos.r}`, i);
+	});
+
+	const precincts: Precinct[] = scenario.precincts.map((pc, i) => {
+		const pos = pc.position;
+		const q = "q" in pos ? (pos as { q: number; r: number }).q : 0;
+		const r = "q" in pos ? (pos as { q: number; r: number }).r : 0;
+
+		const center = hexToPixel(q, r);
+
+		// 6-element neighbors array — null where no adjacent precinct exists
+		const neighbors: (number | null)[] = HEX_DIRECTIONS.map(([dq, dr]) => {
+			const idx = posMap.get(`${q + dq},${r + dr}`);
+			return idx !== undefined ? idx : null;
+		});
+
+		// Population-weighted vote shares (turnout ignored until Sprint 3)
+		let kenShare = 0;
+		let ryuShare = 0;
+		for (const g of pc.demographic_groups) {
+			const vs = g.vote_shares as unknown as VoteShareRecord;
+			kenShare += g.population_share * (vs["ken"] ?? 0);
+			ryuShare += g.population_share * (vs["ryu"] ?? 0);
+		}
+
+		// Map to spike PartyShare: ken→R, ryu→D, minor parties=0
+		const partyShare = {
+			R: Math.round(kenShare * 1000) / 1000,
+			D: Math.round(ryuShare * 1000) / 1000,
+			L: 0,
+			G: 0,
+			I: 0,
+		};
+
+		const winner: "D" | "R" = partyShare.D >= partyShare.R ? "D" : "R";
+		const margin = Math.round(Math.abs(partyShare.D - partyShare.R) * 100) / 100;
+
+		return {
+			id: i,
+			coord: { q, r },
+			center,
+			neighbors,
+			population: pc.total_population,
+			partyShare,
+			previousResult: { winner, margin },
+			demographics: { male: 0.49, female: 0.49, nonbinary: 0.02 },
+		};
+	});
+
+	// Build initial assignments from loader-filled initial_district_id values
+	const assignments: AssignmentMap = new Map();
+	scenario.precincts.forEach((pc, i) => {
+		const sDistId = pc.initial_district_id;
+		const spikeDistId =
+			sDistId != null ? (districtIndexMap.get(sDistId) ?? null) : null;
+		assignments.set(i, spikeDistId);
+	});
+
+	return { precincts, assignments, districtCount: scenario.districts.length };
+}

--- a/game/web/src/model/generator.ts
+++ b/game/web/src/model/generator.ts
@@ -25,7 +25,7 @@ const COLS = 7;
 const ROWS = 8;
 
 /** Flat-top axial hex → pixel center (offset layout) */
-function hexToPixel(q: number, r: number): Point {
+export function hexToPixel(q: number, r: number): Point {
 	const x = HEX_SIZE * (1.5 * q);
 	const y = HEX_SIZE * (Math.sqrt(3) * r + (Math.sqrt(3) / 2) * q);
 	return { x, y };
@@ -45,7 +45,7 @@ function hexToPixel(q: number, r: number): Point {
  *   edge 4 = 270° → up           = [+0, -r]
  *   edge 5 = 330° → upper-right  = [+q, -r]
  */
-const HEX_DIRECTIONS: [number, number][] = [
+export const HEX_DIRECTIONS: [number, number][] = [
 	[1, 0], // edge 0: lower-right
 	[0, 1], // edge 1: down
 	[-1, 1], // edge 2: lower-left

--- a/game/web/src/store/gameStore.ts
+++ b/game/web/src/store/gameStore.ts
@@ -3,11 +3,15 @@
  *
  * State mutations only inside set() callbacks — never mutate state objects directly.
  * Undo/redo tracks assignment diffs (not full state snapshots) via zundo's temporal store.
+ *
+ * GAME-005: Store is no longer created at module load. Call createGameStore(scenario)
+ * after loading and validating the scenario JSON.
  */
 
 import { temporal } from "zundo";
 import { createStore } from "zustand/vanilla";
-import { generatePrecincts } from "../model/generator.js";
+import { scenarioToSpike } from "../model/adapter.js";
+import type { Scenario } from "../model/scenario.js";
 import type { AssignmentMap, DistrictId, GameState } from "../model/types.js";
 import { runElection } from "../simulation/election.js";
 
@@ -22,39 +26,6 @@ export interface GameStore extends GameState {
 	paintStroke: (precinctIds: number[], district: DistrictId) => void;
 }
 
-// ─── Initial state ───────────────────────────────────────────────────────────
-
-function buildInitialState(): GameState {
-	const precincts = generatePrecincts(42);
-	const assignments: AssignmentMap = new Map();
-	// Initialise all precincts as unassigned
-	for (const p of precincts) {
-		assignments.set(p.id, null);
-	}
-
-	// Assign first half to district 1, second half to district 2 as starting point
-	// (so the user has something to work with immediately)
-	const half = Math.floor(precincts.length / 2);
-	for (let i = 0; i < precincts.length; i++) {
-		const p = precincts[i];
-		if (p !== undefined) {
-			assignments.set(p.id, i < half ? 1 : 2);
-		}
-	}
-
-	const initialState: GameState = {
-		precincts,
-		districtCount: 4,
-		assignments,
-		activeDistrict: 1,
-		simulationResult: null,
-	};
-
-	// Run initial simulation
-	initialState.simulationResult = runElection(initialState);
-	return initialState;
-}
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /** Clone an AssignmentMap (Map is reference-typed; we need immutable updates) */
@@ -62,65 +33,77 @@ function cloneAssignments(m: AssignmentMap): AssignmentMap {
 	return new Map(m);
 }
 
-// ─── Store ───────────────────────────────────────────────────────────────────
+// ─── Store factory ───────────────────────────────────────────────────────────
 
-export const useGameStore = createStore<GameStore>()(
-	temporal(
-		(set, get) => ({
-			...buildInitialState(),
+/**
+ * Create a new game store from a loaded Scenario.
+ * Called once in main.ts after fetching + validating the scenario JSON.
+ */
+export function createGameStore(scenario: Scenario) {
+	const { precincts, assignments, districtCount } = scenarioToSpike(scenario);
 
-			setActiveDistrict(id: DistrictId) {
-				set({ activeDistrict: id });
-			},
+	const initialState: GameState = {
+		precincts,
+		districtCount,
+		assignments,
+		activeDistrict: 1,
+		simulationResult: null,
+	};
+	initialState.simulationResult = runElection(initialState);
 
-			paintPrecinct(precinctId: number) {
-				const { assignments, activeDistrict } = get();
-				const current = assignments.get(precinctId);
-				if (current === activeDistrict) return; // no-op
+	const store = createStore<GameStore>()(
+		temporal(
+			(set, get) => ({
+				...initialState,
 
-				const next = cloneAssignments(assignments);
-				next.set(precinctId, activeDistrict);
-				const partial: Pick<GameState, "assignments"> & {
-					simulationResult: GameState["simulationResult"];
-				} = {
-					assignments: next,
-					simulationResult: runElection({ ...get(), assignments: next }),
-				};
-				set(partial);
-			},
+				setActiveDistrict(id: DistrictId) {
+					set({ activeDistrict: id });
+				},
 
-			paintStroke(precinctIds: number[], district: DistrictId) {
-				if (precinctIds.length === 0) return;
-				const { assignments } = get();
-				const next = cloneAssignments(assignments);
-				let changed = false;
-				for (const id of precinctIds) {
-					if (next.get(id) !== district) {
-						next.set(id, district);
-						changed = true;
+				paintPrecinct(precinctId: number) {
+					const { assignments, activeDistrict } = get();
+					const current = assignments.get(precinctId);
+					if (current === activeDistrict) return; // no-op
+
+					const next = cloneAssignments(assignments);
+					next.set(precinctId, activeDistrict);
+					set({
+						assignments: next,
+						simulationResult: runElection({ ...get(), assignments: next }),
+					});
+				},
+
+				paintStroke(precinctIds: number[], district: DistrictId) {
+					if (precinctIds.length === 0) return;
+					const { assignments } = get();
+					const next = cloneAssignments(assignments);
+					let changed = false;
+					for (const id of precinctIds) {
+						if (next.get(id) !== district) {
+							next.set(id, district);
+							changed = true;
+						}
 					}
-				}
-				if (!changed) return;
-				const nextState = { ...get(), assignments: next };
-				set({
-					assignments: next,
-					simulationResult: runElection(nextState),
-				});
+					if (!changed) return;
+					set({
+						assignments: next,
+						simulationResult: runElection({ ...get(), assignments: next }),
+					});
+				},
+			}),
+			{
+				// zundo: equality check — prevents storing a new history entry if assignments unchanged
+				equality: (a: GameStore, b: GameStore) => {
+					if (a.assignments === b.assignments) return true;
+					if (a.assignments.size !== b.assignments.size) return false;
+					for (const [k, v] of a.assignments) {
+						if (b.assignments.get(k) !== v) return false;
+					}
+					return true;
+				},
 			},
-		}),
-		{
-			// zundo: equality check — prevents storing a new history entry if assignments unchanged
-			equality: (a: GameStore, b: GameStore) => {
-				if (a.assignments === b.assignments) return true;
-				if (a.assignments.size !== b.assignments.size) return false;
-				for (const [k, v] of a.assignments) {
-					if (b.assignments.get(k) !== v) return false;
-				}
-				return true;
-			},
-		},
-	),
-);
+		),
+	);
 
-/** Access the temporal (undo/redo) API */
-export const useTemporalStore = () => useGameStore.temporal;
+	return { store };
+}


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: GAME-003 (#37) — merged 2026-04-25; real tutorial-001.json now on main

## Summary

- **adapter.ts** (new): converts `Scenario` spec types → spike internal types for the Sprint 1 renderer. Maps scenario party `ken→R`, `ryu→D`; computes partyShare via population-weighted vote shares; neighbors from hex axial positions; stable numeric IDs from array index.
- **gameStore.ts**: replaced module-level `createStore` with `createGameStore(scenario)` factory; store is now created after async scenario load.
- **main.ts**: async IIFE — fetches `/scenarios/tutorial-001.json`, validates via `loadScenario()`, builds store, wires renderer. Errors logged to console with visible error div.
- **generator.ts**: exported `hexToPixel` and `HEX_DIRECTIONS` (used by adapter).
- **scenarios/tutorial-001.json**: 7-precinct placeholder (hex ring: center + 6 neighbors). Real 30-precinct file comes from GAME-003 (#37, now merged).
- **serve.sh**: copies `scenarios/` dir to `_serve_dist/scenarios/` for runtime fetch.
- **e2e_test.sh**: fixed Bazel 9.x runfiles path (`_main` vs `redistricting_sim`), extend PATH for npx, copy scenario JSON to serve dir.
- **BUILD.bazel** (model + web): `adapter_lib` target; `scenario_files` filegroup; `//scenarios:scenario_files` in e2e data deps.

## Build / test status

- `bazel build //web/...` — PASSED
- `bazel test //web/src/model/... //web:app_typecheck_test` — PASSED (4/4)
- `bazel test //web:e2e_test` — requires one-time setup (`pnpm install` + `npx playwright install chromium`) in the `game/` directory; runfiles path fix included in this PR. Smoke spec waits up to 10s for hex paths — compatible with async scenario load.

## Spike artifacts

`generator.ts` and `types.ts` remain in place (no longer the primary data path). Removal is a follow-up.

## Affected machines / services
- Browser game only; no server-side changes.

## Deployment steps (POST-MERGE)
- N/A — static browser app, no deploy step.

## Tickets addressed
- see GAME-005

## Rollback
- Revert this PR; the spike generator path is still intact in the codebase.
