### PR TITLE
docs: Sprint 1 closeout — new tickets, roadmap outcome, TICKETS.md

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -20,7 +20,7 @@ see game-vision.compressed.md for full scope
 §SPRINT_OVERVIEW
 | $sp | goal | demo | status |
 |-----|------|------|--------|
-| S1 | load+display real scenario | tutorial JSON→hex map; player paints $dists; Playwright harness live | in-progress |
+| S1 | load+display real scenario | tutorial JSON→hex map; player paints $dists; Playwright harness live | complete — 2026-04-25 |
 | S2 | edit map + live feedback | live pop-balance, contiguity, $pc tooltip | backlog |
 | S3 | test the map | Test→per-criterion pass/fail; real sim engine | backlog |
 | S4 | one complete playable scenario | tutorial: intro→edit→test→pass/fail→retry | backlog |
@@ -28,18 +28,17 @@ see game-vision.compressed.md for full scope
 | S6 | game infra + scenarios 5-7 | $sp-select, unlock, persist (Continue); 7 playable | backlog |
 | S7 | complete $v1 | all 8-12 scenarios; achievements; test anim; about; shippable | backlog |
 
-§SPRINT1
+§SPRINT1 [COMPLETE 2026-04-25]
 goal: app renders tutorial-001.json; player paints+undoes; no sim/game-loop yet
-tickets (dependency order):
-  GAME-001 scenario TS types          [no deps; start here]
-  GAME-004 MapRenderer interface      [no deps; parallel w/ GAME-001]
-  CI-002 Phase1 Playwright harness    [no deps; parallel w/ GAME-001; smoke test only]
-  GAME-002 scenario loader+validator  [needs GAME-001]
-  GAME-003 tutorial scenario content  [needs GAME-001+002; sketch proposal FIRST]
-  GAME-005 sprint1 integration        [needs all above; this IS the demo]
-  CI-002 Phase2 behavioral tests      [needs GAME-005; closes CI-002]
-GAME-001 ∥ GAME-004 ∥ CI-002(Ph1) → GAME-002 → GAME-003(Phase2) → GAME-005 → CI-002(Ph2)
-  note: GAME-003 Phase1(sketch) can start alongside GAME-002
+outcome: all tickets closed; demo held 2026-04-25; received as "awesome and successful"
+demo observations:
+  + 30-hex map loads; paint/undo/redo/lean-view/boundaries all work; zippier than spike
+  - view toggle label ambiguous (current-state vs destination) → DESIGN-002
+  - districts view population gradient dominates district color → DESIGN-003
+  + motivated GAME-008 (accessibility) ticket for color-blind palettes + screen reader
+tickets (all resolved):
+  GAME-001 GAME-004 CI-002(Ph1) GAME-002 GAME-003 GAME-005 CI-002(Ph2)
+  PRs: #33 #34 #37 #38 #44 #46 #47 #49 #50 #51
 
 §SPRINT2 (backlog; ticket on sprint-plan before S2 starts)
 live pop-balance per $dist | contiguity validation+highlight | $pc hover tooltip |

--- a/thoughts/shared/tickets/DESIGN-002-view-toggle-ux.md
+++ b/thoughts/shared/tickets/DESIGN-002-view-toggle-ux.md
@@ -1,0 +1,61 @@
+---
+id: DESIGN-002
+title: View toggle button label convention
+area: design, UX
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+The view toggle button currently labels itself with the **current** view mode
+(e.g. "View: Districts"). This reads as descriptive — "you are here" — rather
+than imperative — "go here". Users interpret it as a button that will take them
+to that view, but it is already in that view. The label should instead describe
+the **destination** (what clicking will do), not the current state.
+
+## Current State
+
+`btnViewToggle.textContent` cycles between:
+- `"View: Partisan Lean"` (when in districts mode — means "clicking takes you to lean view")
+- `"View: Districts"` (when in lean mode — means "clicking takes you to districts view")
+
+This is correct behaviour but the labelling is ambiguous — "View: Districts"
+could mean "you are viewing Districts" or "click to view Districts".
+
+Source: `game/web/src/main.ts` around the `btnViewToggle` click handler.
+
+## Goals / Acceptance Criteria
+
+- [ ] Decide on label convention (options below) — document the choice as a
+  micro-decision in the ticket or in `thoughts/shared/decisions/`
+- [ ] Implement chosen convention in `main.ts`
+- [ ] Verify the label change is reflected in the `sprint1.spec.ts` view-toggle
+  test (or update the test if it checks button text)
+
+## Options
+
+**A — Imperative destination** (recommended):
+- In districts mode → `"Switch to Partisan Lean"`
+- In lean mode → `"Switch to Districts"`
+
+**B — Icon + short label with tooltip**:
+- Toggle icon (e.g. `⇄`) + `"Lean"` / `"Districts"`, with `title` attribute
+  giving full description. More compact; requires icon or emoji.
+
+**C — Current-state prefix, explicit action**:
+- `"Districts view — click for Lean"`
+- Verbose; probably too long.
+
+Option A is the simplest and most conventional for toggle buttons.
+
+## Notes
+
+- This is a quick implementation fix once the design decision is made.
+- Related: the button appearance (no visual indicator of active state) may also
+  need polish, but that is out of scope for this ticket.
+
+## References
+
+- `game/web/src/main.ts` — view toggle handler and initial button text
+- `game/web/e2e/sprint1.spec.ts` — view toggle test (checks fill change, not button text currently)

