### PR TITLE
chore: sprint roadmap update, GAME-019/020 tickets, remove WASM diagnostic bar

### DIFF
--- a/game/web/index.html
+++ b/game/web/index.html
@@ -308,15 +308,6 @@
         font-weight: 600;
       }
 
-      #wasm-status-bar {
-        padding: 2px 16px;
-        background: #16213e;
-        border-top: 1px solid #0a1f3a;
-        font-size: 0.7rem;
-        color: #404060;
-        flex-shrink: 0;
-      }
-
       /* ── Scenario select screen (GAME-018) ───────────────────────────────── */
 
       #scenario-select {
@@ -768,10 +759,6 @@
         <h2>Legend</h2>
         <div id="legend-container" class="legend"></div>
       </aside>
-    </div>
-
-    <div id="wasm-status-bar" style="display:none">
-      <span id="wasm-status"></span>
     </div>
 
     <!--

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -1,15 +1,12 @@
 /**
  * Application entry point.
- * Fetches tutorial-001.json, validates it through loadScenario(), builds the
+ * Fetches the active scenario JSON, validates it through loadScenario(), builds the
  * Zustand store, wires D3 renderer and DOM controls.
  *
  * The WASM kernel (Rust → wasm-bindgen no-modules) is loaded by index.html
- * before this bundle. The global wasm_bindgen object is declared below.
+ * before this bundle executes.
  */
 
-// WASM kernel — provided by wasm_calc_bindgen.js (no-modules target).
-// index.html initialises the WASM binary before this bundle executes.
-declare const wasm_bindgen: { add(a: number, b: number): number };
 
 import { loadScenario } from "./model/loader.js";
 import type { Scenario } from "./model/scenario.js";
@@ -44,7 +41,6 @@ const btnResetConfirm = document.getElementById("btn-reset-confirm") as HTMLButt
 const btnResetCancel = document.getElementById("btn-reset-cancel") as HTMLButtonElement | null;
 const appHeader = document.getElementById("app-header") as HTMLElement | null;
 const mainEl = document.getElementById("main") as HTMLElement | null;
-const wasmStatusBar = document.getElementById("wasm-status-bar") as HTMLElement | null;
 
 // Scenario select refs (GAME-018)
 const scenarioSelectEl = document.getElementById("scenario-select") as HTMLElement | null;
@@ -88,19 +84,9 @@ if (
 	btnResetConfirm === null ||
 	btnResetCancel === null ||
 	appHeader === null ||
-	mainEl === null ||
-	wasmStatusBar === null
+	mainEl === null
 ) {
 	throw new Error("Required DOM elements not found");
-}
-
-// ─── WASM kernel diagnostic ───────────────────────────────────────────────────
-// Verifies the Rust→WASM pipeline is wired end-to-end.
-// wasm_bindgen is initialised by index.html before this bundle runs.
-
-const wasmEl = document.getElementById("wasm-status");
-if (wasmEl !== null) {
-	wasmEl.textContent = `WASM kernel: add(2, 3) = ${wasm_bindgen.add(2, 3)}`;
 }
 
 // ─── Async init ───────────────────────────────────────────────────────────────
