### PR TITLE
docs: Sprint 2 tickets — GAME-009 through GAME-013

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -40,9 +40,16 @@ tickets (all resolved):
   GAME-001 GAME-004 CI-002(Ph1) GAME-002 GAME-003 GAME-005 CI-002(Ph2)
   PRs: #33 #34 #37 #38 #44 #46 #47 #49 #50 #51
 
-§SPRINT2 (backlog; ticket on sprint-plan before S2 starts)
-live pop-balance per $dist | contiguity validation+highlight | $pc hover tooltip |
-county border overlay toggle | brush size controls | reset-to-initial
+§SPRINT2 (backlog)
+goal: edit map + live feedback
+tickets:
+  DESIGN-002 view-toggle label fix (destination not current)
+  GAME-009 pan+zoom (d3.zoom; scroll+keyboard; zoom-invariant strokes)
+  GAME-010 map validity panel (pop-balance ±%; contiguity; unassigned count)
+  GAME-011 precinct info panel (sidebar hover section; replaces status bar)
+  GAME-012 county border overlay toggle (flavor; computed from county_id)
+  GAME-013 reset-to-initial (confirmation; clears undo history)
+deferred: brush size controls (not sprint-assigned)
 
 §SPRINT3 (backlog)
 real sim engine: group model(pop_share×voter_eligible×turnout×vote_shares); events applied

--- a/thoughts/shared/tickets/GAME-009-pan-zoom.md
+++ b/thoughts/shared/tickets/GAME-009-pan-zoom.md
@@ -1,0 +1,78 @@
+---
+id: GAME-009
+title: Viewport pan and zoom
+area: game, rendering
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Add pan and zoom to the map viewport using `d3.zoom()`. Pan and zoom share a
+single transform matrix — implementing them together via `d3.zoom` is the
+right approach and adds negligible complexity over pan-only. Zoom stays within
+the scenario boundary (no state-level view, which is v2).
+
+Boundary stroke widths must remain visually constant regardless of zoom level
+(scale inversely with zoom). Base stroke width should be slightly increased
+from Sprint 1 values as part of this work.
+
+## Current State
+
+No pan or zoom. The map renders at a fixed viewBox sized to the scenario bounds.
+Tutorial-001 (30 precincts) fits the window, but Sprint 3+ scenarios (150–300
+precincts) will not.
+
+## Goals / Acceptance Criteria
+
+### Core behaviour
+- [ ] `d3.zoom()` applied to the SVG; pan and zoom share the same transform
+- [ ] **Scroll wheel** zooms in/out
+- [ ] **Keyboard shortcuts**: `=` (zoom in), `-` (zoom out), `0` (reset to
+  default scenario view). `+` (Shift+=) aliased to zoom in.
+- [ ] **Right-click drag** pans (or two-finger trackpad drag — whichever feels
+  most natural in Chromium; document the choice)
+- [ ] Zoom-out **floor**: cannot zoom out past the full scenario boundary view
+- [ ] Zoom-in **ceiling**: reasonable upper limit (e.g. 3–4 precincts fill the
+  screen); prevent zooming in so far the map is a blur of geometry
+- [ ] Zoom/pan does not interfere with the left-click paint brush
+
+### Stroke width
+- [ ] District boundary lines (`line.boundary`, `line.preview-boundary`) scale
+  inversely with zoom so apparent width stays constant
+- [ ] Base boundary stroke width increased slightly from the Sprint 1 value
+  (exact value: visual judgement call during implementation; suggest 2px base)
+- [ ] Outer grid edges and interior district boundary edges remain visually
+  distinguishable at all zoom levels
+
+### Keyboard shortcut design decision
+- Shortcut keys (`=`/`-`/`0`) are the default, not hardcoded: a future
+  Settings screen may allow rebinding. Document them in `index.html` or a
+  keyboard-help tooltip.
+- Note in implementation: `+` (with Shift) aliased to `=` since users
+  instinctively reach for `+` to zoom in.
+
+### State-view note
+This ticket intentionally stops at the scenario boundary. The vision's
+zoom-out-to-state-view transition is a v2 concern; the zoom floor should be
+the full-scenario view, not an arbitrary pixel level, so the transition can
+be added later without refactoring.
+
+## Notes
+
+- `d3.zoom()` applies a `transform` attribute to a wrapper `<g>` group inside
+  the SVG. All existing groups (borderGroup, hexGroup, previewBorderGroup)
+  should be children of this wrapper.
+- Stroke width scaling: listen to the `zoom` event; on each transform update,
+  set `stroke-width` on boundary lines to `baseWidth / transform.k`.
+- Consider whether the zoom/pan wrapper should be between the SVG and the
+  existing layer groups, or whether it replaces the viewBox approach.
+- CSS transform is an alternative to SVG transform for the wrapper; `d3.zoom`
+  works with both. SVG transform is simpler to reason about for stroke scaling.
+
+## References
+
+- `game/web/src/render/mapRenderer.ts` — `initViewBox()`, `renderBoundaries()`,
+  `initBrushEvents()`, `initHoverEvents()`
+- `game/web/src/model/generator.ts` — `mapBounds()` (used for zoom floor)
+- D3 zoom docs: https://d3js.org/d3-zoom