--- a/thoughts/shared/tickets/DESIGN-003-districts-view-color-encoding.md
+++ b/thoughts/shared/tickets/DESIGN-003-districts-view-color-encoding.md
@@ -1,0 +1,74 @@
+---
+id: DESIGN-003
+title: Districts view color encoding — population gradient design decision
+area: design, UX
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+The current Districts view applies a population-density gradient on top of
+district palette colors: high-population precincts are darker, low-population
+precincts are lighter (HSL lightness adjusted by `normPop`). The intent was to
+show population distribution within a district at a glance. In practice, Sprint 1
+demo feedback was that the map reads more as a **population heat map** than a
+district map — the gradient dominates the district-colour signal.
+
+A design decision is needed: should Districts view show population density, and
+if so, how prominently? The answer shapes the color encoding approach for Sprint 2.
+
+## Current Implementation
+
+`hexFill()` in `game/web/src/render/mapRenderer.ts`:
+```typescript
+const c = d3.hsl(base);
+c.l = 0.55 - normPop * 0.30;  // l ranges 0.25 (max pop) → 0.55 (min pop)
+return c.formatHex();
+```
+
+`hexOpacity()` returns `0.75` for assigned precincts.
+
+The 0.30 lightness range is wide enough to visually dominate at low precinct counts.
+
+## Goals / Acceptance Criteria
+
+- [ ] Decide on encoding strategy (options below) — document choice
+- [ ] Implement chosen strategy in `hexFill()` / `hexOpacity()`
+- [ ] Confirm with a quick visual test that districts are clearly legible at
+  30 precincts and (projected) 100+ precincts
+
+## Options
+
+**A — Flat district color, no population encoding** (recommended for v1):
+- All precincts in a district get the same base color.
+- Population is only visible in the hover tooltip and results panel.
+- Cleanest district-boundary readability.
+
+**B — Subtle opacity variation** (current but toned down):
+- Reduce the lightness range from 0.30 to something like 0.10–0.15.
+- Keeps a hint of population density without overwhelming district identity.
+
+**C — Dedicated population view** (deferred to later sprint):
+- Add a third view mode ("Population") in addition to Districts and Lean.
+- Districts view becomes flat; population info is opt-in.
+- Most flexible, but adds UI complexity.
+
+**D — Stipple / dot density overlay** (ambitious):
+- Small dots scaled by population density over flat district fills.
+- High information density but requires extra rendering work.
+
+Option A is recommended for Sprint 2; defer population density to a later sprint
+as an opt-in overlay (option C path).
+
+## Notes
+
+- This intersects with the accessibility ticket (GAME-008): a flat palette is
+  easier to make color-blind safe than a gradient palette.
+- The Partisan Lean view is unaffected — it already uses a clean RdBu encoding.
+
+## References
+
+- `game/web/src/render/mapRenderer.ts` — `hexFill()` and `hexOpacity()`
+- `game/web/src/model/types.ts` — `DISTRICT_COLORS`
+- GAME-008 (accessibility) — color palette decisions should be co-ordinated