@@ -155,7 +141,6 @@ if (wasmEl !== null) {
 		introScreen?.classList.add("hidden");
 		appHeader!.style.display = "";
 		mainEl!.style.display = "";
-		wasmStatusBar!.style.display = "";
 	}
 
 	function startScenarioIntro() {

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -1,6 +1,6 @@
 <!--COMPRESSED v1; source:2026-04-25-sprint-roadmap.md-->
 §META
-date:2026-04-25 status:active type:sprint-roadmap
+date:2026-04-25 last_updated:2026-04-26 status:active type:sprint-roadmap
 LIVING DOC — update at sprint start (fill tickets) + after demo (outcomes, re-evaluate next)
 
 §ABBREV
@@ -21,11 +21,11 @@ see game-vision.compressed.md for full scope
 | $sp | goal | demo | status |
 |-----|------|------|--------|
 | S1 | load+display real scenario | tutorial JSON→hex map; player paints $dists; Playwright harness live | complete — 2026-04-25 |
-| S2 | edit map + live feedback | live pop-balance, contiguity, $pc tooltip | backlog |
-| S3 | test the map | Test→per-criterion pass/fail; real sim engine | backlog |
-| S4 | one complete playable scenario | tutorial: intro→edit→test→pass/fail→retry | backlog |
-| S5 | more criteria + scenarios 2-4 | events; majority_minority/gap criteria; 4 playable | backlog |
-| S6 | game infra + scenarios 5-7 | $sp-select, unlock, persist (Continue); 7 playable | backlog |
+| S2 | edit map + live feedback | live pop-balance, contiguity, $pc tooltip | complete — 2026-04-25 |
+| S3 | test the map | Test→per-criterion pass/fail; real sim engine | complete — 2026-04-25 |
+| S4 | one complete playable scenario | tutorial: intro→edit→test→pass/fail→retry | complete — 2026-04-25 |
+| S5 | more scenarios + remaining criteria | tutorial-002 wired; scenarios 2–4; majority_minority/gap/mean-median | current |
+| S6 | game infra complete | GAME-007 in-progress save; scenarios 5-7 | backlog |
 | S7 | complete $v1 | all 8-12 scenarios; achievements; test anim; about; shippable | backlog |
 
 §SPRINT1 [COMPLETE 2026-04-25]
@@ -35,63 +35,80 @@ demo observations:
   + 30-hex map loads; paint/undo/redo/lean-view/boundaries all work; zippier than spike
   - view toggle label ambiguous (current-state vs destination) → DESIGN-002
   - districts view population gradient dominates district color → DESIGN-003
-  + motivated GAME-008 (accessibility) ticket for color-blind palettes + screen reader
+  + motivated GAME-008 (accessibility)
 tickets (all resolved):
   GAME-001 GAME-004 CI-002(Ph1) GAME-002 GAME-003 GAME-005 CI-002(Ph2)
   PRs: #33 #34 #37 #38 #44 #46 #47 #49 #50 #51
 
-§SPRINT2 (backlog)
-goal: edit map + live feedback
-tickets:
-  DESIGN-002 view-toggle label fix (destination not current)
-  GAME-009 pan+zoom (d3.zoom; scroll+keyboard; zoom-invariant strokes)
-  GAME-010 map validity panel (pop-balance ±%; contiguity; unassigned count)
-  GAME-011 precinct info panel (sidebar hover section; replaces status bar)
-  GAME-012 county border overlay toggle (flavor; computed from county_id)
-  GAME-013 reset-to-initial (confirmation; clears undo history)
-deferred: brush size controls (not sprint-assigned)
+§SPRINT2 [COMPLETE]
+goal: editing experience complete; real-time validity feedback
+outcome: all tickets closed; live pop-balance ±% per dist; contiguity BFS; unassigned count;
+  $pc hover tooltip in sidebar; county border toggle; reset+confirm; view toggle label fixed
+tickets (all resolved): DESIGN-002 GAME-009 GAME-010 GAME-011 GAME-012 GAME-013
+PRs: #55 #57 #59 #61 #63 #65
 
-§SPRINT3 (backlog)
-real sim engine: group model(pop_share×voter_eligible×turnout×vote_shares); events applied
-criterion evaluators: population_balance | seat_count | district_count
-basic Test sequence UI (placeholder anim; real anim=S7)
-GAME-006 (scenario compression): evaluate+resolve or defer
+§SPRINT3 [COMPLETE]
+goal: player runs Test; sees per-criterion pass/fail; real sim engine
+outcome: all tickets closed; election sim (pop-weighted vote shares, seat plurality);
+  evaluators: population_balance seat_count district_count safe_seats competitive_seats compactness;
+  submit button gated on submittability; pass/fail result screen with per-criterion rows
+  stubs remaining for S5: majority_minority efficiency_gap mean_median
+tickets (all resolved): GAME-017
+PRs: #74
 
-§SPRINT4 (backlog)
-scenario intro slides UI | success screen | failure+feedback screen | retry loop
-Canvas+SVG hybrid: assess threshold; defer if all scenarios ≤800 $pcs
+§SPRINT4 [COMPLETE]
+goal: tutorial scenario fully playable end-to-end
+outcome: all tickets closed; full-screen intro slides (narrative, Skip/Prev/Next/Start);
+  pass/fail screen + "Keep Drawing" + "Next Scenario" actions
+  NOTE: scenario select screen + sequential unlock + localStorage completion tracking
+    pulled forward from S6 as part of GAME-018; in-progress save (GAME-007) deferred+open
+tickets (all resolved): GAME-016 GAME-018
+PRs: #71 #77
 
-§SPRINT5 (backlog)
-criterion evaluators: majority_minority(min_eligible_share) | efficiency_gap |
-  mean_median | compactness | safe_seats | competitive_seats
-scenarios 2(Gov Win) 3(Packing) 4(Cracking) authored+playable
-scenario-to-scenario transition (unlock display; no persist yet)
+§SPRINT5 [CURRENT]
+goal: 3+ playable scenarios; all planned criterion types implemented; tutorial-002 wired
+scope:
+  wire tutorial-002.json into SCENARIO_MANIFEST; verify 196-pc scenario + select screen
+  implement stub evaluators: majority_minority(min_eligible_share) efficiency_gap mean_median
+  author scenarios 2-4: "Give the Governor a Win" "The Packing Problem" "Cracking the Opposition"
+  confirm select+unlock works with multiple real scenarios
+  perf check: 196 pcs well within 800 SVG limit; note if degraded
+open questions to resolve before authoring S2-4:
+  OQ9: StateContext redesign — needed for state-level dist view; deferrable if S2-4 don't require it
+candidate IDs: GAME-019(wire tutorial-002) GAME-020(criterion stubs) GAME-021/022/023(scenarios 2/3/4)
 
 §SPRINT6 (backlog)
-scenario select screen | sequential unlock | main menu
-GAME-007 player persistence: in-progress save/resume; completion tracking; Continue menu
-scenarios 5(VRA) 6(Harden) 7(Reform Map)
+goal: game infra complete; player persistence; 7 scenarios
+scope:
+  GAME-007: in-progress save/resume — draft assignments→localStorage; restore on return
+  scenarios 5-7: "A Voice for the Valley" "Harden the Map" "The Reform Map"
+  main menu screen (assess if select screen already serves this)
+  perf pass: confirm all scenarios ≤800 pcs
+NOTE: select screen+unlock+completion tracking already done in S4; S6 scope narrower than planned
 
 §SPRINT7 (backlog)
-scenarios 8(Both Sides) 9(Cats+Dogs) + design-gap scenarios
+remaining scenarios 8(Both Sides Unhappy) 9(Cats vs Dogs) + design-gap scenarios
 Test sequence animation (governor/legislature/lobby icons)
 achievement/star UX (pending DESIGN-001 research)
 About page
-perf pass: confirm ≤800 $pcs pure SVG | Canvas+SVG hybrid if exceeded
-GAME-006 if not done in S3
+perf pass: confirm ≤800 pcs pure SVG | Canvas+SVG hybrid if exceeded
+GAME-006 if not done earlier
 
 §BACKLOG (not sprint-assigned)
-GAME-006  scenario compression          S3 or S7
+GAME-006  scenario compression          S5/S6/S7
 GAME-007  player progress persistence   S6
+GAME-008  accessibility                 any
+DESIGN-003 districts view color encoding any
+DESIGN-004 legend layout               any
 CI-001    GH Action ticket-close sync   any (low priority)
 LEGAL-001 content presentation risk     before public release
 DIST-001  Steam deployment research     before distribution decision
 DESIGN-001 achievement/star ergonomics  before S7 UX work
 
 §BLOCKING_OPEN_QUESTIONS
-OQ4 narrative asset resolution (Slide.image) → blocks S4 intro slides
-OQ9 StateContext redesign → blocks S5/S6 state-level view infra
+OQ9 StateContext redesign → may block S5 scenario authoring (deferrable if scenarios 2-4 don't need state view)
 DESIGN-001 star/achievement UX → blocks S7
+RESOLVED: OQ4 narrative asset resolution — intro shipped without image support; deferred indefinitely
 
 §REFS
 vision: thoughts/shared/vision/game-vision.compressed.md

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -2,6 +2,7 @@
 date: 2026-04-25
 status: active
 type: sprint-roadmap
+last_updated: 2026-04-26
 ---
 
 # Sprint Roadmap — Redistricting Simulator v1
@@ -34,165 +35,161 @@ See `thoughts/shared/vision/game-vision.compressed.md` for full scope.
 
 | Sprint | Goal | Demo target | Status |
 |---|---|---|---|
-| 1 | Load and display a real scenario | Tutorial map renders from JSON; player can paint districts | planned |
-| 2 | Edit the map + live feedback | Live population balance, contiguity indicators, precinct tooltip | backlog |
-| 3 | Test the map | Hit Test → per-criterion pass/fail; real simulation engine | backlog |
-| 4 | One complete playable scenario | Tutorial scenario: intro → edit → test → pass/fail → retry | backlog |
-| 5 | More criteria + scenarios 2–4 | Demographic events; majority_minority/efficiency_gap criteria; 4 playable | backlog |
-| 6 | Game infrastructure + scenarios 5–7 | Scenario select, unlock, persistence ("Continue"); 7 playable | backlog |
+| 1 | Load and display a real scenario | Tutorial map renders from JSON; player can paint districts | complete — 2026-04-25 |
+| 2 | Edit the map + live feedback | Live population balance, contiguity indicators, precinct tooltip | complete — 2026-04-25 |
+| 3 | Test the map | Hit Test → per-criterion pass/fail; real simulation engine | complete — 2026-04-25 |
+| 4 | One complete playable scenario | Tutorial scenario: intro → edit → test → pass/fail → retry | complete — 2026-04-25 |
+| 5 | More scenarios + remaining criteria | tutorial-002 wired; scenarios 2–4 authored; majority_minority/gap/mean-median implemented | current |
+| 6 | Game infrastructure complete | In-progress save/resume (GAME-007); scenarios 5–7 authored | backlog |
 | 7 | Complete v1 | All 8–12 scenarios; achievements UX; test animation; about page; shippable | backlog |
 
 ---
 
-## Sprint 1 — Load and Display a Real Scenario
+## Sprint 1 — Load and Display a Real Scenario [COMPLETE 2026-04-25]
 
 **Goal**: The app renders a real scenario from a JSON file. The player can see
 the hex map, paint districts, undo/redo, and toggle the partisan lean view.
 No simulation or game loop yet.
 
-**Demo**: Open browser via `serve.sh`. Tutorial scenario loads, hex map visible,
-precincts rendered at correct positions. Player can paint districts and undo.
+**Outcome**: All tickets closed; demo held 2026-04-25; received as "awesome and
+successful". 30-hex map loads; paint/undo/redo/lean-view/boundaries all work.
+Demo observations: view toggle label ambiguous (→ DESIGN-002); districts view
+population gradient dominated district color (→ DESIGN-003); motivated
+GAME-008 (accessibility).
 
-**Tickets** (execute in dependency order):
-
-| Ticket | Title | Notes |
-|---|---|---|
-| GAME-001 | Scenario TypeScript types | No dependencies; do first |
-| GAME-004 | MapRenderer interface extraction | No dependencies; parallel with GAME-001 |
-| GAME-002 | Scenario JSON loader + validator | Depends on GAME-001 |
-| GAME-003 | Tutorial scenario content | Depends on GAME-001 (types), GAME-002 (validator); sketch proposal first |
-| GAME-005 | Sprint 1 integration | Depends on all above; this is the demo |
-
-**GAME-001 and GAME-004 can proceed in parallel.** Once GAME-001 is done,
-GAME-002 begins. GAME-003 Phase 1 (the written sketch) can also start once
-GAME-001 is done — it does not need the validator. GAME-003 Phase 2 (full JSON
-authoring) requires GAME-002 to be complete (so the scenario can be validated).
-GAME-005 is last.
-
-DAG: `GAME-001 ∥ GAME-004 → GAME-002 → GAME-003 (Phase 2) → GAME-005`
-Note: GAME-003 Phase 1 (sketch) can start alongside GAME-002.
+**Tickets**: GAME-001, GAME-004, GAME-002, GAME-003, GAME-005, CI-002 (Ph1+Ph2)
+PRs: #33 #34 #37 #38 #44 #46 #47 #49 #50 #51
 
 ---
 
-## Sprint 2 — Edit the Map + Live Feedback
+## Sprint 2 — Edit the Map + Live Feedback [COMPLETE]
 
 **Goal**: The editing experience is complete. The player gets real-time feedback
 on map validity without running the full simulation.
 
-**Planned scope** (tickets to be created at sprint planning):
-- Live population balance per district (% deviation from target shown per district)
-- Contiguity validation — highlight non-contiguous district segments
-- Precinct tooltip on hover (population, demographic summary, current district)
-- County border overlay toggle (wires up `setCountyBordersVisible` from GAME-004)
-- Brush size controls (already partially in spike; needs scenario-aware refinement)
-- Reset to initial state button
+**Outcome**: All tickets closed. Live population balance ±% per district,
+contiguity BFS check, unassigned count, precinct hover tooltip in sidebar,
+county border overlay toggle, reset-to-initial with confirmation, view toggle
+label convention fixed (destination not current state).
 
-**Not yet ticketed** — sprint plan written before Sprint 2 begins.
+**Tickets**: DESIGN-002, GAME-009, GAME-010, GAME-011, GAME-012, GAME-013
+PRs: #55 #57 #59 #61 #63 #65
 
 ---
 
-## Sprint 3 — Test the Map
+## Sprint 3 — Test the Map [COMPLETE]
 
 **Goal**: The player can run Test and see which success criteria pass or fail.
-Introduces the real simulation engine (demographic group model, events).
+Introduces the real simulation engine.
 
-**Planned scope**:
-- Election simulation engine replacing spike's simplified version
-  - Group model: `population_share × voter_eligible × turnout_rate × vote_shares`
-  - Demographic events applied before simulation
-  - Pure function; fully unit-testable
-- Criterion evaluators: `population_balance`, `seat_count`, `district_count`
-  (the types present in tutorial scenario — enough for Sprint 3 demo)
-- Basic Test sequence UI: per-criterion pass/fail list (placeholder animation;
-  real governor/legislature animation is Sprint 7)
-- Scenario compression (GAME-006) evaluated and addressed this sprint or deferred
+**Outcome**: All tickets closed. Election sim engine (population-weighted vote
+shares, seat plurality); criteria evaluators for `population_balance`,
+`seat_count`, `district_count`, `safe_seats`, `competitive_seats`,
+`compactness`. Submit button gated on submittability. Pass/fail result screen
+with per-criterion rows. Three criteria types remain as stubs for Sprint 5:
+`majority_minority`, `efficiency_gap`, `mean_median`.
 
-**Not yet ticketed.**
+**Tickets**: GAME-017 (covered sim engine + submit + result screen)
+PRs: #74
 
 ---
 
-## Sprint 4 — One Complete Playable Scenario
+## Sprint 4 — One Complete Playable Scenario [COMPLETE]
 
 **Goal**: The tutorial scenario is fully playable end-to-end. The game loop is
 complete for one scenario.
 
-**Planned scope**:
-- Scenario intro slides UI (character framing, narrative context)
-- Success screen (required criteria all passed; optional criteria status)
-- Failure/feedback screen (which criteria failed; return to editing)
-- Retry loop
-- MapRenderer interface: confirm Canvas+SVG hybrid threshold is not yet hit;
-  defer Canvas implementation if all scenarios stay ≤ 800 precincts
+**Outcome**: All tickets closed. Full-screen intro slides (narrative character,
+objective, slide sequence, Skip/Prev/Next/Start). Pass/fail screen with
+"Keep Drawing" and "Next Scenario" actions. **Scenario select screen, sequential
+unlock logic, and localStorage completion tracking were implemented here as
+well** — pulled forward from Sprint 6 as part of GAME-018. In-progress save
+(GAME-007) was explicitly deferred and remains open.
 
-**Not yet ticketed.**
-
----
-
-## Sprint 5 — More Criteria + Scenarios 2–4
-
-**Goal**: Four scenarios are playable. All common criterion types implemented.
-
-**Planned scope**:
-- Additional criterion evaluators: `majority_minority` (uses `min_eligible_share`
-  and eligibility_rules), `efficiency_gap`, `mean_median`, `compactness`,
-  `safe_seats`, `competitive_seats`
-- Scenarios 2 (Give the Governor a Win), 3 (The Packing Problem),
-  4 (Cracking the Opposition) — authored as JSON
-- Scenario-to-scenario transition (completing one shows the next is unlocked;
-  no persist yet — that's Sprint 6)
-
-**Not yet ticketed.**
+**Tickets**: GAME-016, GAME-018
+PRs: #71 #77
 
 ---
 
-## Sprint 6 — Game Infrastructure + Scenarios 5–7
+## Sprint 5 — More Scenarios + Remaining Criteria [CURRENT]
 
-**Goal**: The game feels like a real game. Progression, persistence, scenario
-select screen. Seven scenarios playable.
+**Goal**: At least three scenarios are playable. All planned criterion types
+implemented. tutorial-002 (196-precinct) wired into the manifest.
 
-**Planned scope**:
-- Scenario select screen (completed / next unlocked / locked visible)
-- Sequential unlock: completing scenario N unlocks N+1
-- Player progress persistence (GAME-007): in-progress session save/resume,
-  completion tracking, "Continue" from main menu
-- Main menu screen
-- Scenarios 5 (A Voice for the Valley), 6 (Harden the Map), 7 (The Reform Map)
+**Scope**:
 
-**Known tickets**: GAME-007. Remainder TBD.
+- Wire `tutorial-002.json` into `SCENARIO_MANIFEST` in `main.ts`; verify the
+  196-precinct scenario loads and the select screen shows two entries
+- Implement the three stub criterion evaluators:
+  - `majority_minority` (uses `min_eligible_share` + scenario eligibility_rules)
+  - `efficiency_gap`
+  - `mean_median`
+- Author scenarios 2–4 as JSON (scenario names from vision: "Give the Governor
+  a Win", "The Packing Problem", "Cracking the Opposition")
+- Scenario-to-scenario transition already works (select screen + unlock is done);
+  confirm it works with multiple real scenarios
+- Performance check: tutorial-002 has 196 precincts (well within 800 SVG limit);
+  note but do not act unless degraded
+
+**Open questions that must be resolved before authoring scenarios 2–4**:
+- OQ9: StateContext redesign — needed if any new scenario requires state-level
+  district view (may be deferrable if scenarios 2–4 don't require it)
+
+**Known tickets**: None open that map to this sprint yet — create at sprint start.
+Candidate IDs: GAME-019 (wire tutorial-002), GAME-020 (criterion stubs),
+GAME-021/022/023 (scenarios 2/3/4).
 
 ---
 
-## Sprint 7 — Complete v1
+## Sprint 6 — Game Infrastructure Complete [BACKLOG]
+
+**Goal**: The game feels like a real game. Player persistence; seven scenarios.
+
+**Scope**:
+- GAME-007: In-progress session save/resume — save draft district assignments
+  to localStorage; restore on return; distinguish from completion tracking
+- Scenarios 5–7: "A Voice for the Valley", "Harden the Map", "The Reform Map"
+- Main menu screen (optional: assess whether select screen already serves this)
+- Performance pass: confirm all scenarios ≤ 800 precincts
+
+**Known tickets**: GAME-007. Remainder TBD at sprint planning.
+
+**Note**: Scenario select screen, sequential unlock, and completion tracking
+were already implemented in Sprint 4. Sprint 6 scope is now narrower than
+originally planned.
+
+---
+
+## Sprint 7 — Complete v1 [BACKLOG]
 
 **Goal**: Shippable v1. All scenarios, polish, about page.
 
-**Planned scope**:
+**Scope**:
 - Remaining scenarios: 8 (Both Sides Unhappy), 9 (Cats vs. Dogs), plus
-  any additional scenarios needed to fill the design gap (see vision §SCENARIOS
-  note about needing 1+ scenarios complicating the reform narrative)
+  any additional scenarios needed to fill the design gap (see vision §SCENARIOS)
 - Test sequence animation (governor/legislature/lobby icons — see vision §TEST)
 - Achievement/optional criteria UX (star display or equivalent; see DESIGN-001)
 - About page
 - Performance pass: confirm all scenarios ≤ 800 precincts (pure SVG) or
   implement Canvas+SVG hybrid if needed
-- Scenario compression (GAME-006) confirmed/implemented if not done in Sprint 3
+- GAME-006 (scenario compression) if not resolved earlier
 
-**Known tickets**: GAME-006 (if not Sprint 3), DESIGN-001 (research informs UX).
-Remainder TBD.
+**Known tickets**: GAME-006 (if not Sprint 5/6), DESIGN-001.
+Remainder TBD at sprint planning.
 
 ---
 
-## Backlog (not yet sprint-assigned)
-
-These tickets exist but are not assigned to a sprint. They will be slotted in
-at sprint planning for the appropriate sprint.
+## Backlog (not sprint-assigned)
 
 | Ticket | Area | Sprint target |
 |---|---|---|
-| GAME-006 | Scenario compression | Sprint 3 or 7 |
-| GAME-007 | Player progress persistence | Sprint 6 |
-| CI-001 | GitHub Action ticket-close sync | Any (infrastructure; low priority) |
-| LEGAL-001 | Content presentation risk research | Before any public release |
+| GAME-006 | Scenario compression | Sprint 5, 6, or 7 |
+| GAME-007 | Player progress persistence (in-progress save) | Sprint 6 |
+| GAME-008 | Accessibility | Any sprint |
+| DESIGN-003 | Districts view color/population encoding | Any sprint |
+| DESIGN-004 | Legend layout (horizontal strip above map) | Any sprint |
+| CI-001 | GitHub Action ticket-close sync | Any (low priority) |
+| LEGAL-001 | Content presentation risk research | Before public release |
 | DIST-001 | Steam deployment research | Before distribution decision |
 | DESIGN-001 | Achievement/star system ergonomics | Before Sprint 7 UX work |
 
@@ -200,11 +197,10 @@ at sprint planning for the appropriate sprint.
 
 ## Open Spec Questions That Will Block Implementation
 
-These open questions from the scenario data format spec need resolution before
-the relevant sprint begins. Flagged here so they don't get lost.
-
 | Question | Blocks | ADR/spec reference |
 |---|---|---|
-| OQ4: Narrative asset resolution strategy (Slide.image path vs. key) | Sprint 4 (intro slides) | scenario-data-format.md OQ4 |
-| OQ9: StateContext redesign | Sprint 5/6 (state-level view infrastructure) | scenario-data-format.md OQ9 |
+| OQ9: StateContext redesign | Sprint 5/6 (state-level view infra; may be deferrable) | scenario-data-format.md OQ9 |
 | DESIGN-001: Star/achievement UX | Sprint 7 | DESIGN-001 ticket |
+
+**Resolved**: OQ4 (narrative asset resolution) — intro slides shipped in Sprint 4
+without image support; image handling deferred indefinitely.

--- a/thoughts/shared/tickets/GAME-019-tutorial-002-winnability-and-e2e-solve.md
+++ b/thoughts/shared/tickets/GAME-019-tutorial-002-winnability-and-e2e-solve.md
@@ -1,0 +1,56 @@
+---
+id: GAME-019
+title: "tutorial-002 winnability: verify solvable, adjust if needed, e2e test that solves the map"
+area: game, content, testing
+status: open
+created: 2026-04-26
+---
+
+## Summary
+
+tutorial-002 (196-precinct three-county scenario) is the live scenario but has never been
+playtested to confirm it is actually winnable. The initial district assignment is badly
+skewed (d1: 174k, d2: 289k, d3: 150k vs. ~204k target), which is intentional — but it is
+unknown whether a valid solution (all districts contiguous, population within ±10%) is
+reachable through normal play. The existing e2e submit test bypasses the validity gate by
+force-enabling the button in JavaScript rather than legitimately solving the map.
+
+This ticket covers: (1) verifying tutorial-002 is winnable, adjusting the scenario JSON if
+not; (2) writing an e2e test that actually paints precincts until the submit button enables
+naturally, then submits and asserts a pass result.
+
+## Current State
+
+- `tutorial-002.json`: 196 precincts, 3 districts, population_tolerance 0.1, contiguity required
+- Initial populations: d1=174,473 d2=289,254 d3=149,517 (target ≈204,408 each)
+- Existing e2e test in `sprint3.spec.ts` force-enables the submit button to test the result
+  screen structure — it does not validate that the map can be legitimately solved
+- No human or automated test has confirmed a winning configuration exists
+
+## Goals / Acceptance Criteria
+
+- [ ] Play through tutorial-002 manually (via `serve.sh`) and find a valid winning assignment
+- [ ] If no valid solution is reachable (contiguity + population balance simultaneously
+      satisfiable), adjust precinct `initial_district_id` assignments or `total_population`
+      values in tutorial-002.json until a solution exists
+- [ ] Write an e2e test (in `sprint3.spec.ts` or a new `e2e/winnability.spec.ts`) that:
+      - Paints precincts by clicking/dragging until the submit button is naturally enabled
+        (no JS force-enable)
+      - Clicks submit
+      - Asserts `#result-verdict` contains "Map Passed!"
+      - Asserts all required criteria show PASS badges
+- [ ] The winning paint sequence must be deterministic and reproducible (hardcoded precinct
+      IDs or a fixed paint path, not random)
+- [ ] All existing e2e tests continue to pass
+
+## Test Coverage
+
+The new e2e test IS the primary deliverable. It proves the game can be won, not just that
+the result screen renders.
+
+## References
+
+- Scenario file: `game/scenarios/tutorial-002.json`
+- Existing submit tests: `game/web/e2e/sprint3.spec.ts` (GAME-017 section)
+- Criteria evaluators: `game/web/src/simulation/evaluate.ts`
+- Validity gate: `game/web/src/simulation/evaluate.ts` `isMapSubmittable()`

--- a/thoughts/shared/tickets/GAME-020-last-scenario-wrap-up-screen.md
+++ b/thoughts/shared/tickets/GAME-020-last-scenario-wrap-up-screen.md
@@ -1,0 +1,50 @@
+---
+id: GAME-020
+title: "Last scenario: wrap-up screen / completion animation after all scenarios finished"
+area: game, UX
+status: open
+created: 2026-04-26
+---
+
+## Summary
+
+When the player completes the final scenario in the manifest, clicking "Next Scenario"
+currently leads to the scenario select screen — which shows all scenarios as completed
+and no clear next action. This is a dead end. The game needs a wrap-up experience:
+a congratulations screen, short summary of what the player learned, and a clear
+"you finished the game" moment. A placeholder animation or static screen is acceptable
+for v1; the full Test-sequence animation (S7) is a separate ticket.
+
+## Current State
+
+- After passing the last scenario, `btnNextScenario` fires `showScenarioSelect()`
+- The select screen renders all scenarios as "Completed" with "Play Again" buttons
+- No wrap-up screen, no end-game state, no closure for the player
+- The scenario manifest is currently one entry (tutorial-002); this matters more as
+  scenarios 2–N are added
+
+## Goals / Acceptance Criteria
+
+- [ ] Detect when the player has completed the last scenario in SCENARIO_MANIFEST
+- [ ] Instead of showing the select screen, show a wrap-up/congratulations screen with:
+      - A "You've completed all scenarios" heading
+      - Brief closing text (written to match game tone — fictional region framing)
+      - A "Play Again" button (restarts from scenario select) and optionally a
+        "Share" or "About" link
+- [ ] The wrap-up screen is distinct from the pass/fail result screen
+- [ ] If more scenarios exist (i.e., the completed scenario is not the last), behaviour
+      is unchanged (select screen as before)
+- [ ] e2e test: seed localStorage with all-but-last completed, complete the last scenario,
+      assert wrap-up screen is shown (not select screen)
+
+## Test Coverage
+
+- One Playwright e2e test: seed progress, force-pass the last scenario, assert wrap-up
+  screen visible and "Next Scenario" / select screen not shown
+
+## References
+
+- `game/web/src/main.ts` — `btnNextScenario` click handler (line ~436)
+- `game/web/src/main.ts` — `SCENARIO_MANIFEST` and `showScenarioSelect()`
+- Related S7 work: Test-sequence animation (separate ticket, not a dependency here)
+- GAME-018 (progression, select screen) — resolved PR #77

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -91,6 +91,8 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-003-districts-view-color-encoding.md` | design, UX | Districts view color/population gradient: decide encoding strategy for v1 |
 | `DESIGN-004-legend-layout.md` | design, UX | Move legend to horizontal strip above map; free sidebar space for data panels |
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
+| `GAME-019-tutorial-002-winnability-and-e2e-solve.md` | game, content, testing | Verify tutorial-002 is winnable; adjust scenario if not; e2e test that legitimately solves the map |
+| `GAME-020-last-scenario-wrap-up-screen.md` | game, UX | Wrap-up/congratulations screen after completing the final scenario (instead of dead-end select screen) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Sprint roadmap updated to reflect actual state: S1–S4 complete, S5 current (plan was stale, still showed only S1 as done)
- Filed GAME-019: verify tutorial-002 is winnable; write e2e test that legitimately solves the map
- Filed GAME-020: wrap-up screen after completing the final scenario
- Removed WASM diagnostic status bar from `index.html` and `main.ts` (dev artifact visible to players)

## Validation performed

- [x] `bazel build //web:app_typecheck_lib` passes after main.ts edits
- [ ] kubectl dry-run passed (N/A — no infra changes)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services

- N/A — browser game only; no server, no infra

## Deployment steps

- N/A — static site; served via `serve.sh` or Bazel

## Tickets addressed

- see #78 (GAME-014 close — sprint roadmap reflects completion)

## Rollback

- Revert commit; no data migration or infra change required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
