### PR TITLE
plan: Sprint 3 game-loop tickets (GAME-015 through GAME-018)

### DIFF
--- a/thoughts/shared/tickets/GAME-015-scenario-success-criteria.md
+++ b/thoughts/shared/tickets/GAME-015-scenario-success-criteria.md
@@ -1,0 +1,43 @@
+---
+id: GAME-015
+title: Success criteria in scenario format and data model
+area: game, content
+status: open
+created: 2026-04-26
+---
+
+## Summary
+
+The scenario format currently has no way to express what "winning" looks like. This ticket adds a `criteria` field to the scenario JSON schema and TypeScript types, so each scenario can declare required and optional success conditions (seat counts, population balance thresholds, contiguity requirements, VRA constraints, etc.). This is the prerequisite for the evaluation phase (GAME-017) and for authoring any scenario beyond the tutorial.
+
+## Current State
+
+`game/scenarios/kalanoa_westford.json` has no `criteria` field. `game/web/src/model/scenario.ts` has no `ScenarioCriteria` type. The loader validates structure but has nothing to check about win conditions. The map editor runs freely with no pass/fail concept.
+
+## Goals / Acceptance Criteria
+
+- [ ] `ScenarioCriteria` TypeScript type defined in `scenario.ts` covering at least:
+  - [ ] Per-district seat target (party wins district N)
+  - [ ] Population balance tolerance (already in `ScenarioRules`)
+  - [ ] Contiguity requirement (already in `ScenarioRules` — reuse or reference)
+  - [ ] Optional vs. required flag per criterion
+- [ ] `Scenario` type gains `criteria: ScenarioCriteria[]` field (required)
+- [ ] `loadScenario` validates that `criteria` is present and well-formed
+- [ ] Tutorial scenario JSON updated with a minimal criteria array (e.g. "draw any valid map" = population balance only)
+- [ ] Existing loader unit tests updated/extended to cover criteria validation
+
+## Test Coverage
+
+- [ ] Unit: `loadScenario` rejects scenario missing `criteria` field
+- [ ] Unit: `loadScenario` rejects malformed criterion (missing required fields)
+- [ ] Unit: `loadScenario` accepts valid criteria array
+- [ ] Unit: N/A for UI — this ticket is data model only; rendering is GAME-017
+
+## References
+
+- Vision §LOOP, §TEST, §SCENARIOS — success criteria drive the evaluation phase
+- `game/web/src/model/scenario.ts` — Scenario types
+- `game/web/src/model/loader.ts` — loadScenario validator
+- `game/web/src/model/loader_test.ts` — existing unit tests
+- Depends on: none
+- Blocks: GAME-017 (evaluation phase)

--- a/thoughts/shared/tickets/GAME-016-scenario-intro.md
+++ b/thoughts/shared/tickets/GAME-016-scenario-intro.md
@@ -1,0 +1,40 @@
+---
+id: GAME-016
+title: Scenario intro — narrative slides before map editing
+area: game, content
+status: open
+created: 2026-04-26
+---
+
+## Summary
+
+Before the player reaches the map editor, they need context: who they're playing as, what region they're drawing, what they're trying to achieve, and any mechanic notes specific to this scenario. The vision calls for a slide-based intro sequence. This ticket implements that screen and wires it into the game flow so the player always lands on the intro before editing begins.
+
+## Current State
+
+The app loads directly into the map editor with no preamble. The scenario format has no `intro` field. Players have no narrative context for why they are drawing districts or what success looks like.
+
+## Goals / Acceptance Criteria
+
+- [ ] `ScenarioIntro` type added to `scenario.ts`: array of slides, each with title, body text, and optional flavor image reference
+- [ ] `Scenario` type gains `intro: ScenarioIntro` field (required)
+- [ ] `loadScenario` validates `intro` is present and non-empty
+- [ ] Intro screen renders slides with Next / Previous navigation and a "Start Drawing" button on the final slide
+- [ ] "Start Drawing" transitions to the map editor
+- [ ] Tutorial scenario JSON updated with a 2–3 slide intro (context, objective, mechanic hint)
+- [ ] Intro screen is skippable (keyboard shortcut or skip button) for returning players
+
+## Test Coverage
+
+- [ ] Unit: `loadScenario` rejects scenario missing `intro`; accepts valid intro array
+- [ ] e2e: intro screen visible on load before map editor
+- [ ] e2e: "Start Drawing" (or skip) reveals map editor
+- [ ] e2e: slide navigation (Next/Previous) updates displayed content
+
+## References
+
+- Vision §SCENARIO_INTRO, §LOOP
+- `game/web/src/model/scenario.ts` — types to extend
+- `game/web/src/model/loader.ts` — validation to extend
+- `game/web/index.html` + `src/main.ts` — UI entry point
+- Independent of GAME-015 and GAME-017; can be implemented in parallel

