### PR TITLE
docs: add AGENT-003 ticket; fix ticket category table in AGENTS.md

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -63,6 +63,10 @@ ID categories (sequential within each):
   OPT = performance optimization
   AGENT = agentic workflow+tooling changes
   SPIKE = time-boxed proof-of-concept investigations
+  LEGAL = legal, content liability, compliance research
+  DIST = distribution, deployment, platform research
+  DESIGN = game design, UX, ergonomics research
+  GAME = game implementation (rendering, simulation, content, game loop)
 check TICKETS.md Open+Resolved sections for highest existing ID in category before creating new ticket; files deleted on resolve but IDs stay in index permanently — filesystem check alone causes collisions
 
 ticket file conventions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,10 @@ concrete action. The whole file should rarely exceed 30 lines.
 | `OPT-NNN` | Performance optimization |
 | `AGENT-NNN` | Agentic workflow and agent tooling changes |
 | `SPIKE-NNN` | Time-boxed proof-of-concept investigations |
+| `LEGAL-NNN` | Legal, content liability, and compliance research |
+| `DIST-NNN` | Distribution, deployment, and platform research |
+| `DESIGN-NNN` | Game design, UX, and ergonomics research |
+| `GAME-NNN` | Game implementation work (rendering, simulation, content, game loop) |
 
 Check **both** the Open and Resolved sections of `TICKETS.md` to find the highest existing number in a category before creating a new ticket. Ticket files are deleted when resolved, but their IDs remain in the index permanently — checking only the filesystem will miss them and cause collisions.
 

--- a/thoughts/shared/tickets/AGENT-003-infra-pr-review-bot-comment-handling.md
+++ b/thoughts/shared/tickets/AGENT-003-infra-pr-review-bot-comment-handling.md
@@ -1,0 +1,50 @@
+---
+id: AGENT-003
+title: Propose bot comment handling to infra pr-review-cycle workflow
+area: agentic workflow, infra
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+The `geekinasuit/infra` project owns the `pr-review-cycle` workflow that agents follow
+(`/opt/geekinasuit/agents/internal/workflows/pr-review-cycle.md`). That workflow currently
+covers responding to and resolving human reviewer threads (Steps 4 and 7), but does not
+address bot-generated review comments.
+
+During PR #47 review in this project, GitHub Copilot code review and CodeQL were configured
+as required ruleset checks. The workflow gave no guidance on how to handle bot review
+threads — whether to respond, how to resolve them, or what to do when a bot check blocks
+merge. This gap caused confusion and manual intervention.
+
+## Current State
+
+Steps 4 and 7 in `pr-review-cycle.md` scope "open review comments" to human reviewers.
+Bot comments (Copilot code review, CodeQL annotations, automated linting bots) are not
+mentioned. There is no guidance on:
+
+- Whether bot comments should be addressed like human comments or treated differently
+- How to trigger a bot re-review (e.g., if Copilot hasn't posted for a docs-only PR)
+- What to do when a bot review is a required status check that hasn't fired
+
+## Goals / Acceptance Criteria
+
+- [ ] Propose to the infra project (via PR to `geekinasuit/infra`) that Steps 4 and 7 of
+      `pr-review-cycle.md` (and its compressed sibling) explicitly cover bot-generated
+      review comments alongside human ones.
+- [ ] Proposal should include guidance on:
+  - Bot comments should be addressed in the response agent pass (Step 4) just like human
+    comments — reply and resolve.
+  - When a required bot check (Copilot, CodeQL) hasn't fired: try close/reopen; if still
+    absent, check if the rule applies (e.g., code scanning only runs when code changes exist);
+    escalate to user if still blocked.
+  - Bot thread resolution follows the same pattern as human threads (reply first, then
+    resolve via `gh-pr-threads --resolve`).
+- [ ] Both `.md` and `.compressed.md` forms updated in the infra PR.
+
+## References
+
+- `pr-review-cycle.compressed.md`: `/opt/geekinasuit/agents/internal/workflows/pr-review-cycle.compressed.md`
+- Incident: PR #47 in `cgruber/redistricting-sim` — Copilot review rule blocked merge;
+  CodeQL didn't fire on docs-only PR; no workflow guidance existed for either situation.

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -46,6 +46,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `LEGAL-001-content-presentation-risks.md` | legal, content | Research legal risk from partial/no eligibility-restriction warnings in sim authoring tool |
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
 | `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
+| `AGENT-003-infra-pr-review-bot-comment-handling.md` | agentic workflow, infra | Propose bot comment handling (Copilot, CodeQL) to infra pr-review-cycle workflow |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary
- Adds AGENT-003 ticket: proposal to update the infra `pr-review-cycle` workflow to cover
  bot-generated review comments (Copilot code review, CodeQL). Arose from PR #47 where
  Copilot and CodeQL were required checks but the workflow gave no guidance on handling them.
- Fixes long-standing gap in AGENTS.md and AGENTS.compressed.md: the ticket ID category
  table was missing LEGAL, DIST, DESIGN, and GAME prefixes (all of which already exist in
  TICKETS.md). Found in round 3 critique of PR #47.

## Validation performed
- [x] N/A — prose and metadata only.

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A (this PR opens AGENT-003, not resolves it)

## Rollback
- N/A — docs only; revert if content is wrong.
