### PR TITLE
docs: dimensional dot map design decisions and updated ticket backlog

### DIFF
--- a/thoughts/shared/decisions/2026-04-27-dimensional-dot-map-design.compressed.md
+++ b/thoughts/shared/decisions/2026-04-27-dimensional-dot-map-design.compressed.md
@@ -1,0 +1,48 @@
+<!--COMPRESSED v1; source:2026-04-27-dimensional-dot-map-design.md-->
+§META
+date:2026-04-27 status:accepted
+
+§ABBREV
+ts=thoughts/shared res=$ts/research dec=$ts/decisions
+
+§CONTEXT
+Districts view: population dot overlay (DESIGN-005) + demographic dimension encoding open question.
+Two questions: (1) how dot color encodes active dimension; (2) random vs. sorted placement.
+Research: $res/2026-04-27-dimensional-dot-map-design-research.md
+
+§DECISIONS
+
+**1. Option B — Adaptive Encoding by Dimension Type**
+Dot color adapts to dimension's data type:
+
+| type | dot encoding | examples |
+|---|---|---|
+| categorical | dot color per group, count ∝ group share | race, party |
+| scalar | sequential single-hue per precinct avg | income, age |
+| modifier | dot count = turnout-adjusted pop, neutral color | voter turnout |
+
+dimension_type declared in scenario JSON → rendering engine branches on it; no per-group heuristics.
+District fills stay flat (DESIGN-003). Dot color is independent channel.
+
+Rejected: A(no encoding), C(partisan-only), D(hex halo—too busy), E(sidebar-only), F(size+color—deferred v1.1; 3-4 ordinal steps only at 2-6px radius; needs tutorial support)
+
+**2. Sorted Placement Toggle**
+Default: random within hex interior (seeded by precinctId → deterministic).
+Toggle: sorted mode → dots grouped by categorical dimension → micro-bar-chart effect.
+Use: sorted best when zoomed in for fine assignment work; random better at overview.
+Future: may auto-gate by zoom level; launches as always-available control.
+
+**3. Palette + Accessibility**
+Paul Tol Bright | Okabe-Ito; ≤5 hues; 1px white outline on all dots.
+Tooltip = authoritative data carrier (keyboard-focusable).
+
+§CONSEQUENCES
+scenario JSON: dimension_type field per group|dimension
+render engine: branches on dimension_type; 3 modes only
+sorted: needs deterministic sort key (group name|index)
+Option F addable later without rearchitecting dot layer
+
+§REFS
+$res/2026-04-27-dimensional-dot-map-design-research.md
+$res/2026-04-27-design-003-color-encoding-research.md
+DESIGN-005 (base layer) | DESIGN-007 (impl ticket)

--- a/thoughts/shared/decisions/2026-04-27-dimensional-dot-map-design.md
+++ b/thoughts/shared/decisions/2026-04-27-dimensional-dot-map-design.md
@@ -1,0 +1,97 @@
+---
+date: 2026-04-27
+status: accepted
+---
+
+# ADR: Dimensional Dot Map — Demographic Overlay Design
+
+## Status
+
+Accepted
+
+## Context
+
+The Districts view needs to convey the spatial shape of population concentrations (not
+just totals) and, when a demographic dimension is active, communicate how that
+dimension is distributed across the map. Two design questions were open:
+
+1. **How should dot color encode an active demographic dimension?** Six options were
+   researched (A–F), ranging from no encoding to simultaneous size+color bivariate
+   encoding.
+
+2. **Should dots be placed randomly or sorted by type within each hex?** Random is the
+   cartographic standard; sorted placement acts like an embedded micro-bar chart.
+
+Research document: `thoughts/shared/research/2026-04-27-dimensional-dot-map-design-research.md`
+
+## Decisions
+
+### 1. Option B — Adaptive Encoding by Dimension Type
+
+Dot color encoding adapts to the data type of the active demographic dimension:
+
+| Dimension type | Dot encoding | Examples |
+|---|---|---|
+| `categorical` | dot color per group, count proportional to group's share | race, party affiliation |
+| `scalar` | all dots same sequential single-hue color per precinct average | income, age, turnout rate |
+| `modifier` | dot count = turnout-adjusted population, neutral dot color | voter turnout count |
+
+The dimension type is declared in the scenario JSON alongside the demographic group
+definition. This gives the rendering engine a principled rule: no per-dimension
+rendering heuristics, just three well-defined modes.
+
+District fills remain flat (DESIGN-003 decision). Dot color is an independent channel —
+no hue/lightness interference with district identity.
+
+**Rejected alternatives:**
+- Option A (no demographic encoding): loses the spatial shape of the demographic
+  distribution entirely; defeats the purpose of the overlay.
+- Option C (partisan lean only): not generalizable; hardcodes a single dimension.
+- Option D (hex halo/ring): three simultaneous channels (fill + dots + ring); too
+  visually busy for general audiences.
+- Option E (sidebar only): same attention gap that motivated the dot overlay design.
+- Option F (size + color simultaneously): deferred to v1.1. At 2–6px dot radius,
+  only 3–4 ordinal size steps are perceptually legible; general audiences require
+  tutorial support to decode dual encoding correctly. Viable in principle but premature.
+
+### 2. Sorted Placement Toggle
+
+Dot placement defaults to **random** within the hex interior (seeded by precinct ID
+for determinism across re-renders). This preserves the population-distribution
+metaphor: a random scatter of dots represents people distributed across the precinct.
+
+A **sorted toggle** is also provided. In sorted mode, dots are grouped by their
+categorical dimension (e.g. all group-A dots first, then group-B, etc.) within each
+hex. This produces an embedded micro-bar-chart effect that makes proportions more
+legible when zoomed in for fine-grained work. Sorted mode is most useful during
+close precinct-by-precinct assignment decisions, less useful at whole-map overview.
+
+The toggle may be zoom-gated in a future refinement (auto-sort at high zoom,
+auto-random at low zoom), but launches as an always-available user control.
+
+### 3. Palette and Accessibility
+
+- Categorical dot palette: Paul Tol Bright or Okabe-Ito (both colorblind-safe);
+  maximum 5 simultaneous hues.
+- All dots have 1px white outline to ensure separation from the district fill.
+- Tooltip remains the authoritative data carrier (keyboard-focusable) for users
+  who cannot distinguish dot colors.
+
+## Consequences
+
+- Scenario JSON needs a `dimension_type: "categorical" | "scalar" | "modifier"` field
+  on each demographic group (or at the dimension/axis level if multiple groups share
+  a dimension).
+- The rendering engine branches on `dimension_type` to select the dot-color encoding
+  mode; no per-group heuristics needed.
+- Sorted placement requires a deterministic sort key (group name or group index) so
+  the layout is stable across re-renders.
+- Option F (bivariate size+color) can be added later without rearchitecting the dot
+  layer — it is an additive encoding on top of the categorical mode.
+
+## References
+
+- `thoughts/shared/research/2026-04-27-dimensional-dot-map-design-research.md`
+- `thoughts/shared/research/2026-04-27-design-003-color-encoding-research.md`
+- DESIGN-005 — population dot density overlay (base layer)
+- DESIGN-007 — implementation ticket for this design

--- a/thoughts/shared/research/2026-04-27-design-003-color-encoding-research.compressed.md
+++ b/thoughts/shared/research/2026-04-27-design-003-color-encoding-research.compressed.md
@@ -1,0 +1,88 @@
+<!--COMPRESSED v1; source:2026-04-27-design-003-color-encoding-research.md-->
+§META
+date:2026-04-27 researcher:claude(design-researcher) branch:main repo:cgruber/redistricting-sim
+topic:DESIGN-003-districts-view-color-encoding status:complete
+tags:ux-design,cartography,color-encoding,accessibility,game-design
+
+§ABBREV
+DRA=Dave's Redistricting App EG=efficiency-gap A=OptionA B=OptionB C=OptionC D=OptionD
+WCAG=Web Content Accessibility Guidelines
+
+§SUMMARY
+Two competing data dims (district-identity+population-density) encoded in same channel
+(color-lightness) degrade each other — sprint demo confirmed this empirically; Bertin+Ware
+predict it. $A (flat district color, no gradient) is correct for v1: maximizes boundary
+readability, simplifies colorblind-safe palette, offloads population to sidebar+tooltip where
+already accessible. $C is sound architecture for later; $B+D not recommended for v1.
+
+§FINDINGS
+
+§F1_COGNITIVE_LOAD
+Bertin visual-variables: hue→nominal(which category?) lightness→ordinal(how much?)
+When both modulated on same polygon: viewer must perform conjunction search (serial, high-effort)
+to answer either question. Preattentive categorical pop-out lost.
+Sprint feedback ("reads as heat map") = textbook hue-lightness interference confirmation.
+$B tones down gradient but does not resolve semantic ambiguity; ongoing tuning risk.
+Principle: 2 independent dims → independent channels | or separate views.
+For polygon fills (shape/texture/orientation limited) → view separation($C) | tooltip/sidebar.
+
+§F2_PRECEDENTS
+Redistricting tools — all use flat fills for district assignment:
+  $DRA: flat hues; pop-balance in sidebar stats; partisan lean = separate overlay mode
+  Districtr: flat fills; demographics in side panel
+  Redistricting Game(USC 2007): flat fills; info in side panels
+  DistrictBuilder: flat fills; statistics in sidebar
+
+Strategy/sim games — assignment layer flat; quantitative data = separate toggle layer:
+  Civ VI: political-map=flat hues; yield overlays=separate toggle(icons/overlay colors)
+  Cities:Skylines: zone-view=flat fills; density/traffic/pollution=separate overlay modes
+  XCOM tactical: terrain=flat categorical; environmental-effects=separate particle overlay
+
+Pattern: primary-action layer = flat categorical → maximizes discriminability.
+Quantitative secondary → tooltip | sidebar | deliberate overlay mode.
+
+§F3_ACCESSIBILITY
+Colorblind-safe qualitative palettes(ColorBrewer,Paul Tol) designed for uniform lightness.
+Modulating lightness for density: breaks tuned hue-distances; pale hues converge for colorblind.
+$A: select 1 certified 8-hue qualitative palette(e.g. ColorBrewer Set2 | Tol Bright) → holds
+  throughout; no per-scenario tuning as population distribution changes.
+$B: requires continuous validation that lightness range doesn't collapse hue discrimination →
+  burden grows with district count.
+WCAG 1.4.1: color not sole conveyor of info. Flat fills satisfy if boundaries/labels present.
+  Gradient-encoded population = second info layer with no non-color backup → additional concern.
+
+§F4_OPTION_C
+Sound architecture in principle(GIS standard: ArcGIS/QGIS/Kepler use layer toggles).
+Not warranted for v1 because:
+  1. Population already accessible via tooltip+sidebar validity panel (2 paths)
+  2. Player task ≠ continuous density monitoring; periodic balance-check → sidebar sufficient
+  3. 3 view modes → UI discoverability burden; 2(Districts+Partisan) already meaningful load
+  4. $A cleanly positions codebase for $C later — no technical debt from gradient approach
+Natural trigger for $C: malapportionment scenario where population distribution = primary
+  teaching surface (pre-Reynolds v. Sims "one person one vote"), not just balance constraint.
+
+§RECOMMENDATION
+Choose: $A — flat district color, no population encoding in Districts view.
+
+Rationale: eliminates hue-lightness interference; aligns with all domain precedents; removes
+colorblind-palette maintenance burden; no information gap (data already in tooltip+sidebar);
+architecture open to $C later.
+
+Conditions for different choice:
+  $C: add when malapportionment scenario exists — population spatial reasoning = primary task
+  $B: only if playtesting confirms specific player confusion tooltip+sidebar can't resolve;
+      empirical confirmation required, not preemptive; lightness range ≤0.10 if adopted
+  $D: not for v1 — rendering complexity, dot-size accessibility issues, sidebar already covers
+
+§REFS
+Bertin 1967/1983 Semiology of Graphics — visual variables taxonomy
+Ware 2004/2013 Information Visualization — conjunction search; channel independence
+ColorBrewer: colorbrewer2.org — qualitative 8-class safe palettes
+Tol 2021 SRON/EPS/TN/09-002 — colorblind-safe palette sets
+WCAG 2.1 SC 1.4.1 — Use of Color: w3.org/TR/WCAG21/
+$DRA: davesredistricting.org — flat fills confirmed
+Districtr: districtr.org — flat fills confirmed
+Redistricting Game USC 2007 — flat fills in drawing mode
+DistrictBuilder(Public Mapping) — flat fills + sidebar stats
+Civ VI 2016 — political map flat; yield overlays separate toggle
+Cities:Skylines 2015 — zone view flat; data layers separate overlay

