### PR TITLE
feat(GAME-013): reset to initial district assignments

### DIFF
--- a/game/web/index.html
+++ b/game/web/index.html
@@ -82,6 +82,60 @@
         border-color: #3a7abd;
       }
 
+      #btn-reset {
+        padding: 4px 10px;
+        background: #3a1020;
+        color: #e0e0e0;
+        border: 1px solid #7a2030;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.85rem;
+      }
+
+      #btn-reset:hover {
+        background: #5a1828;
+      }
+
+      #reset-confirm {
+        display: none;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.82rem;
+        color: #e0a0a0;
+      }
+
+      #reset-confirm.visible {
+        display: flex;
+      }
+
+      #btn-reset-confirm, #btn-reset-cancel {
+        padding: 3px 8px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.82rem;
+        border: 1px solid transparent;
+      }
+
+      #btn-reset-confirm {
+        background: #7a2030;
+        color: #fff;
+        border-color: #a03040;
+      }
+
+      #btn-reset-confirm:hover {
+        background: #a03040;
+      }
+
+      #btn-reset-cancel {
+        background: #0f3460;
+        color: #e0e0e0;
+        border-color: #1a4a7a;
+      }
+
+      #btn-reset-cancel:hover {
+        background: #1a4a7a;
+      }
+
       #main {
         display: flex;
         flex: 1;
@@ -254,6 +308,12 @@
         <button id="btn-redo" disabled>↪ Redo</button>
         <button id="btn-view-toggle">Switch to Partisan Lean</button>
         <button id="btn-county-toggle">Show County Borders</button>
+        <button id="btn-reset">Reset</button>
+        <span id="reset-confirm">
+          Reset to start?
+          <button id="btn-reset-confirm">Yes</button>
+          <button id="btn-reset-cancel">No</button>
+        </span>
       </div>
     </header>
 

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -35,6 +35,10 @@ const btnUndo = document.getElementById("btn-undo") as HTMLButtonElement | null;
 const btnRedo = document.getElementById("btn-redo") as HTMLButtonElement | null;
 const btnViewToggle = document.getElementById("btn-view-toggle") as HTMLButtonElement | null;
 const btnCountyToggle = document.getElementById("btn-county-toggle") as HTMLButtonElement | null;
+const btnReset = document.getElementById("btn-reset") as HTMLButtonElement | null;
+const resetConfirm = document.getElementById("reset-confirm") as HTMLElement | null;
+const btnResetConfirm = document.getElementById("btn-reset-confirm") as HTMLButtonElement | null;
+const btnResetCancel = document.getElementById("btn-reset-cancel") as HTMLButtonElement | null;
 
 if (
 	svgEl === null ||
@@ -45,7 +49,11 @@ if (
 	btnUndo === null ||
 	btnRedo === null ||
 	btnViewToggle === null ||
-	btnCountyToggle === null
+	btnCountyToggle === null ||
+	btnReset === null ||
+	resetConfirm === null ||
+	btnResetConfirm === null ||
+	btnResetCancel === null
 ) {
 	throw new Error("Required DOM elements not found");
 }
@@ -150,6 +158,25 @@ if (wasmEl !== null) {
 		btnCountyToggle!.textContent = countyBordersVisible ? "Hide County Borders" : "Show County Borders";
 		btnCountyToggle!.classList.toggle("active", countyBordersVisible);
 	});
+
+	// ── Reset ─────────────────────────────────────────────────────────────────
+	btnReset!.addEventListener("click", () => {
+		resetConfirm!.classList.add("visible");
+		btnReset!.disabled = true;
+	});
+
+	btnResetCancel!.addEventListener("click", () => {
+		resetConfirm!.classList.remove("visible");
+		btnReset!.disabled = false;
+	});
+
+	btnResetConfirm!.addEventListener("click", () => {
+		store.getState().resetToInitial();
+		temporalStore.getState().clear();
+		resetConfirm!.classList.remove("visible");
+		btnReset!.disabled = false;
+	});
+
 
 	// ── Subscribe to state changes ────────────────────────────────────────────
 	store.subscribe(() => updateUI());

--- a/game/web/src/store/gameStore.ts
+++ b/game/web/src/store/gameStore.ts
@@ -24,6 +24,8 @@ export interface GameStore extends GameState {
 	paintPrecinct: (precinctId: number) => void;
 	/** Assign a batch of precincts (one brush stroke) as a single undo step */
 	paintStroke: (precinctIds: number[], district: DistrictId) => void;
+	/** Restore all assignments to the scenario's initial state */
+	resetToInitial: () => void;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -41,6 +43,9 @@ function cloneAssignments(m: AssignmentMap): AssignmentMap {
  */
 export function createGameStore(scenario: Scenario) {
 	const { precincts, assignments, districtCount } = scenarioToSpike(scenario);
+
+	// Snapshot of initial assignments — used by resetToInitial() to restore scenario start state
+	const initialAssignments: AssignmentMap = new Map(assignments);
 
 	const initialState: GameState = {
 		precincts,
@@ -88,6 +93,14 @@ export function createGameStore(scenario: Scenario) {
 					set({
 						assignments: next,
 						simulationResult: runElection({ ...get(), assignments: next }),
+					});
+				},
+
+				resetToInitial() {
+					const restored = new Map(initialAssignments);
+					set({
+						assignments: restored,
+						simulationResult: runElection({ ...get(), assignments: restored }),
 					});
 				},
 			}),

--- a/thoughts/shared/tickets/GAME-013-reset-to-initial.md
+++ b/thoughts/shared/tickets/GAME-013-reset-to-initial.md
@@ -4,6 +4,7 @@ title: Reset-to-initial district assignments
 area: game, rendering
 status: open
 created: 2026-04-25
+github_issue: 62
 ---
 
 ## Summary


### PR DESCRIPTION
## Prerequisites
- [N/A] No parent PR dependency

## Summary
- Adds a Reset button in the toolbar that restores all precinct assignments to the scenario's initial state
- Requires inline confirmation gesture ("Reset to start? Yes / No") to prevent accidental resets
- On confirmation: calls `store.resetToInitial()` then `temporalStore.clear()` — map re-renders to initial colors, undo/redo both become disabled

## Validation performed
- [x] `bazel build //web:app_typecheck_lib` — passed, no type errors
- [x] `bazel test //web/src/model:loader_test` — passed

## Affected machines / services
- Browser game only (static frontend)

## Deployment steps (POST-MERGE)
- N/A — static asset; deployed on next game bundle build

## Tickets addressed
- see #62

## Rollback
- Revert this commit; no data migration involved