--- a/thoughts/shared/tickets/GAME-008-accessibility.md
+++ b/thoughts/shared/tickets/GAME-008-accessibility.md
@@ -1,0 +1,87 @@
+---
+id: GAME-008
+title: Accessibility pass — color blindness, keyboard navigation, screen reader support
+area: game, accessibility
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+The game has no accessibility provisions. Before public release (and ideally
+before Sprint 4 playability work), the core interaction loop should be usable
+by players who rely on keyboard navigation, screen readers, or have color vision
+deficiencies. This ticket covers the full v1 accessibility pass.
+
+## Current State
+
+- All interaction is mouse-only (paint strokes use mousedown/mousemove/mouseup).
+- District colors (`DISTRICT_COLORS`) and the RdBu lean palette are not
+  color-blind safe (red/green are in the extended palette; RdBu is particularly
+  problematic for deuteranopia).
+- No ARIA labels on SVG elements or control buttons.
+- No keyboard navigation for precinct assignment.
+- No `prefers-reduced-motion` handling.
+
+## Goals / Acceptance Criteria
+
+### Color blindness
+- [ ] Audit current district palette (`DISTRICT_COLORS`) and lean palette
+  against the three main deficiency types (deuteranopia, protanopia, tritanopia)
+  using a tool such as Coblis or Sim Daltonism.
+- [ ] Replace or supplement with a color-blind-safe palette for district colors
+  (e.g. Wong 2011 or Okabe-Ito 8-color set).
+- [ ] Evaluate lean view: RdBu is problematic for red-green blindness.
+  Consider a blue-orange diverging palette (e.g. PRGn or a custom blue/orange pair).
+- [ ] Document chosen palettes in `types.ts` with source citations.
+
+### Screen reader support
+- [ ] Add `role`, `aria-label`, and `aria-describedby` attributes to the SVG map
+  and key precinct paths (at minimum: the SVG element and a summary region).
+- [ ] Ensure district buttons (`#district-buttons`) and control buttons
+  (`#btn-undo`, `#btn-redo`, `#btn-view-toggle`) have descriptive labels.
+- [ ] Add a live region (`aria-live`) for election results so screen readers
+  announce updates when districts change.
+- [ ] Test with macOS VoiceOver and (if feasible) NVDA/JAWS.
+
+### Keyboard navigation
+- [ ] Tab order covers district buttons, undo/redo, view toggle.
+- [ ] Research and sketch a keyboard approach for precinct assignment
+  (e.g. arrow-key navigation between precincts + Space to assign). This is
+  complex; a basic scheme is acceptable for v1; full keyboard painting can
+  be post-v1.
+- [ ] `prefers-reduced-motion`: suppress or replace any CSS transitions added
+  in future sprints.
+
+### Focus and contrast
+- [ ] Verify contrast ratios for button text against background meet WCAG 2.1 AA
+  (4.5:1 for normal text, 3:1 for large text / UI components).
+- [ ] Ensure focus rings are visible on all interactive elements (not suppressed
+  by `outline: none` without replacement).
+
+## Notes
+
+- Target standard: **WCAG 2.1 AA** as a baseline.
+- Color palette changes should be coordinated with DESIGN-003 (districts view
+  color encoding) — both touch `DISTRICT_COLORS`.
+- Keyboard painting is the hardest part; a "select precinct + assign" model
+  (arrow keys + number keys for district) is likely more feasible than
+  replicating continuous brush painting.
+- Playwright tests for accessibility: `axe-playwright` or `@axe-core/playwright`
+  can automate WCAG audits and should be added to the e2e suite as part of this
+  ticket.
+
+## Sprint slot
+
+Not sprint-assigned. Target: before Sprint 4 (playability), since color/palette
+decisions affect scenario authoring. Color-blind palette work is the highest
+priority sub-item.
+
+## References
+
+- `game/web/src/model/types.ts` — `DISTRICT_COLORS`, `PARTY_COLORS`
+- `game/web/src/render/mapRenderer.ts` — `hexFill()`, SVG element construction
+- `game/web/index.html` — button markup
+- DESIGN-003 — districts view color encoding (coordinate palette changes)
+- Wong (2011) color-blind-safe palette: https://www.nature.com/articles/nmeth.1618
+- Okabe-Ito palette: https://jfly.uni-koeln.de/color/

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -46,6 +46,9 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
 | `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
 | `AGENT-003-infra-pr-review-bot-comment-handling.md` | agentic workflow, infra | Propose bot comment handling (Copilot, CodeQL) to infra pr-review-cycle workflow |
+| `DESIGN-002-view-toggle-ux.md` | design, UX | View toggle button label convention: show destination mode, not current mode |
+| `DESIGN-003-districts-view-color-encoding.md` | design, UX | Districts view color/population gradient: decide encoding strategy for v1 |
+| `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
 
 ---
 


### PR DESCRIPTION
## Summary

Sprint 1 closeout housekeeping following the 2026-04-25 demo.

- Sprint roadmap: S1 marked complete; demo outcome + observations recorded
- **DESIGN-002**: View toggle button label convention (destination mode, not current mode)
- **DESIGN-003**: Districts view color/population gradient — design decision needed
- **GAME-008**: Full accessibility pass (color-blind palettes, ARIA, keyboard nav, screen readers)
- TICKETS.md: all three added to Open section

## Test plan
- N/A docs-only change
