### PR TITLE
fix: precinct info panel auto-sizes; add DESIGN-004 + GAME-014 tickets

### DIFF
--- a/game/web/index.html
+++ b/game/web/index.html
@@ -239,8 +239,7 @@
         border: 1px solid #1a3a5c;
         border-radius: 6px;
         padding: 10px;
-        min-height: 80px;
-        font-size: 0.82rem;
+        font-size: 0.85rem;
       }
 
       #precinct-info .precinct-name {

--- a/thoughts/shared/tickets/DESIGN-004-legend-layout.md
+++ b/thoughts/shared/tickets/DESIGN-004-legend-layout.md
@@ -1,0 +1,35 @@
+---
+id: DESIGN-004
+title: Move legend to horizontal strip above map
+area: design, UX
+status: open
+created: 2026-04-26
+---
+
+## Summary
+
+The district color legend currently sits at the bottom of the right sidebar, stacked vertically. As the number of districts grows it consumes significant sidebar space and competes with the validity panel and precinct info. Moving it to a horizontal strip above (or overlaid on) the map frees sidebar space for data panels and keeps the legend adjacent to the map it annotates.
+
+## Current State
+
+Legend is rendered in `#legend-container` inside `#sidebar` as a vertical list of color swatches + labels. This works for 2–3 districts but becomes cramped as district count grows.
+
+## Goals / Acceptance Criteria
+
+- [ ] Legend is rendered as a horizontal row of swatch+label pairs, positioned above the map or as a floating overlay at the top of `#map-container`
+- [ ] Legend does not overlap the map controls in the header
+- [ ] Legend remains readable at all scenario district counts (up to ~8 districts)
+- [ ] Sidebar no longer contains the legend section
+- [ ] Layout works at typical browser viewport widths (1280px+)
+
+## Test Coverage
+
+- [ ] e2e: legend element is present in the map container (not sidebar) after load
+- [ ] e2e: all district color swatches are visible in the legend
+- [ ] Unit: N/A — layout is DOM/CSS only
+
+## References
+
+- Raised during Sprint 2 demo review (2026-04-26)
+- `game/web/index.html` — `#legend-container`, `#sidebar`, `#map-container`
+- `game/web/src/main.ts` — legend rendering logic

--- a/thoughts/shared/tickets/GAME-014-scenario-scale.md
+++ b/thoughts/shared/tickets/GAME-014-scenario-scale.md
@@ -1,0 +1,38 @@
+---
+id: GAME-014
+title: Scale tutorial scenario to prove out UI features
+area: game, content
+status: open
+created: 2026-04-26
+---
+
+## Summary
+
+The current tutorial scenario (Kalanoa/Westford) has only 30 precincts in a single county. At this scale, pan/zoom is barely useful, county border overlay has nothing to show, and the validity panel has too little variation to be interesting. For Sprint 3 we need a scenario large enough that all Sprint 2 UI features have something meaningful to exercise.
+
+## Current State
+
+`game/scenarios/kalanoa_westford.json` — 30 precincts, 2 districts, single county. Generated procedurally. Adequate for unit testing; inadequate for feature demonstration.
+
+## Goals / Acceptance Criteria
+
+- [ ] At least one scenario with 150–300 precincts (enough to require pan/zoom to navigate)
+- [ ] At least 3 counties represented (so county border overlay shows visible borders between them)
+- [ ] At least 3 districts (so validity panel has meaningful per-district comparisons)
+- [ ] Realistic-feeling population distribution (precincts vary in size, not uniform grid)
+- [ ] Scenario passes all `loadScenario` validation invariants (existing unit tests cover this)
+- [ ] Existing 30-precinct scenario retained for fast unit-test runs
+- [ ] New scenario loads and renders in the browser without visible lag
+
+## Test Coverage
+
+- [ ] Unit: new scenario passes `bazel test //web/src/model:loader_test` (existing validator covers all invariants)
+- [ ] e2e: app loads with new scenario; `path.hex` count matches expected precinct count
+- [ ] Manual: county borders visible after clicking "Show County Borders"; pan/zoom required to see full map
+
+## References
+
+- Raised during Sprint 2 demo review (2026-04-26)
+- `game/scenarios/kalanoa_westford.json` — current 30-precinct scenario
+- `thoughts/shared/tickets/GAME-003-author-tutorial-scenario.md` — original scenario authoring ticket (resolved)
+- `game/web/src/model/loader_test.ts` — invariant tests that new scenario must pass

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -88,7 +88,9 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
 | `AGENT-003-infra-pr-review-bot-comment-handling.md` | agentic workflow, infra | Propose bot comment handling (Copilot, CodeQL) to infra pr-review-cycle workflow |
 | `DESIGN-003-districts-view-color-encoding.md` | design, UX | Districts view color/population gradient: decide encoding strategy for v1 |
+| `DESIGN-004-legend-layout.md` | design, UX | Move legend to horizontal strip above map; free sidebar space for data panels |
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
+| `GAME-014-scenario-scale.md` | game, content | Scale tutorial scenario to 150–300 precincts across 3+ counties for Sprint 3 feature demo |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [x] Sprint 2 fully merged and closed (#66, #67)

## Summary
- Removes `min-height: 80px` constraint on `#precinct-info` panel so it auto-sizes to its content; bumps font from 0.82rem to 0.85rem — fixes clipping on longer precinct names observed during Sprint 2 demo
- Adds DESIGN-004 ticket: move legend to horizontal strip above map
- Adds GAME-014 ticket: scale tutorial scenario to 150–300 precincts across 3+ counties (Sprint 3)
- Updates TICKETS.md index with both new tickets

## Validation performed
- [x] Rebuilt bundle and verified in browser; precinct info panel now expands to fit content
- [x] N/A — ticket files are metadata only; no logic changes

## Affected machines / services
- N/A

## Deployment steps
- N/A

## Tickets addressed
- N/A — this PR creates DESIGN-004 and GAME-014 (no existing ticket to close)

## Rollback
- N/A — CSS change is trivially reversible; ticket files can be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
