### PR TITLE
fix: resolve e2e_test.sh workspace dir when run under bazel test

### DIFF
--- a/game/web/e2e_test.sh
+++ b/game/web/e2e_test.sh
@@ -108,10 +108,18 @@ fi
 # falling back to BUILD_WORKSPACE_DIRECTORY if set.
 WORKSPACE_DIR="${BUILD_WORKSPACE_DIRECTORY:-}"
 if [[ -z "${WORKSPACE_DIR}" ]]; then
-  # Derive from script path: the script is in $WORKSPACE/web/, so go two levels
-  # up from its runfiles location to get the workspace root.
-  # Note: use cd+pwd -P instead of readlink -f (macOS BSD readlink lacks -f).
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  # Bazel invokes sh_test with a relative path, so BASH_SOURCE[0] is relative.
+  # We must make it absolute, then follow symlinks to reach the actual source
+  # file (the runfiles copy is a symlink to the source tree).
+  # Note: readlink without -f works on macOS BSD; we loop manually.
+  _s="${BASH_SOURCE[0]}"
+  [[ "${_s}" = /* ]] || _s="$(pwd)/${_s}"
+  while [[ -L "${_s}" ]]; do
+    _t="$(readlink "${_s}")"
+    [[ "${_t}" = /* ]] || _t="$(dirname "${_s}")/${_t}"
+    _s="${_t}"
+  done
+  SCRIPT_DIR="$(cd "$(dirname "${_s}")" && pwd -P)"
   WORKSPACE_DIR="$(dirname "${SCRIPT_DIR}")"
 fi
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary
- Fixes `e2e_test.sh` workspace directory resolution when run under `bazel test`.
- When Bazel invokes `sh_test`, `BASH_SOURCE[0]` is a relative path (e.g. `./e2e_test.sh`). The previous logic did `cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P`, which resolved to the runfiles root instead of the source tree — because `dirname` of a relative filename is `.`.
- Fix: make the path absolute first (combining with `pwd`), then follow symlinks until the real source file is reached. The runfiles copy is a symlink to the actual source tree; following it gives the real `game/web/` directory, and its parent is the workspace root (`game/`).
- Pre-existing bug: this test never ran to completion on CI before because previous CI builds always failed at the build step. It was exposed by PR #46 getting the build step green for the first time.
- Works in all three invocation contexts:
  - `bazel test` — `BASH_SOURCE` is relative; symlink followed to source tree
  - `bazel run` — `BUILD_WORKSPACE_DIRECTORY` is set; bypasses this block entirely
  - Direct invocation — script is already in the source tree; no symlinks to follow

## Validation performed
- [x] `bazel build --config=ci //web:e2e_test` passes locally.
- [x] `bazel test --config=ci --test_tag_filters=-e2e //...` — 5/5 non-e2e tests pass locally.
- [ ] N/A — full e2e Playwright run requires CI agent (pnpm/Playwright/Chromium not on this machine).

## Affected machines / services
- Buildkite macOS agent CI only.

## Deployment steps (POST-MERGE)
- N/A — takes effect on next build automatically.

## Tickets addressed
- N/A

## Rollback
- Revert `game/web/e2e_test.sh` to the previous workspace resolution logic. CI e2e test will fail again.