--- a/thoughts/shared/tickets/GAME-010-map-validity-panel.md
+++ b/thoughts/shared/tickets/GAME-010-map-validity-panel.md
@@ -1,0 +1,74 @@
+---
+id: GAME-010
+title: Map validity panel — population balance, contiguity, unassigned
+area: game, rendering
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Add a persistent validity panel (sidebar section or bottom bar) that shows the
+current state of the player's district assignments in real time:
+
+- Per-district population balance (% deviation from ideal)
+- Count of unassigned precincts
+- Contiguity status per district (valid | warning | violation — depending on
+  scenario rules)
+
+This gives the player actionable feedback without requiring them to run the
+full Test sequence.
+
+## Current State
+
+No live feedback exists. The status bar at the bottom shows a static message.
+Population totals are available in the store but not displayed. Contiguity is
+not computed at all.
+
+## Goals / Acceptance Criteria
+
+### Population balance
+- [ ] Compute ideal population = `totalPop / districtCount`
+- [ ] Display per-district actual population and `±N%` deviation from ideal
+- [ ] ±5% threshold used as the Sprint 2 placeholder (to be tuned in later
+  sprints once scoring is implemented)
+- [ ] Districts within threshold shown as "ok"; outside shown as "over" / "under"
+
+### Unassigned precincts
+- [ ] Display count of unassigned precincts (precincts with no district assignment)
+- [ ] Count updates live as the player paints
+
+### Contiguity
+- [ ] Contiguity check behavior driven by `scenario.rules.contiguity`:
+  - `"required"` → non-contiguous districts flagged as invalid (red indicator)
+  - `"warn"` → non-contiguous districts flagged as warnings (yellow indicator)
+  - `"allowed"` → no contiguity check or indicator shown
+- [ ] Contiguity computed via BFS/DFS over `Precinct.neighbors` per district
+- [ ] Scenario spec extended to include `rules.contiguity` field; tutorial-001
+  scenario JSON updated to `"required"` (30-precinct grid, all precincts
+  reachable — contiguity always valid in the tutorial)
+
+### Panel layout
+- [ ] Panel lives in the sidebar (below the district buttons), with sufficient
+  contrast to be noticed
+- [ ] Updates reactively on every store change (no manual refresh needed)
+
+## Notes
+
+- Contiguity algorithm: for each district, collect all precincts in that
+  district; BFS from any one precinct using `neighbors` filtered to same
+  district; if any precinct is not reached → non-contiguous.
+- `Precinct.neighbors` is already populated by the loader from the scenario
+  JSON adjacency data.
+- The `rules` field is a new addition to the `Scenario` TypeScript type and
+  JSON schema. Validator must enforce it.
+- Contiguity check on every paint event is O(precincts-in-district) — fine for
+  Sprint 2 scenario sizes (≤300 precincts). No optimization needed yet.
+
+## References
+
+- `game/web/src/store/gameStore.ts` — district assignment state
+- `game/web/src/model/types.ts` — `Scenario`, `Precinct`, `District` types
+- `game/web/src/model/loader.ts` — scenario loading and validation
+- `game/web/src/render/mapRenderer.ts` — existing UI layout reference
+- `thoughts/shared/tickets/GAME-001-scenario-ts-types.md` — type definitions

