### PR TITLE
feat(GAME-010): map validity panel — population balance, contiguity, unassigned

### DIFF
--- a/game/web/index.html
+++ b/game/web/index.html
@@ -201,6 +201,34 @@
         line-height: 1.5;
       }
 
+      .validity-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 4px 6px 4px 10px;
+        border-radius: 4px;
+        font-size: 0.78rem;
+        border-left: 3px solid transparent;
+        background: #0a1f3a;
+        margin-bottom: 3px;
+      }
+
+      .validity-ok { color: #80c080; }
+      .validity-warn { color: #e0c040; }
+      .validity-error { color: #e94560; }
+
+      .validity-section-label {
+        font-size: 0.72rem;
+        color: #606080;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 6px 0 3px;
+      }
+
+      .validity-badge {
+        font-weight: 600;
+      }
+
       #wasm-status-bar {
         padding: 2px 16px;
         background: #16213e;
@@ -236,6 +264,8 @@
         <div id="results-container">
           <div style="color:#606080;font-size:0.85rem;">Draw districts to see results</div>
         </div>
+        <h2>Map Validity</h2>
+        <div id="validity-container"></div>
         <h2>Legend</h2>
         <div id="legend-container" class="legend"></div>
       </aside>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -20,6 +20,7 @@ import {
 	renderDistrictButtons,
 	renderLegend,
 	renderResults,
+	renderValidityPanel,
 } from "./render/mapRenderer.js";
 import { createGameStore } from "./store/gameStore.js";
 
@@ -27,6 +28,7 @@ import { createGameStore } from "./store/gameStore.js";
 
 const svgEl = document.getElementById("map-svg") as SVGSVGElement | null;
 const resultsEl = document.getElementById("results-container") as HTMLElement | null;
+const validityEl = document.getElementById("validity-container") as HTMLElement | null;
 const legendEl = document.getElementById("legend-container") as HTMLElement | null;
 const districtBtnsEl = document.getElementById("district-buttons") as HTMLElement | null;
 const btnUndo = document.getElementById("btn-undo") as HTMLButtonElement | null;
@@ -36,6 +38,7 @@ const btnViewToggle = document.getElementById("btn-view-toggle") as HTMLButtonEl
 if (
 	svgEl === null ||
 	resultsEl === null ||
+	validityEl === null ||
 	legendEl === null ||
 	districtBtnsEl === null ||
 	btnUndo === null ||
@@ -109,6 +112,7 @@ if (wasmEl !== null) {
 		renderer.render();
 
 		renderResults(resultsEl!, state);
+		renderValidityPanel(validityEl!, state, scenario.rules);
 		renderLegend(legendEl!, state.districtCount);
 		renderDistrictButtons(districtBtnsEl!, state.districtCount, state.activeDistrict, (id) => {
 			store.getState().setActiveDistrict(id);

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -21,8 +21,10 @@
 
 import * as d3 from "d3";
 import { hexCorners, mapBounds } from "../model/generator.js";
+import type { ScenarioRules } from "../model/scenario.js";
 import type { Precinct } from "../model/types.js";
 import { DISTRICT_COLORS, PARTY_COLORS, PARTY_LABELS } from "../model/types.js";
+import { computeValidityStats } from "../simulation/validity.js";
 import type { GameStore } from "../store/gameStore.js";
 
 // ─── Public interface ─────────────────────────────────────────────────────────
@@ -587,4 +589,55 @@ export function renderDistrictButtons(
 		btn.addEventListener("click", () => onSelect(i));
 		container.appendChild(btn);
 	}
+}
+
+export function renderValidityPanel(
+	container: HTMLElement,
+	state: GameStore,
+	rules: ScenarioRules,
+): void {
+	const { precincts, assignments, districtCount } = state;
+	const stats = computeValidityStats(precincts, assignments, districtCount, rules);
+
+	let html = "";
+
+	// Unassigned count
+	const unassignedCls = stats.unassignedCount > 0 ? "validity-warn" : "validity-ok";
+	const unassignedLabel =
+		stats.unassignedCount === 1 ? "1 precinct" : `${stats.unassignedCount} precincts`;
+	html += `<div class="validity-row ${unassignedCls}">`;
+	html += `<span>Unassigned</span><span class="validity-badge">${unassignedLabel}</span>`;
+	html += `</div>`;
+
+	// Population balance
+	html += `<div class="validity-section-label">Population balance</div>`;
+	for (const d of stats.districtPop) {
+		const color = DISTRICT_COLORS[d.districtId - 1] ?? "#888";
+		const sign = d.deviationPct >= 0 ? "+" : "";
+		const cls = d.status === "ok" ? "validity-ok" : "validity-error";
+		const statusLabel = d.status === "ok" ? "ok" : d.status;
+		html += `<div class="validity-row ${cls}" style="border-left-color:${color}">`;
+		html += `<span>D${d.districtId}: ${d.population.toLocaleString()}</span>`;
+		html += `<span class="validity-badge">${sign}${d.deviationPct.toFixed(1)}% ${statusLabel}</span>`;
+		html += `</div>`;
+	}
+
+	// Contiguity (skipped when "allowed")
+	if (stats.contiguity !== null) {
+		html += `<div class="validity-section-label">Contiguity</div>`;
+		for (const [did, ok] of stats.contiguity) {
+			const color = DISTRICT_COLORS[did - 1] ?? "#888";
+			const cls = ok
+				? "validity-ok"
+				: rules.contiguity === "required"
+					? "validity-error"
+					: "validity-warn";
+			const label = ok ? "Connected" : "Non-contiguous";
+			html += `<div class="validity-row ${cls}" style="border-left-color:${color}">`;
+			html += `<span>D${did}</span><span class="validity-badge">${label}</span>`;
+			html += `</div>`;
+		}
+	}
+
+	container.innerHTML = html;
 }

--- a/game/web/src/simulation/validity.ts
+++ b/game/web/src/simulation/validity.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure validity computations for the live feedback panel (GAME-010).
+ *
+ * All functions are stateless and side-effect-free — they take store state
+ * and scenario rules, return plain data objects. No DOM, no D3.
+ */
+
+import type { AssignmentMap, Precinct } from "../model/types.js";
+import type { ScenarioRules } from "../model/scenario.js";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface DistrictPopStats {
+	districtId: number;
+	population: number;
+	/** Signed percentage deviation from ideal, e.g. +2.3 or -4.1 */
+	deviationPct: number;
+	status: "ok" | "over" | "under";
+}
+
+export interface ValidityStats {
+	idealPopulation: number;
+	totalPopulation: number;
+	unassignedCount: number;
+	districtPop: DistrictPopStats[];
+	/** null when rules.contiguity === "allowed" (not checked) */
+	contiguity: Map<number, boolean> | null;
+}
+
+// ─── Main entry point ─────────────────────────────────────────────────────────
+
+export function computeValidityStats(
+	precincts: Precinct[],
+	assignments: AssignmentMap,
+	districtCount: number,
+	rules: ScenarioRules,
+): ValidityStats {
+	const totalPopulation = precincts.reduce((s, p) => s + p.population, 0);
+	const idealPopulation = districtCount > 0 ? totalPopulation / districtCount : 0;
+	const tolerance = rules.population_tolerance;
+
+	// Unassigned count
+	let unassignedCount = 0;
+	for (const v of assignments.values()) {
+		if (v === null) unassignedCount++;
+	}
+
+	// Per-district population sums
+	const popByDistrict = new Map<number, number>();
+	for (let d = 1; d <= districtCount; d++) popByDistrict.set(d, 0);
+	for (const [precinctId, distId] of assignments) {
+		if (distId !== null) {
+			const pc = precincts[precinctId];
+			if (pc !== undefined) {
+				popByDistrict.set(distId, (popByDistrict.get(distId) ?? 0) + pc.population);
+			}
+		}
+	}
+
+	const districtPop: DistrictPopStats[] = [];
+	for (let d = 1; d <= districtCount; d++) {
+		const pop = popByDistrict.get(d) ?? 0;
+		const deviationPct =
+			idealPopulation > 0 ? ((pop - idealPopulation) / idealPopulation) * 100 : 0;
+		let status: "ok" | "over" | "under" = "ok";
+		if (deviationPct > tolerance * 100) status = "over";
+		else if (deviationPct < -(tolerance * 100)) status = "under";
+		districtPop.push({ districtId: d, population: pop, deviationPct, status });
+	}
+
+	// Contiguity — BFS per district; skipped when "allowed"
+	let contiguity: Map<number, boolean> | null = null;
+	if (rules.contiguity !== "allowed") {
+		contiguity = new Map();
+		for (let d = 1; d <= districtCount; d++) {
+			contiguity.set(d, isContiguous(precincts, assignments, d));
+		}
+	}
+
+	return { idealPopulation, totalPopulation, unassignedCount, districtPop, contiguity };
+}
+
+// ─── BFS contiguity check ─────────────────────────────────────────────────────
+
+function isContiguous(
+	precincts: Precinct[],
+	assignments: AssignmentMap,
+	districtId: number,
+): boolean {
+	const inDistrict: number[] = [];
+	for (const [pid, did] of assignments) {
+		if (did === districtId) inDistrict.push(pid);
+	}
+	if (inDistrict.length <= 1) return true; // 0 or 1 precincts: trivially contiguous
+
+	const inSet = new Set(inDistrict);
+	const visited = new Set<number>();
+	const queue: number[] = [inDistrict[0]!];
+	visited.add(inDistrict[0]!);
+
+	while (queue.length > 0) {
+		const curr = queue.shift()!;
+		const p = precincts[curr];
+		if (p === undefined) continue;
+		for (const nbId of p.neighbors) {
+			if (nbId !== null && inSet.has(nbId) && !visited.has(nbId)) {
+				visited.add(nbId);
+				queue.push(nbId);
+			}
+		}
+	}
+
+	return visited.size === inSet.size;
+}

--- a/thoughts/shared/tickets/GAME-010-map-validity-panel.md
+++ b/thoughts/shared/tickets/GAME-010-map-validity-panel.md
@@ -4,6 +4,7 @@ title: Map validity panel — population balance, contiguity, unassigned
 area: game, rendering
 status: open
 created: 2026-04-25
+github_issue: 64
 ---
 
 ## Summary


### PR DESCRIPTION
## Prerequisites
- [N/A] No parent PR dependency

## Summary
- Adds a live "Map Validity" panel in the sidebar that updates reactively on every paint action
- New `validity.ts` module: pure `computeValidityStats()` — population balance per district, unassigned count, BFS contiguity check per district
- `renderValidityPanel()` added to `mapRenderer.ts`; reads `scenario.rules.population_tolerance` and `contiguity` mode
- Population balance shows ±% deviation from ideal; colored green/red based on tolerance threshold
- Contiguity status colored red (required) or yellow (preferred) when non-contiguous; hidden when "allowed"

## Validation performed
- [x] `bazel build //web:app_typecheck_lib` — passed, `validity.js` in output
- [x] `bazel test //web/src/model:loader_test` — passed

## Affected machines / services
- Browser game only (static frontend)

## Deployment steps (POST-MERGE)
- N/A — static asset; deployed on next game bundle build

## Tickets addressed
- see #64

## Rollback
- Revert this commit; no data migration involved