--- a/thoughts/shared/research/2026-04-27-design-003-color-encoding-research.md
+++ b/thoughts/shared/research/2026-04-27-design-003-color-encoding-research.md
@@ -1,0 +1,204 @@
+---
+date: 2026-04-27
+researcher: claude (design-researcher)
+branch: main
+repository: cgruber/redistricting-sim
+topic: DESIGN-003 — Districts view color encoding and population density display
+tags: ux-design, cartography, color-encoding, accessibility, game-design
+status: complete
+---
+
+## Summary
+
+When two independent data dimensions — district identity and population density — are encoded
+in the same visual channel (color lightness), each signal degrades the other's readability.
+Sprint 1 demo feedback confirms this empirically; cartographic theory and game design precedent
+both predict it. For the Districts view in v1, **Option A (flat district color, no population
+encoding)** is the correct choice: it maximizes boundary readability, simplifies colorblind-safe
+palette design, and offloads population data to the sidebar and tooltip where it is already
+accessible and contextually appropriate.
+
+---
+
+## Findings
+
+### 1. Cognitive Load and Layered Visual Encoding
+
+Jacques Bertin's theory of visual variables (1967) classifies visual channels by the properties
+they communicate most reliably. *Hue* is selective and associative — it answers "which category
+does this belong to?" Lightness (value) is *ordered* — it answers "how much of this is here?"
+These are semantically distinct roles. When both are modulated simultaneously on the same mark,
+the viewer must perform a cognitive *conjunction search* to answer either question: to determine
+district membership, they must mentally subtract the lightness variation; to read density, they
+must mentally normalize across hues. Colin Ware's *Information Visualization: Perception for
+Design* identifies conjunction search as an intrinsically serial, high-effort operation compared
+to the preattentive pop-out that flat categorical color provides.
+
+In the specific context of the Districts view:
+- District identity is the *primary* cognitive task: players must reliably determine which
+  district a precinct belongs to in order to draw and evaluate boundaries.
+- Population density is *secondary* context: the player consults it for balance checking, not
+  for moment-to-moment boundary decisions.
+
+When lightness variation is added to the district hues, the map shifts from a categorical map
+to an appearance resembling a choropleth or heat map. The categorical (hue) signal becomes
+harder to read because hue discrimination degrades at low lightness (dark colors collapse toward
+indistinguishable near-black) and at high lightness (pale pastels converge toward white). The
+sprint demo feedback — "reads more as a population heat map than a district map" — is textbook
+confirmation of this interference. Toning down the gradient (Option B) does not eliminate the
+interference; it reduces it, but imposes ongoing tuning risk and does not resolve the semantic
+ambiguity.
+
+The general principle: when two data dimensions must be shown simultaneously, they should be
+encoded in *independent* channels (e.g., hue for category, shape for secondary attribute) or
+separated into distinct views. For polygon fills — where shape, texture, and orientation options
+are limited — view separation (Option C) or tooltip/sidebar delegation is the standard answer.
+
+### 2. Game Design and Cartographic Precedents
+
+A consistent pattern emerges across all relevant precedents: primary assignment views use flat
+fills; secondary quantitative data is placed in a separate layer or tooltip.
+
+**Election redistricting tools:**
+
+- **Dave's Redistricting App (DRA):** Districts view uses flat, distinct hues per district with
+  no lightness gradient. Population balance is shown in a sidebar statistics panel, not encoded
+  in the fill color. A separate "Partisan Lean" overlay uses the RdBu diverging palette —
+  treated as a dedicated mode, not a simultaneous layer.
+- **Districtr:** Flat colored fills for district assignment. Population and demographic data
+  surface in side panels and are not encoded in the map fill.
+- **The Redistricting Game (USC, 2007):** Flat district fills for the drawing view. Secondary
+  information (demographic, partisan) is in side panels.
+- **DistrictBuilder (Public Mapping Project):** Flat district fills; statistics in sidebar panel.
+
+The pattern is uniform: every redistricting tool in the domain treats the district assignment
+layer as flat-colored, and moves quantitative secondary data to side panels or separate overlay
+modes. This is not coincidence — it reflects the same principle that the assignment view's job
+is to answer "which district?" clearly.
+
+**Strategy and simulation games:**
+
+- **Civilization (all entries):** Political map mode uses flat hues per civilization/nation.
+  Yield overlays (food/production/gold) are a separate toggle layer using icons or overlay colors
+  distinct from the political fill — never blended into the political fill itself.
+- **SimCity / Cities: Skylines:** Zone view (residential/commercial/industrial) uses flat colored
+  fills. Density, traffic, pollution, and land value are each separate overlay modes accessed
+  through a dedicated data views menu.
+- **XCOM tactical maps:** Terrain types (cover, elevation) use flat categorical fills for the
+  action layer; environmental effects (smoke, fire) are rendered as separate particle/overlay
+  layers, not blended into the base tile color.
+
+The structural lesson across all precedents: the *primary action layer* (the surface where the
+player makes decisions) uses flat categorical color to maximize discriminability. Quantitative
+secondary data is either a tooltip, a sidebar, or a separate overlay mode the player activates
+deliberately.
+
+### 3. Accessibility
+
+Encoding two variables simultaneously in hue + lightness creates significant colorblind-safety
+challenges:
+
+- Colorblind-safe qualitative palettes (ColorBrewer, Paul Tol palettes) are designed for
+  *uniform lightness*. The standard 8-class qualitative safe set (e.g., ColorBrewer `Set2` or
+  `Paired`) achieves discriminability by selecting hues that remain distinguishable under
+  deuteranopia, protanopia, and tritanopia — but only at the palette's designed lightness level.
+- If lightness is modulated for population density, the carefully tuned hue distances no longer
+  hold. A pale blue and a pale orange that are distinguishable at full saturation may converge
+  toward indistinct pastels at high lightness.
+- WCAG 1.4.1 (Use of Color) requires that color not be the sole means of conveying information.
+  Flat district fills satisfy this if district labels or boundary lines are also present. A
+  gradient fill that encodes population adds a second information layer that has *no* non-color
+  backup, creating an additional WCAG concern.
+
+Option A (flat fills) allows the team to select a single 8-hue qualitative palette (e.g.,
+ColorBrewer `Set2` or Paul Tol's `Bright`) that is certified colorblind-safe, and that
+palette's properties hold throughout the application. No per-scenario tuning is needed as
+population distributions change. Option B requires continuous validation that the lightness
+range used does not collapse hue discrimination for colorblind users — a burden that grows with
+the number of districts.
+
+### 4. Option C Viability (Third View Mode)
+
+Option C (dedicated Population view as a third toggle) is a sound architectural decision in
+principle. It achieves clean separation of concerns: Districts view is unambiguously categorical;
+Population view is unambiguously quantitative. The GIS and data visualization tradition favors
+this approach (ArcGIS, QGIS, Kepler.gl all use layer toggles for independent data dimensions).
+
+For v1 of this game, however, Option C is not yet warranted. The reasons:
+
+1. **Population data is already accessible via two other paths.** The hover tooltip provides
+   per-precinct population. The sidebar validity panel shows per-district population balance
+   with deviation percentages. Players who need population context have it without a mode switch.
+
+2. **The player's task does not require continuous population monitoring.** Population balance
+   is checked periodically (after drawing a block of precincts) rather than cell-by-cell. This
+   is well-served by the sidebar panel, which updates continuously. Embedding it in the map is
+   only valuable if the player needs to spatially reason about density in real time while
+   drawing — which is a GIS analyst's workflow, not an educational game player's.
+
+3. **Three view modes adds a UI discoverability burden.** Players must learn which mode they are
+   in, why the colors changed, and how to switch back. For a game targeting a general audience,
+   two modes (Districts, Partisan Lean) is already a meaningful cognitive load. A third mode
+   should be deferred until there is a scenario where population distribution is a *primary*
+   teaching objective, not just a constraint.
+
+4. **Option C does not preclude adding it later.** Starting with Option A cleanly positions the
+   codebase for Option C if needed. The rendering path remains flat; a population-choropleth mode
+   can be added as a third toggle without any technical debt from the gradient approach.
+
+The natural trigger for revisiting Option C: a future scenario teaching *malapportionment* (the
+pre-*Reynolds v. Sims* era, "one person, one vote" violations) where population distribution is
+itself the subject of manipulation. In that scenario, a Population view mode would be a primary
+teaching surface, not secondary context.
+
+---
+
+## Recommendation
+
+**Adopt Option A: flat district color, no population density encoding in Districts view.**
+
+Rationale:
+- Eliminates the hue-lightness interference that is causing the "heat map" misread confirmed
+  in sprint feedback.
+- Aligns with every redistricting tool and strategy game in the domain: assignment views are
+  flat; quantitative data goes to separate panels or modes.
+- Removes ongoing colorblind-palette maintenance burden: one well-chosen 8-hue qualitative
+  palette works without per-scenario tuning.
+- Population data is already accessible via tooltip and sidebar panel — there is no information
+  gap created by removing gradient encoding.
+- Leaves the architecture open to Option C later without any technical debt.
+
+**Conditions under which a different option would be preferred:**
+
+- **Option C** becomes worth adding when the game includes a malapportionment scenario or any
+  scenario where *spatial reasoning about population distribution* is the primary player task
+  (not just a balance constraint). At that point a dedicated Population mode would be a teaching
+  surface, justifying its UI cost.
+- **Option B** is not recommended for v1. If future playtesting reveals a specific player
+  confusion ("I don't know that precincts have different populations") that tooltip + sidebar
+  cannot resolve, Option B with a minimal, explicitly documented lightness range (≤0.10) could be
+  reconsidered — but only after the player confusion is confirmed empirically, not preemptively.
+- **Option D** (stipple overlay) is not recommended for v1. It adds rendering complexity,
+  introduces its own accessibility issues (small dots are hard to distinguish at small hex size),
+  and serves the same population-data purpose that the sidebar already fulfills.
+
+---
+
+## References
+
+- Bertin, J. (1967/1983). *Semiology of Graphics*. University of Wisconsin Press. (Visual
+  variables taxonomy: hue=nominal, lightness=ordinal/quantitative)
+- Ware, C. (2004/2013). *Information Visualization: Perception for Design*. Morgan Kaufmann.
+  (Conjunction search; preattentive separability; channel independence)
+- Brewer, C. (2003). ColorBrewer. colorbrewer2.org. (Qualitative 8-class safe palettes for
+  cartographic use)
+- Tol, P. (2021). "Colour Schemes." SRON Technical Note SRON/EPS/TN/09-002. (Paul Tol's
+  colorblind-safe palette sets)
+- WCAG 2.1 Success Criterion 1.4.1 — Use of Color. w3.org/TR/WCAG21/
+- Dave's Redistricting App: davesredistricting.org — Districts view uses flat fills; partisan
+  data in separate overlay.
+- Districtr: districtr.org — Flat fills for district assignment; demographics in side panel.
+- The Redistricting Game (USC Annenberg, 2007): flat fills in drawing mode.
+- DistrictBuilder (Public Mapping Project): flat fills; statistics in sidebar panel.
+- Civilization VI (2016): Political map mode — flat hues; yield overlays as separate toggle.
+- Cities: Skylines (2015): Zone view — flat fills; data layers as separate overlay modes.

--- a/thoughts/shared/research/2026-04-27-dimensional-dot-map-design-research.compressed.md
+++ b/thoughts/shared/research/2026-04-27-dimensional-dot-map-design-research.compressed.md
@@ -1,0 +1,393 @@
+<!--COMPRESSED v2; source:2026-04-27-dimensional-dot-map-design-research.md-->
+§META
+date:2026-04-27 researcher:claude(design-researcher) branch:main repo:cgruber/redistricting-sim
+topic:dimensional-dot-map-model-design status:complete
+tags:ux-design,cartography,dot-density,accessibility,color-encoding,game-design,demographic-visualization
+
+§ABBREV
+DDM=dimensional-dot-map DRA=Dave's Redistricting App
+A=OptionA B=OptionB C=OptionC D=OptionD E=OptionE F=OptionF
+WCAG=Web Content Accessibility Guidelines
+cable=Cable-UVA-2013-racial-dot-map
+TypeA=categorical-multigroup TypeB=partisan-spectrum TypeC=continuous-scalar TypeD=binary-ternary
+PSM=proportional-symbol-map
+
+§SUMMARY
+NOTE: DESIGN-003 deferred dot density; subsequent design discussion adopted it as primary
+population encoding — this research takes that as given.
+$DDM (dot count=population, dot color=active demographic dimension, user-switchable dimension)
+combines $cable encoding + Victoria3 switchable-overlay interaction — no existing tool does
+all 4 simultaneously. Random dot placement within hexes is cartographic standard +
+perceptually correct for aggregated precinct data. 3 encoding modes cover all dimension types:
+categorical(race/party) | scalar(income/age) | count-modifier(turnout). Accessibility requires
+Tol/Okabe-Ito palette discipline, tooltip-as-authoritative-source, keyboard focus on precincts.
+
+ADDENDUM: Dot SIZE as scalar encoding investigated. Bertin identifies size as the only
+inherently quantitative retinal variable; $PSM tradition (Flannery 1971) establishes it for
+magnitude encoding. At 2–6px radius: ~3–4 coarse ordinal steps only (not continuous scale).
+Size+color simultaneous = separable conjunction — each readable independently but not
+preattentively together. Theoretically coherent dimensional-type taxonomy (categorical→color,
+scalar→size, count→dotcount, lean→fill-blend) is design-team-facing, NOT self-evident to
+general audiences without legend/tutorial.
+
+Recommend $B (adaptive 3-mode taxonomy, scalar via color) + accessibility provisions from $D.
+$F (bivariate size+color) deferred to v1.1; taxonomy adopted as internal design guide.
+
+§FINDINGS
+
+§F1_PRECEDENTS
+cable: 308M dots, 5 racial groups, random placement, fixed-dimension, static — foundational;
+  no dimension toggle, no interactivity beyond pan/zoom; UNIFORM dot size (size not used)
+NYT-2018(Gamio): precinct dot density, D/R partisan dots, ~1dot/250votes — closest published
+  precedent to partisan lean encoding; single dimension, fixed at publication; uniform dot size
+WaPo: similar precinct-level partisan dot density; fixed at publication; uniform dot size
+
+Redistricting tools — NONE use dot density:
+  $DRA+Districtr+DistrictBuilder+Redistricting-Game: all flat fills; demographics in side panels
+
+Strategy games — NO dot density; closest is Victoria3:
+  Victoria3(2022): pop objects→switchable color by culture|religion|ideology on map overlays
+    [KEY: exact interaction model this game needs — switch what color means — but uses bar fills]
+  Civ6: flat political fills; separate yield icon overlays
+  Cities:Skylines: flat zone fills; separate data overlay modes
+
+$PSM PRIOR ART (for dot size encoding):
+  Bertin 1967: SIZE is the ONLY inherently quantitative retinal variable — "more/less of
+    something"; involuntary interpretation; cannot be misread as nominal/categorical
+  Flannery 1971: foundational $PSM study; subjects systematically underestimate area ratios;
+    correction factor: power exponent 0.5716 on radius; implemented in ArcGIS Pro
+  Bivariate $PSM: size = primary variable (quantity/magnitude); color = secondary (category
+    or 2nd scalar); documented in PSU GEOG486 + Axis Maps guide
+  GEOG486 (PSU): size+color = "separable conjunction" — each readable independently;
+    challenge: "different visual variables make multiple vars hard to directly compare"
+  KEY GAP: conventional dot density maps hold dot SIZE constant — count is the magnitude.
+    Variable dot size within a dot density field = hybrid of two traditions with thin precedent.
+    No existing dot density map (cable, NYT, WaPo) uses variable dot size.
+
+Academic:
+  Kimerling 2009: canonical dot placement; random-within-enumeration-unit = standard
+  Dorling cartograms(worldmapper.org): population-scaled area, some support switchable color dim
+  Bunge 1960s: static single-dim dot maps for Detroit inequality work
+  Dasymetric mapping: sub-unit informed placement (no sub-precinct spatial data available here)
+  MacEachren 1995: naive users interpret visual salience holistically — "large = more important",
+    not "large = older"; expert/naive gap is significant for multi-encoding designs
+
+NOVELTY: $DDM combines (1)dot-count=population (2)dot-color=demographic-dim (3)user-switchable
+color-dim (4)layered under flat district fill → no existing tool does all 4. Addendum adds
+potential (5)dot-size=scalar-magnitude — hybrid with thin direct precedent; further from
+established practice than elements 1–4.
+
+§F2_DOT_PLACEMENT
+RANDOM (standard):
+  Kimerling + Robinson: random placement within enumeration unit = cartographic standard
+  Rationale: cartographer knows precinct-total, not sub-precinct locations → random = honest
+  Gestalt mixing: random intermix → additive color mixing at distance (halftone principle)
+    Bayer 1973 + Ulichney 1987: random/quasi-random dithering → most accurate perceived color mix
+  60/40 D/R → reads as blue scatter with red visible ← correct perceptual output
+  At 300-hex scale: hex size small → dots produce color texture, not individually legible points
+
+SORTED (clustered by group within hex):
+  Equivalent to embedding micro-bar-chart in each hex
+  Tufte 1983 small multiples: require sufficient size for legibility; ~40px diameter minimum
+  At full-map zoom: patchwork/striped texture → reads presence/absence not proportions
+    → LESS informative than random color mix
+  At high zoom (few precincts visible): sorted clusters readable as proportional regions
+    → only scale where sorting helps
+  Spatial artifact: sorted assigns arbitrary within-precinct geography (D-side vs R-side)
+    → spatial claim data does not support; breaks "individuals in space" metaphor
+
+TOGGLE (random↔sorted):
+  Prior art: thin — no established map tool implements this exact toggle
+  Closest: Tableau/Observable jitter toggles; NYT dot-plot↔bar transitions (different context)
+  Assessment: technically straightforward but marginal player value; game = district boundaries,
+    not within-precinct proportions; tooltip+sidebar = authoritative for proportions
+  If implemented: secondary control; default random; visible only when zoom shows <15 precincts
+
+VERDICT: random = default + correct; sorted = marginal v1 value; tooltip = authoritative source
+
+§F3_DIMENSIONAL_TYPES
+4 structural types require 3 encoding modes:
+
+$TypeA categorical-multigroup (race/ethnicity 5-7 groups, party affiliation):
+  Mutually exclusive; "what fraction per group?"
+  Encoding: dot color per group, proportional count within hex; dot size UNIFORM
+  Limit: max 5 simultaneous hues (colorblind constraint); fold extras to "Other"
+
+$TypeB partisan-spectrum (D/R/L/other vote shares, continuous):
+  Appears categorical but has continuous-spectrum nature (D-R spread = 1-dim)
+  Two-party case → existing RdBu Partisan Lean fill mode already handles lean
+  Dot layer in partisan mode: adds population; use party-hue dots proportionally
+  Note: RdBu fill + party dots → can double-encode; must differentiate visually
+
+$TypeC continuous-scalar (turnout%, income, age, education):
+  Single numeric per precinct; "how high/low?"
+  Encoding A (color): all dots in hex same color on single-hue sequential scale
+    → choropleth at dot layer; dot size UNIFORM
+  Encoding B (size): dot radius varies by scalar → see §F6 for perceptual limits + tradeoffs
+  Encoding C (turnout-specific): dot count = population × turnout rate → "these are the voters"
+    [requires clear UI: "population mode" vs "electorate mode"]
+
+$TypeD binary-ternary (gender, urban/rural):
+  2-3 hues; educational value limited alone; gender best as compound modifier (gender×party,
+  gender×turnout) → compound encoding not cleanly supported by single dot-color channel
+  → defer or handle via tooltip/sidebar
+
+3-MODE TAXONOMY (primary recommendation):
+  Mode       | Dimensions          | Dot color                        | Dot size | Dot count
+  -----------|---------------------|----------------------------------|----------|------------------
+  Categorical | Race, party         | One hue/group, proportional      | Uniform  | = population
+  Scalar      | Income, age, educ  | Single-hue sequential per hex    | Uniform  | = population
+  Modifier    | Turnout             | Neutral                          | Uniform  | = pop×turnout-rate
+
+§F4_SIDEBAR_TOOLTIP
+Problem with "68%D lean":
+  Collapses multi-party dist to single scalar; method unclear (2-party share? margin? all-vote?);
+  hides third-party votes; omits population count; ambiguous across dimension modes
+
+Prior art — compact multi-group proportion formats:
+  Stacked horizontal bar (NYT election pages 2016–2024): proportional segment widths;
+    color-consistent with map; compact vertical footprint; extends to 4-5 parties ← BEST
+  Small pie: angular judgments < length (Cleveland+McGill 1984); 5+ slices → illegible at sidebar scale
+  Treemap small-scale: hierarchical complexity adds noise; no benefit for flat categorical distributions
+  Labeled percentage list: most screen-reader accessible; unwieldy at 7+ groups; should accompany visual
+
+Recommended sidebar format per hover:
+  1. Title: dimension name ("Partisan Lean" | "Race/Ethnicity" | "Voter Turnout")
+  2. Stacked horizontal bar: colored segments ∝ group shares; colors match dot encoding
+  3. % labels: show if share > 8%
+  4. Population note: "Population: N" | "Voters: N (TK% turnout)"
+  [For scalar dim active: single-value bar + size swatch if $F active]
+
+Tooltip (precinct hover):
+  Precinct ID + district (color swatch) + population + mini stacked bar + current dim summary
+
+Consistency requirement: dimension switch → dots change color + sidebar bar changes → same
+underlying data in both views. Dimension selector UI should visually link to sidebar legend
+(shared title, shared color swatches).
+
+§F5_ACCESSIBILITY
+Challenge: 5-7 categorical dot colors at 4-8px dot size → small dots have lower perceived
+saturation than large areas; carefully tuned hue distances may not transfer.
+Deuteranopia (~8% male): D(blue)/R(red) fails immediately. Protanopia (~1%): similar failure.
+
+Strategies:
+  1. Palette restriction: max 5 simultaneous hues; Tol Bright | Okabe-Ito; tested under
+     deuteranopia+protanopia simulation
+     Partisan: shift red→orange(#E66100)/blue(#5D3A9B) — Okabe-Ito; deuteranope-safe
+  2. Shape/symbol redundant: circle|square|triangle|diamond|hexagon per group (toggle-able)
+     Limit: legible only if dots ≥8-10px; increases rendering complexity
+  3. White 1px outline on all dots: visibility against varying district fill colors
+  4. Tooltip-as-authoritative: dot layer = supplemental visual texture; tooltip+sidebar =
+     authoritative data; colorblind user can ignore dot colors without info loss
+     → requires tooltip keyboard-accessible (WCAG 2.4.3 Focus Order; 4.1.3 Status Messages)
+  5. High-contrast mode (v1.1): shape toggle replaces | supplements hue encoding;
+     black/white/pattern palette as alternative to hue-based encoding
+  NOTE: dot SIZE variation (if active) is colorblind-neutral — adds info without color dependency.
+    But size variation does NOT solve the color discrimination problem; it adds a second independent
+    dimension, not a substitute for the color channel.
+
+$cable acknowledged accessibility issues but provided no colorblind mode —
+known unresolved gap in the primary precedent.
+
+§F6_DOT_SIZE_ENCODING (ADDENDUM)
+
+PRIOR ART:
+  Bertin 1967: SIZE = only inherently quantitative visual variable; involuntary "more/less"
+    interpretation; correct channel for scalar/ordinal magnitude
+  Flannery 1971: systematic area underestimation; correction exponent 0.5716; valid for
+    20-100px symbols; untested at 4-12px dot size range of this game
+  Bivariate $PSM: size(magnitude) + color(category) on same symbol — documented form;
+    "separable conjunction"; requires explicit dual legend; general audience challenge
+  KEY GAP: no existing dot density map varies dot size — cable/NYT/WaPo all hold size constant.
+    Variable-size within dot density = hybrid tradition; thin direct precedent.
+
+PERCEPTUAL LIMITS AT 2-6px RADIUS (4-12px diameter):
+  Weber fraction for area: ~6-12% area change required for reliable detection
+    2px→3px radius = 2.25x area change ← above detection threshold in isolation;
+      but in mixed-density dot field, signal/noise drops sharply
+  Stevens power law for area: exponent ~0.7-0.87 (sublinear) → systematic underestimation;
+    Flannery correction untested below 20px diameter
+  Practical discriminable steps in 2-6px radius range: ~3-4 COARSE ORDINAL levels
+    (small/medium/large/XL) — NOT a continuous scale
+  Implication: size at this scale = ordinal gestalt encoding ("older/younger precinct")
+    NOT ratio/precise magnitude encoding; legend must use qualitative ordinal labels
+  Floor: below 4px diameter, dots barely legible as marks; size variation below that = imperceptible
+  At 4-6px radius: 3-4 steps feasible with permanent legend establishing scale
+
+SIZE + COLOR SIMULTANEOUS (conjunction analysis):
+  Ware 2004: hue preattentive alone; size preattentive alone;
+    CONJUNCTION (large red) = NOT preattentive → requires serial search
+  GEOG486 / Roth 2015: size + color = SEPARABLE conjunction — each readable independently
+    but NOT automatically integrated; conscious sequential effort required
+  
+  DESIGN INTENT MATTERS:
+    If user attends to one dimension at a time (color mode | size mode) → conjunction load reduced;
+      viable IF: (a) legend makes encoding unambiguous; (b) UI signals which dim is "active";
+      (c) both encodings not simultaneously required as primary reading tasks
+    If user expected to read both simultaneously ("find old+Black precincts") → serial search;
+      will slow general audience comprehension significantly
+  
+  "ALWAYS VISIBLE" PROBLEM: dot size variation is always on; cannot be toggled independently.
+    If size=income and color=race: when reading racial dimension, income size variation competes
+    for attention → more significant practical concern than formal conjunction search
+  
+  ASSESSMENT: viable at coarse granularity (3-4 size steps + 5 hue categories) for users
+    who understand dual encoding — NOT self-decodable at a glance; requires permanent legend
+    + tutorial; general audience will conflate size variation with rendering artifact or
+    population density if not explicitly instructed
+
+DIMENSIONAL TYPE TAXONOMY (addendum framing device):
+  | Type                   | Examples                    | Dot attribute       |
+  |------------------------|-----------------------------|---------------------|
+  | Categorical/compositional | Race, party, gender      | Dot COLOR           |
+  | Scalar/magnitude       | Income, age, attainment     | Dot SIZE            |
+  | Density/count          | Population                  | Dot COUNT           |
+  | Spatial lean           | Partisan lean (derived)     | Color blend / fill  |
+
+  Theoretical grounding: maps directly to Bertin retinal variables:
+    hue→nominal/categorical; size→quantitative; count→density/magnitude
+  COHERENCE: theoretically sound; Bertin would recognize this as faithful application
+  LEARNABILITY (general audience): NOT self-evident; MacEachren 1995 — naive users interpret
+    salience holistically; 3 rules to internalize (color=kind, size=intensity, count=how-many)
+    exceeds what players discover without explicit instruction
+  ASSESSMENT: adopt as INTERNAL DESIGN GUIDE (team consistency tool), NOT player-facing convention.
+    In-game legend/tutorial must state rules in plain language, not taxonomy terms.
+    Taxonomy utility: ensures consistent assignment of dims to channels as new dims added.
+
+§OPTIONS
+
+$A Uniform-Scatter (minimal, Cable-faithful):
+  Placement: random, always; no sort; dot size UNIFORM
+  Encoding: 1 mode — categorical only; continuous dims binned to 4-5 ranges; turnout→count modifier
+  Sidebar: stacked bar + "N people"; tooltip: % list + count
+  Accessibility: Tol Bright 5-hue max; white outlines; tooltip authoritative; no shapes
+  Tradeoffs: simplest impl; continuous→bins loses information; turnout-as-count non-obvious
+
+$B Adaptive-Encoding (3-mode taxonomy) [RECOMMENDED]:
+  Placement: random, always; no sort; dot size UNIFORM
+  Encoding: categorical(race/party→hue-per-group) | scalar(income/age→sequential single-hue)
+             | modifier(turnout→count)
+  Sidebar: categorical→stacked bar | scalar→single-value bar+endpoint labels
+           | turnout→"N of M voters (TK%)"
+  Tooltip: dimension-appropriate compact summary per mode
+  Accessibility: Tol Bright + Okabe-Ito for categorical; Viridis|SRON-rainbow-free for scalar;
+                 white outlines; keyboard-focusable tooltip
+
+$C Uniform-Scatter-with-Sort-Toggle:
+  Placement: random default; user toggle→sorted-by-group within hex; dot size UNIFORM
+  Encoding: same as $A (categorical + binning)
+  Sidebar: same as $A
+  Accessibility: same as $A
+  Tradeoffs: sort toggle useful only at high zoom; default-off; show only when <15 precincts visible
+
+$D Adaptive-Encoding-with-Shape-Accessibility:
+  Placement: random; dot size UNIFORM
+  Encoding: same as $B (3-mode)
+  Sidebar: same as $B
+  Accessibility: full shape redundancy — each group gets unique shape in addition to hue;
+    shape toggle-able via accessibility settings; high-contrast mode: shape+B&W replaces hue
+  Tradeoffs: most accessible; dots need ≥8-10px for shape legibility at 300-hex scale;
+    highest rendering complexity
+
+$E Dot-Layer-as-Texture-Only:
+  Placement: random; dot size UNIFORM
+  Encoding: categorical with deliberately subdued color (low saturation, secondary visual weight)
+    dots = "people here" (primary); dot color = "who they are" (supplemental)
+  Sidebar: full stacked bar + absolute counts; sidebar = PRIMARY dimensional display
+  Accessibility: low-saturation dots + high-contrast outlines; colorblind users rely on
+    sidebar/tooltip; dot color not required reading
+  Tradeoffs: most accessible semantically; may frustrate players who expect dot layer to carry
+    more info; requires UI guidance ("dot colors show [dimension]")
+
+$F Bivariate-Dot (size=scalar, color=categorical) [v1.1 candidate]:
+  Placement: random; dot size VARIABLE by precinct-level scalar
+  Encoding:
+    dot color = categorical dim (race/party, hue-per-group, proportional within hex)
+    dot size = scalar dim (income/age), ALL dots in hex same radius; 3-4 ordinal steps
+               2px(min)→5px(max) range; Flannery correction applied
+    dot count = population (as always)
+  Size labels: qualitative ordinal only ("younger/older", "lower/higher income"), not numeric
+  Sidebar: TWO rows: (1) categorical stacked bar (2) scalar bar/label + size swatch showing
+    this precinct's dot radius; dual-legend PERMANENTLY VISIBLE
+  Tooltip: explicitly states both dims ("Median income: high (large dots); Race: 45% Black…")
+  Accessibility: same palette as $B; size variation = colorblind-neutral additional channel;
+    dual-legend required; tooltip carries both dims for users who cannot read size variation
+  Tradeoffs:
+    + Theoretically most informationally dense; two dims simultaneously without mode switch
+    + Bertin-coherent; $PSM tradition supports this channel assignment
+    − "always visible" problem: size encoding competes with color reading even in color-mode
+    − 3-4 size steps only at 2-6px range; no precision; ordinal gestalt only
+    − General audience: two encoding rules simultaneously → tutorial required; not self-evident
+    − Benefit mainly at medium/high zoom; subtle at 300-precinct full-map zoom
+    − NOT recommended for v1. Revisit at v1.1 if: players successfully read single-channel
+      encoding; scenario requires simultaneous scalar+categorical dims; dots render at ≥5px radius
+
+§RECOMMENDATION
+Choose: $B Adaptive-Encoding + accessibility provisions from $D
+
+Rationale:
+  1. Semantic accuracy: each dim type encoded in most appropriate channel; binning continuous
+     dims (A/C/E) loses info + misrepresents data type
+  2. Educational alignment: accurate dimensional encoding → accurate learning about demo→electoral
+  3. Manageable impl: 3 rendering modes = 3 code paths; one-off-per-dim harder to maintain
+  4. Sidebar consistency: 3 sidebar formats match 3 encoding modes; eliminates "68%D" ambiguity
+
+On $F (dot size / bivariate):
+  NOT recommended for v1. Barriers: perceptual limits (3-4 ordinal steps only at 2-6px);
+  general audience cannot decode dual encoding without tutorial; "always visible" problem;
+  Revisit at v1.1 if rendering scale + playtesting support it.
+
+On dimensional type taxonomy:
+  ADOPT as internal design guide (team consistency tool).
+  NOT player-facing — in-game legend/tutorial states rules in plain language:
+    "dot colors show [dimension]" | "dot sizes show [scalar]" | "dot count shows population"
+  Utility: consistent channel assignment as new dims added; prevents ad-hoc one-off treatments.
+
+Accessibility minimums:
+  Tol Bright | Okabe-Ito for categorical; ≤5 simultaneous hues
+  Partisan shift: red→#E66100 orange / blue→#5D3A9B
+  White 1px outlines on all dots
+  Tooltip keyboard-focusable; full text data in tooltip
+  Doc: dot color = supplemental; tooltip+sidebar = authoritative
+
+Conditions for different choice:
+  $A: if v1 scenarios limited to party+race (both categorical) + timeline short
+  $D: if player audience has significant CVD prevalence + accessibility = primary v1 req
+  $E: if playtesting reveals players over-reading dot layer and ignoring sidebar
+  $F: at v1.1 when rendering scale + playtesting confirm readiness for dual encoding
+
+§REFS
+Kimerling 2009 "Dotting the Dot Map Revisited" Cartographic Perspectives 64 — dot placement standard
+Robinson+al 1995 Elements of Cartography 6th ed — dot density map design
+Bertin 1967/1983 Semiology of Graphics — visual variables taxonomy; SIZE=only quantitative variable
+Ware 2004/2013 Information Visualization — conjunction search; channel independence
+Tufte 1983 Visual Display of Quantitative Information — small multiples; data density
+Bayer 1973 IEEE ICASSP "Optimum Method for Two-Level Rendition" — ordered dither; dot mixing
+Ulichney 1987 Digital Halftoning MIT Press — random vs ordered dithering perceptual tradeoffs
+MacEachren 1995 How Maps Work Guilford Press — naive map reader behavior; holistic salience interpretation
+Roth 2015 "Interactive Maps" J.Spatial Info Science — visual variable conjunctions; separability
+
+Flannery 1971 Canadian Cartographer 8(2) — $PSM foundational study; underestimation; correction exponent
+PSU GEOG486 "Multivariate Dot and Proportional Symbol Maps" courses.ems.psu.edu/geog486/node/901
+  — bivariate $PSM; size+color simultaneous; separable conjunction; legend requirements
+Axis Maps "Bivariate Proportional Symbols" axismaps.com/guide/bivariate-proportional-symbols
+  — bivariate design guide; general audience interpretation challenge
+Stevens 1957 "On the Psychophysical Law" Psychological Review 64(3) — power law; area exponent ~0.7-0.87
+Cleveland+McGill 1984 JASA 79(387) — graphical perception; length > angle; area judgment accuracy
+Treisman+Gelade 1980 "Feature Integration Theory" Cognitive Psychology 12(1) — conjunction search; serial vs parallel
+
+cable: demographics.virginia.edu — one dot/person, 5 racial groups, random placement, fixed dim, UNIFORM SIZE
+NYT-Gamio 2018 — precinct dot density D/R; ~1dot/250votes; closest published partisan precedent; uniform size
+Victoria3(2022 Paradox): pop objects, switchable color dim (culture|religion|ideology) — key game precedent
+Civ6(2016 Firaxis): political flat fills; yield overlays separate — correct layer separation
+Cities:Skylines(2015 Colossal Order): zone flat fills; data overlay modes separate
+$DRA: davesredistricting.org — flat fills; no dot density
+Districtr: districtr.org — flat fills; demographics side panel
+Redistricting Game USC 2007 — flat fills; side panels
+worldmapper.org — Dorling cartograms; some switchable color dim (incomplete precedent)
+
+Tol 2021 SRON/EPS/TN/09-002 personal.sron.nl/~pault/ — Bright+High-Contrast+Muted palettes
+Okabe+Ito 2008 CUD jfly.uni-koeln.de/color/ — 8-color colorblind-safe categorical palette
+ColorBrewer colorbrewer2.org — qualitative 8-class safe palettes
+WCAG 2.1 SC 1.4.1(Use of Color) 2.4.3(Focus Order) 4.1.3(Status Messages) w3.org/TR/WCAG21/
+Dorling 1996 Area Cartograms CATMOG 59 — population-scaled areas; channel separation concept

--- a/thoughts/shared/research/2026-04-27-dimensional-dot-map-design-research.md
+++ b/thoughts/shared/research/2026-04-27-dimensional-dot-map-design-research.md
@@ -1,0 +1,1034 @@
+---
+date: 2026-04-27
+researcher: claude (design-researcher)
+branch: main
+repository: cgruber/redistricting-sim
+topic: Dimensional dot map model — dot density overlay design for multi-dimensional demographic encoding
+tags: ux-design, cartography, dot-density, accessibility, color-encoding, game-design, demographic-visualization
+status: complete
+---
+
+## Summary
+
+*Note: DESIGN-003 (color encoding research, 2026-04-27) deferred dot density overlay to a
+future version. Subsequent design discussion adopted dot density as the primary population
+encoding strategy. This research takes that decision as given and focuses on how to implement
+the dimensional dot map model correctly.*
+
+The dimensional dot map model — dots within each hex precinct where count encodes population
+and color encodes the active demographic dimension — has strong precedent in Cable's racial dot
+map (2013) but extends it in a direction for which few direct precedents exist: user-switchable
+dimensional encoding on an interactive map. Random dot placement within hexes is the standard
+cartographic approach and reads well at distance; sorted/clustered placement is effectively
+embedded micro-charting and breaks the population metaphor.
+
+An addendum to this research incorporates dot SIZE as a candidate visual variable for encoding
+scalar/magnitude demographic dimensions (income, age, turnout). Bertin (1967) identifies size
+as the only truly quantitative visual variable, and the proportional symbol map tradition
+(Flannery 1971) has decades of practice applying it. However, at the 2–6px radius range of this
+game's dot rendering, size discrimination is constrained to 3–4 coarse ordinal steps, not a
+continuous scale. Used simultaneously with dot color (color = categorical group membership,
+size = scalar intensity), size+color creates a bivariate proportional dot layer — an established
+cartographic form with known legibility tradeoffs for general audiences.
+
+The research proposes a dimensional type taxonomy — categorical/compositional, scalar/magnitude,
+density/count, spatial lean — as a visual design framing device. Each dimensional type maps to a
+different dot attribute (color, size, count), which is theoretically coherent (Bertin's retinal
+variables) but requires explicit in-game legend/tutorial support to be learnable by a general
+audience without cartographic background.
+
+The full system requires a small taxonomy of 2–3 encoding modes (categorical multi-group,
+continuous scalar, count-modifier) that covers all demographic dimension types uniformly, rather
+than one-off treatment per dimension. Accessibility for 5–7 color categorical dot schemes
+requires palette discipline, shape/symbol fallback in high-contrast mode, and treating the
+tooltip as the authoritative data carrier — not the dot layer.
+
+---
+
+## Findings
+
+### 1. Precedents and Prior Art
+
+#### Cable's Racial Dot Map (UVA, 2013) and Descendants
+
+Dustin Cable's racial dot map (demographics.virginia.edu, 2013, now mirrored as
+racialdotmap.demographics.virginia.edu) is the foundational reference for this encoding
+strategy. Each dot represents one person; dot color encodes racial/ethnic group (White, Black,
+Hispanic, Asian, Other — five values). The map renders 308 million dots over the continental
+US at multiple zoom levels using tile-based rendering. At the national scale, color blending
+produces a gestalt perception of regional demographic composition. At the neighborhood scale,
+individual dots become legible.
+
+Key properties of the Cable map relevant to this project:
+- Fixed dimension: the map always shows race. There is no user toggle to a different dimension.
+- Static (no interactivity beyond pan/zoom): the map is a visual artifact, not a game.
+- Random placement within Census block: dots are placed uniformly at random within each block's
+  polygon. No sorting or clustering by group within blocks.
+- Dot size: uniform. All dots are the same size — size is not used as a visual variable.
+
+**Descendants and relatives:**
+- The *New York Times* 2018 map "An Extremely Detailed Map of the 2016 Election Results"
+  (Gamio) uses dot density for partisan vote breakdown at the precinct level — one dot per
+  ~250 votes, colored Red/Blue. This is the closest existing precedent to this project's
+  partisan lean encoding: dots represent voters, color = party.
+- The *Washington Post* uses similar precinct-level dot density encoding for election coverage,
+  with dots colored by winning margin rather than raw vote share.
+- Neither the NYT nor WaPo implementations allow switching the color dimension — each map is
+  fixed at publication time. Neither uses variable dot size.
+
+**Key gap**: no existing public tool implements user-switchable dot color dimension on an
+interactive map. The dimensional dot map model is novel in that respect. None of these maps
+use dot size as a variable — all hold dot size constant and vary only count and color.
+
+#### Proportional Symbol Maps — Prior Art for Size as a Scalar Encoding
+
+The proportional symbol map tradition is the established cartographic form for encoding
+scalar/magnitude data using symbol size. Key properties and precedents:
+
+- **Bertin (1967/1983), *Semiology of Graphics*:** Bertin's taxonomy of visual variables
+  identifies SIZE as the only variable that is inherently quantitative — it can be matched
+  precisely to a numerical value in a way that viewers interpret as "more/less of something."
+  Hue is selective (nominal/categorical); lightness is ordered (ordinal/sequential); size is
+  quantitative. This makes size the theoretically correct channel for scalar magnitude data.
+  Bertin specifically notes that large symbols "look like more of something" — the interpretation
+  is involuntary and difficult to override.
+
+- **Flannery (1971)**, "The Relative Effectiveness of Some Common Graduated Point Symbols in the
+  Presentation of Quantitative Data:" The foundational empirical study of proportional symbol
+  maps. Subjects systematically *underestimate* the area ratio between large and small circles.
+  Flannery's correction factor (power exponent 0.5716 applied to circle radius) partially
+  compensates for this bias; it is still implemented in ArcGIS Pro (the "Appearance Compensation
+  (Flannery)" checkbox). The implication: even in the best case, proportional size encoding is
+  subject to systematic perceptual error for area judgments.
+
+- **Bivariate proportional symbol maps:** The established form for combining size and color on a
+  single point symbol. Size encodes one variable (typically quantity/magnitude); color/hue encodes
+  a second variable (typically category or a second scalar). This form is documented in GEOG 486
+  (PSU Cartography and Visualization course) and by Axis Maps. Standard design guidance:
+  - Size communicates the primary variable; color communicates the secondary variable.
+  - Legend must explicitly explain both dimensions simultaneously.
+  - Interpretation challenge: "as the visual variables of size and color are quite different, this
+    can make it challenging for the multiple variables on the map to be directly compared by
+    readers" (Axis Maps bivariate proportional symbols guide).
+
+**Key gap regarding dot density specifically:** In conventional dot density maps, dot SIZE is
+held constant — count is the magnitude encoding. Introducing variable dot size within a dot
+density map creates a hybrid of two cartographic traditions (dot density + proportional symbol)
+for which there is thin direct precedent. The Cable map, the Gamio/NYT map, and all dot density
+election coverage use uniform dot size. Using variable dot size in a dot density layer is a
+novel extension of both traditions.
+
+#### Election Redistricting Tools
+
+- **Dave's Redistricting App (DRA):** Uses flat fills for district assignment; choropleth
+  overlays for partisan lean. Does not use dot density for any data dimension.
+- **Districtr:** Flat fills for district assignment; demographic data in side panels only. No
+  dot density layer.
+- **The Redistricting Game (USC Annenberg, 2007):** Flat fills; all quantitative data in side
+  panels. No dot density.
+- **Representable:** Similar to Districtr — flat fills, side panel demographics.
+
+None of these tools use dot density overlays. The dimensional dot map model would be novel
+among redistricting educational tools.
+
+#### Strategy Games with Demographic Overlays
+
+- **Civilization VI (2016):** Political map mode uses flat hues per civilization. No dot density
+  for any layer. Demographic concepts (population, culture, religion) are shown as per-tile
+  icons or numeric yields, never as dot density.
+- **Victoria 3 (2022):** Models population as explicit "pops" (population groups with
+  attributes: culture, religion, ideology, occupation). The map can show pop composition via
+  colored bar overlays on provinces. No dot density — pops are abstracted to bar fills. This
+  is the closest strategy-game precedent to the dimensional concept: the same underlying pop
+  objects can be colored by different attributes (culture vs. religion vs. ideology). Victoria 3
+  does exactly the "switch what the color means" interaction, but with bar fills, not dots.
+- **Crusader Kings III (2020):** Similar to Victoria 3 — choropleth overlays switchable by
+  dimension (culture, religion, development). No dot density.
+- **SimCity / Cities: Skylines:** Zone view uses flat fills; data layers (traffic, pollution,
+  land value) are choropleth overlays. No dot density.
+
+**Victoria 3 is the most relevant strategy-game precedent** for the "switch what color
+means" interaction, despite using bars rather than dots.
+
+#### Academic Cartography
+
+- **Bunge's dot density maps (1960s):** William Bunge's Detroit work placed dots representing
+  individuals with attributes (income, race) to reveal spatial inequality. The method was
+  static and single-dimension per map.
+- **Dorling Cartograms:** Scale each area's size to population, then use color for a secondary
+  attribute. Comparable to dot density in separating population (size) from a second variable
+  (color). Interactive versions exist (e.g., worldmapper.org), and some allow switching the
+  color dimension — a relevant but inexact precedent.
+- **Dasymetric mapping:** Redistributes census data within zones using ancillary data about
+  where population actually lives. Relevant to dot placement within hexes (random vs. informed),
+  though this game does not have the sub-precinct spatial data to implement dasymetric methods.
+- **Kimerling (2009), "Dotting the Dot Map, Revisited":** The canonical modern treatment of dot
+  density map design. Establishes that random placement within enumeration units is standard and
+  perceptually appropriate for the statistical aggregation that enumeration-unit data represents.
+  Kimerling notes that sorted or clustered placement within units misrepresents the spatial
+  randomness of individuals within those units.
+
+#### Summary of What's Novel
+
+The dimensional dot map model as specified combines:
+1. Dot count = population (Cable)
+2. Dot color = demographic dimension (Cable, fixed to race; this project generalizes)
+3. User-switchable color dimension (Victoria 3's interaction model applied to dots)
+4. Layered with flat district fill underneath (independent categorical channel)
+
+The addendum adds a potential fifth element:
+5. Dot size = scalar magnitude dimension (Bertin/Flannery proportional symbol tradition, applied
+   to individual dots within a dot density layer — a hybrid with thin direct precedent)
+
+No existing public tool or game implements all four of the original elements together. The
+design is a coherent combination of well-understood individual techniques, but the combination
+is novel. The variable-size extension (element 5) is further from established practice and
+requires additional design justification.
+
+---
+
+### 2. Random vs. Sorted Dot Placement — Tradeoffs
+
+#### Standard Cartographic Practice: Random
+
+Kimerling (2009) and Robinson et al. (1995) *Elements of Cartography* establish random
+placement as standard for dot density maps within enumeration units. The rationale:
+
+1. **Epistemological honesty:** The cartographer knows that 1,400 people live in a precinct.
+   The cartographer does not know *where within the precinct* they live. Random placement
+   faithfully represents this uncertainty — it makes no claim about sub-precinct spatial
+   distribution. Sorted placement implies that Democrats live on the left side of the precinct,
+   which is a spatial claim the data does not support.
+
+2. **Gestalt color mixing at distance:** When dots of different colors are randomly intermixed,
+   the human visual system performs additive mixing at normal viewing distances. A 60/40 D/R
+   precinct with randomly placed dots reads as a predominantly blue area with red visible —
+   this is the intended perceptual output. This is the same mechanism that makes halftone
+   printing and television pixels work. Dithering and halftone literature (Bayer 1973; Ulichney
+   1987) confirm that random or quasi-random mixing produces the most accurate perceived color
+   mix with the fewest visual artifacts.
+
+3. **Scale-appropriate legibility:** At the scale of 300 hexes on a browser map, individual
+   hexes are small. The dot density within each hex will produce a color texture, not
+   individually legible points. Random mixing produces an accurate color texture. Sorted
+   placement produces a striped or segmented texture that looks like a bar chart embedded in
+   each hex — a different visual idiom that conflicts with the "individuals in space" metaphor.
+
+#### Sorted/Clustered Placement
+
+Sorting dots by demographic group within each hex is equivalent to embedding a micro-bar-chart
+or micro-pie-chart in each hex. The technique has independent precedents:
+
+- **Small multiples / sparklines (Tufte 1983):** Embedding miniature charts within map regions.
+  Tufte advocates for small multiples but recommends sufficient size for legibility — hexes in
+  a 300-precinct map are unlikely to be large enough for sorted dot clusters to be distinctly
+  readable.
+- **Chernoff faces, glyph maps:** Embedding data glyphs in map cells. Well-documented as
+  effective only when cells are large enough to render the glyph (typically 40+ pixels diameter).
+
+**Perceptual tradeoffs of sorted placement:**
+- At zoom level showing the full map: sorted pattern produces a patchwork or striped texture
+  that reads as "some precincts have two parties, some have one" — the relative proportions
+  are not readable, only presence/absence. This is *less* informative than the color mix from
+  random placement.
+- At zoom level showing a few precincts: sorted dots become legible as proportional regions.
+  This is the one scale where sorting helps legibility.
+- Sorting introduces an arbitrary spatial assignment (which side is "left"?) that could be
+  read as meaningful geographic variation within the precinct.
+
+#### User-Toggleable Placement (Option C)
+
+The prior art for toggle between random and sorted dot placement is thin. No established tool
+implements this exact interaction. The closest analogues:
+
+- **Scatterplot jitter toggles:** Some data visualization tools (Tableau, Observable Plot) allow
+  toggling between jittered and non-jittered scatter layouts. The perceptual purpose is similar
+  (random distribution vs. structured layout), but the context is non-geographic.
+- **Dot plot to bar chart transitions:** Animated transitions between dot distributions and
+  summary statistics (bar or box plots) exist in data journalism (e.g., NYT "You Draw It"
+  series). These are transitions between chart types, not within a map.
+
+**Assessment of toggle viability:** A toggle is technically straightforward but introduces UI
+complexity without a clear player need. The game's educational purpose is about district
+boundaries, not within-precinct demographic precision. The sorted mode serves a use case
+(reading within-precinct proportions at high zoom) that is secondary to the game's core
+mechanics. If implemented, it should be a secondary control (not prominent in the main UI)
+and default to random.
+
+#### Recommendation within this finding
+
+Random placement is correct as the primary and default mode. It is perceptually accurate for
+the statistical nature of the data, consistent with cartographic standards, and reads better
+at the scale this game operates. Sorted mode could be offered as a zoom-dependent or
+user-togglable secondary mode, but adds complexity for marginal educational benefit. The
+tooltip and sidebar should be the authoritative source for within-precinct proportions —
+not the dot arrangement.
+
+---
+
+### 3. Handling Different Dimensional Types
+
+The game's demographic dimensions span structurally different data types that do not all
+respond well to the same visual encoding. The goal is a small taxonomy of encoding modes —
+ideally 2–3 — that covers the full range without one-off treatment per dimension.
+
+#### Dimensional Type Taxonomy
+
+**Type A — Categorical multi-group (mutually exclusive, 3–7 values)**
+Examples: race/ethnicity (White, Black, Hispanic, Asian, Other), party affiliation (D, R, L,
+Other), religion (if modeled).
+
+Properties: groups are mutually exclusive; each person belongs to exactly one group; the
+question is "what fraction belongs to each group?"
+
+Encoding: Dot color per group. Each group gets a hue. Within each precinct hex, dots are
+colored proportionally to group membership — a 60% White, 25% Black, 15% Hispanic precinct
+places dots in those proportions with those three hues. Standard dot density map encoding.
+This is the Cable racial dot map model.
+
+Challenge: 7 simultaneous hues strains colorblind-safe palette selection (see Section 5).
+Practical limit is 5 perceptually distinct, colorblind-safe hues. Dimensions with more than
+5 groups should be collapsed (e.g., fold smaller groups into "Other").
+
+**Type B — Partisan spectrum (vote shares, 2–4+ parties, continuous)**
+Examples: D/R two-party vote share; D/R/L/Other multi-party share.
+
+While partisan lean appears similar to Type A (categorical by party), its nature is different:
+vote shares are proportional data, and the relevant question is "where does this precinct fall
+on the partisan spectrum?" rather than "how many people belong to each party?" The two-party
+case collapses to a single continuous dimension (D-R spread), for which the RdBu diverging
+palette already exists as the established encoding (used in DRA, NYT, WaPo, and this game's
+existing Partisan Lean view mode).
+
+For the dot layer, partisan encoding can be treated as Type A (dot color = reported party
+affiliation or vote preference) but it should be flagged that partisan lean as a continuous
+spectrum is better read via the precinct fill (the existing RdBu Partisan Lean mode) than
+via dot color. The dot layer in partisan mode primarily adds population information — the
+fill already handles the lean.
+
+**Type C — Continuous scalar (ordered, single dimension)**
+Examples: turnout rate (0–100%), median income, median age, educational attainment.
+
+Properties: single numeric value per precinct; no group membership; the question is "how
+high or low is this value?"
+
+Encoding option 1 (color): All dots within a precinct take the same color, and that color
+reflects the precinct's scalar value on a single-hue sequential palette (e.g., light→dark).
+This is equivalent to a choropleth encoded at the dot layer rather than the fill.
+
+Encoding option 2 (size): Dot radius varies proportionally to the scalar value. A wealthier
+precinct = larger dots; an older precinct = larger dots; a higher-turnout precinct = larger
+dots. Dot count still represents population. This is discussed further in Section 6 (dot size
+encoding).
+
+Alternative encoding for turnout specifically: turnout affects the *number* of dots shown
+rather than their color or size. A 100% turnout precinct shows all population dots; a 50%
+turnout precinct shows half. This is the most natural encoding for turnout — "these are the
+people who actually voted" — but requires separating the concept of "all residents" (total
+dot count) from "voters" (turnout-weighted dot count), which may require two dot layers or a
+clear UI toggle between population and electorate modes.
+
+**Type D — Binary or ternary (2–3 values, not mutually exclusive)**
+Examples: gender (binary or ternary if nonbinary is modeled), urban/rural classification.
+
+Properties: each person belongs to one of 2–3 categories; the encoding challenge is that the
+resulting palette is simpler but the educational relevance of showing gender alone is limited
+(as noted in the brief — gender doesn't predict voting without turnout and preference data).
+
+Encoding: Same as Type A but with 2–3 hues. For gender, if shown as a separate dimension,
+this produces a dot map that reads as a sex ratio per precinct, which is a valid demographic
+indicator. However, gender is likely better shown as a modifier to another dimension (e.g.,
+show female turnout vs. male turnout, or partisan lean split by gender) — a compound
+encoding that this v1 system cannot cleanly support with a single dot color channel.
+
+**Practical recommendation — 3 encoding modes:**
+
+| Mode        | Dimensional types     | Dot color                          | Dot count       |
+|-------------|-----------------------|------------------------------------|-----------------|
+| Categorical | Race, party, religion | One hue per group, proportional    | = population    |
+| Scalar      | Turnout, income, age  | Single-hue sequential per precinct (or: neutral if size is active) | = population (or = voters for turnout) |
+| Partisan    | D/R/L vote share      | Party hues per dot, proportional   | = population    |
+
+"Partisan" is separated from "Categorical" because the existing Partisan Lean view mode
+handles the lean encoding; the dot layer in partisan mode should be clearly differentiated
+from the existing RdBu fill.
+
+For dimensions that do not fit cleanly into these three modes (e.g., compound gender×party
+encoding), the recommendation is to defer or handle via tooltip/sidebar rather than force
+the dot layer to encode something it cannot cleanly represent.
+
+---
+
+### 4. Sidebar and Tooltip Consistency
+
+#### The Problem with the Current "68% D Lean" Summary
+
+A single-number partisan lean summary (68% D) is problematic for multiple reasons:
+- It collapses a multi-party distribution to a single scalar without disclosing what it is
+  measuring (two-party D share? D margin over R? D share of all votes?).
+- It does not show the full distribution (if there is a 10% third-party vote, that is invisible).
+- It does not indicate population (a 68% D precinct of 200 people affects a district very
+  differently than a 68% D precinct of 4,000 people).
+- It is ambiguous under different dimensional modes — the sidebar must show consistent
+  information across all active dot modes.
+
+#### Prior Art: Compact Multi-Group Proportion Display
+
+**Stacked horizontal bar charts** are the standard compact format for multi-group proportions
+in sidebar contexts. The New York Times election results pages (2016–2024) use stacked
+horizontal bars for party vote shares at the county/state level. The format's advantages:
+- Proportional area encoding — the relative widths directly represent shares.
+- Color-consistent with the map — same party colors appear in bar segments and dots.
+- Compact vertical footprint — a single bar row with percentage labels fits in a narrow panel.
+- Extensible to 4–5 parties without losing legibility.
+
+**Small pie charts** have known readability problems:
+- Angular judgments are less accurate than length judgments (Cleveland & McGill 1984).
+- At sidebar scale (typically 200–300px wide), pie charts with 5+ slices become illegible.
+- Color-coding a pie chart requires the same palette as the map, which is appropriate, but
+  the small size limits label placement.
+
+**Treemaps at small scale** (sometimes used in data journalism) have similar small-size
+problems — the hierarchical structure adds visual complexity without adding information for
+flat categorical distributions.
+
+**Labeled percentage lists** (e.g., "D: 52%, R: 34%, L: 8%, Other: 6%") are the most
+accessible format for screen readers and keyboard users. They work well for 4–5 groups but
+become unwieldy at 7+. They should be present alongside the visual encoding as text
+alternatives, not as the sole format.
+
+#### Recommended Sidebar Format
+
+For each demographic dimension shown:
+1. **Title row:** Dimension name (e.g., "Partisan Lean", "Race/Ethnicity", "Voter Turnout")
+2. **Stacked horizontal bar:** One colored segment per group, widths proportional to shares;
+   color matches dot encoding on map
+3. **Percentage labels:** Key groups labeled directly on bar or below (threshold: show label
+   if share > 8%)
+4. **Population note:** "Population: N" or "Voters: N (TK% turnout)" — the absolute count
+   that contextualizes the proportions
+
+For the tooltip (on hover over a precinct):
+- Precinct name/ID
+- District assignment (with district color swatch)
+- Population count
+- The same stacked bar at smaller scale (or percentage list if bar is too small)
+- Current dimension summary
+
+This ensures that the dot layer and the sidebar/tooltip always show the same underlying
+data in consistent visual form — dot proportions match bar segment widths.
+
+#### Consistency Under Dimension Switching
+
+When the user switches from "Partisan Lean" to "Race/Ethnicity" view:
+- The dots on the map change color (party colors → racial/ethnic group colors)
+- The sidebar stacked bar must change accordingly (same bar position, new segment colors
+  and labels)
+- The tooltip stacked bar updates to match
+
+The dimension selector (whatever UI element controls the active dot color dimension) should
+be visually linked to the sidebar — ideally, the sidebar legend and the dimension selector
+are the same element or share a visual relationship (e.g., same title text, same color
+swatches). This reduces the risk of the player looking at one dimension's dots while reading
+another dimension's sidebar numbers.
+
+---
+
+### 5. Accessibility
+
+#### The Challenge of Multi-Color Dot Schemes
+
+Dot density maps with 5–7 categorical colors present the most demanding accessibility case
+in this design. Individual dots at the rendering scale of a 300-hex map will be small (likely
+4–8px diameter at normal zoom). Small colored dots are subject to:
+- **Color confusion under color vision deficiency:** Deuteranopia (red-green) affects ~8% of
+  male users; protanopia affects ~1%; tritanopia (blue-yellow) is rarer (~0.01%) but exists.
+  A D (blue) / R (red) dot scheme fails immediately for deuteranopes and protanopes.
+- **Size effects on hue perception:** Small dots have lower color saturation perceived by the
+  visual system than large areas of the same hue. A palette designed for polygon fills may
+  not translate to small dots — hues that are distinct at polygon scale may converge at dot
+  scale.
+
+#### Existing Multi-Color Dot Map Accessibility Strategies
+
+Cable's racial dot map uses five colors for racial groups. The map's authors acknowledged
+accessibility concerns but did not provide a colorblind mode — a known limitation of the
+original. Several subsequent users have criticized it on accessibility grounds. No public
+tool has solved multi-category dot density accessibility definitively.
+
+**Strategies documented in the literature:**
+
+**1. Palette restriction (most practical):**
+Limit categorical dot encoding to 4–5 groups maximum. Use Paul Tol's "Bright" or "High
+Contrast" palettes or ColorBrewer qualitative sets that are tested under deuteranopia
+simulation. The 2-party partisan case (D/R) can be made colorblind-safe by shifting from
+pure red/blue to orange/blue (deuteranope-safe) or using shape encoding for a second
+redundant cue.
+
+**2. Shape/symbol redundant encoding:**
+Use different dot shapes (circle, square, triangle, diamond) in addition to color, one shape
+per demographic group. This makes groups distinguishable without relying solely on color.
+Limits: (a) small dot sizes reduce shape legibility; (b) 5–7 distinct recognizable small
+shapes is at the edge of what is perceptually feasible; (c) rendering complexity increases.
+
+**3. Pattern fills (for larger features, not dots):**
+Pattern fills (hatching, stippling) are an alternative to color for area fills — well-suited
+for colorblind accessibility at the precinct fill level. Not applicable to individual dots.
+
+**4. High-contrast mode with outline dots:**
+Render dots with a high-contrast border (white or black outline) to improve visibility
+against varying background fill colors. The fill color of the dot encodes group; the outline
+ensures the dot is visible regardless of the underlying district fill color.
+
+**5. Opacity / density differentiation:**
+For cases where only two groups need to be distinguished (e.g., D/R partisan split), use
+opacity variation rather than hue — full opacity = one group, semi-transparent = the other.
+Limited to two groups; does not generalize to 5+ categories.
+
+**6. Tooltip as authoritative carrier:**
+The most robust accessibility strategy: design the dot layer as *supplemental* visual
+texture, not as the primary information carrier. The tooltip and sidebar carry the authoritative
+data (precise percentages and counts). A user who cannot distinguish dot colors still has
+full access to the data through hover interaction. This requires that the tooltip be keyboard-
+accessible (focusable precincts navigable by keyboard) per WCAG 2.1 SC 4.1.3 (Status
+Messages) and 2.4.3 (Focus Order).
+
+#### Recommended Accessibility Approach
+
+**For v1:**
+1. Use Paul Tol's "Bright" 7-color palette for categorical dimensions, tested under deuteranopia
+   and protanopia simulation (available at personal.sron.nl/~pault/). Limit to 5 simultaneous
+   hues; fold remaining groups into "Other."
+2. Partisan encoding specifically: shift from pure red/blue to orange (#E66100) / blue (#5D3A9B)
+   (Okabe-Ito palette, designed for colorblind-safe categorical distinction).
+3. Add white outline (1px) to all dots to ensure dot visibility against colored fills.
+4. Ensure tooltip is keyboard-focusable; all dot-layer information is also available as text.
+5. Document that color is supplemental — the dot layer adds visual texture; numbers in tooltip
+   and sidebar are the authoritative data source.
+
+**For a later high-contrast mode:**
+- Add a shape toggle (dots become squares/triangles/circles by group)
+- Offer a high-contrast palette with black/white/pattern texture encoding as an alternative
+  to hue-based encoding
+
+---
+
+### 6. Dot Size as a Scalar Encoding — Prior Art, Perceptual Limits, and Dual Encoding
+
+#### Framing: The Addendum Question
+
+The addendum proposes that for scalar/magnitude demographic dimensions — median age, median
+household income, turnout rate — dot SIZE (radius) may be a more natural encoding than dot
+color. The intuition: a precinct with an older population gets larger dots; a wealthier precinct
+gets larger dots; a high-turnout precinct gets larger dots. Dot count still represents population;
+dot color can remain neutral or encode a categorical dimension simultaneously.
+
+Three research questions:
+1. Is there prior art for dot size encoding in dot density maps?
+2. What are the perceptual limits of size encoding at the 2–6px radius range?
+3. Can size and color be used simultaneously without creating an unworkable conjunction problem?
+
+#### Prior Art: Proportional Symbol Maps
+
+The proportional symbol map tradition (Flannery 1971, Robinson et al. 1995, Bertin 1967) is
+the established cartographic use of size to encode scalar magnitude. Bertin identifies size
+as the only visual variable that is inherently quantitative — viewers interpret it as "more/less
+of something" without instruction. This is theoretically sound for scalar dimensions.
+
+However, conventional dot density maps hold dot size constant. Size encodes nothing — count
+is the magnitude channel. Cable, the Gamio/NYT maps, and all survey-linked dot density
+election maps use uniform dot size. Using variable dot size *within* a dot density layer —
+where count also varies — creates a hybrid of two traditions:
+- Dot density: count = population
+- Proportional symbol: size = attribute magnitude
+
+This hybrid has thin direct precedent in published cartography. PSU GEOG 486 (Multivariate Dot
+and Proportional Symbol Maps) documents bivariate designs that combine proportional symbol maps
+with choropleth or other layers — but these typically place proportional symbols ON TOP OF
+another map layer, not vary the size of individual dots within a dot density field. The
+perceptual result of varying dot sizes within a density field (where a viewer must simultaneously
+read "many dots here = many people" and "bigger dots here = older population") is documented
+as challenging for non-expert readers.
+
+The closest published form is the **bivariate proportional symbol map**, which sizes point
+symbols by one variable and colors them by another. The Axis Maps guide on bivariate
+proportional symbols notes the interpretation challenge directly: readers must decompose two
+simultaneously active visual variables that operate on different channels (size → magnitude;
+color → category), and this decomposition is not automatic for general audiences.
+
+#### Perceptual Limits of Size Encoding at Small Dot Sizes
+
+The 2–6px radius range (4–12px diameter) presents significant perceptual constraints.
+
+**Weber's law and just-noticeable differences for area:**
+Weber's law states that the minimum detectable change in a stimulus is proportional to the
+baseline magnitude. For visual area, the Weber fraction is approximately 0.06–0.12 — that is,
+a circle must change in area by roughly 6–12% to be reliably detected as different. At small
+sizes, this means:
+- A 2px radius dot has area ≈ 12.6 sq px
+- A 3px radius dot has area ≈ 28.3 sq px (≈ 2.25x area change — well above detection threshold)
+- But in a field of mixed-size dots under simultaneous population-count variation, the
+  signal-to-noise ratio drops sharply. A viewer cannot easily separate "this dot is bigger
+  (older precinct)" from "this region has more dots (denser population)."
+
+**Stevens' power law for area:**
+Stevens (1957) showed that perceived magnitude follows a power function of physical magnitude.
+For visual area, the exponent is approximately 0.7–0.87 (sublinear), meaning viewers
+consistently underestimate the difference between large and small areas. Flannery's (1971)
+correction factor (exponent 0.5716 applied to radius) was developed specifically to compensate
+for this bias in proportional circle maps. At the very small sizes in this game's dot layer
+(4–12px diameter), the Flannery correction is untested — most proportional symbol research
+was conducted with symbols 20–100px in diameter.
+
+**Discriminable size steps at 2–6px radius:**
+Combining Weber fraction considerations and practical rendering constraints:
+- At 2px radius: a 3px radius dot is a 2.25x area increase — detectable but marginal in a
+  mixed-density field.
+- At 3px radius: a 5px radius dot is a 2.78x area increase — clearly larger in isolation;
+  discriminable against other dots of known baseline.
+- Practical discriminable steps in the 2–6px range: approximately 3–4 coarse ordinal levels
+  (e.g., small/medium/large/extra-large), not a continuous scale.
+
+**Implication:** Dot size at this scale works as a coarse ordinal encoding — "this precinct's
+population skews older" reads clearly; "this precinct's median age is 52 vs. 48" does not.
+This is acceptable for the educational game's purpose (gestalt impressions of demographic
+distribution), but the design must not imply precision. Legend labels should use qualitative
+ordinal terms ("younger / older", "lower income / higher income") rather than numeric scales.
+
+**Minimum functional size:**
+Below 4px diameter, dots become difficult to distinguish as distinct marks, and size variation
+within that range is nearly imperceptible. 2px radius (4px diameter) is effectively the floor
+for the entire dot layer. At 2px radius minimum, size variation from 2–4px radius (4–8px
+diameter) gives approximately 2–3 discriminable steps. At 4–6px radius range, 3–4 steps
+are feasible if the legend clearly establishes the scale.
+
+#### Simultaneous Size + Color Encoding — Conjunction Search Analysis
+
+The critical design question: if size encodes a scalar dimension (income, age) and color
+simultaneously encodes a categorical dimension (race, party), does the viewer face an
+unworkable conjunction search problem?
+
+**The standard finding:** Ware (2004/2013, *Information Visualization*) establishes that hue
+and size are both preattentive *individually* — a uniquely colored dot pops out from a field;
+a uniquely large dot pops out from a field. However, the conjunction of the two ("find the
+large red dot") is NOT preattentive — it requires serial search (Treisman & Gelade 1980,
+Feature Integration Theory). This is the conjunction search problem.
+
+**The GEOG 486 finding on separability:** PSU GEOG 486 (Multivariate Dot and Proportional
+Symbol Maps) characterizes size + color value (lightness) as a "separable conjunction" —
+both visual variables are dissociative (each can be analyzed independently of the other).
+This means a viewer CAN read size without being confused by color, and read color without
+being confused by size — but doing so requires conscious, sequential effort, not automatic
+parallel processing.
+
+**For this game's design:**
+
+The design intent matters here. If the user is expected to switch between "viewing the color
+dimension" and "viewing the size dimension" — that is, always attending to one at a time —
+then the conjunction load is reduced. The viewer who is looking at racial distribution ignores
+dot size; the viewer who is looking at income ignores dot color. This is workable IF:
+1. The legend makes it unambiguous which channel encodes which variable.
+2. The interface signals which dimension is "active" (e.g., a highlighted legend entry).
+3. The two encodings are not active simultaneously as primary reading tasks.
+
+If, however, the design intends that a viewer read BOTH at once (e.g., "find precincts where
+the population is old AND predominantly Black"), the conjunction search is real and will slow
+comprehension significantly for a general audience.
+
+**The "always visible" problem:** Variable dot size is visually always present — it cannot be
+toggled off without switching to a different rendering mode. If size encodes income and color
+encodes race, then whenever the player is looking at the racial dimension, they also see the
+income encoding (larger/smaller dots). This ambient second dimension competes for attention
+and may interfere with clean reading of either dimension. This is the more significant
+practical concern than the formal conjunction search problem.
+
+**Assessment:** Size + color simultaneous encoding is viable at coarse granularity (3–4 size
+steps + 5 hue categories) for a user who understands the dual encoding — but it exceeds what
+can be learned at a glance by a general audience without explicit tutorial support. The legend
+must be permanently visible and must simultaneously show the size scale and the color scale.
+A player encountering the map cold will not know whether dot size variation is a rendering
+artifact, a population density signal, or an attribute encoding.
+
+#### Dimensional Type Taxonomy as a Visual Design Framing Device
+
+The addendum proposes a dimensional type taxonomy as a visual design categorization:
+
+| Dimensional type | Examples | Dot attribute |
+|---|---|---|
+| **Categorical/compositional** | Race, party affiliation, gender | Dot color |
+| **Scalar/magnitude** | Income, age, educational attainment | Dot size |
+| **Density/count** | Population | Dot count |
+| **Spatial lean** | Partisan lean (derived from compositional) | Dot color blend / precinct fill |
+
+This taxonomy maps directly to Bertin's (1967) retinal variables:
+- Hue → nominal (categorical, associative, selective) — "this group vs. that group"
+- Size → quantitative (ordered, proportional) — "more/less of something"
+- Count (position/density) → quantitative magnitude at aggregate level
+
+The theoretical coherence of the taxonomy is strong: Bertin would recognize it as a faithful
+application of his framework. Hue for category; size for magnitude; count for quantity.
+
+**The learnability question for a general audience:**
+
+The taxonomy requires internalizing three rules:
+1. Color = what kind of group (categorical)
+2. Size = how intense/high (scalar magnitude)
+3. Count = how many people (population)
+
+These are three conceptually distinct rules, each operating on a different visual channel.
+Cartographers learn this framework; general audiences typically do not have it. Research on
+map reading by non-experts (MacEachren 1995, *How Maps Work*) finds that naive users interpret
+visual salience holistically — a large dot is "more important," not "older" — without explicit
+framing. For this game's audience (general public, educational context), the taxonomy will NOT
+be self-evident from the map alone.
+
+**Conclusion on taxonomy as framing device:** The taxonomy is visually coherent as a design
+categorization — it is theoretically grounded, non-contradictory, and extensible. It is NOT
+self-interpreting for a general audience. Its utility is for the design team (ensuring
+consistent assignment of dimensions to channels) and for the in-game legend/tutorial (which
+must explicitly teach the mapping). If the legend/tutorial adequately explains the encoding,
+the taxonomy can work for players. If players encounter the map without instruction, the
+simultaneous use of different dot attributes for different dimensions will create more confusion
+than clarity.
+
+**Recommendation on taxonomy:** Adopt the taxonomy as a design guide document, not as a
+player-facing explanatory device. The in-game legend should express the rules in natural
+language ("dot colors show racial composition; dot sizes show median income") rather than
+presenting the taxonomy category names. The rules need to be stated explicitly, not implied
+by visual convention alone.
+
+---
+
+## Options
+
+The following options describe concrete design configurations for the full dimensional dot map
+system. The original five options (A–E) are preserved; a new Option F (Bivariate Dot —
+Size+Color) is added to address the addendum's dot size proposal.
+
+---
+
+### Option A — Uniform Scatter (Minimal, Cable-faithful)
+
+**Dot placement:** Random within hex, always. No sorting mode.
+
+**Dimensional encoding:**
+- One encoding mode: categorical multi-group. Each dimension's values are treated as
+  categorical groups with hue assignment.
+- Continuous scalars (income, age) are binned into 4–5 ranges and treated as categorical.
+- Turnout is treated as a scalar overlay: dot count is modulated by turnout rate (dots shown
+  = population × turnout rate), not by color.
+- Dot size: uniform. No size variation.
+
+**Sidebar format:** Stacked horizontal bar (single bar, colored segments) + "N people" note.
+Tooltip: percentage list (text) + population count.
+
+**Accessibility:** Paul Tol Bright palette, 5-hue max. White dot outlines. Tooltip as
+authoritative source. No shape encoding.
+
+**Tradeoffs:** Simplest to implement; most consistent (one algorithm for all cases); but
+collapses continuous dimensions into bins, losing distributional information. Turnout as
+count modifier is non-obvious to players ("why are there fewer dots here?").
+
+---
+
+### Option B — Adaptive Encoding (3-Mode Taxonomy)
+
+**Dot placement:** Random within hex. No sorting mode.
+
+**Dimensional encoding (3 modes, selected automatically based on dimension type):**
+- *Categorical mode:* race/ethnicity, party affiliation — dot color per group, proportional.
+  Dot size: uniform.
+- *Scalar mode:* income, age, educational attainment — all dots in hex same single-hue color
+  on sequential scale; color encodes precinct-level scalar value. Dot size: uniform.
+- *Modifier mode:* turnout — dot count reflects turnout-adjusted population; all dots same
+  neutral color; the count IS the message. Dot size: uniform.
+
+**Sidebar format:** Stacked horizontal bar for categorical; single-value bar with endpoint
+labels for scalar; turnout shown as "X% turnout — N of M registered voters voted."
+
+**Tooltip:** Dimension-appropriate compact summary (bar for categorical; number + bar
+position for scalar; N/M fraction for turnout).
+
+**Accessibility:** Paul Tol Bright palette for categorical; Viridis or single-hue sequential
+(SRON rainbow-free) for scalar. White dot outlines for all modes. Tooltip keyboard-accessible.
+
+**Tradeoffs:** Most semantically appropriate encoding per dimension type; requires implementing
+3 rendering modes; player must understand mode transitions as they switch dimensions.
+
+---
+
+### Option C — Uniform Scatter with Sort Toggle
+
+**Dot placement:** Random by default. User toggle (small icon in map controls) switches to
+sorted-by-group placement within each hex.
+
+**Dimensional encoding:** Same as Option A (categorical, with binning for continuous).
+Dot size: uniform.
+
+**Sidebar format:** Same as Option A.
+
+**Accessibility:** Same as Option A.
+
+**Tradeoffs:** Adds a UI control (sort toggle) that benefits zoom-in exploration but adds
+cognitive overhead. Random mode serves 90% of gameplay; sorted mode is useful only at high
+zoom for players investigating within-precinct composition. Sort toggle default-off; visible
+only when zoomed in past a threshold (e.g., fewer than 15 precincts visible) to reduce
+UI noise.
+
+---
+
+### Option D — Adaptive Encoding with Shape Accessibility Mode
+
+**Dot placement:** Random within hex. No sorting.
+
+**Dimensional encoding:** Same as Option B (3-mode taxonomy). Dot size: uniform.
+
+**Sidebar format:** Same as Option B.
+
+**Accessibility:** Full shape-encoding redundancy:
+- Categorical mode: each group gets a unique shape (circle/square/triangle/diamond/hexagon)
+  in addition to hue. Shape encoding toggleable via accessibility settings.
+- Scalar mode: unaffected (no shape needed; single hue per precinct, all dots same shape).
+- Turnout mode: unaffected (count is the encoding).
+- High-contrast mode: black/white palette with shape encoding replaces hue encoding entirely.
+
+**Tradeoffs:** Most accessible design; but shape encoding at small dot sizes (4–8px) is
+marginally effective and requires careful size calibration. Rendering at the 300-hex scale
+will require dots to be 8–10px minimum to make shapes distinguishable — which may be larger
+than the hex can comfortably contain at full-map zoom. Implementation complexity is highest
+of all options.
+
+---
+
+### Option E — Dot Layer as Texture Only (Minimal Semantic Load)
+
+**Dot placement:** Random within hex.
+
+**Dimensional encoding:** Dot color always encodes population group membership (categorical),
+but color encoding is deliberately subdued (low saturation, secondary visual weight). Dots
+function primarily as population texture; dimensional color is a "bonus" layer, not the
+primary reading. Dot size: uniform.
+
+The dimensional encoding is explicit in the sidebar and tooltip; the dot color is a
+confirmatory visual aid, not the primary source of information. This inverts the design
+emphasis: dots = "people are here" (primary); dot color = "these are the people" (secondary).
+
+**Sidebar format:** Full stacked bar with percentage labels and absolute counts. The sidebar
+is the primary dimensional display; the dot layer is visual texture.
+
+**Accessibility:** Low-saturation dots with high-contrast outlines. Colorblind accessibility
+is managed by the sidebar being authoritative (not the dot color). Colorblind users can ignore
+dot colors and rely on sidebar/tooltip entirely without losing information.
+
+**Tradeoffs:** Most accessible semantically (dot color is supplemental, not required reading).
+May frustrate players who expect the dot layer to carry more information — they may not realize
+there is dimensional information encoded in the dot colors. Requires clear UI guidance ("dot
+colors show [dimension]") to ensure players understand the encoding is present.
+
+---
+
+### Option F — Bivariate Dot (Size = Scalar, Color = Categorical)
+
+**Dot placement:** Random within hex.
+
+**Dimensional encoding:**
+- Dot color encodes a categorical dimension (race/ethnicity, party affiliation) as in
+  categorical mode — one hue per group, proportional within each hex.
+- Dot size encodes a scalar dimension simultaneously — all dots in a hex are scaled to the
+  same radius, which reflects the precinct's scalar value (income, age, etc.) on a 3–4 step
+  ordinal scale: small / medium / large / extra-large.
+- Dot count encodes population as in all other options.
+- The result is a bivariate dot density layer: color reads racial/party composition; size reads
+  the intensity of the selected scalar attribute; count reads population.
+
+**Size scale design:**
+- Size levels: 3–4 ordinal steps, not a continuous scale (see Section 6 perceptual limits).
+- Radius range: 2px (smallest) → 5px (largest) within the hex constraint.
+- Flannery correction (power 0.5716) applied to radius scaling for compensation.
+- Legend: permanent, simultaneous color + size legend (matrix or dual-legend layout).
+- Labels: qualitative ordinal terms ("younger / older", "lower / higher income"), not numeric.
+
+**Sidebar format:**
+- Two rows: (1) categorical dimension stacked bar + (2) scalar dimension bar/label with size
+  swatch showing the dot radius for this precinct.
+- Population note as in other options.
+
+**Accessibility:**
+- Same palette constraints as Option B (Tol Bright / Okabe-Ito for color; ≤5 hues).
+- Size variation is colorblind-neutral — it adds information not dependent on color vision.
+- Dual-legend must be permanently visible; tooltip must explicitly state both dimensions
+  ("Median income: high (large dots); Race: 45% Black, 30% White, 25% Hispanic").
+- Players who cannot read size variation reliably still have full data in tooltip/sidebar.
+
+**Tradeoffs:**
+- Theoretically the most informationally dense option — two demographic dimensions active
+  simultaneously without a mode switch.
+- Requires internalizing two simultaneous encoding rules (color = category, size = magnitude),
+  which is documented as non-trivial for general audiences without tutorial support.
+- The "always visible" problem: size encoding is always on; even when reading the color
+  dimension, size variation competes for attention.
+- At small hex sizes (300 precincts, full-map zoom), dot size variation at 2–5px is subtle;
+  benefit accrues mainly at medium-to-high zoom levels.
+- Not recommended as a v1 starting point. Best evaluated after v1 playtesting reveals whether
+  players successfully read single-channel dot encoding; if so, dual-channel may be a v1.1
+  enhancement.
+- Conjunction search: color + size is a separable conjunction (per GEOG 486 / Roth 2015) —
+  each channel can be read independently but not preattentively together. This is workable but
+  requires explicit in-game legend support.
+
+---
+
+## Recommendation
+
+**Adopt Option B — Adaptive Encoding (3-Mode Taxonomy)** as the design target, with
+accessibility provisions borrowed from Option D.
+
+**Rationale:**
+
+1. **Semantic accuracy.** Each dimensional type (categorical, scalar, turnout modifier) is
+   encoded in the visual channel most appropriate to its data structure. Binning continuous
+   data into fake categories (Options A, C) loses information and misrepresents the data type.
+   A stacked bar that shows "Income: $40K–$60K (most common)" is less accurate and less
+   educational than a dot layer that encodes income as a sequential color scale per precinct.
+
+2. **Consistency with stated educational goals.** The game aims to teach how demographic
+   composition affects electoral outcomes. Accurate encoding of dimensional types supports
+   accurate understanding. Approximate encoding (binning, fake categories) risks teaching
+   the wrong lessons.
+
+3. **Manageable implementation scope.** Three rendering modes (categorical, scalar, modifier)
+   map cleanly to 3 rendering code paths. Each mode is well-defined and can be implemented
+   independently. The alternative (one-off encoding per dimension) is harder to maintain as
+   dimensions are added.
+
+4. **Sidebar consistency.** Option B's three sidebar formats (stacked bar for categorical,
+   single-value bar for scalar, N/M fraction for turnout) are dimension-appropriate and
+   avoid the "68% D lean" ambiguity problem by showing full distributions.
+
+**On dot size (Option F):** Option F is not recommended for v1, but it is a coherent and
+theoretically grounded extension. The dimensional type taxonomy (categorical → color; scalar
+→ size; count → dot count; partisan lean → fill blend) is well-supported by Bertin's retinal
+variable framework and by the proportional symbol map tradition. The barriers to v1 adoption are:
+- Perceptual limits at 2–6px radius constrain size to 3–4 ordinal steps; precise magnitude
+  reading is not achievable at this rendering scale.
+- General audiences cannot decode dual dot encoding (size + color simultaneously) without
+  explicit tutorial instruction; this is a UI/UX burden that exceeds v1 scope.
+- The "always visible" problem: size encoding competes with color reading even when the player
+  is attending to the color dimension.
+
+Option F should be revisited at v1.1 if: (a) playtesting shows players successfully reading
+single-channel dot encoding and asking for more information density; (b) a specific scenario
+requires a scalar dimension (e.g., income or age) and a categorical dimension (e.g., race) to
+be readable simultaneously to understand the educational point; (c) rendering resolution
+permits dots at 5–8px radius at normal zoom.
+
+**On the dimensional type taxonomy:** The taxonomy (categorical → color; scalar → size;
+count → dot count; lean → fill blend) is adopted as an internal design guide. It should not
+be presented as player-facing terminology. In-game legends and tutorial text should express
+the rules in plain language: "dot colors show [dimension]", "dot sizes show [scalar]",
+"dot count shows population." The taxonomy is a consistency tool for the design team, not a
+self-explanatory visual convention for players.
+
+**Accessibility conditions:**
+- Use Paul Tol Bright or Okabe-Ito palettes for categorical; limit to 5 simultaneous hues.
+- Add white 1px outlines to all dots.
+- Add shape-encoding as an accessibility mode (can be a v1.1 enhancement).
+- Ensure tooltip is keyboard-focusable and carries full text data.
+- Treat dot color as supplemental, not sole carrier — document this in UI tooltip help text.
+
+**Conditions under which a different option is preferred:**
+- **Option A** is appropriate if implementation timeline is short and dimensional variety in
+  v1 scenarios is limited to party and race (both categorical). Binning continuous data is
+  acceptable if continuous scalar dimensions are not in v1 scenarios.
+- **Option D** is preferable to Option B if the game's player audience includes users with
+  significant color vision deficiency and accessibility is a primary v1 requirement. The shape
+  encoding overhead is justified if the target audience requires it.
+- **Option E** is appropriate if playtesting reveals that players are over-reading the dot
+  layer and ignoring the sidebar — shifting the semantic weight to the sidebar would correct
+  this. It should not be the starting choice, but could be a simplification if needed.
+- **Option F** is appropriate at v1.1 or later, specifically for scenarios requiring two
+  simultaneous demographic dimensions; requires tutorial/legend support and rendering at
+  sufficient zoom to make 3–4 size steps discriminable.
+
+---
+
+## References
+
+**Cartographic theory and dot density:**
+- Kimerling, A.J. (2009). "Dotting the Dot Map, Revisited." *Cartographic Perspectives*, 64.
+  — Canonical treatment of dot placement algorithms; random vs. non-random placement.
+- Robinson, A., Morrison, J., Muehrcke, P., Kimerling, A.J., & Guptill, S. (1995).
+  *Elements of Cartography* (6th ed.). Wiley. — Standard cartographic dot density map design.
+- Bertin, J. (1967/1983). *Semiology of Graphics*. University of Wisconsin Press.
+  — Visual variables taxonomy; hue=nominal, lightness=ordinal/quantitative, size=quantitative;
+  size is the only variable inherently interpretable as a ratio/magnitude.
+- Ware, C. (2004/2013). *Information Visualization: Perception for Design*. Morgan Kaufmann.
+  — Conjunction search; preattentive separability; channel independence.
+- Tufte, E. (1983). *The Visual Display of Quantitative Information*. Graphics Press.
+  — Small multiples; sparklines; data density principles.
+- MacEachren, A. (1995). *How Maps Work: Representation, Visualization, and Design*.
+  Guilford Press. — Map reading by non-experts; naive vs. expert user interpretation.
+- Roth, R.E. (2015). "Interactive Maps: What We Know and What We Need to Know."
+  *Journal of Spatial Information Science*. — Visual variable conjunctions and separability.
+
+**Proportional symbol maps and size encoding:**
+- Flannery, J.J. (1971). "The Relative Effectiveness of Some Common Graduated Point Symbols
+  in the Presentation of Quantitative Data." *The Canadian Cartographer*, 8(2), 96–109.
+  — Foundational empirical study; systematic underestimation of circle area; Flannery correction
+  factor (exponent 0.5716); relevant to size-encoded dot design.
+- PSU GEOG 486 Cartography and Visualization, "Multivariate Dot and Proportional Symbol Maps."
+  courses.ems.psu.edu/geog486/node/901 — Bivariate proportional symbol map design; size +
+  color simultaneous encoding; separable conjunction; legend design requirements.
+- Axis Maps, "Bivariate Proportional Symbols." axismaps.com/guide/bivariate-proportional-symbols
+  — Practical bivariate design guidance; interpretation challenge for general audiences.
+
+**Perceptual limits:**
+- Stevens, S.S. (1957). "On the Psychophysical Law." *Psychological Review*, 64(3), 153–181.
+  — Power law for perceived magnitude; area exponent ~0.7–0.87 (sublinear).
+- Cleveland, W.S. & McGill, R. (1984). "Graphical Perception." *JASA*, 79(387).
+  — Accuracy of different visual encodings; length > angle (bars > pies); area judgment accuracy.
+- Treisman, A. & Gelade, G. (1980). "A Feature Integration Theory of Attention."
+  *Cognitive Psychology*, 12(1), 97–136. — Conjunction search; preattentive features vs.
+  conjunction targets; serial vs. parallel search.
+
+**Dot density map precedents:**
+- Cable, D. (2013). "The Racial Dot Map." Weldon Cooper Center for Public Service, UVA.
+  demographics.virginia.edu — foundational dot density demographic map; one dot per person,
+  five racial group colors, random placement within Census block; uniform dot size.
+- Gamio, L. (2018). "An Extremely Detailed Map of the 2016 Election Results." *New York Times*.
+  — Precinct-level dot density for partisan vote breakdown; closest published precedent to
+  partisan lean encoding in this game; uniform dot size.
+
+**Game design precedents:**
+- Victoria 3 (2022). Paradox Interactive. — Switchable demographic overlay dimension (culture/
+  religion/ideology) on the same underlying "pop" objects; closest game precedent to
+  user-switchable dot color dimension.
+- Civilization VI (2016). Firaxis / 2K Games. — Political map flat fills; separate yield
+  overlays; example of correct primary/secondary layer separation.
+- Cities: Skylines (2015). Colossal Order / Paradox Interactive. — Zone view flat fills;
+  separate overlay modes for quantitative data.
+
+**Election redistricting tools:**
+- Dave's Redistricting App: davesredistricting.org — flat fills; no dot density.
+- Districtr: districtr.org — flat fills; demographics in side panel.
+- The Redistricting Game (USC Annenberg, 2007) — flat fills; side panels.
+
+**Color accessibility:**
+- Tol, P. (2021). "Colour Schemes." SRON Technical Note SRON/EPS/TN/09-002.
+  personal.sron.nl/~pault/ — Paul Tol palettes (Bright, High Contrast, Muted).
+- Okabe, M. & Ito, K. (2008). "Color Universal Design (CUD)." jfly.uni-koeln.de/color/
+  — Okabe-Ito 8-color palette for colorblind-safe categorical encoding.
+- Brewer, C. (2003). ColorBrewer. colorbrewer2.org — Qualitative 8-class safe palettes.
+- WCAG 2.1 SC 1.4.1 — Use of Color; 2.4.3 — Focus Order; 4.1.3 — Status Messages.
+  w3.org/TR/WCAG21/
+
+**Halftone and dithering (dot mixing theory):**
+- Bayer, B.E. (1973). "An Optimum Method for Two-Level Rendition of Continuous-Tone Pictures."
+  *IEEE ICASSP*. — Ordered dither; basis for understanding color mixing via dot patterns.
+- Ulichney, R. (1987). *Digital Halftoning*. MIT Press. — Comprehensive treatment of dot
+  pattern perception; random vs. ordered dithering perceptual tradeoffs.
+
+**Dorling cartograms:**
+- Dorling, D. (1996). *Area Cartograms: Their Use and Creation.* CATMOG 59.
+  — Population-scaled area cartograms; comparable channel separation to dot density.
+- worldmapper.org — Interactive Dorling cartogram tool with switchable data dimensions.

--- a/thoughts/shared/tickets/DESIGN-003-districts-view-color-encoding.md
+++ b/thoughts/shared/tickets/DESIGN-003-districts-view-color-encoding.md
@@ -2,9 +2,13 @@
 id: DESIGN-003
 title: Districts view color encoding — population gradient design decision
 area: design, UX
-status: open
+status: resolved
 created: 2026-04-25
 ---
+
+## Resolution
+
+Superseded. Decision made: Districts view uses flat district fills (no population gradient). Population density is addressed by new tickets DESIGN-005 (dot density overlay) and DESIGN-006 (zoom-adaptive dot scaling). See research: `thoughts/shared/research/2026-04-27-design-003-color-encoding-research.md`
 
 ## Summary
 

--- a/thoughts/shared/tickets/DESIGN-004-legend-layout.md
+++ b/thoughts/shared/tickets/DESIGN-004-legend-layout.md
@@ -1,6 +1,6 @@
 ---
 id: DESIGN-004
-title: Move legend to horizontal strip above map
+title: Move legend to floating bar at bottom of map
 area: design, UX
 status: open
 created: 2026-04-26
@@ -8,28 +8,53 @@ created: 2026-04-26
 
 ## Summary
 
-The district color legend currently sits at the bottom of the right sidebar, stacked vertically. As the number of districts grows it consumes significant sidebar space and competes with the validity panel and precinct info. Moving it to a horizontal strip above (or overlaid on) the map frees sidebar space for data panels and keeps the legend adjacent to the map it annotates.
+The district color legend currently sits at the bottom of the right sidebar, stacked
+vertically. As the number of districts grows it consumes significant sidebar space and
+competes with the validity panel and precinct info. Moving it to a floating horizontal
+bar at the bottom of the map canvas frees sidebar space for data panels and keeps the
+legend adjacent to the map it annotates.
+
+The legend is purely a color-context annotation for the current view/filter. View
+mode toggles and demographic dimension selectors are separate controls and are not
+part of this ticket (see DESIGN-007 for the dimension selector placement question).
 
 ## Current State
 
-Legend is rendered in `#legend-container` inside `#sidebar` as a vertical list of color swatches + labels. This works for 2–3 districts but becomes cramped as district count grows.
+Legend is rendered in `#legend-container` inside `#sidebar` as a vertical list of
+color swatches + labels. This works for 2–3 districts but becomes cramped as district
+count grows.
 
 ## Goals / Acceptance Criteria
 
-- [ ] Legend is rendered as a horizontal row of swatch+label pairs, positioned above the map or as a floating overlay at the top of `#map-container`
+- [ ] Legend is rendered as a floating overlay positioned at the **bottom** of
+  `#map-container` (overlapping the bottom edge of the map canvas, not below it)
+- [ ] Legend position (floating overlay vs. fixed strip) is togglable via a debug
+  button; the toggle state is not persisted
+- [ ] Legend label format: `[Region name] — D[N]` (e.g. "Clearwater — D1"), where
+  region name comes from `scenario.region` or equivalent scenario field
+- [ ] Label slot accommodates future variable-length names without breaking layout
 - [ ] Legend does not overlap the map controls in the header
 - [ ] Legend remains readable at all scenario district counts (up to ~8 districts)
 - [ ] Sidebar no longer contains the legend section
 - [ ] Layout works at typical browser viewport widths (1280px+)
 
+## Future / Out of Scope
+
+- County names rendered along the inside of county borders (like a real map) — deferred
+- View mode toggle placement — already exists in header; no changes in this ticket
+- Dimension selector placement (DESIGN-007) — separate floating control, top-right
+  area or header; coordinated with DESIGN-007 when that ticket is implemented
+
 ## Test Coverage
 
 - [ ] e2e: legend element is present in the map container (not sidebar) after load
 - [ ] e2e: all district color swatches are visible in the legend
+- [ ] e2e: legend label contains the scenario region name and district number
 - [ ] Unit: N/A — layout is DOM/CSS only
 
 ## References
 
 - Raised during Sprint 2 demo review (2026-04-26)
+- DESIGN-007 — dimension selector placement (separate floating control; not part of legend)
 - `game/web/index.html` — `#legend-container`, `#sidebar`, `#map-container`
 - `game/web/src/main.ts` — legend rendering logic

--- a/thoughts/shared/tickets/DESIGN-005-population-dot-density-overlay.md
+++ b/thoughts/shared/tickets/DESIGN-005-population-dot-density-overlay.md
@@ -1,0 +1,66 @@
+---
+id: DESIGN-005
+title: Population dot density overlay on district map
+area: design, rendering
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+Add a dot density overlay to the Districts view so players can perceive the spatial
+shape of population concentrations at a glance. Dots are placed within each precinct
+hex; dot count is proportional to the precinct's population. This addresses the
+"attention gap" — the sidebar panel gives population totals, but does not let the
+player see where people live spatially across the whole map simultaneously.
+
+District fills remain flat (DESIGN-003 decision). Dots use a separate visual channel
+(mark count) so there is no hue/lightness interference.
+
+## Current State
+
+Districts view uses a lightness gradient that was removed (DESIGN-003). No spatial
+population representation exists on the map canvas.
+
+## Goals / Acceptance Criteria
+
+- [ ] Each precinct hex displays N dots proportional to its population (0 dots at
+  minimum population precinct, up to ~6 dots at maximum population precinct)
+- [ ] Dot count uses a linear scale across the scenario's precinct population range
+- [ ] Dot color adapts to district hue brightness: dark district hues → light/white dots;
+  light/pastel district hues → dark dots (threshold: d3.hsl(color).l > 0.5)
+- [ ] Dots are small (≤3px radius) and placed within the hex interior without clipping
+- [ ] Dot positions are deterministic per precinct (seeded by precinct ID) so they
+  don't re-randomize on re-render
+- [ ] Dots are rendered in the Districts view only; Partisan Lean view is unaffected
+- [ ] A colorblind-safe 8-hue qualitative palette (Paul Tol Bright or ColorBrewer Set2)
+  replaces the current ad-hoc DISTRICT_COLORS at the same time
+- [ ] Both a "dark" palette variant and a "light/pastel" variant are defined; the
+  dot-color logic is tied to which palette is active
+
+## Test Coverage
+
+- [ ] e2e: dot elements are present in the SVG after scenario loads
+- [ ] e2e: precinct with highest population has more dots than precinct with lowest
+- [ ] e2e: dots are absent in Partisan Lean view
+
+## Notes
+
+- Dot positions: place randomly within a circle of radius ~0.6 × hex_radius centered
+  on the hex center. This avoids needing per-hex SVG clipPath elements.
+- Dot count scale: map normPop (0–1) to integer dot count via Math.round(normPop * MAX_DOTS)
+  where MAX_DOTS = 6 for v1.
+- Deterministic placement: use a simple seeded PRNG (e.g. mulberry32 with seed=precinctId)
+  so positions are stable across re-renders.
+- Zoom-adaptive scaling is intentionally deferred to DESIGN-006.
+- Demographic overlay via dot color is DESIGN-007 (dimensional dot map, Option B adaptive
+  encoding). This ticket establishes the base dot layer (population-only) that DESIGN-007
+  builds on.
+
+## References
+
+- DESIGN-003 (superseded) — flat fill decision
+- DESIGN-006 — zoom-adaptive dot scaling (refinement, possibly post-v1)
+- `game/web/src/render/mapRenderer.ts` — hexFill(), hex rendering
+- `game/web/src/model/types.ts` — DISTRICT_COLORS
+- Research: thoughts/shared/research/2026-04-27-design-003-color-encoding-research.md

--- a/thoughts/shared/tickets/DESIGN-006-zoom-adaptive-dot-density.md
+++ b/thoughts/shared/tickets/DESIGN-006-zoom-adaptive-dot-density.md
@@ -1,0 +1,46 @@
+---
+id: DESIGN-006
+title: Zoom-adaptive dot density scaling
+area: design, rendering, performance
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+Refine the dot density overlay (DESIGN-005) so that dot count scales with the current
+zoom level: fewer dots when zoomed out (each dot represents more people), more dots
+when zoomed in (finer-grained population texture). Proportions are preserved across
+zoom levels — the relative visual density between precincts stays constant.
+
+This is a refinement on top of DESIGN-005 and can be deferred post-v1 if DESIGN-005's
+static dot count reads well enough at the game's default zoom level.
+
+## Current State
+
+Depends on DESIGN-005 (population dot overlay). DESIGN-005 uses a fixed MAX_DOTS=6
+regardless of zoom level.
+
+## Goals / Acceptance Criteria
+
+- [ ] Dot count per precinct scales continuously with d3 zoom transform scale (k)
+- [ ] At minimum zoom (full map view): 0–2 dots per precinct (sparse, readable at small size)
+- [ ] At maximum zoom (single precinct fills most of viewport): 10–20 dots per precinct
+- [ ] Proportions between precincts preserved at all zoom levels
+- [ ] Scaling uses a smooth function (e.g. log or sqrt of k) rather than stepped tiers
+- [ ] Re-render on zoom events does not cause perceptible jank (debounced or RAF-gated)
+- [ ] Person glyph icons (SVG silhouette) replace dot circles when per-precinct pixel
+  area exceeds a threshold (e.g. hex radius > 20px in screen space); below threshold, dots
+
+## Notes
+
+- This ticket requires research into performance characteristics of re-rendering
+  dot overlays on zoom events for 300+ precinct scenarios.
+- The person glyph threshold is a UX/rendering research question — recommend a
+  SPIKE or research doc before implementing the glyph path.
+- Depends on: DESIGN-005
+
+## References
+
+- DESIGN-005 — base dot density overlay (prerequisite)
+- `game/web/src/render/mapRenderer.ts` — zoom handling

--- a/thoughts/shared/tickets/DESIGN-007-dimensional-dot-map-demographic-overlay.md
+++ b/thoughts/shared/tickets/DESIGN-007-dimensional-dot-map-demographic-overlay.md
@@ -1,0 +1,138 @@
+---
+id: DESIGN-007
+title: Dimensional dot map — demographic dimension overlay and sorted placement toggle
+area: design, rendering
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+Extend the population dot density overlay (DESIGN-005) to encode an active demographic
+dimension via dot color, using Option B adaptive encoding (see ADR
+`thoughts/shared/decisions/2026-04-27-dimensional-dot-map-design.md`). Add a sorted
+placement toggle so players can switch between random scatter (default) and grouped
+placement (micro-bar-chart effect for zoomed-in precision work).
+
+This is the implementation ticket for the decisions recorded in the ADR above.
+Depends on DESIGN-005 (base dot overlay must be in place first).
+
+## Current State
+
+DESIGN-005 (once implemented) will render dots with a fixed hue-aware color (light or
+dark depending on district hue brightness). No demographic dimension switching exists.
+Dot placement is random/deterministic per precinct but not sorted.
+
+## Goals / Acceptance Criteria
+
+### Dimension type taxonomy
+
+- [ ] Scenario JSON supports a `dimension_type` field (`"categorical"`, `"scalar"`, or
+  `"modifier"`) on demographic group/dimension definitions
+- [ ] Loader validates `dimension_type` and rejects unknown values
+
+### Categorical mode (race, party affiliation, etc.)
+
+- [ ] When a categorical dimension is active, each dot within a hex is colored by the
+  demographic group it represents
+- [ ] Dot count per group within a hex is proportional to that group's share of the
+  precinct population
+- [ ] Palette: Paul Tol Bright or Okabe-Ito; maximum 5 simultaneous hues; 1px white
+  outline on all dots to separate from district fill
+- [ ] Colors remain distinguishable under deuteranopia / protanopia simulation
+
+### Scalar mode (income, age, etc.)
+
+- [ ] When a scalar dimension is active, all dots in a hex share a single sequential
+  single-hue color mapped to the precinct's average scalar value
+- [ ] Color ramp is single-hue (e.g. light-to-dark blue) to avoid hue interference with
+  district fills
+- [ ] Legend shows the sequential ramp with min/max labels
+
+### Modifier mode (voter turnout)
+
+- [ ] When a modifier dimension is active, dot count per hex is scaled by the modifier
+  value (e.g. dot count = population × turnout rate)
+- [ ] Dot color reverts to neutral (hue-aware light/dark from DESIGN-005 base behavior)
+- [ ] Legend explains the modifier interpretation ("dots represent likely voters")
+
+### Sorted placement toggle
+
+- [ ] A toggle button (or keyboard shortcut) switches between random and sorted dot
+  placement within each hex
+- [ ] Sorted mode: dots are grouped by categorical dimension (deterministic sort by
+  group name or index) — produces an embedded micro-bar-chart effect
+- [ ] Sorted mode applies only in categorical mode; random placement is always used in
+  scalar and modifier modes
+- [ ] Toggle state persists through pan/zoom re-renders (not reset on zoom)
+- [ ] Default: random
+
+### Lean Dot view (temporary experimental mode)
+
+A third view mode — **Lean Dot** — is added alongside Districts and Partisan Lean as an
+explicit A/B comparison surface. It renders flat district fills + party-hue dots for the
+partisan dimension. The existing Partisan Lean view (RdBu fill, no dots) is unchanged.
+
+After evaluation, the weaker encoding will be removed. This mode is explicitly marked
+temporary; do not invest in polish.
+
+- [ ] View toggle cycles Districts → Partisan Lean → Lean Dot (→ Districts…)
+- [ ] Lean Dot view: flat district fills + categorical dot layer with party dimension active
+- [ ] Lean Dot view is visually labelled as experimental (e.g. "Lean (Dot) ⚗" or similar)
+- [ ] Partisan Lean view is unchanged — no dots added
+
+### Dimension switching UI
+
+- [ ] A dimension selector (buttons or dropdown) lets the player switch between
+  available demographic dimensions
+- [ ] "No overlay" is always available as an option (returns to plain population dots
+  from DESIGN-005)
+- [ ] Switching dimension re-renders the dot layer without flickering or full page reload
+- [ ] Active dimension is visually indicated in the selector
+
+### Legend
+
+- [ ] Categorical: legend shows each group color with its label
+- [ ] Scalar: legend shows sequential ramp with min/max labels
+- [ ] Modifier: legend shows explanation text
+- [ ] "No overlay" / population-only: legend omitted or shows "Population density"
+
+## Test Coverage
+
+- [ ] Unit: `dimension_type` validation — accepts `categorical`, `scalar`, `modifier`;
+  rejects unknown values
+- [ ] Unit: categorical dot color assignment — given precinct group distribution,
+  produces correct group-color dot counts
+- [ ] Unit: sorted placement — given a seed and group counts, sorted output groups dots
+  by group index deterministically
+- [ ] e2e: switching to a categorical dimension changes dot colors in the SVG
+- [ ] e2e: switching to scalar mode changes all dots to a single-hue ramp color
+- [ ] e2e: switching to "No overlay" returns dots to hue-aware neutral color
+- [ ] e2e: sorted toggle button changes dot grouping within a hex (check DOM order or
+  data attributes)
+- [ ] e2e: Lean Dot view shows dots; Partisan Lean view does not show dots
+
+## Notes
+
+- The sorted toggle is most valuable when zoomed in. Consider auto-gating
+  (auto-sort at high zoom, auto-random at overview) as a DESIGN-006 follow-on.
+- Option F (dot size = scalar, dot color = categorical simultaneously) is explicitly
+  deferred to v1.1 per the ADR. Do not implement or scaffold it here.
+- The dimension selector UI placement: floating control panel, top-right of the map
+  canvas, or integrated into the existing header/menu bar. Separate from the legend
+  (DESIGN-004). Legend = bottom of map, color context only. Controls = top-right,
+  separate floating widget or header. Exact placement to confirm during implementation.
+- At most 5 categorical groups can be shown simultaneously with the colorblind-safe
+  palette constraint. If a scenario has >5 groups, the rendering must bucket or
+  merge low-frequency groups into an "Other" category.
+
+## References
+
+- ADR: `thoughts/shared/decisions/2026-04-27-dimensional-dot-map-design.md`
+- Research: `thoughts/shared/research/2026-04-27-dimensional-dot-map-design-research.md`
+- DESIGN-005 — base dot density overlay (prerequisite)
+- DESIGN-006 — zoom-adaptive dot scaling (parallel; sorted-toggle auto-gating may
+  merge into DESIGN-006)
+- DESIGN-004 — legend layout (coordinate on dimension selector placement)
+- `game/web/src/render/mapRenderer.ts` — dot rendering entry point
+- `game/web/src/model/scenario.ts` — scenario JSON types (add `dimension_type`)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -88,8 +88,10 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
 | `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
 | `AGENT-003-infra-pr-review-bot-comment-handling.md` | agentic workflow, infra | Propose bot comment handling (Copilot, CodeQL) to infra pr-review-cycle workflow |
-| `DESIGN-003-districts-view-color-encoding.md` | design, UX | Districts view color/population gradient: decide encoding strategy for v1 |
 | `DESIGN-004-legend-layout.md` | design, UX | Move legend to horizontal strip above map; free sidebar space for data panels |
+| `DESIGN-005-population-dot-density-overlay.md` | design, rendering | Population dot density overlay: dot count per precinct proportional to population; hue-aware dot color; colorblind-safe palette |
+| `DESIGN-006-zoom-adaptive-dot-density.md` | design, rendering | Zoom-adaptive dot density scaling + person glyph threshold (refinement on DESIGN-005, possibly post-v1) |
+| `DESIGN-007-dimensional-dot-map-demographic-overlay.md` | design, rendering | Dimensional dot map: demographic dimension switching (Option B adaptive encoding) + sorted placement toggle |
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
 | `GAME-020-last-scenario-wrap-up-screen.md` | game, UX | Wrap-up/congratulations screen after completing the final scenario (instead of dead-end select screen) |
 
@@ -99,6 +101,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| DESIGN-003: districts view color encoding | Superseded — flat fills decided; population density → DESIGN-005 + DESIGN-006 |
 | GAME-025: cracking the opposition | All AC met; 120-precinct Lakeview scenario; merged PR #97 |
 | GAME-024: packing problem | All AC met; 120-precinct Riverport scenario; merged PR #97 |
 | GAME-023: give the governor a win | All AC met; 96-precinct Clearwater scenario; merged PR #97 |


### PR DESCRIPTION
## Prerequisites
- [ ] N/A — no parent PR; changes are docs only

## Summary
- Locks in the dimensional dot map design decisions following two research rounds (DESIGN-003 color encoding; dimensional dot map Options A–F)
- ADR records Option B adaptive encoding (categorical/scalar/modifier modes) and sorted placement toggle as accepted design; Option F (bivariate size+color) explicitly deferred to v1.1
- DESIGN-004 updated: legend moves to floating bar at **bottom** of map; controls (view toggle, dimension selector) are a separate floating widget top-right; legend and controls are not unified
- Visual aesthetic recorded: Civ/SimCity-like strategy game feel — dark HUD chrome, map-first, floating overlays
- New tickets DESIGN-005, DESIGN-006, DESIGN-007 formalize the dot overlay + dimensional encoding + zoom-adaptive work; DESIGN-003 resolved

## Validation performed
- [ ] N/A — prose/docs only; no config, no code, no secrets

## Affected machines / services
- N/A — docs only

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see #DESIGN-003 (resolved — superseded by DESIGN-005 + DESIGN-006)
- DESIGN-004 updated (legend bottom placement, controls separate)
- DESIGN-005 new (population dot density overlay)
- DESIGN-006 new (zoom-adaptive dot scaling)
- DESIGN-007 new (dimensional overlay + sorted toggle)

## Rollback
- N/A — docs only; revert commit if needed