--- a/thoughts/shared/tickets/GAME-011-precinct-info-panel.md
+++ b/thoughts/shared/tickets/GAME-011-precinct-info-panel.md
@@ -1,0 +1,53 @@
+---
+id: GAME-011
+title: Precinct info panel — hover tooltip in sidebar
+area: game, rendering
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Replace the existing `#status-bar` bottom strip with a dedicated precinct info
+section in the sidebar. When the player hovers over a precinct, display:
+
+- Precinct name
+- Current district assignment
+- Population
+- Any other precinct-level data surfaced by the scenario
+
+The panel has a fixed-height container and shows a neutral placeholder ("Hover
+over a precinct to see details") when no precinct is hovered.
+
+## Current State
+
+A thin status bar exists at the bottom of the viewport (`#status-bar`). It
+shows minimal info and is easy to miss — the Sprint 1 demo confirmed players
+did not notice it. Hover events are already wired via `initHoverEvents()` in
+`mapRenderer.ts`.
+
+## Goals / Acceptance Criteria
+
+- [ ] Sidebar section `#precinct-info` added below the district buttons
+- [ ] Fixed-height container; does not shift layout when content changes
+- [ ] Shows placeholder text when no precinct is hovered
+- [ ] On precinct hover: displays precinct name, current district, population
+- [ ] Styling: distinct contrast from the rest of the sidebar so it is
+  noticeable; not so prominent it distracts from the map
+- [ ] Existing `#status-bar` removed (or repurposed if it serves another need)
+- [ ] `initHoverEvents()` updated to write to `#precinct-info` instead of
+  (or in addition to) `#status-bar`
+
+## Notes
+
+- The panel intentionally sits in the sidebar rather than as a floating tooltip
+  to avoid interfering with the paint brush interaction area.
+- The design should make the section visible-but-not-shouting: a slightly
+  different background tone or a subtle border is sufficient.
+- If `#status-bar` carries any other live data (e.g., keyboard hints), that
+  content should be reviewed and either migrated or kept separately.
+
+## References
+
+- `game/web/src/render/mapRenderer.ts` — `initHoverEvents()`
+- `game/web/index.html` — `#status-bar`, sidebar layout and inline styles

--- a/thoughts/shared/tickets/GAME-012-county-border-overlay.md
+++ b/thoughts/shared/tickets/GAME-012-county-border-overlay.md
@@ -1,0 +1,59 @@
+---
+id: GAME-012
+title: County border overlay toggle
+area: game, rendering
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Add a toggle button that shows or hides county boundary lines on the map.
+County borders are flavor — they help orient the player geographically but
+carry no game mechanic in Sprint 2. The overlay is off by default.
+
+## Current State
+
+`setCountyBordersVisible()` is a no-op stub in `mapRenderer.ts`. County data
+is present in the scenario JSON (`county_id` per precinct) but is not rendered.
+
+## Goals / Acceptance Criteria
+
+- [ ] "County borders" toggle button added to the sidebar or toolbar
+- [ ] Default state: off (borders not shown on load)
+- [ ] When toggled on: county boundary segments rendered as a distinct line
+  style (dashed or a different color) that reads as a secondary layer below
+  district boundaries
+- [ ] When toggled off: county boundary segments hidden
+- [ ] Toggle state is not persisted (resets to off on reload)
+
+### County boundary computation
+- [ ] County boundary segments computed from `county_id` per precinct: an edge
+  between two adjacent precincts is a county boundary if their `county_id`
+  values differ
+- [ ] Adjacency data from `Precinct.neighbors` used for edge detection
+- [ ] Boundary segments computed once at load time (not on every toggle)
+
+### Visual design
+- [ ] County borders visually subordinate to district boundaries
+- [ ] Readable at all zoom levels (stroke width scales inversely with zoom,
+  consistent with GAME-009 zoom implementation)
+- [ ] Outer map edges not drawn as county borders (only internal edges where
+  two precincts have different `county_id`)
+
+## Notes
+
+- The `setCountyBordersVisible()` stub exists as a method on the renderer
+  interface; this ticket implements it.
+- County borders are flavor only in Sprint 2. Future scenarios may use county
+  boundaries as a game criterion (e.g. "minimize county splits"), but that is
+  a content-layer concern, not a rendering concern.
+- If GAME-009 (pan/zoom) is not yet merged, coordinate on the zoom-invariant
+  stroke width approach.
+
+## References
+
+- `game/web/src/render/mapRenderer.ts` — `setCountyBordersVisible()` stub,
+  `renderBoundaries()`
+- `game/web/src/model/types.ts` — `Precinct.county_id`
+- GAME-009: pan/zoom (zoom-invariant stroke widths)

--- a/thoughts/shared/tickets/GAME-013-reset-to-initial.md
+++ b/thoughts/shared/tickets/GAME-013-reset-to-initial.md
@@ -1,0 +1,50 @@
+---
+id: GAME-013
+title: Reset-to-initial district assignments
+area: game, rendering
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Add a "Reset" action that restores all precinct assignments to the scenario's
+initial state and clears the undo history. Because reset is destructive and
+irreversible, it requires a confirmation gesture before executing.
+
+## Current State
+
+No reset mechanism exists. Players can undo step-by-step, but there is no way
+to return to the scenario starting state in one action. The undo store's
+`clear()` API is available but unused.
+
+## Goals / Acceptance Criteria
+
+- [ ] "Reset" button visible in the sidebar or toolbar
+- [ ] Clicking Reset shows a confirmation prompt (e.g. an inline confirmation
+  row — "Are you sure? [Confirm] [Cancel]" — or a modal dialog)
+- [ ] On confirmation: all precinct assignments restored to
+  `scenario.precincts[*].initial_district_id` values
+- [ ] On confirmation: undo/redo history cleared via
+  `temporalStore.getState().clear()`
+- [ ] On cancel: no change; player returns to current state
+- [ ] Undo/redo buttons reflect cleared history immediately after reset
+  (Undo disabled, Redo disabled)
+- [ ] Map re-renders to show initial assignment colors
+
+## Notes
+
+- The confirmation gesture prevents accidental resets during play. An inline
+  "Are you sure?" row is lower friction than a modal and consistent with the
+  game's minimal-UI aesthetic.
+- `temporalStore.getState().clear()` wipes both past and future states. After
+  reset the undo button must be disabled — verify the Zustand temporal store
+  re-evaluates `pastStates.length` reactively.
+- The reset target is the scenario's `initial_district_id` values, which the
+  loader stores on the `Precinct` objects. No re-fetch needed.
+
+## References
+
+- `game/web/src/store/gameStore.ts` — Zustand store, `temporalStore`
+- `game/web/src/render/mapRenderer.ts` — paint and undo button wiring
+- `game/web/src/model/loader.ts` — `initial_district_id` auto-fill logic

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -49,6 +49,11 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `DESIGN-002-view-toggle-ux.md` | design, UX | View toggle button label convention: show destination mode, not current mode |
 | `DESIGN-003-districts-view-color-encoding.md` | design, UX | Districts view color/population gradient: decide encoding strategy for v1 |
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
+| `GAME-009-pan-zoom.md` | game, rendering | Pan + zoom via d3.zoom(); scroll wheel + keyboard shortcuts; zoom-invariant stroke widths |
+| `GAME-010-map-validity-panel.md` | game, rendering | Live validity panel: per-district pop balance ±%, unassigned count, contiguity status |
+| `GAME-011-precinct-info-panel.md` | game, rendering | Precinct hover info in sidebar (name, district, population); replaces status bar |
+| `GAME-012-county-border-overlay.md` | game, rendering | County border overlay toggle; flavor only; computed from county_id adjacency edges |
+| `GAME-013-reset-to-initial.md` | game, rendering | Reset all assignments to scenario initial state; clears undo history; confirmation required |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [ ] N/A — parent PR #52 (Sprint 1 closeout) already merged

## Summary
- File Sprint 2 tickets GAME-009 through GAME-013 and update TICKETS.md + sprint roadmap
- GAME-009: Pan + zoom via d3.zoom(); scroll wheel + `=`/`-`/`0` keyboard shortcuts; zoom-invariant stroke widths; zoom floor = full scenario boundary
- GAME-010: Map validity panel — per-district population balance ±%, unassigned precinct count, contiguity status (scenario-driven `rules.contiguity` field)
- GAME-011: Precinct info panel — sidebar section replaces status bar; shows precinct name/district/population on hover; placeholder when none hovered
- GAME-012: County border overlay toggle — flavor only; county boundary segments computed from `county_id` adjacency edges; off by default
- GAME-013: Reset-to-initial — restores all assignments to `initial_district_id`; clears undo history; requires confirmation gesture
- TICKETS.md: all five added to Open section
- Sprint roadmap §SPRINT2: filled with full ticket list; brush size controls deferred

## Validation performed
- [ ] N/A — docs-only change; no code modified

## Affected machines / services
- N/A — docs only

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see GAME-009, GAME-010, GAME-011, GAME-012, GAME-013 (ticket files are what's being filed)

## Rollback
- N/A — docs only
