### PR TITLE
feat(GAME-018): scenario select screen + progression persistence

### DIFF
--- a/game/web/e2e/sprint3.spec.ts
+++ b/game/web/e2e/sprint3.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Sprint 3 behavioral tests — GAME-016 (scenario intro) + GAME-017 (evaluation).
+ * Sprint 3 behavioral tests:
+ *   GAME-016 (scenario intro), GAME-017 (evaluation), GAME-018 (progression).
  *
  * GAME-016: Intro slide flow:
- *   1. Intro screen is visible on initial load (before map editor)
+ *   1. Intro screen is visible on initial load (before map editor) — new player
  *   2. Character info is populated from scenario narrative
  *   3. Slide navigation (Next / Previous) cycles through slides correctly
  *   4. "Start Drawing" appears on the last slide and reveals the editor
@@ -12,10 +13,16 @@ import { test, expect } from "@playwright/test";
  *
  * GAME-017: Evaluation phase:
  *   6. Submit button is disabled on initial (all-D1) state (district 2 empty)
- *   7. Submit button enables after drawing a valid balanced map
- *   8. Submitting a passing map shows the pass result screen
- *   9. Submitting a failing map shows the fail result screen
- *   10. "Keep Drawing" button hides the result screen
+ *   7. Submit button remains in DOM after painting precincts
+ *   8. Clicking submit shows result screen with criteria
+ *   9. "Keep Drawing" button hides the result screen
+ *
+ * GAME-018: Progression:
+ *   10. Scenario select screen is shown for returning players (localStorage has completion data)
+ *   11. Scenario card shows "Completed" status and "Play Again" button for completed scenario
+ *   12. "Play Again" from select screen shows intro then editor
+ *   13. Page reload restores completion state from localStorage
+ *   14. New player (no localStorage) sees intro, not scenario select
  */
 
 /** Navigate, dismiss intro, wait for hex grid. */
@@ -166,4 +173,77 @@ test("submit: Keep Drawing button hides result screen", async ({ page }) => {
 
   await page.locator("#btn-keep-drawing").click();
   await expect(page.locator("#result-screen")).not.toBeVisible();
+});
+
+// ─── GAME-018: Progression ────────────────────────────────────────────────────
+
+/** Seed localStorage with completed scenario IDs before navigating. */
+async function seedProgress(
+  page: import("@playwright/test").Page,
+  completedIds: string[],
+): Promise<void> {
+  // Set localStorage before the page loads JS (use storageState or addInitScript)
+  await page.addInitScript((ids: string[]) => {
+    localStorage.setItem(
+      "redistricting-sim-progress",
+      JSON.stringify({ completed: ids }),
+    );
+  }, completedIds);
+}
+
+test("progression: scenario select screen is shown for returning players", async ({ page }) => {
+  await seedProgress(page, ["tutorial-001"]);
+  await page.goto("/");
+
+  // Scenario select must be visible; intro screen and editor must not be
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#intro-screen")).not.toBeVisible();
+  await expect(page.locator("#app-header")).not.toBeVisible();
+});
+
+test("progression: scenario card shows Completed status for completed scenario", async ({ page }) => {
+  await seedProgress(page, ["tutorial-001"]);
+  await page.goto("/");
+
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".sc-status.completed")).toBeVisible();
+  await expect(page.locator(".sc-status.completed")).toContainText("Completed");
+  await expect(page.locator(".sc-play-btn.replay")).toBeVisible();
+});
+
+test("progression: Play Again from select screen shows intro then editor", async ({ page }) => {
+  await seedProgress(page, ["tutorial-001"]);
+  await page.goto("/");
+
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await page.locator(".sc-play-btn.replay").click();
+
+  // Intro screen appears after clicking Play Again
+  await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 5_000 });
+
+  // Skip intro to get to editor
+  await page.locator("#btn-intro-skip").click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+});
+
+test("progression: page reload restores completion state from localStorage", async ({ page }) => {
+  await seedProgress(page, ["tutorial-001"]);
+  await page.goto("/");
+
+  // First load: scenario select visible with completed status
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".sc-status.completed")).toBeVisible();
+
+  // Reload: state should be restored from localStorage
+  await page.reload();
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".sc-status.completed")).toBeVisible();
+});
+
+test("progression: new player (no localStorage) sees intro, not scenario select", async ({ page }) => {
+  // No seedProgress call — fresh localStorage
+  await page.goto("/");
+
+  await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#scenario-select")).not.toBeVisible();
 });

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -705,7 +705,7 @@
     </div>
 
     <!-- ── Intro screen (GAME-016) ──────────────────────────────────────── -->
