### PR TITLE
build: fix CopyFile darwin-sandbox incompatibility in CI .bazelrc

### DIFF
--- a/game/.bazelrc
+++ b/game/.bazelrc
@@ -1,5 +1,8 @@
 build:ci --spawn_strategy=sandboxed
 build:ci --disk_cache=/tmp/bazel-disk-cache-game
+# CopyFile (used by aspect_rules_ts ts_config) cannot run under darwin-sandbox on macOS.
+# Allow it to fall back to local execution while keeping everything else sandboxed.
+build:ci --strategy=CopyFile=local
 
 # aspect_rules_ts 3.x requires explicit transpiler selection.
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler


### PR DESCRIPTION
## Prerequisites
- [ ] N/A — no parent PR

## Summary
- Fixes CI build #1 failure: `CopyFile spawn cannot be executed with any of the available strategies: [darwin-sandbox]`.
- The `ts_config` rule in `aspect_rules_ts` generates a `CopyFile` action that macOS's `darwin-sandbox` cannot execute. Adding `--strategy=CopyFile=local` allows this specific action to run outside the sandbox while keeping everything else sandboxed.
- Root cause: polyglot (the reference for this `.bazelrc` pattern) has no TypeScript, so it never hits this. The CopyFile incompatibility is specific to `aspect_rules_ts`'s `ts_config` rule on macOS.

## Validation performed
- [x] Root cause identified from build log: `game/web/BUILD.bazel:6:10: Copying file web/tsconfig.json failed`.
- [ ] N/A — fix is a one-line `.bazelrc` addition; will verify on next CI run.

## Affected machines / services
- Buildkite macOS agent CI only.

## Deployment steps (POST-MERGE)
- N/A — `.bazelrc` change takes effect on next build trigger automatically.

## Tickets addressed
- No ticket.

## Rollback
- Remove the `--strategy=CopyFile=local` line from `.bazelrc`.
