### PR TITLE
fix: county borders visible at all zoom levels; serve.sh auto-restart

### DIFF
--- a/game/serve.sh
+++ b/game/serve.sh
@@ -2,9 +2,11 @@
 set -euo pipefail
 
 PORT=58080
-if lsof -i :"${PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
-  echo "ERROR: port ${PORT} already in use — kill the old server first (lsof -ti :${PORT} | xargs kill)" >&2
-  exit 1
+OLD_PID=$(lsof -ti :"${PORT}" 2>/dev/null || true)
+if [[ -n "${OLD_PID}" ]]; then
+  echo "Stopping previous server (pid ${OLD_PID})…"
+  kill "${OLD_PID}"
+  while lsof -i :"${PORT}" -sTCP:LISTEN >/dev/null 2>&1; do sleep 0.2; done
 fi
 
 # bazel run sets BUILD_WORKSPACE_DIRECTORY to the workspace root (game/).

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -162,6 +162,7 @@ export class SvgMapRenderer implements MapRenderer {
 	// Base stroke widths (apparent px at any zoom level)
 	private static readonly BOUNDARY_BASE_WIDTH = 2;
 	private static readonly PREVIEW_BASE_WIDTH = 2.5;
+	private static readonly COUNTY_BASE_WIDTH = 3;
 
 	// County border overlay (GAME-012): computed once at load, toggled on/off
 	private countySegments: Segment[] = [];
@@ -180,11 +181,12 @@ export class SvgMapRenderer implements MapRenderer {
 		this.svg = d3.select(svgEl);
 
 		// Zoom group wraps all map layers so the single transform drives pan/zoom.
-		// Layer order (bottom → top inside zoomGroup): county borders, district borders, hexes, preview.
+		// Layer order (bottom → top inside zoomGroup): district borders, hexes, county borders, preview.
+		// County borders must sit above hexes so filled hex paths don't obscure them.
 		this.zoomGroup = this.svg.append("g").attr("class", "zoom-layer");
-		this.countyBorderGroup = this.zoomGroup.append("g").attr("class", "county-borders");
 		this.borderGroup = this.zoomGroup.append("g").attr("class", "borders");
 		this.hexGroup = this.zoomGroup.append("g").attr("class", "hexes");
+		this.countyBorderGroup = this.zoomGroup.append("g").attr("class", "county-borders");
 		this.previewBorderGroup = this.zoomGroup.append("g").attr("class", "preview-borders");
 
 		const pops = getState().precincts.map((p) => p.population);
@@ -229,10 +231,10 @@ export class SvgMapRenderer implements MapRenderer {
 			.attr("y1", (d) => d.y1)
 			.attr("x2", (d) => d.x2)
 			.attr("y2", (d) => d.y2)
-			.attr("stroke", "#a0a0a0")
-			.attr("stroke-width", 1)
-			.attr("stroke-dasharray", "4,4")
-			.attr("opacity", 0.5);
+			.attr("stroke", "#606060")
+			.attr("stroke-width", SvgMapRenderer.COUNTY_BASE_WIDTH / this.currentK)
+			.attr("stroke-dasharray", `${6 / this.currentK},${4 / this.currentK}`)
+			.attr("opacity", 0.7);
 	}
 
 	// ─── Zoom init (GAME-009) ─────────────────────────────────────────────────


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- County border SVG layer was appended below the hex fill layer, so filled hex paths completely obscured it; moved above hexes
- County border stroke-width and dash-array were fixed values in SVG user units, making them sub-pixel thin at the initial fit zoom; now scaled by `1/currentK` to stay constant in screen pixels at any zoom level (same pattern as district borders)
- Darkened stroke color (#a0a0a0 → #606060) and raised opacity (0.5 → 0.7) for legibility against colored hex fills
- `serve.sh` now kills any existing process on port 58080 before building and starting, rather than erroring out and leaving a stale server silently in place

## Validation performed
- [x] Confirmed county border toggle visually shows/hides dashed lines across county boundaries in the running game
- [x] N/A — kubectl dry-run (no infra changes)
- [x] N/A — sops decrypt (no secrets)

## Affected machines / services
- N/A — browser game only

## Deployment steps
- N/A

## Tickets addressed
- N/A — bugs found during S4 demo

## Rollback
- Revert commit; no data migration required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