-    <div id="intro-screen">
+    <div id="intro-screen" class="hidden">
       <button id="btn-intro-skip">Skip intro</button>
       <div id="intro-card">
         <div id="intro-character">

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -138,31 +138,39 @@ if (wasmEl !== null) {
 		return;
 	}
 
-	// ── Intro screen (GAME-016) ───────────────────────────────────────────────
-	const slides = scenario.narrative?.intro_slides ?? [];
+	// ── GAME-018: Scenario manifest + progress ───────────────────────────────
+	const SCENARIO_MANIFEST: Array<{ id: string; title: string }> = [
+		{ id: scenario.id, title: scenario.title },
+	];
+	let progress = loadProgress();
 
-	// escHandler declared here so showEditor() can remove it regardless of
-	// which dismissal path (Start Drawing, Skip, or Escape) fires first.
-	let escHandler: ((e: KeyboardEvent) => void) | null = null;
+	// ── Intro screen (GAME-016) + scenario routing (GAME-018) ────────────────
+	// AbortController lets startScenarioIntro() be safely called multiple times:
+	// each call cancels the previous intro's event listeners before re-wiring.
+	let introController: AbortController | null = null;
 
 	function showEditor() {
-		if (escHandler !== null) {
-			document.removeEventListener("keydown", escHandler);
-			escHandler = null;
-		}
+		introController?.abort();
+		introController = null;
 		introScreen?.classList.add("hidden");
 		appHeader!.style.display = "";
 		mainEl!.style.display = "";
 		wasmStatusBar!.style.display = "";
 	}
 
-	if (slides.length === 0 || introScreen === null) {
-		// No narrative slides — go straight to editor
-		showEditor();
-	} else {
-		const { character, objective } = scenario.narrative!;
+	function startScenarioIntro() {
+		const slides = scenario.narrative?.intro_slides ?? [];
 
-		// Populate static character info
+		if (slides.length === 0 || introScreen === null) {
+			showEditor();
+			return;
+		}
+
+		introController?.abort();
+		introController = new AbortController();
+		const { signal } = introController;
+
+		const { character, objective } = scenario.narrative!;
 		if (charNameEl) charNameEl.textContent = character.name;
 		if (charRoleEl) charRoleEl.textContent = character.role;
 		if (charMotivationEl) charMotivationEl.textContent = character.motivation ?? "";
@@ -176,33 +184,27 @@ if (wasmEl !== null) {
 			if (introSlideHeading) introSlideHeading.textContent = slide.heading ?? "";
 			if (introSlideBody) introSlideBody.textContent = slide.body;
 			if (introProgress) introProgress.textContent = `${index + 1} / ${slides.length}`;
-
 			if (btnIntroPrev) btnIntroPrev.disabled = index === 0;
-
 			const isLast = index === slides.length - 1;
 			if (btnIntroNext) btnIntroNext.style.display = isLast ? "none" : "";
 			if (btnIntroStart) btnIntroStart.classList.toggle("visible", isLast);
 		}
 
 		renderSlide(0);
+		introScreen.classList.remove("hidden");
 
 		btnIntroPrev?.addEventListener("click", () => {
 			if (currentSlide > 0) renderSlide(--currentSlide);
-		});
-
+		}, { signal });
 		btnIntroNext?.addEventListener("click", () => {
 			if (currentSlide < slides.length - 1) renderSlide(++currentSlide);
-		});
-
+		}, { signal });
 		const startHandler = () => showEditor();
