### PR TITLE
ux(DESIGN-002): imperative destination labels on view toggle

### DIFF
--- a/game/web/index.html
+++ b/game/web/index.html
@@ -202,7 +202,7 @@
         <div id="district-buttons"></div>
         <button id="btn-undo" disabled>↩ Undo</button>
         <button id="btn-redo" disabled>↪ Redo</button>
-        <button id="btn-view-toggle">View: Partisan Lean</button>
+        <button id="btn-view-toggle">Switch to Partisan Lean</button>
       </div>
     </header>
 

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -133,7 +133,7 @@ if (wasmEl !== null) {
 		currentViewMode = currentViewMode === "districts" ? "lean" : "districts";
 		renderer.setViewMode(currentViewMode);
 		btnViewToggle!.textContent =
-			currentViewMode === "districts" ? "View: Partisan Lean" : "View: Districts";
+			currentViewMode === "districts" ? "Switch to Partisan Lean" : "Switch to Districts";
 	});
 
 	// ── Subscribe to state changes ────────────────────────────────────────────

--- a/thoughts/shared/tickets/DESIGN-002-view-toggle-ux.md
+++ b/thoughts/shared/tickets/DESIGN-002-view-toggle-ux.md
@@ -4,6 +4,7 @@ title: View toggle button label convention
 area: design, UX
 status: open
 created: 2026-04-25
+github_issue: 54
 ---
 
 ## Summary
@@ -27,10 +28,10 @@ Source: `game/web/src/main.ts` around the `btnViewToggle` click handler.
 
 ## Goals / Acceptance Criteria
 
-- [ ] Decide on label convention (options below) — document the choice as a
+- [x] Decide on label convention (options below) — document the choice as a
   micro-decision in the ticket or in `thoughts/shared/decisions/`
-- [ ] Implement chosen convention in `main.ts`
-- [ ] Verify the label change is reflected in the `sprint1.spec.ts` view-toggle
+- [x] Implement chosen convention in `main.ts`
+- [x] Verify the label change is reflected in the `sprint1.spec.ts` view-toggle
   test (or update the test if it checks button text)
 
 ## Options
@@ -48,6 +49,13 @@ Source: `game/web/src/main.ts` around the `btnViewToggle` click handler.
 - Verbose; probably too long.
 
 Option A is the simplest and most conventional for toggle buttons.
+
+## Decision
+
+**Option A chosen** (imperative destination): "Switch to Partisan Lean" / "Switch to Districts".
+Simplest, most conventional for toggle buttons. No micro-decision doc needed — decision captured here.
+
+The Sprint 1 test (`sprint1.spec.ts`) checks fill changes on toggle, not button text — no test update required.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- View toggle button now labels itself with the **destination** mode, not the current mode
- "Switch to Partisan Lean" when in districts mode; "Switch to Districts" when in lean mode
- Option A (imperative destination) chosen — simplest, most conventional for toggle buttons
- `index.html` initial label updated; `main.ts` toggle handler updated

## Decision

Option A: imperative destination labels. No separate micro-decision doc — choice documented in ticket.

Sprint 1 test (`sprint1.spec.ts`) checks fill changes on toggle, not button text — no test update required.

see #54

## Test plan

- [x] Manual: toggle button reads "Switch to Partisan Lean" on load
- [x] Manual: after click, reads "Switch to Districts"
- [x] Manual: toggles correctly on subsequent clicks
- [N/A] Sprint 1 Playwright test: checks fill not button text — no change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
