### PR TITLE
chore: close GAME-019 ticket

### DIFF
--- a/memory/feedback_no_inline_python.md
+++ b/memory/feedback_no_inline_python.md
@@ -1,0 +1,11 @@
+---
+name: No inline Python in PR workflow
+description: Never use inline Python (python3, subprocess, etc.) in PR-related operations; use kotlin scripts or jq
+type: feedback
+---
+
+Never use inline Python for any PR-related work or JSON parsing.
+
+**Why:** Explicitly forbidden for PR use. Kotlin scripts in /opt/geekinasuit/agents/tools/ are the sanctioned tools for all PR operations (comments, threads, diff summaries). jq is the sanctioned tool for JSON parsing.
+
+**How to apply:** For PR comment posting, thread replies, and status checks — use the .main.kts scripts. For JSON parsing — use jq. Never call python3 inline in a Bash tool call for these purposes.

--- a/thoughts/shared/tickets/GAME-019-tutorial-002-winnability-and-e2e-solve.md
+++ b/thoughts/shared/tickets/GAME-019-tutorial-002-winnability-and-e2e-solve.md
@@ -2,8 +2,9 @@
 id: GAME-019
 title: "tutorial-002 winnability: verify solvable, adjust if needed, e2e test that solves the map"
 area: game, content, testing
-status: open
+status: resolved
 created: 2026-04-26
+github_issue: 84
 ---
 
 ## Summary

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -91,7 +91,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-003-districts-view-color-encoding.md` | design, UX | Districts view color/population gradient: decide encoding strategy for v1 |
 | `DESIGN-004-legend-layout.md` | design, UX | Move legend to horizontal strip above map; free sidebar space for data panels |
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
-| `GAME-019-tutorial-002-winnability-and-e2e-solve.md` | game, content, testing | Verify tutorial-002 is winnable; adjust scenario if not; e2e test that legitimately solves the map |
 | `GAME-020-last-scenario-wrap-up-screen.md` | game, UX | Wrap-up/congratulations screen after completing the final scenario (instead of dead-end select screen) |
 
 ---
@@ -100,6 +99,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| GAME-019: tutorial-002 winnability + e2e solve test | All AC met; county-aligned initial assignments (north→d1, central→d2, south→d3); painting p071–p075 (indices 70–74) solves the map; 39th e2e test verifies end-to-end pass; merged PR #83 |
 | GAME-014: Scale tutorial scenario | All AC met; 196-precinct tutorial-002 scenario (3 counties, 4 districts); merged PR #79 |
 | GAME-018: Progression | All AC met; scenario select screen + localStorage completion + AbortController intro; 18 unit tests + 5 e2e tests; merged PR #77 |
 | GAME-017: Evaluation phase | All AC met; Submit button + evaluateCriteria + pass/fail screen; 15 unit tests + 5 e2e tests; merged PR #74 |


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #83

## Summary
- GAME-019 ticket marked resolved; moved to Resolved section of TICKETS.md
- feedback_no_inline_python.md memory file added (use kotlin scripts / jq; no inline python for PR work)

## Validation performed
- [x] N/A — kubectl dry-run (no infra changes)
- [x] N/A — sops decrypt (no secrets)

## Affected machines / services
- N/A — docs/tickets only

## Deployment steps
- N/A

## Tickets addressed
- Closes GAME-019 (close-ticket PR)

## Rollback
- Revert commit; no data migration required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