-		btnIntroStart?.addEventListener("click", startHandler);
-		btnIntroSkip?.addEventListener("click", startHandler);
-
-		// Escape key skips intro; cleaned up by showEditor() on any dismissal path
-		escHandler = (e: KeyboardEvent) => {
+		btnIntroStart?.addEventListener("click", startHandler, { signal });
+		btnIntroSkip?.addEventListener("click", startHandler, { signal });
+		document.addEventListener("keydown", (e: KeyboardEvent) => {
 			if (e.key === "Escape") showEditor();
-		};
-		document.addEventListener("keydown", escHandler);
+		}, { signal });
 	}
 
 	// ── Build store from scenario ─────────────────────────────────────────────
@@ -370,6 +372,12 @@ if (wasmEl !== null) {
 		btnKeepDrawing!.style.display = "";
 		btnNextScenario!.style.display = evalResult.overallPass ? "" : "none";
 
+		// ── GAME-018: persist completion on pass ──────────────────────────────────
+		if (evalResult.overallPass) {
+			progress = markCompleted(progress, scenario.id);
+			saveProgress(progress);
+		}
+
 		resultScreen.classList.remove("hidden");
 	}
 
@@ -381,9 +389,53 @@ if (wasmEl !== null) {
 		resultScreen!.classList.add("hidden");
 	});
 
-	// "Next Scenario" is a placeholder until GAME-018 adds the select screen
+	// ── Scenario select screen (GAME-018) ─────────────────────────────────────
+	function renderScenarioCards() {
+		if (!scenarioCardsEl) return;
+		scenarioCardsEl.innerHTML = "";
+		SCENARIO_MANIFEST.forEach((entry, i) => {
+			const completed = isCompleted(progress, entry.id);
+			const unlocked = i === 0 || isCompleted(progress, SCENARIO_MANIFEST[i - 1]?.id ?? "");
+			const locked = !unlocked;
+
+			const card = document.createElement("div");
+			card.className = `scenario-card${locked ? " locked" : ""}`;
+
+			const titleEl = document.createElement("div");
+			titleEl.className = "sc-title";
+			titleEl.textContent = entry.title;
+
+			const statusEl = document.createElement("div");
+			statusEl.className = `sc-status ${completed ? "completed" : unlocked ? "unlocked" : "locked"}`;
+			statusEl.textContent = completed ? "Completed" : unlocked ? "Ready" : "Locked";
+
+			const playBtn = document.createElement("button");
+			playBtn.className = `sc-play-btn ${completed ? "replay" : unlocked ? "play" : "locked-btn"}`;
+			playBtn.textContent = completed ? "Play Again" : unlocked ? "Play" : "Locked";
+			playBtn.disabled = locked;
+			if (!locked) {
+				playBtn.addEventListener("click", () => {
+					scenarioSelectEl?.classList.add("hidden");
+					startScenarioIntro();
+				});
+			}
+
+			card.appendChild(titleEl);
+			card.appendChild(statusEl);
+			card.appendChild(playBtn);
+			scenarioCardsEl.appendChild(card);
+		});
+	}
+
+	function showScenarioSelect() {
+		renderScenarioCards();
+		scenarioSelectEl?.classList.remove("hidden");
+	}
+
+	// "Next Scenario" → re-render cards (progress updated) then show select
 	btnNextScenario!.addEventListener("click", () => {
 		resultScreen!.classList.add("hidden");
+		showScenarioSelect();
 	});
 
 	// ── Subscribe to state changes ────────────────────────────────────────────
@@ -392,4 +444,13 @@ if (wasmEl !== null) {
 
 	// ── Initial render ────────────────────────────────────────────────────────
 	updateUI();
+
+	// ── GAME-018: progress-aware startup routing ──────────────────────────────
+	// Returning players (any completed scenario) go to the select screen.
+	// New players go directly to the scenario intro.
+	if (progress.completed.length > 0 && scenarioSelectEl !== null) {
+		showScenarioSelect();
+	} else {
+		startScenarioIntro();
+	}
 })();