--- a/thoughts/shared/tickets/GAME-017-evaluation-phase.md
+++ b/thoughts/shared/tickets/GAME-017-evaluation-phase.md
@@ -1,0 +1,41 @@
+---
+id: GAME-017
+title: Evaluation phase — Test button, criteria check, pass/fail feedback
+area: game, simulation
+status: open
+created: 2026-04-26
+---
+
+## Summary
+
+After the player finishes drawing districts they need to find out if they won. The vision calls for an animated "Test" sequence that evaluates each success criterion and shows which passed and which failed, before transitioning to either a success screen or a feedback-and-retry loop. This ticket implements the evaluation logic and a minimal (non-animated) pass/fail result screen; animation polish is deferred.
+
+## Current State
+
+The map editor runs freely with no evaluation. Election results are computed live via `runElection` in `election.ts`, but they are never compared to success criteria. There is no "Test" button, no pass/fail state, and no result screen.
+
+## Goals / Acceptance Criteria
+
+- [ ] "Submit Map" (or "Test") button added to the editor UI; enabled only when all required validity constraints are met (population balance, contiguity if required, no unassigned precincts)
+- [ ] Clicking Submit evaluates each criterion in `scenario.criteria` against current district assignments + election results
+- [ ] Result screen shows: each criterion with pass/fail indicator; overall pass or fail; which optional criteria were met
+- [ ] Pass: shows success message + "Next Scenario" button (progression gated on GAME-018; for now, just a placeholder)
+- [ ] Fail: shows which required criteria failed + "Keep Drawing" button to return to editor
+- [ ] Evaluation is pure/deterministic given assignments + scenario; no randomness
+
+## Test Coverage
+
+- [ ] Unit: evaluation function correctly passes/fails each criterion type against known assignments
+- [ ] Unit: all-required-pass + some-optional-fail → overall pass
+- [ ] Unit: any-required-fail → overall fail
+- [ ] e2e: Submit button appears after map is valid
+- [ ] e2e: submitting a map that meets all criteria shows pass screen
+- [ ] e2e: submitting a map that fails a criterion shows fail screen with that criterion highlighted
+
+## References
+
+- Vision §LOOP, §TEST, §SUCCESS_SCREEN
+- `game/web/src/simulation/election.ts` — runElection (already computes district results)
+- `game/web/src/simulation/validity.ts` — computeValidityStats (already checks pop balance + contiguity)
+- Depends on: GAME-015 (criteria in scenario format)
+- Blocks: GAME-018 (progression needs a pass signal)

--- a/thoughts/shared/tickets/GAME-018-progression.md
+++ b/thoughts/shared/tickets/GAME-018-progression.md
@@ -1,0 +1,38 @@
+---
+id: GAME-018
+title: Scenario progression — sequential unlock and scenario select screen
+area: game, content
+status: open
+created: 2026-04-26
+---
+
+## Summary
+
+Players should progress through scenarios in order, with each completion unlocking the next. This requires a scenario select screen (showing completed, current, and locked scenarios) and a completion signal flowing from the evaluation phase. Progress is persisted in localStorage so it survives page reload.
+
+## Current State
+
+There is only one scenario and no concept of "current scenario" — the app always loads `kalanoa_westford.json` directly. There is no scenario select screen and no persistence of completion state.
+
+## Goals / Acceptance Criteria
+
+- [ ] Scenario select screen replaces direct-load-into-editor; shows all known scenarios as cards: completed (with achievement indicator), unlocked-current, locked (visible but dimmed)
+- [ ] Completing a scenario (passing evaluation in GAME-017) marks it complete in localStorage and unlocks the next
+- [ ] Selecting an unlocked scenario loads its intro (GAME-016) then editor
+- [ ] Returning players land on scenario select (not intro), with progress restored from localStorage
+- [ ] Works with 1 scenario (tutorial) without crashing; gracefully handles "all scenarios complete"
+- [ ] Scenario manifest (ordered list of scenario file paths) is a config file or hardcoded list — not auto-discovered
+
+## Test Coverage
+
+- [ ] Unit: localStorage read/write for completion state (pure serialization functions)
+- [ ] e2e: scenario select screen visible on initial load (before any scenario chosen)
+- [ ] e2e: completing a scenario (mocked pass signal) marks it complete and shows next as unlocked
+- [ ] e2e: page reload restores completion state
+
+## References
+
+- Vision §PROGRESSION, §MENU, §LOOP
+- `game/web/src/main.ts` — current entry point
+- Depends on: GAME-016 (intro), GAME-017 (evaluation/pass signal)
+- GAME-007 (player progress persistence) — overlapping scope; review before starting; may subsume or be subsumed

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -91,6 +91,10 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-004-legend-layout.md` | design, UX | Move legend to horizontal strip above map; free sidebar space for data panels |
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
 | `GAME-014-scenario-scale.md` | game, content | Scale tutorial scenario to 150–300 precincts across 3+ counties for Sprint 3 feature demo |
+| `GAME-015-scenario-success-criteria.md` | game, content | Add criteria field to scenario format + types; prerequisite for evaluation phase |
+| `GAME-016-scenario-intro.md` | game, content | Narrative slide intro before map editor; wired into game flow |
+| `GAME-017-evaluation-phase.md` | game, simulation | Submit button + criteria evaluation + pass/fail result screen |
+| `GAME-018-progression.md` | game, content | Scenario select screen + sequential unlock + localStorage completion persistence |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [x] Sprint 2 fully closed (#67, #68)

## Summary
- Adds 4 new tickets for the Sprint 3 game loop: GAME-015 (success criteria in scenario format), GAME-016 (scenario intro slides), GAME-017 (evaluation phase / pass-fail), GAME-018 (progression / scenario select)
- Updates TICKETS.md index with all 4
- These cover the gap between "functional map editor" (Sprint 2) and "actual game" (Sprint 3 target): ScenarioIntro → Level → Test → SuccessScreen

## Validation performed
- [x] N/A — ticket metadata only; no code changes

## Affected machines / services
- N/A

## Deployment steps
- N/A

## Tickets addressed
- N/A — this PR creates GAME-015, GAME-016, GAME-017, GAME-018

## Rollback
- N/A — ticket files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
