### PR TITLE
docs: resolve CI-002; update ticket and TICKETS.md index

### DIFF
--- a/thoughts/shared/tickets/CI-002-playwright-behavioral-tests.md
+++ b/thoughts/shared/tickets/CI-002-playwright-behavioral-tests.md
@@ -2,7 +2,7 @@
 id: CI-002
 title: Playwright behavioral test harness
 area: ci, testing, automation
-status: open
+status: resolved
 created: 2026-04-25
 ---
 
@@ -18,7 +18,20 @@ tested with Vitest unit tests in the tickets that implement that logic.
 Playwright covers everything that requires a browser: SVG rendering,
 mouse interaction, view-mode toggles, and end-to-end scenario loading.
 
-## Current State
+## Resolution
+
+All AC met. Phase 1 (smoke test + framework) merged PR #38. Phase 2 (5 behavioral
+tests) merged PR #50. Sprint 1 close condition satisfied.
+
+Key implementation notes:
+- `data-precinct-id` attribute added to hex paths in `SvgMapRenderer` enter selection
+  for reliable per-precinct targeting.
+- `locator.dispatchEvent("mousedown")` + `window.dispatchEvent(new MouseEvent("mouseup"))`
+  used instead of `page.mouse` — more reliable for SVG with large/negative viewBox.
+- All precincts start as District 1 (loader auto-fills null initial_district_id);
+  tests switch to District 2 before painting so strokes are real changes.
+
+## Current State (archived)
 
 No behavioral tests exist. CI runs `bazel test //web/...` which only exercises
 TypeScript typechecks. Smoke-testing the app is manual.
@@ -36,14 +49,14 @@ TypeScript typechecks. Smoke-testing the app is manual.
 - [x] `bazel test //web/...` includes the e2e target and passes
 
 **Phase 2 — Sprint 1 demo behavioral tests (immediately after GAME-005 merges):**
-- [ ] Scenario load: `tutorial-001.json` loaded; precinct count in SVG matches
+- [x] Scenario load: `tutorial-001.json` loaded; precinct count in SVG matches
   scenario precinct count; no validation errors in console
-- [ ] Paint interaction: mousedown+mousemove across precincts assigns them to
+- [x] Paint interaction: mousedown+mousemove across precincts assigns them to
   the active district (verified via DOM attribute or store state)
-- [ ] Undo: after a paint stroke, undo restores previous assignments
-- [ ] View toggle: clicking the view-toggle button changes hex fill colors
+- [x] Undo: after a paint stroke, undo restores previous assignments
+- [x] View toggle: clicking the view-toggle button changes hex fill colors
   (districts → lean mode produces RdBu interpolated fills)
-- [ ] District boundary rendering: adjacent precincts in different districts
+- [x] District boundary rendering: adjacent precincts in different districts
   have a boundary line between them
 
 **Ongoing convention (applies from this ticket forward):**

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -42,7 +42,6 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `GAME-006-scenario-compression.md` | game, build | Compressed scenario delivery: HTTP gzip for bundled; `.scenarioz` format for future downloads |
 | `GAME-007-player-progress-persistence.md` | game, storage | Save/resume in-progress scenario + completion tracking; "Continue" menu; localStorage |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
-| `CI-002-playwright-behavioral-tests.md` | ci, testing, automation | Playwright behavioral test harness: Phase 1 (framework + smoke test) in S1 parallel; Phase 2 (scenario/paint/undo/view tests) after GAME-005 |
 | `LEGAL-001-content-presentation-risks.md` | legal, content | Research legal risk from partial/no eligibility-restriction warnings in sim authoring tool |
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
 | `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
@@ -55,6 +54,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | Summary | Resolution |
 |---|---|
 | GAME-003: Author tutorial scenario JSON | All AC met; 30-precinct Kalanoa/Westford scenario; proposal + full JSON; merged PR #37 |
+| CI-002: Playwright behavioral test harness | All AC met; Phase 1 smoke test (PR #38) + Phase 2 five behavioral tests (PR #50); Sprint 1 close condition satisfied |
 | GAME-005: Sprint 1 integration — render scenario from JSON | All AC met; adapter + async store init + serve.sh wiring; Sprint 1 demo complete; merged PR #38 |
 | GAME-001: Define scenario TypeScript types from spec | All AC met; branded types + full Scenario interface; merged PR #33 |
 | GAME-002: Scenario JSON loader and validator | All AC met; loadScenario + all 13 invariants + 33 unit tests; merged PR #34 |


### PR DESCRIPTION
## Summary

Marks CI-002 as resolved following the merge of PR #50 (Sprint 1 Phase 2 behavioral Playwright tests).

- CI-002 status → `resolved`; AC checkboxes checked; resolution note added
- TICKETS.md: CI-002 moved from Open to Resolved section

## Test plan
- N/A docs-only change