--- a/game/web/src/model/BUILD.bazel
+++ b/game/web/src/model/BUILD.bazel
@@ -89,6 +89,40 @@ ts_project(
     visibility = ["//web:__subpackages__"],
 )
 
+# ── progress_typecheck_test: type-check passes ───────────────────────────────
+
+build_test(
+    name = "progress_typecheck_test",
+    targets = [":progress_lib"],
+    visibility = ["//visibility:public"],
+)
+
+# ── progress_test_lib: compile the test file ──────────────────────────────────
+
+ts_project(
+    name = "progress_test_lib",
+    srcs = ["progress_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [":progress_lib"],
+    testonly = True,
+)
+
+# ── progress_test: run tests with Node built-in test runner ──────────────────
+
+js_test(
+    name = "progress_test",
+    entry_point = "progress_test.js",
+    data = [
+        ":progress_test_lib",
+        ":progress_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # ── loader_typecheck_test: type-check passes ──────────────────────────────────
 
 build_test(

--- a/game/web/src/model/progress_test.ts
+++ b/game/web/src/model/progress_test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for progress.ts — pure serialization and mutation functions.
+ * Hand-rolled TAP runner (no external test framework); compatible with Node 18+.
+ *
+ * Run via: bazel test //web/src/model:progress_test
+ */
+
+import {
+	serializeProgress,
+	deserializeProgress,
+	markCompleted,
+	isCompleted,
+	type Progress,
+} from "./progress.js";
+
+let passed = 0;
+let failed = 0;
+let total = 0;
+
+function assert(description: string, condition: boolean): void {
+	total++;
+	if (condition) {
+		console.log(`ok ${total} - ${description}`);
+		passed++;
+	} else {
+		console.log(`not ok ${total} - ${description}`);
+		failed++;
+	}
+}
+
+function assertDeepEqual(description: string, actual: unknown, expected: unknown): void {
+	assert(description, JSON.stringify(actual) === JSON.stringify(expected));
+}
+
+// ─── serializeProgress ────────────────────────────────────────────────────────
+
+{
+	const p: Progress = { completed: [] };
+	const json = serializeProgress(p);
+	assert("serializeProgress: empty completed is valid JSON", (() => {
+		try { JSON.parse(json); return true; } catch { return false; }
+	})());
+}
+
+{
+	const p: Progress = { completed: ["tutorial-001"] };
+	const json = serializeProgress(p);
+	const parsed = JSON.parse(json) as { completed: string[] };
+	assertDeepEqual("serializeProgress: round-trips a single id", parsed.completed, ["tutorial-001"]);
+}
+
+{
+	const p: Progress = { completed: ["tutorial-001", "level-002"] };
+	const json = serializeProgress(p);
+	const parsed = JSON.parse(json) as { completed: string[] };
+	assertDeepEqual("serializeProgress: round-trips multiple ids", parsed.completed, ["tutorial-001", "level-002"]);
+}
+
+// ─── deserializeProgress ─────────────────────────────────────────────────────
+
+{
+	const p = deserializeProgress('{"completed":["tutorial-001"]}');
+	assertDeepEqual("deserializeProgress: parses valid JSON", p.completed, ["tutorial-001"]);
+}
+
+{
+	const p = deserializeProgress('{"completed":[]}');
+	assertDeepEqual("deserializeProgress: parses empty completed", p.completed, []);
+}
+
+{
+	const p = deserializeProgress("not-json");
+	assertDeepEqual("deserializeProgress: malformed JSON returns empty", p.completed, []);
+}
+
+{
+	const p = deserializeProgress('{"completed":["a",42,null,"b"]}');
+	assertDeepEqual("deserializeProgress: filters non-string items", p.completed, ["a", "b"]);
+}
+
+{
+	const p = deserializeProgress('{"other":"field"}');
+	assertDeepEqual("deserializeProgress: missing completed returns empty", p.completed, []);
+}
+
+{
+	const p = deserializeProgress("null");
+	assertDeepEqual("deserializeProgress: null JSON returns empty", p.completed, []);
+}
+
+// ─── round-trip ───────────────────────────────────────────────────────────────
+
+{
+	const original: Progress = { completed: ["a", "b", "c"] };
+	const roundTripped = deserializeProgress(serializeProgress(original));
+	assertDeepEqual("round-trip: serialize then deserialize preserves ids", roundTripped.completed, original.completed);
+}
+
+// ─── markCompleted ────────────────────────────────────────────────────────────
+
+{
+	const p: Progress = { completed: [] };
+	const updated = markCompleted(p, "tutorial-001");
+	assertDeepEqual("markCompleted: adds id to empty progress", updated.completed, ["tutorial-001"]);
+}
+
+{
+	const p: Progress = { completed: ["tutorial-001"] };
+	const updated = markCompleted(p, "tutorial-001");
+	assertDeepEqual("markCompleted: does not duplicate existing id", updated.completed, ["tutorial-001"]);
+}
+
+{
+	const p: Progress = { completed: ["tutorial-001"] };
+	const updated = markCompleted(p, "level-002");
+	assertDeepEqual("markCompleted: appends new id to existing", updated.completed, ["tutorial-001", "level-002"]);
+}
+
+{
+	const p: Progress = { completed: ["a"] };
+	const updated = markCompleted(p, "b");
+	assert("markCompleted: returns new object (immutable)", updated !== p);
+	assertDeepEqual("markCompleted: original unchanged", p.completed, ["a"]);
+}
+
+// ─── isCompleted ──────────────────────────────────────────────────────────────
+
+{
+	const p: Progress = { completed: ["tutorial-001"] };
+	assert("isCompleted: true for present id", isCompleted(p, "tutorial-001"));
+}
+
+{
+	const p: Progress = { completed: ["tutorial-001"] };
+	assert("isCompleted: false for absent id", !isCompleted(p, "level-002"));
+}
+
+{
+	const p: Progress = { completed: [] };
+	assert("isCompleted: false for empty progress", !isCompleted(p, "tutorial-001"));
+}
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+
+console.log(`\n1..${total}`);
+if (failed > 0) {
+	console.error(`# ${failed} of ${total} tests failed`);
+	throw new Error(`Test suite failed: ${failed} of ${total} tests failed`);
+} else {
+	console.log(`# All ${total} tests passed`);
+}


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #74 (GAME-017 evaluation phase)
- [x] Parent PR merged: #75 (GAME-017 close ticket)

## Summary
- Implements GAME-018: scenario select screen + localStorage completion persistence
- New players see the intro screen directly on first load
- Returning players (any completed scenario in localStorage) land on scenario select
- Passing the evaluation marks the scenario complete, saves progress, enables "Next Scenario" → select screen
- Progress uses pure serialization functions (testable without mocking localStorage)
- 18 unit tests for progress.ts serialization/mutation; 5 Playwright e2e tests for progression flows

## Changes
- `game/web/index.html`: `#intro-screen` starts hidden (class="hidden"); JS shows it on startup routing
- `game/web/src/main.ts`:
  - Scenario manifest (hardcoded for v1 with 1 scenario)
  - `startScenarioIntro()` with AbortController for clean re-entry on "Play Again"
  - `renderScenarioCards()` / `showScenarioSelect()` for scenario select screen
  - Progress-aware startup routing: returning player → select, new player → intro
  - `showResultScreen()` saves progress to localStorage on pass
  - "Next Scenario" button routes to scenario select (re-renders cards with updated state)
- `game/web/src/model/progress.ts`: already on main (pure functions + localStorage I/O)
- `game/web/src/model/progress_test.ts`: 18 unit tests (new file)
- `game/web/src/model/BUILD.bazel`: added `progress_test_lib`, `progress_test`
- `game/web/e2e/sprint3.spec.ts`: 5 GAME-018 e2e tests added

## Validation performed
- [x] `bazel build //web:app_typecheck_lib` passes
- [x] `bazel test //web/src/model:progress_test` passes (18 tests)
- [x] `bazel test //web/src/simulation:evaluate_test //web/src/model:loader_test` cached pass

## Tickets addressed
- see #76
