### PR TITLE
docs: clarify ticket ID collision rule; add BUILD-003 research ticket

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -63,7 +63,7 @@ ID categories (sequential within each):
   OPT = performance optimization
   AGENT = agentic workflow+tooling changes
   SPIKE = time-boxed proof-of-concept investigations
-check existing tickets in category for next number before creating new ticket
+check TICKETS.md Open+Resolved sections for highest existing ID in category before creating new ticket; files deleted on resolve but IDs stay in index permanently — filesystem check alone causes collisions
 
 ticket file conventions:
   filename: <ID>-<kebab>.md in $ts/tickets/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ concrete action. The whole file should rarely exceed 30 lines.
 | `AGENT-NNN` | Agentic workflow and agent tooling changes |
 | `SPIKE-NNN` | Time-boxed proof-of-concept investigations |
 
-Check existing tickets in a category to find the next number before creating a new ticket.
+Check **both** the Open and Resolved sections of `TICKETS.md` to find the highest existing number in a category before creating a new ticket. Ticket files are deleted when resolved, but their IDs remain in the index permanently — checking only the filesystem will miss them and cause collisions.
 
 ### Ticket File Conventions
 

--- a/thoughts/shared/tickets/BUILD-003-ts-rules-spawn-strategy-research.md
+++ b/thoughts/shared/tickets/BUILD-003-ts-rules-spawn-strategy-research.md
@@ -1,0 +1,45 @@
+---
+id: BUILD-003
+title: Research optimal spawn_strategy configuration for aspect_rules_ts on macOS
+area: build, typescript
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+During CI bring-up (PR #46) we discovered that `aspect_rules_ts` + `--spawn_strategy=local` causes
+multiple `ts_project` targets in the same Bazel package to race on shared outputs (EACCES). We
+worked around this with `--strategy=TsProject=sandboxed`, but the root interaction between
+`darwin-sandbox`, `aspect_rules_ts` internal copy actions, and per-package multi-target layouts
+deserves documented, principled guidance.
+
+## Current State
+
+`.bazelrc` ci config uses:
+```
+build:ci --spawn_strategy=local           # avoids darwin-sandbox CopyFile/CopyDirectory failures
+build:ci --strategy=TsProject=sandboxed  # avoids multi-target output races
+```
+
+This works, but was arrived at empirically. It is not clear whether:
+- There are other action types beyond `TsProject` that need sandboxing
+- There are known `aspect_rules_ts` recommendations for this exact scenario
+- The per-package multi-target layout is itself an anti-pattern under these rules
+- `--strategy=CopyFile=local --strategy=CopyDirectory=local` (with global sandboxed) would be cleaner
+
+## Goals / Acceptance Criteria
+
+- [ ] Review aspect_rules_ts docs/GitHub issues for guidance on spawn strategy with multi-target packages
+- [ ] Identify the canonical set of action types that fail under `darwin-sandbox` on macOS
+- [ ] Determine whether `--strategy=TsProject=sandboxed` is the right scalpel or if there's a better approach
+- [ ] Determine if having multiple `ts_project` targets sharing a `tsconfig.json` (without per-target `include`) is an anti-pattern
+- [ ] Update `.bazelrc` and/or BUILD files if a better configuration is found
+- [ ] Document findings in a research doc (`thoughts/shared/research/`) so the decision is auditable
+
+## References
+
+- PR #46: switch spawn strategy, fix tsc compilation under local strategy
+- `game/.bazelrc` — current ci config
+- `game/web/src/model/BUILD.bazel` — multi-target package that triggered the race
+- `game/web/src/model/tsconfig.json` — `"types": []` workaround for implicit @types discovery

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -38,6 +38,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
+| `BUILD-003-ts-rules-spawn-strategy-research.md` | build, typescript | Research optimal spawn_strategy config for aspect_rules_ts on macOS (darwin-sandbox + multi-target packages) |
 | `GAME-006-scenario-compression.md` | game, build | Compressed scenario delivery: HTTP gzip for bundled; `.scenarioz` format for future downloads |
 | `GAME-007-player-progress-persistence.md` | game, storage | Save/resume in-progress scenario + completion tracking; "Continue" menu; localStorage |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary
- Tightens the ticket ID rule in `AGENTS.md` and `AGENTS.compressed.md`: agents must check both Open **and** Resolved sections of `TICKETS.md` before picking a new ID. Resolved ticket files are deleted but their IDs remain in the index permanently — checking only the filesystem causes collisions.
- Triggered by accidentally creating BUILD-001 (already resolved); fixed to BUILD-003.
- Adds `BUILD-003-ts-rules-spawn-strategy-research.md`: research ticket to investigate optimal `aspect_rules_ts` spawn strategy configuration on macOS (darwin-sandbox + multi-target package interactions). Captures the empirical workaround from PR #46 and the open questions for follow-up.

## Validation performed
- [x] N/A — prose/docs only; no code changes.

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A

## Rollback
- N/A — revert the PR if the wording is wrong.
