### PR TITLE
feat(GAME-007): in-progress scenario save/resume via localStorage WIP

### DIFF
--- a/game/web/e2e/sprint3.spec.ts
+++ b/game/web/e2e/sprint3.spec.ts
@@ -255,6 +255,137 @@ test("progression: new player (no localStorage) sees intro, not scenario select"
   await expect(page.locator("#scenario-select")).not.toBeVisible();
 });
 
+// ─── GAME-007: WIP save/resume ───────────────────────────────────────────────
+
+/** Seed a WIP save in localStorage before the page loads. */
+async function seedWip(
+  page: import("@playwright/test").Page,
+  scenarioId: string,
+  assignments: Record<string, number>,
+  activeDistrict: number,
+): Promise<void> {
+  await page.addInitScript(
+    (args: { scenarioId: string; assignments: Record<string, number>; activeDistrict: number }) => {
+      localStorage.setItem("redistricting-sim-wip", JSON.stringify(args));
+    },
+    { scenarioId, assignments, activeDistrict },
+  );
+}
+
+test("wip: scenario select shows 'In Progress' for scenario with saved WIP", async ({ page }) => {
+  // Seed completion for tutorial-002 so select screen appears, plus WIP for scenario-002
+  await seedProgress(page, ["tutorial-002"]);
+  await seedWip(page, "scenario-002", { "0": 1, "1": 2 }, 2);
+  await page.goto("/");
+
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  // scenario-002 card must show "In Progress" status and "Continue" button
+  const cards = page.locator(".scenario-card");
+  const scenario002Card = cards.nth(1); // second card in manifest
+  await expect(scenario002Card.locator(".sc-status.in-progress")).toBeVisible();
+  await expect(scenario002Card.locator(".sc-status.in-progress")).toContainText("In Progress");
+  await expect(scenario002Card.locator(".sc-play-btn.continue")).toBeVisible();
+  await expect(scenario002Card.locator(".sc-play-btn.continue")).toContainText("Continue");
+});
+
+test("wip: select screen shown when WIP exists even for new player", async ({ page }) => {
+  // No completed scenarios, but a WIP exists — should show select screen
+  await seedWip(page, "tutorial-002", { "0": 1 }, 1);
+  await page.goto("/");
+
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#intro-screen")).not.toBeVisible();
+});
+
+test("wip: saved assignment map is restored on scenario load", async ({ page }) => {
+  // Pre-paint precinct 0 → district 2, precinct 1 → district 3 in the WIP
+  // Then load tutorial-002 and verify via window.__gameStore that assignments match
+  const wipAssignments: Record<string, number> = {};
+  // tutorial-002 has 196 precincts; build a complete assignment with index 0 → 2 (district 2)
+  for (let i = 0; i < 196; i++) wipAssignments[String(i)] = i === 0 ? 2 : 1;
+
+  await seedWip(page, "tutorial-002", wipAssignments, 2);
+  await page.goto("/?s=tutorial-002");
+
+  // Wait for editor to be ready (intro appears because it's a fresh load without completed state)
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  // Verify that precinct 0 is assigned to district 2 via the exposed store
+  const district = await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>)["__gameStore"] as
+      | { getState: () => { assignments: Map<number, number> } }
+      | undefined;
+    return store?.getState().assignments.get(0);
+  });
+  expect(district).toBe(2);
+});
+
+test("wip: painting precincts triggers a debounced WIP save to localStorage", async ({ page }) => {
+  // Load tutorial-002, skip intro, paint precinct 0 → district 2 via store shortcut,
+  // then wait > 800ms and confirm the WIP key was written with the expected assignment.
+  await page.goto("/?s=tutorial-002");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  // Paint precinct 0 into district 2 (it starts in district 1).
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>)["__gameStore"] as
+      | { getState: () => { paintStroke: (ids: number[], d: number) => void; setActiveDistrict: (d: number) => void } }
+      | undefined;
+    if (!store) throw new Error("__gameStore not exposed");
+    store.getState().setActiveDistrict(2);
+    store.getState().paintStroke([0], 2);
+  });
+
+  // Wait 1100ms for the 800ms debounce to fire.
+  await page.waitForTimeout(1100);
+
+  // WIP key must now exist in localStorage.
+  const wipRaw = await page.evaluate(() => localStorage.getItem("redistricting-sim-wip"));
+  expect(wipRaw).not.toBeNull();
+
+  // Precinct 0 must be stored as district 2.
+  const wip = JSON.parse(wipRaw!) as { scenarioId: string; assignments: Record<string, number>; activeDistrict: number };
+  expect(wip.scenarioId).toBe("tutorial-002");
+  expect(wip.assignments["0"]).toBe(2);
+  expect(wip.activeDistrict).toBe(2);
+});
+
+test("wip: WIP is cleared from localStorage after scenario completion", async ({ page }) => {
+  // Load tutorial-002 fresh (no pre-seeded WIP), skip intro, paint winning move,
+  // submit, then verify the WIP key is absent from localStorage.
+  await page.goto("/?s=tutorial-002");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  // Paint the 5 boundary precincts (indices 70-74) from d2→d1 — same winning move
+  // as the winnability test. After this the map is valid and submit is enabled.
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>)["__gameStore"] as
+      | { getState: () => { paintStroke: (ids: number[], d: number) => void; setActiveDistrict: (d: number) => void } }
+      | undefined;
+    if (!store) throw new Error("__gameStore not exposed");
+    store.getState().setActiveDistrict(1);
+    store.getState().paintStroke([70, 71, 72, 73, 74], 1);
+  });
+
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+
+  // WIP key must be gone from localStorage after a successful pass
+  const wipAfter = await page.evaluate(() => localStorage.getItem("redistricting-sim-wip"));
+  expect(wipAfter).toBeNull();
+});
+
 // ─── GAME-019: Tutorial-002 winnability ───────────────────────────────────────
 
 test("winnability: painting 5 boundary precincts enables submit and produces a passing map", async ({ page }) => {

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -371,9 +371,10 @@
         align-self: flex-start;
       }
 
-      .sc-status.completed { background: #1a4a30; color: #4caf80; }
-      .sc-status.unlocked  { background: #0f3460; color: #80a8d8; }
-      .sc-status.locked    { background: #222230; color: #505070; }
+      .sc-status.completed   { background: #1a4a30; color: #4caf80; }
+      .sc-status.in-progress { background: #3a2800; color: #d4a030; }
+      .sc-status.unlocked    { background: #0f3460; color: #80a8d8; }
+      .sc-status.locked      { background: #222230; color: #505070; }
 
       .scenario-card .sc-play-btn {
         padding: 8px 0;
@@ -387,6 +388,8 @@
 
       .sc-play-btn.play    { background: #e94560; color: #fff; }
       .sc-play-btn.play:hover { background: #c73050; }
+      .sc-play-btn.continue { background: #6a4a00; color: #f0c050; border: 1px solid #a07010; }
+      .sc-play-btn.continue:hover { background: #8a6010; }
       .sc-play-btn.replay  { background: #1a4a30; color: #4caf80; border: 1px solid #2a6040; }
       .sc-play-btn.replay:hover { background: #2a6040; }
       .sc-play-btn.locked-btn { background: #222230; color: #404060; cursor: not-allowed; }

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -22,7 +22,16 @@ import {
 import { createGameStore } from "./store/gameStore.js";
 import { evaluateCriteria, isMapSubmittable } from "./simulation/evaluate.js";
 import { computeValidityStats } from "./simulation/validity.js";
-import { loadProgress, saveProgress, markCompleted, isCompleted } from "./model/progress.js";
+import {
+	loadProgress,
+	saveProgress,
+	markCompleted,
+	isCompleted,
+	loadWip,
+	saveWip,
+	clearWip,
+	type WipState,
+} from "./model/progress.js";
 
 // ─── Scenario manifest (GAME-021) ─────────────────────────────────────────────
 // Static list of all available scenarios in play order.
@@ -114,11 +123,13 @@ if (
 
 	function renderScenarioCards() {
 		if (!scenarioCardsEl) return;
+		const wip = loadWip();
 		scenarioCardsEl.innerHTML = "";
 		SCENARIO_MANIFEST.forEach((entry, i) => {
 			const completed = isCompleted(progress, entry.id);
 			const unlocked = i === 0 || isCompleted(progress, SCENARIO_MANIFEST[i - 1]?.id ?? "");
 			const locked = !unlocked;
+			const inProgress = !completed && wip?.scenarioId === entry.id;
 
 			const card = document.createElement("div");
 			card.className = `scenario-card${locked ? " locked" : ""}`;
@@ -128,12 +139,14 @@ if (
 			titleEl.textContent = entry.title;
 
 			const statusEl = document.createElement("div");
-			statusEl.className = `sc-status ${completed ? "completed" : unlocked ? "unlocked" : "locked"}`;
-			statusEl.textContent = completed ? "Completed" : unlocked ? "Ready" : "Locked";
+			const statusLabel = completed ? "Completed" : inProgress ? "In Progress" : unlocked ? "Ready" : "Locked";
+			const statusClass = completed ? "completed" : inProgress ? "in-progress" : unlocked ? "unlocked" : "locked";
+			statusEl.className = `sc-status ${statusClass}`;
+			statusEl.textContent = statusLabel;
 
 			const playBtn = document.createElement("button");
-			playBtn.className = `sc-play-btn ${completed ? "replay" : unlocked ? "play" : "locked-btn"}`;
-			playBtn.textContent = completed ? "Play Again" : unlocked ? "Play" : "Locked";
+			playBtn.className = `sc-play-btn ${completed ? "replay" : inProgress ? "continue" : unlocked ? "play" : "locked-btn"}`;
+			playBtn.textContent = completed ? "Play Again" : inProgress ? "Continue" : unlocked ? "Play" : "Locked";
 			playBtn.disabled = locked;
 			if (!locked) {
 				playBtn.addEventListener("click", () => {
@@ -166,8 +179,8 @@ if (
 	if (requestedEntry !== undefined) {
 		// Explicit scenario requested via URL — play it directly
 		entryToLoad = requestedEntry;
-	} else if (progress.completed.length > 0) {
-		// Returning player with no explicit request — show select screen
+	} else if (progress.completed.length > 0 || loadWip() !== null) {
+		// Returning player (has completed or in-progress scenario) — show select screen
 		showScenarioSelect();
 		return;
 	} else {
@@ -215,6 +228,45 @@ if (
 	// Gated to localhost so production deployments do not expose a solve shortcut.
 	if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
 		(window as unknown as Record<string, unknown>)["__gameStore"] = store;
+	}
+
+	// ── WIP save/restore (GAME-007) ───────────────────────────────────────────
+
+	// isRestoringWip prevents scheduleWipSave() from firing during the restore call.
+	// (store.subscribe is wired later, so this guard is defensive — it makes the
+	// invariant explicit regardless of future code reordering.)
+	let isRestoringWip = false;
+	let wipTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// Restore in-progress state from a previous session if it matches this scenario.
+	const savedWip = loadWip();
+	if (savedWip !== null && savedWip.scenarioId === scenario.id) {
+		isRestoringWip = true;
+		const restoredMap = new Map<number, number | null>(
+			Object.entries(savedWip.assignments).map(([k, v]) => [Number(k), v]),
+		);
+		store.getState().restoreAssignments(restoredMap, savedWip.activeDistrict);
+		// Wipe undo history so the player doesn't undo back before the restored state.
+		temporalStore.getState().clear();
+		isRestoringWip = false;
+	}
+	function scheduleWipSave() {
+		if (isRestoringWip) return;
+		if (wipTimer !== null) clearTimeout(wipTimer);
+		wipTimer = setTimeout(() => {
+			wipTimer = null;
+			const { assignments, activeDistrict } = store.getState();
+			const assignmentsRecord: Record<string, number> = {};
+			for (const [k, v] of assignments) {
+				if (v !== null) assignmentsRecord[String(k)] = v;
+			}
+			const wip: WipState = {
+				scenarioId: scenario.id,
+				assignments: assignmentsRecord,
+				activeDistrict,
+			};
+			saveWip(wip);
+		}, 800);
 	}
 
 	// ── Create renderer ───────────────────────────────────────────────────────
@@ -444,6 +496,8 @@ if (
 		if (evalResult.overallPass) {
 			progress = markCompleted(progress, scenario.id);
 			saveProgress(progress);
+			// GAME-007: clear the WIP for this scenario — it's done.
+			clearWip();
 		}
 
 		resultScreen.classList.remove("hidden");
@@ -464,7 +518,10 @@ if (
 	});
 
 	// ── Subscribe to state changes ────────────────────────────────────────────
-	store.subscribe(() => updateUI());
+	store.subscribe(() => {
+		updateUI();
+		scheduleWipSave();
+	});
 	temporalStore.subscribe(() => updateUI());
 
 	// ── Initial render + intro ────────────────────────────────────────────────

--- a/game/web/src/model/progress.ts
+++ b/game/web/src/model/progress.ts
@@ -1,15 +1,74 @@
 /**
- * Player progress persistence (GAME-018).
+ * Player progress persistence (GAME-018 / GAME-007).
  *
- * Tracks which scenario IDs the player has completed. Persisted to
- * localStorage under STORAGE_KEY as JSON.
+ * Two concerns:
+ *   1. Completion tracking — which scenarios the player has finished.
+ *      Persisted under PROGRESS_KEY as JSON (GAME-018).
+ *   2. In-progress WIP state — the current assignment map for an active
+ *      scenario so the player can resume after a page reload (GAME-007).
+ *      Persisted under WIP_KEY as JSON. One WIP at a time; overwritten
+ *      when the player switches scenarios.
  *
- * Pure serialization functions (serializeProgress / deserializeProgress)
- * take/return plain values — testable in Node without mocking localStorage.
- * The loadProgress / saveProgress functions call localStorage directly.
+ * Pure serialization functions take/return plain values — testable in Node
+ * without mocking localStorage. The load/save/clear functions call
+ * localStorage directly.
  */
 
-const STORAGE_KEY = "redistricting-sim-progress";
+const PROGRESS_KEY = "redistricting-sim-progress";
+const WIP_KEY = "redistricting-sim-wip";
+
+// ─── WIP types + I/O ─────────────────────────────────────────────────────────
+
+export interface WipState {
+	/** Which scenario the player was in the middle of */
+	scenarioId: string;
+	/**
+	 * Serialized assignment map: precinct ID (as string key, JSON requirement)
+	 * → district ID (number).
+	 */
+	assignments: Record<string, number>;
+	/** Which district button was active when the state was saved */
+	activeDistrict: number;
+}
+
+export function saveWip(wip: WipState): void {
+	try {
+		localStorage.setItem(WIP_KEY, JSON.stringify(wip));
+	} catch {
+		// storage unavailable (private browsing quota, etc.) — silently ignore
+	}
+}
+
+export function loadWip(): WipState | null {
+	try {
+		const raw = localStorage.getItem(WIP_KEY);
+		if (raw === null) return null;
+		const parsed = JSON.parse(raw) as unknown;
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			typeof (parsed as { scenarioId?: unknown }).scenarioId === "string" &&
+			typeof (parsed as { assignments?: unknown }).assignments === "object" &&
+			(parsed as { assignments?: unknown }).assignments !== null &&
+			typeof (parsed as { activeDistrict?: unknown }).activeDistrict === "number"
+		) {
+			return parsed as WipState;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+export function clearWip(): void {
+	try {
+		localStorage.removeItem(WIP_KEY);
+	} catch {
+		// ignore
+	}
+}
+
+// ─── Completion tracking ──────────────────────────────────────────────────────
 
 export interface Progress {
 	/** Set of scenario IDs that have been completed at least once */
@@ -53,7 +112,7 @@ export function isCompleted(progress: Progress, scenarioId: string): boolean {
 
 export function loadProgress(): Progress {
 	try {
-		const raw = localStorage.getItem(STORAGE_KEY);
+		const raw = localStorage.getItem(PROGRESS_KEY);
 		if (raw === null) return { completed: [] };
 		return deserializeProgress(raw);
 	} catch {
@@ -63,7 +122,7 @@ export function loadProgress(): Progress {
 
 export function saveProgress(progress: Progress): void {
 	try {
-		localStorage.setItem(STORAGE_KEY, serializeProgress(progress));
+		localStorage.setItem(PROGRESS_KEY, serializeProgress(progress));
 	} catch {
 		// storage quota exceeded or private browsing — silently ignore
 	}

--- a/game/web/src/store/gameStore.ts
+++ b/game/web/src/store/gameStore.ts
@@ -26,6 +26,8 @@ export interface GameStore extends GameState {
 	paintStroke: (precinctIds: number[], district: DistrictId) => void;
 	/** Restore all assignments to the scenario's initial state */
 	resetToInitial: () => void;
+	/** Restore a previously saved assignment map (e.g. from WIP storage) */
+	restoreAssignments: (assignments: AssignmentMap, activeDistrict: DistrictId) => void;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -100,6 +102,15 @@ export function createGameStore(scenario: Scenario) {
 					const restored = new Map(initialAssignments);
 					set({
 						assignments: restored,
+						simulationResult: runElection({ ...get(), assignments: restored }),
+					});
+				},
+
+				restoreAssignments(assignments: AssignmentMap, activeDistrict: DistrictId) {
+					const restored = new Map(assignments);
+					set({
+						assignments: restored,
+						activeDistrict,
 						simulationResult: runElection({ ...get(), assignments: restored }),
 					});
 				},

--- a/thoughts/shared/tickets/GAME-007-player-progress-persistence.md
+++ b/thoughts/shared/tickets/GAME-007-player-progress-persistence.md
@@ -4,6 +4,7 @@ title: Player progress persistence — save/resume game state
 area: game, storage
 status: open
 created: 2026-04-25
+github_issue: 99
 ---
 
 ## Summary


### PR DESCRIPTION
## Prerequisites
- [x] N/A — standalone feature, no parent PR dependency

## Summary
- Add in-progress (WIP) scenario save/resume so players can quit and return without losing work
- `progress.ts`: new `WipState` type + `saveWip` / `loadWip` / `clearWip` functions; storage key `redistricting-sim-wip`; also rename internal `STORAGE_KEY` → `PROGRESS_KEY` (no behavior change)
- `gameStore.ts`: new `restoreAssignments(assignments, activeDistrict)` action
- `main.ts`: restore WIP on scenario load (with undo-history clear); debounced 800ms WIP save on every assignment change; clear WIP on scenario completion; scenario select cards show "In Progress" badge + "Continue" button when WIP exists; routing shows select screen when WIP exists (not only when completed)
- `sprint3.spec.ts`: 4 new e2e tests — WIP badge visible, select screen shown for WIP-only player, assignment map restored, WIP cleared after pass

## Validation performed
- [x] `bazel build //web/...` — clean (no type errors)
- [x] `bazel test //web:e2e_test` — 52/52 pass

## Affected machines / services
- N/A — static browser bundle only; all WIP state is client-side (localStorage); no server-side component

## Deployment steps (POST-MERGE)
- N/A — static bundle; no server restart or migration required

## Tickets addressed
- see #99

## Rollback
- Revert the 4-file commit; leftover `redistricting-sim-wip` localStorage keys are harmless
