### PR TITLE
feat(GAME-027): hex-of-hexes scenarios 007-009 + dynamic party adapter

### DIFF
--- a/game/scenarios/gen-scenario-006.main.kts
+++ b/game/scenarios/gen-scenario-006.main.kts
@@ -1,0 +1,205 @@
+#!/usr/bin/env kotlin
+/**
+ * Generator for scenario-006.json: "Harden the Map"
+ *
+ * Lesson: Incumbency protection — the bipartisan gerrymander.
+ *
+ * Layout: 10 columns (q=0..9) × 12 rows (r=0..11) = 120 precincts, 5 districts of 24.
+ *
+ * Partisan geography:
+ *   Left flank  (q=0..5): ~62% Ken (6 cols × 12 rows = 72 precincts = 3 districts exactly)
+ *   Right flank (q=6..9): ~38% Ken / ~62% Ryu (4 cols × 12 rows = 48 = 2 districts exactly)
+ *
+ * Initial assignment: "mirror pair" — each district pairs one left col with one right col.
+ *   D1: q=0 + q=9 → (62%+38%)/2 = 50% Ken → margin ≈0% → COMPETITIVE
+ *   D2: q=1 + q=8 → same → COMPETITIVE
+ *   D3: q=2 + q=7 → same → COMPETITIVE
+ *   D4: q=3 + q=6 → same → COMPETITIVE
+ *   D5: q=4 + q=5 → (62%+62%)/2 = 62% Ken → safe for Ken only (1 safe seat)
+ *   → safe_seats_ken criterion (≥3) fails; safe_seats_ryu (≥2) fails ✓
+ *
+ * Winning solution: vertical strips — separate the flanks
+ *   D1: q=0-1, all rows (62% Ken → margin ~24% → SAFE Ken ✓)
+ *   D2: q=2-3, all rows (62% Ken → SAFE Ken ✓)
+ *   D3: q=4-5, all rows (62% Ken → SAFE Ken ✓)
+ *   D4: q=6-7, all rows (62% Ryu → SAFE Ryu ✓)
+ *   D5: q=8-9, all rows (62% Ryu → SAFE Ryu ✓)
+ *   → Ken: 3 safe seats ✓; Ryu: 2 safe seats ✓
+ *
+ * safe_seats margin threshold: 0.15 (winner needs ≥57.5% to qualify as "safe")
+ *
+ * Run from repo root:
+ *   kotlin game/scenarios/gen-scenario-006.main.kts
+ */
+
+import kotlin.random.Random
+
+val rng = Random(66)
+val NUM_Q = 10
+val NUM_R = 12
+val BASE_POP = 1500
+
+// Partisan geography: clean left/right split, no battleground column
+fun baseKenShare(q: Int): Double = if (q <= 5) 0.62 else 0.38
+
+// Initial: mirror pairs — each district gets one col from each flank
+fun initialDistrict(q: Int): String = when (q) {
+    0, 9 -> "d1"
+    1, 8 -> "d2"
+    2, 7 -> "d3"
+    3, 6 -> "d4"
+    else -> "d5"  // q=4, q=5
+}
+
+fun countyId(q: Int): String = if (q <= 5) "westbrook" else "eastbrook"
+fun colLetter(q: Int) = "ABCDEFGHIJ"[q].toString()
+fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+val precincts = StringBuilder()
+var first = true
+
+for (r in 0 until NUM_R) {
+    for (q in 0 until NUM_Q) {
+        val idx = r * NUM_Q + q
+        val pid = "p%03d".format(idx + 1)
+
+        val pop = BASE_POP + rng.nextInt(-150, 151)
+
+        val kenShare = (baseKenShare(q) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+        val kenStr = kenShare.fmt(4)
+        val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
+        val turnout = rng.nextDouble(0.55, 0.70)
+
+        val districtId = initialDistrict(q)
+        val county = countyId(q)
+        val side = if (q <= 5) "West" else "East"
+        val name = "$side ${colLetter(q)}${r + 1}"
+
+        if (!first) precincts.append(",\n")
+        first = false
+
+        precincts.append("""    {
+      "id": "$pid",
+      "editable": true,
+      "county_id": "$county",
+      "position": { "q": $q, "r": $r },
+      "total_population": $pop,
+      "initial_district_id": "$districtId",
+      "name": "$name",
+      "demographic_groups": [
+        {
+          "id": "${pid}-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": ${turnout.fmt(2)},
+          "vote_shares": { "ken": $kenStr, "ryu": $ryuStr }
+        }
+      ]
+    }""")
+    }
+}
+
+val json = """{
+  "format_version": "1",
+  "id": "scenario-006",
+  "title": "Harden the Map",
+  "election_type": "state_house",
+  "region": {
+    "id": "brookfield_county",
+    "name": "Brookfield County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
+    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" },
+    { "id": "d5", "name": "District 5" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+$precincts
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All five districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All five districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-safe-seats-ken",
+      "required": true,
+      "description": "Ken Party incumbents are protected — at least 3 districts won by a margin of 15 points or more.",
+      "criterion": {
+        "type": "safe_seats",
+        "party": "ken",
+        "margin": 0.15,
+        "min_count": 3
+      }
+    },
+    {
+      "id": "sc-safe-seats-ryu",
+      "required": true,
+      "description": "Ryu Party incumbents are protected — at least 2 districts won by a margin of 15 points or more.",
+      "criterion": {
+        "type": "safe_seats",
+        "party": "ryu",
+        "margin": 0.15,
+        "min_count": 2
+      }
+    },
+    {
+      "id": "sc-compactness",
+      "required": false,
+      "description": "The map follows natural geographic lines — all districts are reasonably compact (≥ 35%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.35
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Bipartisan Redistricting Consultant, Brookfield County",
+      "motivation": "Both parties have agreed — privately — that the current map is too competitive. Too many incumbents lost their seats last cycle. You've been hired by both sides to draw a new map where each party keeps what it has. The voters don't need to know the details."
+    },
+    "intro_slides": [
+      {
+        "heading": "The Deal",
+        "body": "It doesn't happen at a press conference. It happens in a conference room, with lawyers from both parties, a map, and a handshake.\n\nThe current map has too many swing districts. Too many incumbents are at risk every two years. The solution, both sides agree, is simple: draw lines that protect everyone."
+      },
+      {
+        "heading": "Safe Seats for Everyone",
+        "body": "The goal isn't to help one party win more seats. It's to make sure neither party loses the seats they already have.\n\nConcentrate Ken voters into Ken districts. Concentrate Ryu voters into Ryu districts. Eliminate the middle ground. Make every race a foregone conclusion."
+      },
+      {
+        "heading": "What the Voters Lose",
+        "body": "A safe seat means your representative doesn't need to worry about losing. They only need to survive their own primary — which means appealing to their party's base, not to the median voter.\n\nCompetitive elections create accountability. This map is designed to eliminate them. Notice how many races are decided before anyone votes."
+      }
+    ],
+    "objective": "Draw a map that protects incumbents of both parties — Ken Party wins at least 3 safe seats (margin ≥ 15 points), Ryu Party wins at least 2 safe seats (margin ≥ 15 points)."
+  }
+}
+"""
+
+val outFile = java.io.File("game/scenarios/scenario-006.json")
+outFile.writeText(json)
+println("Wrote ${NUM_Q * NUM_R} precincts to ${outFile.path}")

--- a/game/scenarios/gen-scenario-007.main.kts
+++ b/game/scenarios/gen-scenario-007.main.kts
@@ -1,0 +1,235 @@
+#!/usr/bin/env kotlin
+/**
+ * Generator for scenario-007.json: "The Reform Map"
+ *
+ * Lesson: Neutral rules (compactness, equal population, contiguity) constrain
+ * gerrymandering but don't eliminate partisan outcomes. Geography is politics.
+ *
+ * Shape: hex-of-hexes, radius 6 → 127 precincts, 5 districts of ~25-26.
+ * Coordinates: axial, centered at (0,0); range q,r in [-6,6].
+ *
+ * Partisan geography:
+ *   Urban core (|q|+|r|+|q+r| ≤ 4, inner ~37 hexes): ~25% Ken — strong Ryu
+ *   Suburbs (ring 5–8): ~50% Ken — competitive
+ *   Exurbs (ring 9–12, outer): ~65% Ken — strong Ken
+ *   (ring = max(|q|,|r|,|q+r|), i.e. hex distance from center × 2)
+ *
+ * Initial assignment: 5 radial wedge slices (pizza slices) — non-compact,
+ *   long thin districts radiating from center → fail compactness criterion.
+ *   Each wedge mixes all three partisan zones → all districts competitive.
+ *
+ * Winning solution: any sufficiently compact, balanced map (many valid solutions).
+ *   Compact districts naturally sort into: inner (Ryu-heavy) + outer (Ken-heavy).
+ *   A ring-based split produces ~2 Ken, 1 swing, 2 Ryu — not a Ken sweep.
+ *   Educational note: the "fair" geometric map still produces a partisan outcome
+ *   driven by geographic sorting of voters, not by intent.
+ *
+ * Success criteria:
+ *   Required: district_count, population_balance (±10%), compactness ≥ 0.40
+ *   Optional:  efficiency_gap ≤ 15% (show it's still nonzero even on "neutral" map)
+ *
+ * Run from repo root:
+ *   kotlin game/scenarios/gen-scenario-007.main.kts
+ */
+
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.random.Random
+
+val rng = Random(77)
+val R = 6  // hex radius → 127 hexes
+
+// Hex distance from origin (cube metric)
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
+
+// Partisan lean: urban core Ryu-heavy, exurbs Ken-heavy
+fun baseKenShare(q: Int, r: Int): Double {
+    val d = hexDist(q, r)
+    return when {
+        d <= 2 -> 0.25  // inner core: strong Ryu
+        d <= 4 -> 0.45  // inner suburbs
+        d == 5 -> 0.55  // outer suburbs: slight Ken lean
+        else   -> 0.67  // exurbs: strong Ken
+    }
+}
+
+// Initial: diagonal strips (q+r = constant) — thin slashes across the circle.
+// These are extremely non-compact (a strip of width 1 along a diagonal has
+// compactness ~22%) and population-imbalanced (outer diagonals have fewer hexes
+// than central ones). Both population_balance and compactness will fail → submit
+// is disabled; player must completely redraw.
+//   k≤-3: 7+8+9+10 = 34 hexes  (D1, far too many)
+//   k=-2,-1: 11+12 = 23         (D2)
+//   k=0: 13                     (D3, far too few)
+//   k=1,2: 12+11 = 23           (D4)
+//   k≥3: 10+9+8+7 = 34         (D5, far too many)
+fun initialDistrict(q: Int, r: Int): String {
+    val k = q + r
+    return when {
+        k <= -3 -> "d1"
+        k <= -1 -> "d2"
+        k == 0  -> "d3"
+        k <= 2  -> "d4"
+        else    -> "d5"
+    }
+}
+
+// County: inner ring vs outer ring
+fun countyId(q: Int, r: Int): String {
+    val d = hexDist(q, r)
+    return if (d <= 3) "reform_central" else "reform_outer"
+}
+
+fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+// Generate hex-of-hexes positions, sorted row-major
+data class Hex(val q: Int, val r: Int)
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+val BASE_POP = 1500
+
+val precincts = StringBuilder()
+var first = true
+
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
+
+    val pop = BASE_POP + rng.nextInt(-150, 151)
+
+    val kenShare = (baseKenShare(q, r) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+    val kenStr = kenShare.fmt(4)
+    val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
+    val turnout = rng.nextDouble(0.55, 0.70)
+
+    val districtId = initialDistrict(q, r)
+    val county = countyId(q, r)
+    val d = hexDist(q, r)
+    val zoneName = when {
+        d <= 2 -> "Core"
+        d <= 4 -> "Suburb"
+        else   -> "Exurb"
+    }
+    val name = "$zoneName ($q,$r)"
+
+    if (!first) precincts.append(",\n")
+    first = false
+
+    precincts.append("""    {
+      "id": "$pid",
+      "editable": true,
+      "county_id": "$county",
+      "position": { "q": $q, "r": $r },
+      "total_population": $pop,
+      "initial_district_id": "$districtId",
+      "name": "$name",
+      "demographic_groups": [
+        {
+          "id": "${pid}-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": ${turnout.fmt(2)},
+          "vote_shares": { "ken": $kenStr, "ryu": $ryuStr }
+        }
+      ]
+    }""")
+}
+
+val json = """{
+  "format_version": "1",
+  "id": "scenario-007",
+  "title": "The Reform Map",
+  "election_type": "state_house",
+  "region": {
+    "id": "meridian_county",
+    "name": "Meridian County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
+    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" },
+    { "id": "d5", "name": "District 5" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+$precincts
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All five districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All five districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-compactness",
+      "required": true,
+      "description": "All districts must be reasonably compact — no long tentacles or thin strips (compactness ≥ 40%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.40
+      }
+    },
+    {
+      "id": "sc-efficiency-gap",
+      "required": false,
+      "description": "Even a geometrically neutral map has an efficiency gap — see how close to zero you can get (≤ 15%).",
+      "criterion": {
+        "type": "efficiency_gap",
+        "operator": "lte",
+        "threshold": 0.15
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Independent Reform Commissioner, Meridian County",
+      "motivation": "The legislature has deadlocked. A court has ordered an independent commission to draw a new map using only neutral criteria — equal population, geographic compactness, and contiguity. No partisan data allowed. Draw the fairest map you can."
+    },
+    "intro_slides": [
+      {
+        "heading": "The Promise of Neutral Rules",
+        "body": "Reformers have long argued that if we just take politics out of redistricting — use an independent commission, apply mechanical criteria, ignore partisan data — the maps will be fair.\n\nMeridian County is your test case. Draw a map using only geometric rules: compact districts, equal population, no disconnected pieces. No partisan data. Just shapes."
+      },
+      {
+        "heading": "The Geography Problem",
+        "body": "Here's what nobody tells you: voters aren't distributed randomly. In Meridian County — as in most American counties — different communities cluster together. Urban neighborhoods vote differently from suburbs, which vote differently from exurbs.\n\nA perfectly geometric map doesn't erase that. It just captures it differently."
+      },
+      {
+        "heading": "What the Map Will Show You",
+        "body": "When you're done, submit your map and look at the results. You drew it without looking at party data. But the outcome won't be perfectly proportional.\n\nThis is called the geography problem. It's not a bug in your map — it's a feature of where people live. Neutral rules don't produce neutral outcomes. They produce different outcomes."
+      }
+    ],
+    "objective": "Draw a compact, population-balanced map using only geometric criteria. No partisan data required — or allowed."
+  }
+}
+"""
+
+val outFile = java.io.File("game/scenarios/scenario-007.json")
+outFile.writeText(json)
+println("Wrote ${hexes.size} precincts to ${outFile.path}")

--- a/game/scenarios/gen-scenario-008.main.kts
+++ b/game/scenarios/gen-scenario-008.main.kts
@@ -1,0 +1,229 @@
+#!/usr/bin/env kotlin
+/**
+ * Generator for scenario-008.json: "Both Sides Unhappy"
+ *
+ * Lesson: A bipartisan-agreed, independent redistricting commission applies
+ * strict neutral criteria. Both parties walk away furious. Geography made
+ * the outcome inevitable from the start.
+ *
+ * Shape: hex-of-hexes, radius 6 → 127 precincts, 5 districts of ~25-26.
+ * Coordinates: axial, centered at (0,0); range q,r in [-6,6].
+ *
+ * Partisan geography:
+ *   Inner core  (d ≤ 2, 19 hexes): ~20% Ken — strong Ryu
+ *   Suburbs     (d = 3-4, 42 hexes): ~50% Ken — competitive
+ *   Exurbs      (d = 5-6, 66 hexes): ~80% Ken — strong Ken
+ *   → Region overall: ~61% Ken, 39% Ryu
+ *
+ * Initial assignment: 5 angular wedge sectors from center to edge.
+ *   Each sector spans all three partisan zones → all districts competitive.
+ *   Thin elongated wedges → very low compactness → compactness criterion fails.
+ *
+ * Winning solution: any sufficiently compact, population-balanced map.
+ *   Natural outcome: 1 inner Ryu district + 4 outer Ken districts.
+ *   Ken: 4/5 seats (80%) with ~61% of votes → overrepresented.
+ *   Ryu: 1/5 seats (20%) with ~39% of votes → underrepresented.
+ *   Educational note: both parties agreed to neutral rules; geography produced
+ *   an outcome neither called fair.
+ *
+ * Success criteria:
+ *   Required: district_count, population_balance (±10%), compactness ≥ 0.40
+ *   Optional: efficiency_gap ≤ 10% (geography makes this nearly unreachable)
+ *
+ * Run from repo root:
+ *   kotlin game/scenarios/gen-scenario-008.main.kts
+ */
+
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.PI
+import kotlin.random.Random
+
+val rng = Random(88)
+val R = 6
+
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
+
+fun baseKenShare(q: Int, r: Int): Double {
+    val d = hexDist(q, r)
+    return when {
+        d <= 2 -> 0.20  // strong Ryu inner core
+        d <= 4 -> 0.50  // competitive suburbs
+        else   -> 0.80  // strong Ken exurbs
+    }
+}
+
+// Initial: 5 angular wedge sectors from center to edge.
+// Each sector spans all three partisan zones → competitive throughout.
+// Thin elongated wedge shapes → very low compactness → fails criterion.
+fun initialDistrict(q: Int, r: Int): String {
+    if (q == 0 && r == 0) return "d3"
+    val x = q.toDouble() + r.toDouble() * 0.5
+    val y = r.toDouble() * 0.8660254  // sqrt(3)/2
+    val norm = (atan2(y, x) + PI) / (2.0 * PI)  // 0..1
+    return when ((norm * 5).toInt().coerceIn(0, 4)) {
+        0 -> "d1"
+        1 -> "d2"
+        2 -> "d3"
+        3 -> "d4"
+        else -> "d5"
+    }
+}
+
+fun countyId(q: Int, r: Int): String {
+    val d = hexDist(q, r)
+    return if (d <= 3) "accord_central" else "accord_outer"
+}
+
+fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+data class Hex(val q: Int, val r: Int)
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+val BASE_POP = 1500
+
+val precincts = StringBuilder()
+var first = true
+
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
+
+    val pop = BASE_POP + rng.nextInt(-150, 151)
+
+    val kenShare = (baseKenShare(q, r) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+    val kenStr = kenShare.fmt(4)
+    val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
+    val turnout = rng.nextDouble(0.55, 0.70)
+
+    val districtId = initialDistrict(q, r)
+    val county = countyId(q, r)
+    val d = hexDist(q, r)
+    val zoneName = when {
+        d <= 2 -> "Core"
+        d <= 4 -> "Suburb"
+        else   -> "Exurb"
+    }
+    val name = "$zoneName ($q,$r)"
+
+    if (!first) precincts.append(",\n")
+    first = false
+
+    precincts.append("""    {
+      "id": "$pid",
+      "editable": true,
+      "county_id": "$county",
+      "position": { "q": $q, "r": $r },
+      "total_population": $pop,
+      "initial_district_id": "$districtId",
+      "name": "$name",
+      "demographic_groups": [
+        {
+          "id": "${pid}-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": ${turnout.fmt(2)},
+          "vote_shares": { "ken": $kenStr, "ryu": $ryuStr }
+        }
+      ]
+    }""")
+}
+
+val json = """{
+  "format_version": "1",
+  "id": "scenario-008",
+  "title": "Both Sides Unhappy",
+  "election_type": "state_house",
+  "region": {
+    "id": "accord_county",
+    "name": "Accord County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
+    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" },
+    { "id": "d5", "name": "District 5" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+$precincts
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All five districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All five districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-compactness",
+      "required": true,
+      "description": "All districts must be reasonably compact — no long tentacles or thin strips (compactness ≥ 40%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.40
+      }
+    },
+    {
+      "id": "sc-efficiency-gap",
+      "required": false,
+      "description": "How close to zero can you get the efficiency gap on a purely neutral map? (≤ 10%).",
+      "criterion": {
+        "type": "efficiency_gap",
+        "operator": "lte",
+        "threshold": 0.10
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Independent Commissioner, Accord County Redistricting Commission",
+      "motivation": "After years of partisan warfare over district lines, both parties agreed to something remarkable: an independent commission with binding authority. The rules are strict — equal population, geographic compactness, contiguous districts. No partisan data allowed. Both sides signed off on the criteria. Now you draw the map."
+    },
+    "intro_slides": [
+      {
+        "heading": "The Accord",
+        "body": "It took two years of negotiations, three failed bills, and a court order, but both parties finally agreed: an independent commission would draw the new map using strictly neutral criteria.\n\nNo partisan registration data. No incumbent addresses. Just geometry: equal population, compact districts, no disconnected pieces. Both parties signed the agreement. Both parties praised it publicly."
+      },
+      {
+        "heading": "The Problem with Perfect Neutrality",
+        "body": "Here's what both parties understood privately, even as they signed: neutral rules don't produce neutral outcomes. They produce outcomes driven by geography.\n\nIn Accord County, geography has a lean. Ryu voters cluster tightly in the urban core. Ken voters spread across the suburbs and exurbs. Any compact map will reflect that geography — not because anyone drew it that way, but because that's where people live."
+      },
+      {
+        "heading": "A Fair Process, An Unfair Outcome?",
+        "body": "Draw the most geometrically neutral map you can. Then submit it and look at the results.\n\nBoth parties will complain. Ryu will say the compact map packed their voters unfairly. Ken will say their geographic spread deserves more representation. Both arguments will have merit.\n\nThis is not a bug in your map. It's a feature of representative democracy that no one has solved."
+      }
+    ],
+    "objective": "Apply the agreed neutral criteria. Draw a compact, population-balanced map. Watch both sides declare the process rigged."
+  }
+}
+"""
+
+val outFile = java.io.File("game/scenarios/scenario-008.json")
+outFile.writeText(json)
+println("Wrote ${hexes.size} precincts to ${outFile.path}")

--- a/game/scenarios/gen-scenario-009.main.kts
+++ b/game/scenarios/gen-scenario-009.main.kts
@@ -1,0 +1,249 @@
+#!/usr/bin/env kotlin
+/**
+ * Generator for scenario-009.json: "Cats vs. Dogs"
+ *
+ * Lesson: Tone break — same mechanics, ridiculous premise. Cat Party bosses
+ * want to lock in their majority and squeeze out the Dog Party forever.
+ * Reinforces packing/cracking mechanics in a low-stakes, silly context.
+ *
+ * Shape: hex-of-hexes, radius 6 → 127 precincts, 5 districts of ~25-26.
+ * Coordinates: axial, centered at (0,0); range q,r in [-6,6].
+ *
+ * Parties: "cat" (Cat Party / CAT) and "dog" (Dog Party / DOG).
+ *
+ * Partisan geography (ring-based — Cats are the urban party):
+ *   Inner core (d ≤ 2, 19 hexes): ~82% Cat — Cat stronghold
+ *   Middle ring (d = 3-4, 42 hexes): ~72% Cat — Cat-leaning suburbs
+ *   Outer ring (d = 5-6, 66 hexes): ~42% Cat — Dog-leaning exurbs
+ *   → Region overall: ~58% Cat, 42% Dog
+ *
+ * Initial assignment: 5 horizontal slabs (constant-r bands).
+ *   Rows in hex-of-hexes vary in width (7 to 13 hexes), so horizontal
+ *   slabs are population-imbalanced AND non-compact for outer rows.
+ *   Both population_balance and compactness fail → submit disabled.
+ *
+ *   Approximate row-band hex counts:
+ *     D1: r ≥ 3  → 34 hexes (too many)
+ *     D2: r = 1,2 → 23 hexes
+ *     D3: r = 0   → 13 hexes (too few)
+ *     D4: r = -2,-1 → 23 hexes
+ *     D5: r ≤ -3 → 34 hexes (too many)
+ *   → population_balance and compactness both fail.
+ *
+ * Winning solution: 5 compact radial-ish districts.
+ *   1 inner Cat district (d ≤ 2 + some d=3): ~80% Cat → safe Cat
+ *   2 middle Cat districts (mostly d=3-4): ~72% Cat → safe Cat
+ *   2 outer districts (mostly d=5-6): ~42% Cat → Dog wins
+ *   → Cat: 3 safe seats ✓; Dog: 2 seats
+ *
+ * Success criteria:
+ *   Required: district_count, population_balance (±10%), compactness ≥ 0.40,
+ *             safe_seats (cat, margin ≥ 0.15, min_count 3)
+ *   Optional: safe_seats (dog, margin ≥ 0.15, min_count 1) — throw the dogs a bone
+ *
+ * Run from repo root:
+ *   kotlin game/scenarios/gen-scenario-009.main.kts
+ */
+
+import kotlin.math.abs
+import kotlin.random.Random
+
+val rng = Random(99)
+val R = 6
+
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
+
+// Cat share by ring distance: Cats are the urban party (inner = Cat stronghold)
+fun baseCatShare(q: Int, r: Int): Double {
+    val d = hexDist(q, r)
+    return when {
+        d <= 2 -> 0.82  // Cat urban core
+        d <= 4 -> 0.72  // Cat suburban lean
+        else   -> 0.42  // Dog-leaning exurbs
+    }
+}
+
+// Initial: horizontal slabs by r value.
+// Rows in hex-of-hexes vary in width → population imbalance; wide outer slabs → non-compact.
+//   r ≥ 3: 34 hexes → D1 (too many)
+//   r = 1..2: 23 hexes → D2
+//   r = 0: 13 hexes → D3 (too few)
+//   r = -2..-1: 23 hexes → D4
+//   r ≤ -3: 34 hexes → D5 (too many)
+fun initialDistrict(r: Int): String = when {
+    r >= 3  -> "d1"
+    r >= 1  -> "d2"
+    r == 0  -> "d3"
+    r >= -2 -> "d4"
+    else    -> "d5"
+}
+
+fun countyId(q: Int, r: Int): String {
+    val d = hexDist(q, r)
+    return if (d <= 3) "catville" else "dogdale"
+}
+
+fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+data class Hex(val q: Int, val r: Int)
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+val BASE_POP = 1500
+
+val precincts = StringBuilder()
+var first = true
+
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
+
+    val pop = BASE_POP + rng.nextInt(-150, 151)
+
+    val catShare = (baseCatShare(q, r) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+    val catStr = catShare.fmt(4)
+    val dogStr = (1.0 - catStr.toDouble()).fmt(4)
+    val turnout = rng.nextDouble(0.55, 0.70)
+
+    val districtId = initialDistrict(r)
+    val county = countyId(q, r)
+    val d = hexDist(q, r)
+    val zoneName = when {
+        d <= 2 -> "Catville"
+        d <= 4 -> "Midtown"
+        else   -> "Dogdale"
+    }
+    val name = "$zoneName ($q,$r)"
+
+    if (!first) precincts.append(",\n")
+    first = false
+
+    precincts.append("""    {
+      "id": "$pid",
+      "editable": true,
+      "county_id": "$county",
+      "position": { "q": $q, "r": $r },
+      "total_population": $pop,
+      "initial_district_id": "$districtId",
+      "name": "$name",
+      "demographic_groups": [
+        {
+          "id": "${pid}-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": ${turnout.fmt(2)},
+          "vote_shares": { "cat": $catStr, "dog": $dogStr }
+        }
+      ]
+    }""")
+}
+
+val json = """{
+  "format_version": "1",
+  "id": "scenario-009",
+  "title": "Cats vs. Dogs",
+  "election_type": "state_house",
+  "region": {
+    "id": "pawprint_county",
+    "name": "Pawprint County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "cat", "name": "Cat Party", "abbreviation": "CAT" },
+    { "id": "dog", "name": "Dog Party", "abbreviation": "DOG" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" },
+    { "id": "d5", "name": "District 5" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+$precincts
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All five districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All five districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-compactness",
+      "required": true,
+      "description": "Districts must be geographically compact — no sprawling fur-balls (compactness ≥ 40%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.40
+      }
+    },
+    {
+      "id": "sc-safe-seats-cat",
+      "required": true,
+      "description": "The Cat Party must lock in at least 3 safe districts (winning margin ≥ 15 points).",
+      "criterion": {
+        "type": "safe_seats",
+        "party": "cat",
+        "margin": 0.15,
+        "min_count": 3
+      }
+    },
+    {
+      "id": "sc-safe-seats-dog",
+      "required": false,
+      "description": "Even dogs deserve one safe seat — can you give the Dog Party at least 1 district won by 15+ points?",
+      "criterion": {
+        "type": "safe_seats",
+        "party": "dog",
+        "margin": 0.15,
+        "min_count": 1
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Chief Map Strategist, Cat Party",
+      "motivation": "The Cat Party has controlled Pawprint County's legislature for years and intends to keep it that way. The census just came in. The lines need redrawing. Your job: make sure the Cats win at least three unlosable districts. The dogs are loud, but they don't have to be numerous."
+    },
+    "intro_slides": [
+      {
+        "heading": "It's a Dog-Eat-Cat World",
+        "body": "The Cat Party has held the majority in Pawprint County for years. The Dog Party has been nipping at their heels.\n\nThe census data is in. Boundaries must be redrawn. The Cat Party leadership has called you in for one reason: make it stick."
+      },
+      {
+        "heading": "The Math",
+        "body": "Cats make up about 60% of Pawprint County's voters — a comfortable majority in the urban core, but the outer precincts are more competitive.\n\nLeft to chance, those outer districts could swing either way. Your job is to take chance out of the equation. Draw lines that turn a majority into a durable map."
+      },
+      {
+        "heading": "Same Game, Different Fur",
+        "body": "You've seen this before — packing, cracking, population balance, compactness. The tools are the same whether you're drawing for Cats, Dogs, Ken, Ryu, or anyone else.\n\nThe rules of redistricting don't care about the players. Only the lines matter."
+      }
+    ],
+    "objective": "Draw a compact, population-balanced map that locks in at least 3 safe Cat Party districts (winning margin ≥ 15 points). Bonus: leave the dogs one safe seat to chew on."
+  }
+}
+"""
+
+val outFile = java.io.File("game/scenarios/scenario-009.json")
+outFile.writeText(json)
+println("Wrote ${hexes.size} precincts to ${outFile.path}")

--- a/game/scenarios/scenario-006.json
+++ b/game/scenarios/scenario-006.json
@@ -1,0 +1,2258 @@
+{
+  "format_version": "1",
+  "id": "scenario-006",
+  "title": "Harden the Map",
+  "election_type": "state_house",
+  "region": {
+    "id": "brookfield_county",
+    "name": "Brookfield County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
+    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" },
+    { "id": "d5", "name": "District 5" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+    {
+      "id": "p001",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 0 },
+      "total_population": 1562,
+      "initial_district_id": "d1",
+      "name": "West A1",
+      "demographic_groups": [
+        {
+          "id": "p001-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6356, "ryu": 0.3644 }
+        }
+      ]
+    },
+    {
+      "id": "p002",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 0 },
+      "total_population": 1611,
+      "initial_district_id": "d2",
+      "name": "West B1",
+      "demographic_groups": [
+        {
+          "id": "p002-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6277, "ryu": 0.3723 }
+        }
+      ]
+    },
+    {
+      "id": "p003",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 0 },
+      "total_population": 1490,
+      "initial_district_id": "d3",
+      "name": "West C1",
+      "demographic_groups": [
+        {
+          "id": "p003-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5943, "ryu": 0.4057 }
+        }
+      ]
+    },
+    {
+      "id": "p004",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 0 },
+      "total_population": 1581,
+      "initial_district_id": "d4",
+      "name": "West D1",
+      "demographic_groups": [
+        {
+          "id": "p004-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6174, "ryu": 0.3826 }
+        }
+      ]
+    },
+    {
+      "id": "p005",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 0 },
+      "total_population": 1574,
+      "initial_district_id": "d5",
+      "name": "West E1",
+      "demographic_groups": [
+        {
+          "id": "p005-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6077, "ryu": 0.3923 }
+        }
+      ]
+    },
+    {
+      "id": "p006",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 0 },
+      "total_population": 1480,
+      "initial_district_id": "d5",
+      "name": "West F1",
+      "demographic_groups": [
+        {
+          "id": "p006-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6347, "ryu": 0.3653 }
+        }
+      ]
+    },
+    {
+      "id": "p007",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 0 },
+      "total_population": 1548,
+      "initial_district_id": "d4",
+      "name": "East G1",
+      "demographic_groups": [
+        {
+          "id": "p007-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4130, "ryu": 0.5870 }
+        }
+      ]
+    },
+    {
+      "id": "p008",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 0 },
+      "total_population": 1376,
+      "initial_district_id": "d3",
+      "name": "East H1",
+      "demographic_groups": [
+        {
+          "id": "p008-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.3412, "ryu": 0.6588 }
+        }
+      ]
+    },
+    {
+      "id": "p009",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 0 },
+      "total_population": 1431,
+      "initial_district_id": "d2",
+      "name": "East I1",
+      "demographic_groups": [
+        {
+          "id": "p009-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.3748, "ryu": 0.6252 }
+        }
+      ]
+    },
+    {
+      "id": "p010",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 0 },
+      "total_population": 1571,
+      "initial_district_id": "d1",
+      "name": "East J1",
+      "demographic_groups": [
+        {
+          "id": "p010-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.3960, "ryu": 0.6040 }
+        }
+      ]
+    },
+    {
+      "id": "p011",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 1 },
+      "total_population": 1574,
+      "initial_district_id": "d1",
+      "name": "West A2",
+      "demographic_groups": [
+        {
+          "id": "p011-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6166, "ryu": 0.3834 }
+        }
+      ]
+    },
+    {
+      "id": "p012",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 1 },
+      "total_population": 1378,
+      "initial_district_id": "d2",
+      "name": "West B2",
+      "demographic_groups": [
+        {
+          "id": "p012-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6016, "ryu": 0.3984 }
+        }
+      ]
+    },
+    {
+      "id": "p013",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 1 },
+      "total_population": 1593,
+      "initial_district_id": "d3",
+      "name": "West C2",
+      "demographic_groups": [
+        {
+          "id": "p013-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5897, "ryu": 0.4103 }
+        }
+      ]
+    },
+    {
+      "id": "p014",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 1 },
+      "total_population": 1597,
+      "initial_district_id": "d4",
+      "name": "West D2",
+      "demographic_groups": [
+        {
+          "id": "p014-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.5823, "ryu": 0.4177 }
+        }
+      ]
+    },
+    {
+      "id": "p015",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 1 },
+      "total_population": 1456,
+      "initial_district_id": "d5",
+      "name": "West E2",
+      "demographic_groups": [
+        {
+          "id": "p015-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6457, "ryu": 0.3543 }
+        }
+      ]
+    },
+    {
+      "id": "p016",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 1 },
+      "total_population": 1511,
+      "initial_district_id": "d5",
+      "name": "West F2",
+      "demographic_groups": [
+        {
+          "id": "p016-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6558, "ryu": 0.3442 }
+        }
+      ]
+    },
+    {
+      "id": "p017",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 1 },
+      "total_population": 1511,
+      "initial_district_id": "d4",
+      "name": "East G2",
+      "demographic_groups": [
+        {
+          "id": "p017-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.3968, "ryu": 0.6032 }
+        }
+      ]
+    },
+    {
+      "id": "p018",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 1 },
+      "total_population": 1535,
+      "initial_district_id": "d3",
+      "name": "East H2",
+      "demographic_groups": [
+        {
+          "id": "p018-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.3915, "ryu": 0.6085 }
+        }
+      ]
+    },
+    {
+      "id": "p019",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 1 },
+      "total_population": 1431,
+      "initial_district_id": "d2",
+      "name": "East I2",
+      "demographic_groups": [
+        {
+          "id": "p019-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4057, "ryu": 0.5943 }
+        }
+      ]
+    },
+    {
+      "id": "p020",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 1 },
+      "total_population": 1353,
+      "initial_district_id": "d1",
+      "name": "East J2",
+      "demographic_groups": [
+        {
+          "id": "p020-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.3437, "ryu": 0.6563 }
+        }
+      ]
+    },
+    {
+      "id": "p021",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 2 },
+      "total_population": 1528,
+      "initial_district_id": "d1",
+      "name": "West A3",
+      "demographic_groups": [
+        {
+          "id": "p021-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6437, "ryu": 0.3563 }
+        }
+      ]
+    },
+    {
+      "id": "p022",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 2 },
+      "total_population": 1397,
+      "initial_district_id": "d2",
+      "name": "West B3",
+      "demographic_groups": [
+        {
+          "id": "p022-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6163, "ryu": 0.3837 }
+        }
+      ]
+    },
+    {
+      "id": "p023",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 2 },
+      "total_population": 1385,
+      "initial_district_id": "d3",
+      "name": "West C3",
+      "demographic_groups": [
+        {
+          "id": "p023-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6574, "ryu": 0.3426 }
+        }
+      ]
+    },
+    {
+      "id": "p024",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 2 },
+      "total_population": 1378,
+      "initial_district_id": "d4",
+      "name": "West D3",
+      "demographic_groups": [
+        {
+          "id": "p024-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6301, "ryu": 0.3699 }
+        }
+      ]
+    },
+    {
+      "id": "p025",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 2 },
+      "total_population": 1500,
+      "initial_district_id": "d5",
+      "name": "West E3",
+      "demographic_groups": [
+        {
+          "id": "p025-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6267, "ryu": 0.3733 }
+        }
+      ]
+    },
+    {
+      "id": "p026",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 2 },
+      "total_population": 1501,
+      "initial_district_id": "d5",
+      "name": "West F3",
+      "demographic_groups": [
+        {
+          "id": "p026-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5974, "ryu": 0.4026 }
+        }
+      ]
+    },
+    {
+      "id": "p027",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 2 },
+      "total_population": 1373,
+      "initial_district_id": "d4",
+      "name": "East G3",
+      "demographic_groups": [
+        {
+          "id": "p027-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.3875, "ryu": 0.6125 }
+        }
+      ]
+    },
+    {
+      "id": "p028",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 2 },
+      "total_population": 1569,
+      "initial_district_id": "d3",
+      "name": "East H3",
+      "demographic_groups": [
+        {
+          "id": "p028-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.3603, "ryu": 0.6397 }
+        }
+      ]
+    },
+    {
+      "id": "p029",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 2 },
+      "total_population": 1535,
+      "initial_district_id": "d2",
+      "name": "East I3",
+      "demographic_groups": [
+        {
+          "id": "p029-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.3885, "ryu": 0.6115 }
+        }
+      ]
+    },
+    {
+      "id": "p030",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 2 },
+      "total_population": 1452,
+      "initial_district_id": "d1",
+      "name": "East J3",
+      "demographic_groups": [
+        {
+          "id": "p030-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4059, "ryu": 0.5941 }
+        }
+      ]
+    },
+    {
+      "id": "p031",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 3 },
+      "total_population": 1524,
+      "initial_district_id": "d1",
+      "name": "West A4",
+      "demographic_groups": [
+        {
+          "id": "p031-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5998, "ryu": 0.4002 }
+        }
+      ]
+    },
+    {
+      "id": "p032",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 3 },
+      "total_population": 1471,
+      "initial_district_id": "d2",
+      "name": "West B4",
+      "demographic_groups": [
+        {
+          "id": "p032-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6056, "ryu": 0.3944 }
+        }
+      ]
+    },
+    {
+      "id": "p033",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 3 },
+      "total_population": 1613,
+      "initial_district_id": "d3",
+      "name": "West C4",
+      "demographic_groups": [
+        {
+          "id": "p033-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6052, "ryu": 0.3948 }
+        }
+      ]
+    },
+    {
+      "id": "p034",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 3 },
+      "total_population": 1377,
+      "initial_district_id": "d4",
+      "name": "West D4",
+      "demographic_groups": [
+        {
+          "id": "p034-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6205, "ryu": 0.3795 }
+        }
+      ]
+    },
+    {
+      "id": "p035",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 3 },
+      "total_population": 1475,
+      "initial_district_id": "d5",
+      "name": "West E4",
+      "demographic_groups": [
+        {
+          "id": "p035-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6005, "ryu": 0.3995 }
+        }
+      ]
+    },
+    {
+      "id": "p036",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 3 },
+      "total_population": 1519,
+      "initial_district_id": "d5",
+      "name": "West F4",
+      "demographic_groups": [
+        {
+          "id": "p036-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6302, "ryu": 0.3698 }
+        }
+      ]
+    },
+    {
+      "id": "p037",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 3 },
+      "total_population": 1553,
+      "initial_district_id": "d4",
+      "name": "East G4",
+      "demographic_groups": [
+        {
+          "id": "p037-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.3585, "ryu": 0.6415 }
+        }
+      ]
+    },
+    {
+      "id": "p038",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 3 },
+      "total_population": 1546,
+      "initial_district_id": "d3",
+      "name": "East H4",
+      "demographic_groups": [
+        {
+          "id": "p038-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4096, "ryu": 0.5904 }
+        }
+      ]
+    },
+    {
+      "id": "p039",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 3 },
+      "total_population": 1599,
+      "initial_district_id": "d2",
+      "name": "East I4",
+      "demographic_groups": [
+        {
+          "id": "p039-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4019, "ryu": 0.5981 }
+        }
+      ]
+    },
+    {
+      "id": "p040",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 3 },
+      "total_population": 1547,
+      "initial_district_id": "d1",
+      "name": "East J4",
+      "demographic_groups": [
+        {
+          "id": "p040-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4147, "ryu": 0.5853 }
+        }
+      ]
+    },
+    {
+      "id": "p041",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 4 },
+      "total_population": 1567,
+      "initial_district_id": "d1",
+      "name": "West A5",
+      "demographic_groups": [
+        {
+          "id": "p041-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6398, "ryu": 0.3602 }
+        }
+      ]
+    },
+    {
+      "id": "p042",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 4 },
+      "total_population": 1619,
+      "initial_district_id": "d2",
+      "name": "West B5",
+      "demographic_groups": [
+        {
+          "id": "p042-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6265, "ryu": 0.3735 }
+        }
+      ]
+    },
+    {
+      "id": "p043",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 4 },
+      "total_population": 1362,
+      "initial_district_id": "d3",
+      "name": "West C5",
+      "demographic_groups": [
+        {
+          "id": "p043-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6038, "ryu": 0.3962 }
+        }
+      ]
+    },
+    {
+      "id": "p044",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 4 },
+      "total_population": 1374,
+      "initial_district_id": "d4",
+      "name": "West D5",
+      "demographic_groups": [
+        {
+          "id": "p044-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6554, "ryu": 0.3446 }
+        }
+      ]
+    },
+    {
+      "id": "p045",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 4 },
+      "total_population": 1614,
+      "initial_district_id": "d5",
+      "name": "West E5",
+      "demographic_groups": [
+        {
+          "id": "p045-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6483, "ryu": 0.3517 }
+        }
+      ]
+    },
+    {
+      "id": "p046",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 4 },
+      "total_population": 1371,
+      "initial_district_id": "d5",
+      "name": "West F5",
+      "demographic_groups": [
+        {
+          "id": "p046-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6530, "ryu": 0.3470 }
+        }
+      ]
+    },
+    {
+      "id": "p047",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 4 },
+      "total_population": 1617,
+      "initial_district_id": "d4",
+      "name": "East G5",
+      "demographic_groups": [
+        {
+          "id": "p047-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4086, "ryu": 0.5914 }
+        }
+      ]
+    },
+    {
+      "id": "p048",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 4 },
+      "total_population": 1570,
+      "initial_district_id": "d3",
+      "name": "East H5",
+      "demographic_groups": [
+        {
+          "id": "p048-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.3744, "ryu": 0.6256 }
+        }
+      ]
+    },
+    {
+      "id": "p049",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 4 },
+      "total_population": 1480,
+      "initial_district_id": "d2",
+      "name": "East I5",
+      "demographic_groups": [
+        {
+          "id": "p049-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.3856, "ryu": 0.6144 }
+        }
+      ]
+    },
+    {
+      "id": "p050",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 4 },
+      "total_population": 1533,
+      "initial_district_id": "d1",
+      "name": "East J5",
+      "demographic_groups": [
+        {
+          "id": "p050-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.3669, "ryu": 0.6331 }
+        }
+      ]
+    },
+    {
+      "id": "p051",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 5 },
+      "total_population": 1377,
+      "initial_district_id": "d1",
+      "name": "West A6",
+      "demographic_groups": [
+        {
+          "id": "p051-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6014, "ryu": 0.3986 }
+        }
+      ]
+    },
+    {
+      "id": "p052",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 5 },
+      "total_population": 1592,
+      "initial_district_id": "d2",
+      "name": "West B6",
+      "demographic_groups": [
+        {
+          "id": "p052-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.5894, "ryu": 0.4106 }
+        }
+      ]
+    },
+    {
+      "id": "p053",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 5 },
+      "total_population": 1501,
+      "initial_district_id": "d3",
+      "name": "West C6",
+      "demographic_groups": [
+        {
+          "id": "p053-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6370, "ryu": 0.3630 }
+        }
+      ]
+    },
+    {
+      "id": "p054",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 5 },
+      "total_population": 1473,
+      "initial_district_id": "d4",
+      "name": "West D6",
+      "demographic_groups": [
+        {
+          "id": "p054-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5923, "ryu": 0.4077 }
+        }
+      ]
+    },
+    {
+      "id": "p055",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 5 },
+      "total_population": 1381,
+      "initial_district_id": "d5",
+      "name": "West E6",
+      "demographic_groups": [
+        {
+          "id": "p055-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6063, "ryu": 0.3937 }
+        }
+      ]
+    },
+    {
+      "id": "p056",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 5 },
+      "total_population": 1359,
+      "initial_district_id": "d5",
+      "name": "West F6",
+      "demographic_groups": [
+        {
+          "id": "p056-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6104, "ryu": 0.3896 }
+        }
+      ]
+    },
+    {
+      "id": "p057",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 5 },
+      "total_population": 1627,
+      "initial_district_id": "d4",
+      "name": "East G6",
+      "demographic_groups": [
+        {
+          "id": "p057-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.3505, "ryu": 0.6495 }
+        }
+      ]
+    },
+    {
+      "id": "p058",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 5 },
+      "total_population": 1411,
+      "initial_district_id": "d3",
+      "name": "East H6",
+      "demographic_groups": [
+        {
+          "id": "p058-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4077, "ryu": 0.5923 }
+        }
+      ]
+    },
+    {
+      "id": "p059",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 5 },
+      "total_population": 1420,
+      "initial_district_id": "d2",
+      "name": "East I6",
+      "demographic_groups": [
+        {
+          "id": "p059-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.3609, "ryu": 0.6391 }
+        }
+      ]
+    },
+    {
+      "id": "p060",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 5 },
+      "total_population": 1524,
+      "initial_district_id": "d1",
+      "name": "East J6",
+      "demographic_groups": [
+        {
+          "id": "p060-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.3793, "ryu": 0.6207 }
+        }
+      ]
+    },
+    {
+      "id": "p061",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 6 },
+      "total_population": 1394,
+      "initial_district_id": "d1",
+      "name": "West A7",
+      "demographic_groups": [
+        {
+          "id": "p061-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6283, "ryu": 0.3717 }
+        }
+      ]
+    },
+    {
+      "id": "p062",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 6 },
+      "total_population": 1353,
+      "initial_district_id": "d2",
+      "name": "West B7",
+      "demographic_groups": [
+        {
+          "id": "p062-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5971, "ryu": 0.4029 }
+        }
+      ]
+    },
+    {
+      "id": "p063",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 6 },
+      "total_population": 1611,
+      "initial_district_id": "d3",
+      "name": "West C7",
+      "demographic_groups": [
+        {
+          "id": "p063-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6588, "ryu": 0.3412 }
+        }
+      ]
+    },
+    {
+      "id": "p064",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 6 },
+      "total_population": 1603,
+      "initial_district_id": "d4",
+      "name": "West D7",
+      "demographic_groups": [
+        {
+          "id": "p064-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6277, "ryu": 0.3723 }
+        }
+      ]
+    },
+    {
+      "id": "p065",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 6 },
+      "total_population": 1573,
+      "initial_district_id": "d5",
+      "name": "West E7",
+      "demographic_groups": [
+        {
+          "id": "p065-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6148, "ryu": 0.3852 }
+        }
+      ]
+    },
+    {
+      "id": "p066",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 6 },
+      "total_population": 1625,
+      "initial_district_id": "d5",
+      "name": "West F7",
+      "demographic_groups": [
+        {
+          "id": "p066-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6481, "ryu": 0.3519 }
+        }
+      ]
+    },
+    {
+      "id": "p067",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 6 },
+      "total_population": 1474,
+      "initial_district_id": "d4",
+      "name": "East G7",
+      "demographic_groups": [
+        {
+          "id": "p067-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.3447, "ryu": 0.6553 }
+        }
+      ]
+    },
+    {
+      "id": "p068",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 6 },
+      "total_population": 1443,
+      "initial_district_id": "d3",
+      "name": "East H7",
+      "demographic_groups": [
+        {
+          "id": "p068-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.3870, "ryu": 0.6130 }
+        }
+      ]
+    },
+    {
+      "id": "p069",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 6 },
+      "total_population": 1568,
+      "initial_district_id": "d2",
+      "name": "East I7",
+      "demographic_groups": [
+        {
+          "id": "p069-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4095, "ryu": 0.5905 }
+        }
+      ]
+    },
+    {
+      "id": "p070",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 6 },
+      "total_population": 1474,
+      "initial_district_id": "d1",
+      "name": "East J7",
+      "demographic_groups": [
+        {
+          "id": "p070-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.3678, "ryu": 0.6322 }
+        }
+      ]
+    },
+    {
+      "id": "p071",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 7 },
+      "total_population": 1411,
+      "initial_district_id": "d1",
+      "name": "West A8",
+      "demographic_groups": [
+        {
+          "id": "p071-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5973, "ryu": 0.4027 }
+        }
+      ]
+    },
+    {
+      "id": "p072",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 7 },
+      "total_population": 1430,
+      "initial_district_id": "d2",
+      "name": "West B8",
+      "demographic_groups": [
+        {
+          "id": "p072-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6568, "ryu": 0.3432 }
+        }
+      ]
+    },
+    {
+      "id": "p073",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 7 },
+      "total_population": 1571,
+      "initial_district_id": "d3",
+      "name": "West C8",
+      "demographic_groups": [
+        {
+          "id": "p073-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6446, "ryu": 0.3554 }
+        }
+      ]
+    },
+    {
+      "id": "p074",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 7 },
+      "total_population": 1556,
+      "initial_district_id": "d4",
+      "name": "West D8",
+      "demographic_groups": [
+        {
+          "id": "p074-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5972, "ryu": 0.4028 }
+        }
+      ]
+    },
+    {
+      "id": "p075",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 7 },
+      "total_population": 1597,
+      "initial_district_id": "d5",
+      "name": "West E8",
+      "demographic_groups": [
+        {
+          "id": "p075-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6105, "ryu": 0.3895 }
+        }
+      ]
+    },
+    {
+      "id": "p076",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 7 },
+      "total_population": 1354,
+      "initial_district_id": "d5",
+      "name": "West F8",
+      "demographic_groups": [
+        {
+          "id": "p076-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6411, "ryu": 0.3589 }
+        }
+      ]
+    },
+    {
+      "id": "p077",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 7 },
+      "total_population": 1541,
+      "initial_district_id": "d4",
+      "name": "East G8",
+      "demographic_groups": [
+        {
+          "id": "p077-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4026, "ryu": 0.5974 }
+        }
+      ]
+    },
+    {
+      "id": "p078",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 7 },
+      "total_population": 1607,
+      "initial_district_id": "d3",
+      "name": "East H8",
+      "demographic_groups": [
+        {
+          "id": "p078-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.3813, "ryu": 0.6187 }
+        }
+      ]
+    },
+    {
+      "id": "p079",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 7 },
+      "total_population": 1632,
+      "initial_district_id": "d2",
+      "name": "East I8",
+      "demographic_groups": [
+        {
+          "id": "p079-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.3770, "ryu": 0.6230 }
+        }
+      ]
+    },
+    {
+      "id": "p080",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 7 },
+      "total_population": 1495,
+      "initial_district_id": "d1",
+      "name": "East J8",
+      "demographic_groups": [
+        {
+          "id": "p080-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4016, "ryu": 0.5984 }
+        }
+      ]
+    },
+    {
+      "id": "p081",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 8 },
+      "total_population": 1384,
+      "initial_district_id": "d1",
+      "name": "West A9",
+      "demographic_groups": [
+        {
+          "id": "p081-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6323, "ryu": 0.3677 }
+        }
+      ]
+    },
+    {
+      "id": "p082",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 8 },
+      "total_population": 1400,
+      "initial_district_id": "d2",
+      "name": "West B9",
+      "demographic_groups": [
+        {
+          "id": "p082-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6369, "ryu": 0.3631 }
+        }
+      ]
+    },
+    {
+      "id": "p083",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 8 },
+      "total_population": 1389,
+      "initial_district_id": "d3",
+      "name": "West C9",
+      "demographic_groups": [
+        {
+          "id": "p083-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.5879, "ryu": 0.4121 }
+        }
+      ]
+    },
+    {
+      "id": "p084",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 8 },
+      "total_population": 1542,
+      "initial_district_id": "d4",
+      "name": "West D9",
+      "demographic_groups": [
+        {
+          "id": "p084-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.5924, "ryu": 0.4076 }
+        }
+      ]
+    },
+    {
+      "id": "p085",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 8 },
+      "total_population": 1650,
+      "initial_district_id": "d5",
+      "name": "West E9",
+      "demographic_groups": [
+        {
+          "id": "p085-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5825, "ryu": 0.4175 }
+        }
+      ]
+    },
+    {
+      "id": "p086",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 8 },
+      "total_population": 1430,
+      "initial_district_id": "d5",
+      "name": "West F9",
+      "demographic_groups": [
+        {
+          "id": "p086-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5907, "ryu": 0.4093 }
+        }
+      ]
+    },
+    {
+      "id": "p087",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 8 },
+      "total_population": 1357,
+      "initial_district_id": "d4",
+      "name": "East G9",
+      "demographic_groups": [
+        {
+          "id": "p087-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.3713, "ryu": 0.6287 }
+        }
+      ]
+    },
+    {
+      "id": "p088",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 8 },
+      "total_population": 1437,
+      "initial_district_id": "d3",
+      "name": "East H9",
+      "demographic_groups": [
+        {
+          "id": "p088-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4199, "ryu": 0.5801 }
+        }
+      ]
+    },
+    {
+      "id": "p089",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 8 },
+      "total_population": 1589,
+      "initial_district_id": "d2",
+      "name": "East I9",
+      "demographic_groups": [
+        {
+          "id": "p089-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.3921, "ryu": 0.6079 }
+        }
+      ]
+    },
+    {
+      "id": "p090",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 8 },
+      "total_population": 1488,
+      "initial_district_id": "d1",
+      "name": "East J9",
+      "demographic_groups": [
+        {
+          "id": "p090-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.3820, "ryu": 0.6180 }
+        }
+      ]
+    },
+    {
+      "id": "p091",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 9 },
+      "total_population": 1581,
+      "initial_district_id": "d1",
+      "name": "West A10",
+      "demographic_groups": [
+        {
+          "id": "p091-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5863, "ryu": 0.4137 }
+        }
+      ]
+    },
+    {
+      "id": "p092",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 9 },
+      "total_population": 1422,
+      "initial_district_id": "d2",
+      "name": "West B10",
+      "demographic_groups": [
+        {
+          "id": "p092-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6176, "ryu": 0.3824 }
+        }
+      ]
+    },
+    {
+      "id": "p093",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 9 },
+      "total_population": 1398,
+      "initial_district_id": "d3",
+      "name": "West C10",
+      "demographic_groups": [
+        {
+          "id": "p093-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6055, "ryu": 0.3945 }
+        }
+      ]
+    },
+    {
+      "id": "p094",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 9 },
+      "total_population": 1560,
+      "initial_district_id": "d4",
+      "name": "West D10",
+      "demographic_groups": [
+        {
+          "id": "p094-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5803, "ryu": 0.4197 }
+        }
+      ]
+    },
+    {
+      "id": "p095",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 9 },
+      "total_population": 1618,
+      "initial_district_id": "d5",
+      "name": "West E10",
+      "demographic_groups": [
+        {
+          "id": "p095-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6271, "ryu": 0.3729 }
+        }
+      ]
+    },
+    {
+      "id": "p096",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 9 },
+      "total_population": 1536,
+      "initial_district_id": "d5",
+      "name": "West F10",
+      "demographic_groups": [
+        {
+          "id": "p096-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6485, "ryu": 0.3515 }
+        }
+      ]
+    },
+    {
+      "id": "p097",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 9 },
+      "total_population": 1489,
+      "initial_district_id": "d4",
+      "name": "East G10",
+      "demographic_groups": [
+        {
+          "id": "p097-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.3897, "ryu": 0.6103 }
+        }
+      ]
+    },
+    {
+      "id": "p098",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 9 },
+      "total_population": 1509,
+      "initial_district_id": "d3",
+      "name": "East H10",
+      "demographic_groups": [
+        {
+          "id": "p098-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4130, "ryu": 0.5870 }
+        }
+      ]
+    },
+    {
+      "id": "p099",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 9 },
+      "total_population": 1497,
+      "initial_district_id": "d2",
+      "name": "East I10",
+      "demographic_groups": [
+        {
+          "id": "p099-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.3959, "ryu": 0.6041 }
+        }
+      ]
+    },
+    {
+      "id": "p100",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 9 },
+      "total_population": 1359,
+      "initial_district_id": "d1",
+      "name": "East J10",
+      "demographic_groups": [
+        {
+          "id": "p100-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4187, "ryu": 0.5813 }
+        }
+      ]
+    },
+    {
+      "id": "p101",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 10 },
+      "total_population": 1645,
+      "initial_district_id": "d1",
+      "name": "West A11",
+      "demographic_groups": [
+        {
+          "id": "p101-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6007, "ryu": 0.3993 }
+        }
+      ]
+    },
+    {
+      "id": "p102",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 10 },
+      "total_population": 1571,
+      "initial_district_id": "d2",
+      "name": "West B11",
+      "demographic_groups": [
+        {
+          "id": "p102-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6181, "ryu": 0.3819 }
+        }
+      ]
+    },
+    {
+      "id": "p103",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 10 },
+      "total_population": 1482,
+      "initial_district_id": "d3",
+      "name": "West C11",
+      "demographic_groups": [
+        {
+          "id": "p103-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.5903, "ryu": 0.4097 }
+        }
+      ]
+    },
+    {
+      "id": "p104",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 10 },
+      "total_population": 1615,
+      "initial_district_id": "d4",
+      "name": "West D11",
+      "demographic_groups": [
+        {
+          "id": "p104-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6429, "ryu": 0.3571 }
+        }
+      ]
+    },
+    {
+      "id": "p105",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 10 },
+      "total_population": 1544,
+      "initial_district_id": "d5",
+      "name": "West E11",
+      "demographic_groups": [
+        {
+          "id": "p105-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5937, "ryu": 0.4063 }
+        }
+      ]
+    },
+    {
+      "id": "p106",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 10 },
+      "total_population": 1641,
+      "initial_district_id": "d5",
+      "name": "West F11",
+      "demographic_groups": [
+        {
+          "id": "p106-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6596, "ryu": 0.3404 }
+        }
+      ]
+    },
+    {
+      "id": "p107",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 10 },
+      "total_population": 1537,
+      "initial_district_id": "d4",
+      "name": "East G11",
+      "demographic_groups": [
+        {
+          "id": "p107-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.3830, "ryu": 0.6170 }
+        }
+      ]
+    },
+    {
+      "id": "p108",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 10 },
+      "total_population": 1400,
+      "initial_district_id": "d3",
+      "name": "East H11",
+      "demographic_groups": [
+        {
+          "id": "p108-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4129, "ryu": 0.5871 }
+        }
+      ]
+    },
+    {
+      "id": "p109",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 10 },
+      "total_population": 1559,
+      "initial_district_id": "d2",
+      "name": "East I11",
+      "demographic_groups": [
+        {
+          "id": "p109-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.3531, "ryu": 0.6469 }
+        }
+      ]
+    },
+    {
+      "id": "p110",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 10 },
+      "total_population": 1423,
+      "initial_district_id": "d1",
+      "name": "East J11",
+      "demographic_groups": [
+        {
+          "id": "p110-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.3934, "ryu": 0.6066 }
+        }
+      ]
+    },
+    {
+      "id": "p111",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 11 },
+      "total_population": 1572,
+      "initial_district_id": "d1",
+      "name": "West A12",
+      "demographic_groups": [
+        {
+          "id": "p111-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.5810, "ryu": 0.4190 }
+        }
+      ]
+    },
+    {
+      "id": "p112",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 1, "r": 11 },
+      "total_population": 1433,
+      "initial_district_id": "d2",
+      "name": "West B12",
+      "demographic_groups": [
+        {
+          "id": "p112-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6071, "ryu": 0.3929 }
+        }
+      ]
+    },
+    {
+      "id": "p113",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 2, "r": 11 },
+      "total_population": 1419,
+      "initial_district_id": "d3",
+      "name": "West C12",
+      "demographic_groups": [
+        {
+          "id": "p113-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6520, "ryu": 0.3480 }
+        }
+      ]
+    },
+    {
+      "id": "p114",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 3, "r": 11 },
+      "total_population": 1402,
+      "initial_district_id": "d4",
+      "name": "West D12",
+      "demographic_groups": [
+        {
+          "id": "p114-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6463, "ryu": 0.3537 }
+        }
+      ]
+    },
+    {
+      "id": "p115",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 4, "r": 11 },
+      "total_population": 1615,
+      "initial_district_id": "d5",
+      "name": "West E12",
+      "demographic_groups": [
+        {
+          "id": "p115-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6596, "ryu": 0.3404 }
+        }
+      ]
+    },
+    {
+      "id": "p116",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 5, "r": 11 },
+      "total_population": 1586,
+      "initial_district_id": "d5",
+      "name": "West F12",
+      "demographic_groups": [
+        {
+          "id": "p116-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6064, "ryu": 0.3936 }
+        }
+      ]
+    },
+    {
+      "id": "p117",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": 11 },
+      "total_population": 1353,
+      "initial_district_id": "d4",
+      "name": "East G12",
+      "demographic_groups": [
+        {
+          "id": "p117-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.3586, "ryu": 0.6414 }
+        }
+      ]
+    },
+    {
+      "id": "p118",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 7, "r": 11 },
+      "total_population": 1508,
+      "initial_district_id": "d3",
+      "name": "East H12",
+      "demographic_groups": [
+        {
+          "id": "p118-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.3666, "ryu": 0.6334 }
+        }
+      ]
+    },
+    {
+      "id": "p119",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 8, "r": 11 },
+      "total_population": 1480,
+      "initial_district_id": "d2",
+      "name": "East I12",
+      "demographic_groups": [
+        {
+          "id": "p119-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.3959, "ryu": 0.6041 }
+        }
+      ]
+    },
+    {
+      "id": "p120",
+      "editable": true,
+      "county_id": "eastbrook",
+      "position": { "q": 9, "r": 11 },
+      "total_population": 1590,
+      "initial_district_id": "d1",
+      "name": "East J12",
+      "demographic_groups": [
+        {
+          "id": "p120-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.3693, "ryu": 0.6307 }
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All five districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All five districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-safe-seats-ken",
+      "required": true,
+      "description": "Ken Party incumbents are protected — at least 3 districts won by a margin of 15 points or more.",
+      "criterion": {
+        "type": "safe_seats",
+        "party": "ken",
+        "margin": 0.15,
+        "min_count": 3
+      }
+    },
+    {
+      "id": "sc-safe-seats-ryu",
+      "required": true,
+      "description": "Ryu Party incumbents are protected — at least 2 districts won by a margin of 15 points or more.",
+      "criterion": {
+        "type": "safe_seats",
+        "party": "ryu",
+        "margin": 0.15,
+        "min_count": 2
+      }
+    },
+    {
+      "id": "sc-compactness",
+      "required": false,
+      "description": "The map follows natural geographic lines — all districts are reasonably compact (≥ 35%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.35
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Bipartisan Redistricting Consultant, Brookfield County",
+      "motivation": "Both parties have agreed — privately — that the current map is too competitive. Too many incumbents lost their seats last cycle. You've been hired by both sides to draw a new map where each party keeps what it has. The voters don't need to know the details."
+    },
+    "intro_slides": [
+      {
+        "heading": "The Deal",
+        "body": "It doesn't happen at a press conference. It happens in a conference room, with lawyers from both parties, a map, and a handshake.\n\nThe current map has too many swing districts. Too many incumbents are at risk every two years. The solution, both sides agree, is simple: draw lines that protect everyone."
+      },
+      {
+        "heading": "Safe Seats for Everyone",
+        "body": "The goal isn't to help one party win more seats. It's to make sure neither party loses the seats they already have.\n\nConcentrate Ken voters into Ken districts. Concentrate Ryu voters into Ryu districts. Eliminate the middle ground. Make every race a foregone conclusion."
+      },
+      {
+        "heading": "What the Voters Lose",
+        "body": "A safe seat means your representative doesn't need to worry about losing. They only need to survive their own primary — which means appealing to their party's base, not to the median voter.\n\nCompetitive elections create accountability. This map is designed to eliminate them. Notice how many races are decided before anyone votes."
+      }
+    ],
+    "objective": "Draw a map that protects incumbents of both parties — Ken Party wins at least 3 safe seats (margin ≥ 15 points), Ryu Party wins at least 2 safe seats (margin ≥ 15 points)."
+  }
+}

--- a/game/scenarios/scenario-007.json
+++ b/game/scenarios/scenario-007.json
@@ -1,0 +1,2372 @@
+{
+  "format_version": "1",
+  "id": "scenario-007",
+  "title": "The Reform Map",
+  "election_type": "state_house",
+  "region": {
+    "id": "meridian_county",
+    "name": "Meridian County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
+    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" },
+    { "id": "d5", "name": "District 5" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+    {
+      "id": "p001",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 0, "r": -6 },
+      "total_population": 1428,
+      "initial_district_id": "d1",
+      "name": "Exurb (0,-6)",
+      "demographic_groups": [
+        {
+          "id": "p001-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6413, "ryu": 0.3587 }
+        }
+      ]
+    },
+    {
+      "id": "p002",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 1, "r": -6 },
+      "total_population": 1496,
+      "initial_district_id": "d1",
+      "name": "Exurb (1,-6)",
+      "demographic_groups": [
+        {
+          "id": "p002-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6315, "ryu": 0.3685 }
+        }
+      ]
+    },
+    {
+      "id": "p003",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 2, "r": -6 },
+      "total_population": 1543,
+      "initial_district_id": "d1",
+      "name": "Exurb (2,-6)",
+      "demographic_groups": [
+        {
+          "id": "p003-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6940, "ryu": 0.3060 }
+        }
+      ]
+    },
+    {
+      "id": "p004",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 3, "r": -6 },
+      "total_population": 1451,
+      "initial_district_id": "d1",
+      "name": "Exurb (3,-6)",
+      "demographic_groups": [
+        {
+          "id": "p004-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6510, "ryu": 0.3490 }
+        }
+      ]
+    },
+    {
+      "id": "p005",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": -6 },
+      "total_population": 1620,
+      "initial_district_id": "d2",
+      "name": "Exurb (4,-6)",
+      "demographic_groups": [
+        {
+          "id": "p005-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6372, "ryu": 0.3628 }
+        }
+      ]
+    },
+    {
+      "id": "p006",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 5, "r": -6 },
+      "total_population": 1493,
+      "initial_district_id": "d2",
+      "name": "Exurb (5,-6)",
+      "demographic_groups": [
+        {
+          "id": "p006-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+        }
+      ]
+    },
+    {
+      "id": "p007",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 6, "r": -6 },
+      "total_population": 1387,
+      "initial_district_id": "d3",
+      "name": "Exurb (6,-6)",
+      "demographic_groups": [
+        {
+          "id": "p007-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+        }
+      ]
+    },
+    {
+      "id": "p008",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -1, "r": -5 },
+      "total_population": 1511,
+      "initial_district_id": "d1",
+      "name": "Exurb (-1,-5)",
+      "demographic_groups": [
+        {
+          "id": "p008-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6472, "ryu": 0.3528 }
+        }
+      ]
+    },
+    {
+      "id": "p009",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 0, "r": -5 },
+      "total_population": 1492,
+      "initial_district_id": "d1",
+      "name": "Exurb (0,-5)",
+      "demographic_groups": [
+        {
+          "id": "p009-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5182, "ryu": 0.4818 }
+        }
+      ]
+    },
+    {
+      "id": "p010",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 1, "r": -5 },
+      "total_population": 1440,
+      "initial_district_id": "d1",
+      "name": "Exurb (1,-5)",
+      "demographic_groups": [
+        {
+          "id": "p010-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5179, "ryu": 0.4821 }
+        }
+      ]
+    },
+    {
+      "id": "p011",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 2, "r": -5 },
+      "total_population": 1633,
+      "initial_district_id": "d1",
+      "name": "Exurb (2,-5)",
+      "demographic_groups": [
+        {
+          "id": "p011-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5842, "ryu": 0.4158 }
+        }
+      ]
+    },
+    {
+      "id": "p012",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 3, "r": -5 },
+      "total_population": 1430,
+      "initial_district_id": "d2",
+      "name": "Exurb (3,-5)",
+      "demographic_groups": [
+        {
+          "id": "p012-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5256, "ryu": 0.4744 }
+        }
+      ]
+    },
+    {
+      "id": "p013",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": -5 },
+      "total_population": 1623,
+      "initial_district_id": "d2",
+      "name": "Exurb (4,-5)",
+      "demographic_groups": [
+        {
+          "id": "p013-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5770, "ryu": 0.4230 }
+        }
+      ]
+    },
+    {
+      "id": "p014",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 5, "r": -5 },
+      "total_population": 1393,
+      "initial_district_id": "d3",
+      "name": "Exurb (5,-5)",
+      "demographic_groups": [
+        {
+          "id": "p014-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5349, "ryu": 0.4651 }
+        }
+      ]
+    },
+    {
+      "id": "p015",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 6, "r": -5 },
+      "total_population": 1437,
+      "initial_district_id": "d4",
+      "name": "Exurb (6,-5)",
+      "demographic_groups": [
+        {
+          "id": "p015-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.7083, "ryu": 0.2917 }
+        }
+      ]
+    },
+    {
+      "id": "p016",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -2, "r": -4 },
+      "total_population": 1591,
+      "initial_district_id": "d1",
+      "name": "Exurb (-2,-4)",
+      "demographic_groups": [
+        {
+          "id": "p016-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6448, "ryu": 0.3552 }
+        }
+      ]
+    },
+    {
+      "id": "p017",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -1, "r": -4 },
+      "total_population": 1538,
+      "initial_district_id": "d1",
+      "name": "Exurb (-1,-4)",
+      "demographic_groups": [
+        {
+          "id": "p017-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5246, "ryu": 0.4754 }
+        }
+      ]
+    },
+    {
+      "id": "p018",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 0, "r": -4 },
+      "total_population": 1368,
+      "initial_district_id": "d1",
+      "name": "Suburb (0,-4)",
+      "demographic_groups": [
+        {
+          "id": "p018-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4166, "ryu": 0.5834 }
+        }
+      ]
+    },
+    {
+      "id": "p019",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 1, "r": -4 },
+      "total_population": 1534,
+      "initial_district_id": "d1",
+      "name": "Suburb (1,-4)",
+      "demographic_groups": [
+        {
+          "id": "p019-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4805, "ryu": 0.5195 }
+        }
+      ]
+    },
+    {
+      "id": "p020",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 2, "r": -4 },
+      "total_population": 1415,
+      "initial_district_id": "d2",
+      "name": "Suburb (2,-4)",
+      "demographic_groups": [
+        {
+          "id": "p020-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4637, "ryu": 0.5363 }
+        }
+      ]
+    },
+    {
+      "id": "p021",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 3, "r": -4 },
+      "total_population": 1621,
+      "initial_district_id": "d2",
+      "name": "Suburb (3,-4)",
+      "demographic_groups": [
+        {
+          "id": "p021-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4169, "ryu": 0.5831 }
+        }
+      ]
+    },
+    {
+      "id": "p022",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": -4 },
+      "total_population": 1583,
+      "initial_district_id": "d3",
+      "name": "Suburb (4,-4)",
+      "demographic_groups": [
+        {
+          "id": "p022-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4728, "ryu": 0.5272 }
+        }
+      ]
+    },
+    {
+      "id": "p023",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 5, "r": -4 },
+      "total_population": 1522,
+      "initial_district_id": "d4",
+      "name": "Exurb (5,-4)",
+      "demographic_groups": [
+        {
+          "id": "p023-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5213, "ryu": 0.4787 }
+        }
+      ]
+    },
+    {
+      "id": "p024",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 6, "r": -4 },
+      "total_population": 1418,
+      "initial_district_id": "d4",
+      "name": "Exurb (6,-4)",
+      "demographic_groups": [
+        {
+          "id": "p024-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6399, "ryu": 0.3601 }
+        }
+      ]
+    },
+    {
+      "id": "p025",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -3, "r": -3 },
+      "total_population": 1486,
+      "initial_district_id": "d1",
+      "name": "Exurb (-3,-3)",
+      "demographic_groups": [
+        {
+          "id": "p025-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6627, "ryu": 0.3373 }
+        }
+      ]
+    },
+    {
+      "id": "p026",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -2, "r": -3 },
+      "total_population": 1643,
+      "initial_district_id": "d1",
+      "name": "Exurb (-2,-3)",
+      "demographic_groups": [
+        {
+          "id": "p026-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5612, "ryu": 0.4388 }
+        }
+      ]
+    },
+    {
+      "id": "p027",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -1, "r": -3 },
+      "total_population": 1573,
+      "initial_district_id": "d1",
+      "name": "Suburb (-1,-3)",
+      "demographic_groups": [
+        {
+          "id": "p027-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4140, "ryu": 0.5860 }
+        }
+      ]
+    },
+    {
+      "id": "p028",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 0, "r": -3 },
+      "total_population": 1607,
+      "initial_district_id": "d1",
+      "name": "Suburb (0,-3)",
+      "demographic_groups": [
+        {
+          "id": "p028-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4485, "ryu": 0.5515 }
+        }
+      ]
+    },
+    {
+      "id": "p029",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 1, "r": -3 },
+      "total_population": 1442,
+      "initial_district_id": "d2",
+      "name": "Suburb (1,-3)",
+      "demographic_groups": [
+        {
+          "id": "p029-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.4455, "ryu": 0.5545 }
+        }
+      ]
+    },
+    {
+      "id": "p030",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 2, "r": -3 },
+      "total_population": 1558,
+      "initial_district_id": "d2",
+      "name": "Suburb (2,-3)",
+      "demographic_groups": [
+        {
+          "id": "p030-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4189, "ryu": 0.5811 }
+        }
+      ]
+    },
+    {
+      "id": "p031",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 3, "r": -3 },
+      "total_population": 1476,
+      "initial_district_id": "d3",
+      "name": "Suburb (3,-3)",
+      "demographic_groups": [
+        {
+          "id": "p031-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4115, "ryu": 0.5885 }
+        }
+      ]
+    },
+    {
+      "id": "p032",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": -3 },
+      "total_population": 1626,
+      "initial_district_id": "d4",
+      "name": "Suburb (4,-3)",
+      "demographic_groups": [
+        {
+          "id": "p032-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4489, "ryu": 0.5511 }
+        }
+      ]
+    },
+    {
+      "id": "p033",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 5, "r": -3 },
+      "total_population": 1599,
+      "initial_district_id": "d4",
+      "name": "Exurb (5,-3)",
+      "demographic_groups": [
+        {
+          "id": "p033-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5213, "ryu": 0.4787 }
+        }
+      ]
+    },
+    {
+      "id": "p034",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 6, "r": -3 },
+      "total_population": 1456,
+      "initial_district_id": "d5",
+      "name": "Exurb (6,-3)",
+      "demographic_groups": [
+        {
+          "id": "p034-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6966, "ryu": 0.3034 }
+        }
+      ]
+    },
+    {
+      "id": "p035",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": -2 },
+      "total_population": 1448,
+      "initial_district_id": "d1",
+      "name": "Exurb (-4,-2)",
+      "demographic_groups": [
+        {
+          "id": "p035-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6786, "ryu": 0.3214 }
+        }
+      ]
+    },
+    {
+      "id": "p036",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -3, "r": -2 },
+      "total_population": 1560,
+      "initial_district_id": "d1",
+      "name": "Exurb (-3,-2)",
+      "demographic_groups": [
+        {
+          "id": "p036-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5697, "ryu": 0.4303 }
+        }
+      ]
+    },
+    {
+      "id": "p037",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -2, "r": -2 },
+      "total_population": 1437,
+      "initial_district_id": "d1",
+      "name": "Suburb (-2,-2)",
+      "demographic_groups": [
+        {
+          "id": "p037-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4418, "ryu": 0.5582 }
+        }
+      ]
+    },
+    {
+      "id": "p038",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -1, "r": -2 },
+      "total_population": 1517,
+      "initial_district_id": "d1",
+      "name": "Suburb (-1,-2)",
+      "demographic_groups": [
+        {
+          "id": "p038-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4544, "ryu": 0.5456 }
+        }
+      ]
+    },
+    {
+      "id": "p039",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 0, "r": -2 },
+      "total_population": 1564,
+      "initial_district_id": "d2",
+      "name": "Core (0,-2)",
+      "demographic_groups": [
+        {
+          "id": "p039-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.2630, "ryu": 0.7370 }
+        }
+      ]
+    },
+    {
+      "id": "p040",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 1, "r": -2 },
+      "total_population": 1374,
+      "initial_district_id": "d2",
+      "name": "Core (1,-2)",
+      "demographic_groups": [
+        {
+          "id": "p040-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.2615, "ryu": 0.7385 }
+        }
+      ]
+    },
+    {
+      "id": "p041",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 2, "r": -2 },
+      "total_population": 1415,
+      "initial_district_id": "d3",
+      "name": "Core (2,-2)",
+      "demographic_groups": [
+        {
+          "id": "p041-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.2480, "ryu": 0.7520 }
+        }
+      ]
+    },
+    {
+      "id": "p042",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 3, "r": -2 },
+      "total_population": 1506,
+      "initial_district_id": "d4",
+      "name": "Suburb (3,-2)",
+      "demographic_groups": [
+        {
+          "id": "p042-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4342, "ryu": 0.5658 }
+        }
+      ]
+    },
+    {
+      "id": "p043",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": -2 },
+      "total_population": 1541,
+      "initial_district_id": "d4",
+      "name": "Suburb (4,-2)",
+      "demographic_groups": [
+        {
+          "id": "p043-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4474, "ryu": 0.5526 }
+        }
+      ]
+    },
+    {
+      "id": "p044",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 5, "r": -2 },
+      "total_population": 1397,
+      "initial_district_id": "d5",
+      "name": "Exurb (5,-2)",
+      "demographic_groups": [
+        {
+          "id": "p044-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5441, "ryu": 0.4559 }
+        }
+      ]
+    },
+    {
+      "id": "p045",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 6, "r": -2 },
+      "total_population": 1572,
+      "initial_district_id": "d5",
+      "name": "Exurb (6,-2)",
+      "demographic_groups": [
+        {
+          "id": "p045-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6918, "ryu": 0.3082 }
+        }
+      ]
+    },
+    {
+      "id": "p046",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -5, "r": -1 },
+      "total_population": 1547,
+      "initial_district_id": "d1",
+      "name": "Exurb (-5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p046-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6724, "ryu": 0.3276 }
+        }
+      ]
+    },
+    {
+      "id": "p047",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": -1 },
+      "total_population": 1408,
+      "initial_district_id": "d1",
+      "name": "Exurb (-4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p047-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5529, "ryu": 0.4471 }
+        }
+      ]
+    },
+    {
+      "id": "p048",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -3, "r": -1 },
+      "total_population": 1579,
+      "initial_district_id": "d1",
+      "name": "Suburb (-3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p048-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4140, "ryu": 0.5860 }
+        }
+      ]
+    },
+    {
+      "id": "p049",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -2, "r": -1 },
+      "total_population": 1589,
+      "initial_district_id": "d1",
+      "name": "Suburb (-2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p049-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4418, "ryu": 0.5582 }
+        }
+      ]
+    },
+    {
+      "id": "p050",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -1, "r": -1 },
+      "total_population": 1409,
+      "initial_district_id": "d2",
+      "name": "Core (-1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p050-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.2785, "ryu": 0.7215 }
+        }
+      ]
+    },
+    {
+      "id": "p051",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 0, "r": -1 },
+      "total_population": 1383,
+      "initial_district_id": "d2",
+      "name": "Core (0,-1)",
+      "demographic_groups": [
+        {
+          "id": "p051-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.2375, "ryu": 0.7625 }
+        }
+      ]
+    },
+    {
+      "id": "p052",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 1, "r": -1 },
+      "total_population": 1501,
+      "initial_district_id": "d3",
+      "name": "Core (1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p052-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.2605, "ryu": 0.7395 }
+        }
+      ]
+    },
+    {
+      "id": "p053",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 2, "r": -1 },
+      "total_population": 1446,
+      "initial_district_id": "d4",
+      "name": "Core (2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p053-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.2224, "ryu": 0.7776 }
+        }
+      ]
+    },
+    {
+      "id": "p054",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 3, "r": -1 },
+      "total_population": 1378,
+      "initial_district_id": "d4",
+      "name": "Suburb (3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p054-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4886, "ryu": 0.5114 }
+        }
+      ]
+    },
+    {
+      "id": "p055",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": -1 },
+      "total_population": 1593,
+      "initial_district_id": "d5",
+      "name": "Suburb (4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p055-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4708, "ryu": 0.5292 }
+        }
+      ]
+    },
+    {
+      "id": "p056",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 5, "r": -1 },
+      "total_population": 1532,
+      "initial_district_id": "d5",
+      "name": "Exurb (5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p056-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5800, "ryu": 0.4200 }
+        }
+      ]
+    },
+    {
+      "id": "p057",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 6, "r": -1 },
+      "total_population": 1544,
+      "initial_district_id": "d5",
+      "name": "Exurb (6,-1)",
+      "demographic_groups": [
+        {
+          "id": "p057-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6719, "ryu": 0.3281 }
+        }
+      ]
+    },
+    {
+      "id": "p058",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -6, "r": 0 },
+      "total_population": 1561,
+      "initial_district_id": "d1",
+      "name": "Exurb (-6,0)",
+      "demographic_groups": [
+        {
+          "id": "p058-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6956, "ryu": 0.3044 }
+        }
+      ]
+    },
+    {
+      "id": "p059",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -5, "r": 0 },
+      "total_population": 1428,
+      "initial_district_id": "d1",
+      "name": "Exurb (-5,0)",
+      "demographic_groups": [
+        {
+          "id": "p059-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5171, "ryu": 0.4829 }
+        }
+      ]
+    },
+    {
+      "id": "p060",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": 0 },
+      "total_population": 1608,
+      "initial_district_id": "d1",
+      "name": "Suburb (-4,0)",
+      "demographic_groups": [
+        {
+          "id": "p060-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4206, "ryu": 0.5794 }
+        }
+      ]
+    },
+    {
+      "id": "p061",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -3, "r": 0 },
+      "total_population": 1378,
+      "initial_district_id": "d1",
+      "name": "Suburb (-3,0)",
+      "demographic_groups": [
+        {
+          "id": "p061-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4563, "ryu": 0.5437 }
+        }
+      ]
+    },
+    {
+      "id": "p062",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -2, "r": 0 },
+      "total_population": 1426,
+      "initial_district_id": "d2",
+      "name": "Core (-2,0)",
+      "demographic_groups": [
+        {
+          "id": "p062-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.2216, "ryu": 0.7784 }
+        }
+      ]
+    },
+    {
+      "id": "p063",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -1, "r": 0 },
+      "total_population": 1444,
+      "initial_district_id": "d2",
+      "name": "Core (-1,0)",
+      "demographic_groups": [
+        {
+          "id": "p063-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.2410, "ryu": 0.7590 }
+        }
+      ]
+    },
+    {
+      "id": "p064",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 0, "r": 0 },
+      "total_population": 1466,
+      "initial_district_id": "d3",
+      "name": "Core (0,0)",
+      "demographic_groups": [
+        {
+          "id": "p064-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.2184, "ryu": 0.7816 }
+        }
+      ]
+    },
+    {
+      "id": "p065",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 1, "r": 0 },
+      "total_population": 1529,
+      "initial_district_id": "d4",
+      "name": "Core (1,0)",
+      "demographic_groups": [
+        {
+          "id": "p065-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.2731, "ryu": 0.7269 }
+        }
+      ]
+    },
+    {
+      "id": "p066",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 2, "r": 0 },
+      "total_population": 1616,
+      "initial_district_id": "d4",
+      "name": "Core (2,0)",
+      "demographic_groups": [
+        {
+          "id": "p066-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.2847, "ryu": 0.7153 }
+        }
+      ]
+    },
+    {
+      "id": "p067",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 3, "r": 0 },
+      "total_population": 1392,
+      "initial_district_id": "d5",
+      "name": "Suburb (3,0)",
+      "demographic_groups": [
+        {
+          "id": "p067-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4707, "ryu": 0.5293 }
+        }
+      ]
+    },
+    {
+      "id": "p068",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": 0 },
+      "total_population": 1496,
+      "initial_district_id": "d5",
+      "name": "Suburb (4,0)",
+      "demographic_groups": [
+        {
+          "id": "p068-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4518, "ryu": 0.5482 }
+        }
+      ]
+    },
+    {
+      "id": "p069",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 5, "r": 0 },
+      "total_population": 1365,
+      "initial_district_id": "d5",
+      "name": "Exurb (5,0)",
+      "demographic_groups": [
+        {
+          "id": "p069-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5351, "ryu": 0.4649 }
+        }
+      ]
+    },
+    {
+      "id": "p070",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 6, "r": 0 },
+      "total_population": 1636,
+      "initial_district_id": "d5",
+      "name": "Exurb (6,0)",
+      "demographic_groups": [
+        {
+          "id": "p070-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6887, "ryu": 0.3113 }
+        }
+      ]
+    },
+    {
+      "id": "p071",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -6, "r": 1 },
+      "total_population": 1511,
+      "initial_district_id": "d1",
+      "name": "Exurb (-6,1)",
+      "demographic_groups": [
+        {
+          "id": "p071-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6543, "ryu": 0.3457 }
+        }
+      ]
+    },
+    {
+      "id": "p072",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -5, "r": 1 },
+      "total_population": 1493,
+      "initial_district_id": "d1",
+      "name": "Exurb (-5,1)",
+      "demographic_groups": [
+        {
+          "id": "p072-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5762, "ryu": 0.4238 }
+        }
+      ]
+    },
+    {
+      "id": "p073",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": 1 },
+      "total_population": 1451,
+      "initial_district_id": "d1",
+      "name": "Suburb (-4,1)",
+      "demographic_groups": [
+        {
+          "id": "p073-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4611, "ryu": 0.5389 }
+        }
+      ]
+    },
+    {
+      "id": "p074",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -3, "r": 1 },
+      "total_population": 1489,
+      "initial_district_id": "d2",
+      "name": "Suburb (-3,1)",
+      "demographic_groups": [
+        {
+          "id": "p074-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4537, "ryu": 0.5463 }
+        }
+      ]
+    },
+    {
+      "id": "p075",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -2, "r": 1 },
+      "total_population": 1426,
+      "initial_district_id": "d2",
+      "name": "Core (-2,1)",
+      "demographic_groups": [
+        {
+          "id": "p075-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.2270, "ryu": 0.7730 }
+        }
+      ]
+    },
+    {
+      "id": "p076",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -1, "r": 1 },
+      "total_population": 1453,
+      "initial_district_id": "d3",
+      "name": "Core (-1,1)",
+      "demographic_groups": [
+        {
+          "id": "p076-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.2533, "ryu": 0.7467 }
+        }
+      ]
+    },
+    {
+      "id": "p077",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 0, "r": 1 },
+      "total_population": 1436,
+      "initial_district_id": "d4",
+      "name": "Core (0,1)",
+      "demographic_groups": [
+        {
+          "id": "p077-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.2758, "ryu": 0.7242 }
+        }
+      ]
+    },
+    {
+      "id": "p078",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 1, "r": 1 },
+      "total_population": 1642,
+      "initial_district_id": "d4",
+      "name": "Core (1,1)",
+      "demographic_groups": [
+        {
+          "id": "p078-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.2654, "ryu": 0.7346 }
+        }
+      ]
+    },
+    {
+      "id": "p079",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 2, "r": 1 },
+      "total_population": 1461,
+      "initial_district_id": "d5",
+      "name": "Suburb (2,1)",
+      "demographic_groups": [
+        {
+          "id": "p079-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4502, "ryu": 0.5498 }
+        }
+      ]
+    },
+    {
+      "id": "p080",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 3, "r": 1 },
+      "total_population": 1533,
+      "initial_district_id": "d5",
+      "name": "Suburb (3,1)",
+      "demographic_groups": [
+        {
+          "id": "p080-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4200, "ryu": 0.5800 }
+        }
+      ]
+    },
+    {
+      "id": "p081",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": 1 },
+      "total_population": 1587,
+      "initial_district_id": "d5",
+      "name": "Exurb (4,1)",
+      "demographic_groups": [
+        {
+          "id": "p081-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5158, "ryu": 0.4842 }
+        }
+      ]
+    },
+    {
+      "id": "p082",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 5, "r": 1 },
+      "total_population": 1628,
+      "initial_district_id": "d5",
+      "name": "Exurb (5,1)",
+      "demographic_groups": [
+        {
+          "id": "p082-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6917, "ryu": 0.3083 }
+        }
+      ]
+    },
+    {
+      "id": "p083",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -6, "r": 2 },
+      "total_population": 1550,
+      "initial_district_id": "d1",
+      "name": "Exurb (-6,2)",
+      "demographic_groups": [
+        {
+          "id": "p083-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6485, "ryu": 0.3515 }
+        }
+      ]
+    },
+    {
+      "id": "p084",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -5, "r": 2 },
+      "total_population": 1406,
+      "initial_district_id": "d1",
+      "name": "Exurb (-5,2)",
+      "demographic_groups": [
+        {
+          "id": "p084-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5500, "ryu": 0.4500 }
+        }
+      ]
+    },
+    {
+      "id": "p085",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": 2 },
+      "total_population": 1416,
+      "initial_district_id": "d2",
+      "name": "Suburb (-4,2)",
+      "demographic_groups": [
+        {
+          "id": "p085-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4799, "ryu": 0.5201 }
+        }
+      ]
+    },
+    {
+      "id": "p086",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -3, "r": 2 },
+      "total_population": 1541,
+      "initial_district_id": "d2",
+      "name": "Suburb (-3,2)",
+      "demographic_groups": [
+        {
+          "id": "p086-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4355, "ryu": 0.5645 }
+        }
+      ]
+    },
+    {
+      "id": "p087",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -2, "r": 2 },
+      "total_population": 1355,
+      "initial_district_id": "d3",
+      "name": "Core (-2,2)",
+      "demographic_groups": [
+        {
+          "id": "p087-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.2850, "ryu": 0.7150 }
+        }
+      ]
+    },
+    {
+      "id": "p088",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -1, "r": 2 },
+      "total_population": 1362,
+      "initial_district_id": "d4",
+      "name": "Core (-1,2)",
+      "demographic_groups": [
+        {
+          "id": "p088-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.2824, "ryu": 0.7176 }
+        }
+      ]
+    },
+    {
+      "id": "p089",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 0, "r": 2 },
+      "total_population": 1460,
+      "initial_district_id": "d4",
+      "name": "Core (0,2)",
+      "demographic_groups": [
+        {
+          "id": "p089-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.2727, "ryu": 0.7273 }
+        }
+      ]
+    },
+    {
+      "id": "p090",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 1, "r": 2 },
+      "total_population": 1365,
+      "initial_district_id": "d5",
+      "name": "Suburb (1,2)",
+      "demographic_groups": [
+        {
+          "id": "p090-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.4257, "ryu": 0.5743 }
+        }
+      ]
+    },
+    {
+      "id": "p091",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 2, "r": 2 },
+      "total_population": 1552,
+      "initial_district_id": "d5",
+      "name": "Suburb (2,2)",
+      "demographic_groups": [
+        {
+          "id": "p091-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4491, "ryu": 0.5509 }
+        }
+      ]
+    },
+    {
+      "id": "p092",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 3, "r": 2 },
+      "total_population": 1502,
+      "initial_district_id": "d5",
+      "name": "Exurb (3,2)",
+      "demographic_groups": [
+        {
+          "id": "p092-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.5146, "ryu": 0.4854 }
+        }
+      ]
+    },
+    {
+      "id": "p093",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 4, "r": 2 },
+      "total_population": 1539,
+      "initial_district_id": "d5",
+      "name": "Exurb (4,2)",
+      "demographic_groups": [
+        {
+          "id": "p093-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6522, "ryu": 0.3478 }
+        }
+      ]
+    },
+    {
+      "id": "p094",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -6, "r": 3 },
+      "total_population": 1502,
+      "initial_district_id": "d1",
+      "name": "Exurb (-6,3)",
+      "demographic_groups": [
+        {
+          "id": "p094-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6435, "ryu": 0.3565 }
+        }
+      ]
+    },
+    {
+      "id": "p095",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -5, "r": 3 },
+      "total_population": 1419,
+      "initial_district_id": "d2",
+      "name": "Exurb (-5,3)",
+      "demographic_groups": [
+        {
+          "id": "p095-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5717, "ryu": 0.4283 }
+        }
+      ]
+    },
+    {
+      "id": "p096",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": 3 },
+      "total_population": 1647,
+      "initial_district_id": "d2",
+      "name": "Suburb (-4,3)",
+      "demographic_groups": [
+        {
+          "id": "p096-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.4819, "ryu": 0.5181 }
+        }
+      ]
+    },
+    {
+      "id": "p097",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -3, "r": 3 },
+      "total_population": 1360,
+      "initial_district_id": "d3",
+      "name": "Suburb (-3,3)",
+      "demographic_groups": [
+        {
+          "id": "p097-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4761, "ryu": 0.5239 }
+        }
+      ]
+    },
+    {
+      "id": "p098",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -2, "r": 3 },
+      "total_population": 1594,
+      "initial_district_id": "d4",
+      "name": "Suburb (-2,3)",
+      "demographic_groups": [
+        {
+          "id": "p098-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4149, "ryu": 0.5851 }
+        }
+      ]
+    },
+    {
+      "id": "p099",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": -1, "r": 3 },
+      "total_population": 1473,
+      "initial_district_id": "d4",
+      "name": "Suburb (-1,3)",
+      "demographic_groups": [
+        {
+          "id": "p099-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4101, "ryu": 0.5899 }
+        }
+      ]
+    },
+    {
+      "id": "p100",
+      "editable": true,
+      "county_id": "reform_central",
+      "position": { "q": 0, "r": 3 },
+      "total_population": 1373,
+      "initial_district_id": "d5",
+      "name": "Suburb (0,3)",
+      "demographic_groups": [
+        {
+          "id": "p100-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4273, "ryu": 0.5727 }
+        }
+      ]
+    },
+    {
+      "id": "p101",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 1, "r": 3 },
+      "total_population": 1364,
+      "initial_district_id": "d5",
+      "name": "Suburb (1,3)",
+      "demographic_groups": [
+        {
+          "id": "p101-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4709, "ryu": 0.5291 }
+        }
+      ]
+    },
+    {
+      "id": "p102",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 2, "r": 3 },
+      "total_population": 1637,
+      "initial_district_id": "d5",
+      "name": "Exurb (2,3)",
+      "demographic_groups": [
+        {
+          "id": "p102-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5299, "ryu": 0.4701 }
+        }
+      ]
+    },
+    {
+      "id": "p103",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 3, "r": 3 },
+      "total_population": 1517,
+      "initial_district_id": "d5",
+      "name": "Exurb (3,3)",
+      "demographic_groups": [
+        {
+          "id": "p103-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6605, "ryu": 0.3395 }
+        }
+      ]
+    },
+    {
+      "id": "p104",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -6, "r": 4 },
+      "total_population": 1548,
+      "initial_district_id": "d2",
+      "name": "Exurb (-6,4)",
+      "demographic_groups": [
+        {
+          "id": "p104-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6932, "ryu": 0.3068 }
+        }
+      ]
+    },
+    {
+      "id": "p105",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -5, "r": 4 },
+      "total_population": 1619,
+      "initial_district_id": "d2",
+      "name": "Exurb (-5,4)",
+      "demographic_groups": [
+        {
+          "id": "p105-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5864, "ryu": 0.4136 }
+        }
+      ]
+    },
+    {
+      "id": "p106",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": 4 },
+      "total_population": 1566,
+      "initial_district_id": "d3",
+      "name": "Suburb (-4,4)",
+      "demographic_groups": [
+        {
+          "id": "p106-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4117, "ryu": 0.5883 }
+        }
+      ]
+    },
+    {
+      "id": "p107",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -3, "r": 4 },
+      "total_population": 1398,
+      "initial_district_id": "d4",
+      "name": "Suburb (-3,4)",
+      "demographic_groups": [
+        {
+          "id": "p107-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4610, "ryu": 0.5390 }
+        }
+      ]
+    },
+    {
+      "id": "p108",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -2, "r": 4 },
+      "total_population": 1612,
+      "initial_district_id": "d4",
+      "name": "Suburb (-2,4)",
+      "demographic_groups": [
+        {
+          "id": "p108-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4704, "ryu": 0.5296 }
+        }
+      ]
+    },
+    {
+      "id": "p109",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -1, "r": 4 },
+      "total_population": 1440,
+      "initial_district_id": "d5",
+      "name": "Suburb (-1,4)",
+      "demographic_groups": [
+        {
+          "id": "p109-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4643, "ryu": 0.5357 }
+        }
+      ]
+    },
+    {
+      "id": "p110",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 0, "r": 4 },
+      "total_population": 1557,
+      "initial_district_id": "d5",
+      "name": "Suburb (0,4)",
+      "demographic_groups": [
+        {
+          "id": "p110-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4390, "ryu": 0.5610 }
+        }
+      ]
+    },
+    {
+      "id": "p111",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 1, "r": 4 },
+      "total_population": 1515,
+      "initial_district_id": "d5",
+      "name": "Exurb (1,4)",
+      "demographic_groups": [
+        {
+          "id": "p111-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5146, "ryu": 0.4854 }
+        }
+      ]
+    },
+    {
+      "id": "p112",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 2, "r": 4 },
+      "total_population": 1432,
+      "initial_district_id": "d5",
+      "name": "Exurb (2,4)",
+      "demographic_groups": [
+        {
+          "id": "p112-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6739, "ryu": 0.3261 }
+        }
+      ]
+    },
+    {
+      "id": "p113",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -6, "r": 5 },
+      "total_population": 1362,
+      "initial_district_id": "d2",
+      "name": "Exurb (-6,5)",
+      "demographic_groups": [
+        {
+          "id": "p113-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.7039, "ryu": 0.2961 }
+        }
+      ]
+    },
+    {
+      "id": "p114",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -5, "r": 5 },
+      "total_population": 1354,
+      "initial_district_id": "d3",
+      "name": "Exurb (-5,5)",
+      "demographic_groups": [
+        {
+          "id": "p114-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5881, "ryu": 0.4119 }
+        }
+      ]
+    },
+    {
+      "id": "p115",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": 5 },
+      "total_population": 1556,
+      "initial_district_id": "d4",
+      "name": "Exurb (-4,5)",
+      "demographic_groups": [
+        {
+          "id": "p115-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5716, "ryu": 0.4284 }
+        }
+      ]
+    },
+    {
+      "id": "p116",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -3, "r": 5 },
+      "total_population": 1381,
+      "initial_district_id": "d4",
+      "name": "Exurb (-3,5)",
+      "demographic_groups": [
+        {
+          "id": "p116-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5145, "ryu": 0.4855 }
+        }
+      ]
+    },
+    {
+      "id": "p117",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -2, "r": 5 },
+      "total_population": 1467,
+      "initial_district_id": "d5",
+      "name": "Exurb (-2,5)",
+      "demographic_groups": [
+        {
+          "id": "p117-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5509, "ryu": 0.4491 }
+        }
+      ]
+    },
+    {
+      "id": "p118",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -1, "r": 5 },
+      "total_population": 1434,
+      "initial_district_id": "d5",
+      "name": "Exurb (-1,5)",
+      "demographic_groups": [
+        {
+          "id": "p118-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5403, "ryu": 0.4597 }
+        }
+      ]
+    },
+    {
+      "id": "p119",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 0, "r": 5 },
+      "total_population": 1533,
+      "initial_district_id": "d5",
+      "name": "Exurb (0,5)",
+      "demographic_groups": [
+        {
+          "id": "p119-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5178, "ryu": 0.4822 }
+        }
+      ]
+    },
+    {
+      "id": "p120",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 1, "r": 5 },
+      "total_population": 1370,
+      "initial_district_id": "d5",
+      "name": "Exurb (1,5)",
+      "demographic_groups": [
+        {
+          "id": "p120-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6415, "ryu": 0.3585 }
+        }
+      ]
+    },
+    {
+      "id": "p121",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -6, "r": 6 },
+      "total_population": 1418,
+      "initial_district_id": "d3",
+      "name": "Exurb (-6,6)",
+      "demographic_groups": [
+        {
+          "id": "p121-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.7040, "ryu": 0.2960 }
+        }
+      ]
+    },
+    {
+      "id": "p122",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -5, "r": 6 },
+      "total_population": 1446,
+      "initial_district_id": "d4",
+      "name": "Exurb (-5,6)",
+      "demographic_groups": [
+        {
+          "id": "p122-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6584, "ryu": 0.3416 }
+        }
+      ]
+    },
+    {
+      "id": "p123",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -4, "r": 6 },
+      "total_population": 1644,
+      "initial_district_id": "d4",
+      "name": "Exurb (-4,6)",
+      "demographic_groups": [
+        {
+          "id": "p123-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6817, "ryu": 0.3183 }
+        }
+      ]
+    },
+    {
+      "id": "p124",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -3, "r": 6 },
+      "total_population": 1360,
+      "initial_district_id": "d5",
+      "name": "Exurb (-3,6)",
+      "demographic_groups": [
+        {
+          "id": "p124-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6735, "ryu": 0.3265 }
+        }
+      ]
+    },
+    {
+      "id": "p125",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -2, "r": 6 },
+      "total_population": 1392,
+      "initial_district_id": "d5",
+      "name": "Exurb (-2,6)",
+      "demographic_groups": [
+        {
+          "id": "p125-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6463, "ryu": 0.3537 }
+        }
+      ]
+    },
+    {
+      "id": "p126",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": -1, "r": 6 },
+      "total_population": 1648,
+      "initial_district_id": "d5",
+      "name": "Exurb (-1,6)",
+      "demographic_groups": [
+        {
+          "id": "p126-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6408, "ryu": 0.3592 }
+        }
+      ]
+    },
+    {
+      "id": "p127",
+      "editable": true,
+      "county_id": "reform_outer",
+      "position": { "q": 0, "r": 6 },
+      "total_population": 1360,
+      "initial_district_id": "d5",
+      "name": "Exurb (0,6)",
+      "demographic_groups": [
+        {
+          "id": "p127-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6656, "ryu": 0.3344 }
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All five districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All five districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-compactness",
+      "required": true,
+      "description": "All districts must be reasonably compact — no long tentacles or thin strips (compactness ≥ 40%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.40
+      }
+    },
+    {
+      "id": "sc-efficiency-gap",
+      "required": false,
+      "description": "Even a geometrically neutral map has an efficiency gap — see how close to zero you can get (≤ 15%).",
+      "criterion": {
+        "type": "efficiency_gap",
+        "operator": "lte",
+        "threshold": 0.15
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Independent Reform Commissioner, Meridian County",
+      "motivation": "The legislature has deadlocked. A court has ordered an independent commission to draw a new map using only neutral criteria — equal population, geographic compactness, and contiguity. No partisan data allowed. Draw the fairest map you can."
+    },
+    "intro_slides": [
+      {
+        "heading": "The Promise of Neutral Rules",
+        "body": "Reformers have long argued that if we just take politics out of redistricting — use an independent commission, apply mechanical criteria, ignore partisan data — the maps will be fair.\n\nMeridian County is your test case. Draw a map using only geometric rules: compact districts, equal population, no disconnected pieces. No partisan data. Just shapes."
+      },
+      {
+        "heading": "The Geography Problem",
+        "body": "Here's what nobody tells you: voters aren't distributed randomly. In Meridian County — as in most American counties — different communities cluster together. Urban neighborhoods vote differently from suburbs, which vote differently from exurbs.\n\nA perfectly geometric map doesn't erase that. It just captures it differently."
+      },
+      {
+        "heading": "What the Map Will Show You",
+        "body": "When you're done, submit your map and look at the results. You drew it without looking at party data. But the outcome won't be perfectly proportional.\n\nThis is called the geography problem. It's not a bug in your map — it's a feature of where people live. Neutral rules don't produce neutral outcomes. They produce different outcomes."
+      }
+    ],
+    "objective": "Draw a compact, population-balanced map using only geometric criteria. No partisan data required — or allowed."
+  }
+}

--- a/game/scenarios/scenario-008.json
+++ b/game/scenarios/scenario-008.json
@@ -1,0 +1,2372 @@
+{
+  "format_version": "1",
+  "id": "scenario-008",
+  "title": "Both Sides Unhappy",
+  "election_type": "state_house",
+  "region": {
+    "id": "accord_county",
+    "name": "Accord County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
+    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" },
+    { "id": "d5", "name": "District 5" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+    {
+      "id": "p001",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 0, "r": -6 },
+      "total_population": 1463,
+      "initial_district_id": "d1",
+      "name": "Exurb (0,-6)",
+      "demographic_groups": [
+        {
+          "id": "p001-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.8064, "ryu": 0.1936 }
+        }
+      ]
+    },
+    {
+      "id": "p002",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 1, "r": -6 },
+      "total_population": 1612,
+      "initial_district_id": "d1",
+      "name": "Exurb (1,-6)",
+      "demographic_groups": [
+        {
+          "id": "p002-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.8376, "ryu": 0.1624 }
+        }
+      ]
+    },
+    {
+      "id": "p003",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 2, "r": -6 },
+      "total_population": 1542,
+      "initial_district_id": "d2",
+      "name": "Exurb (2,-6)",
+      "demographic_groups": [
+        {
+          "id": "p003-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.7942, "ryu": 0.2058 }
+        }
+      ]
+    },
+    {
+      "id": "p004",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 3, "r": -6 },
+      "total_population": 1367,
+      "initial_district_id": "d2",
+      "name": "Exurb (3,-6)",
+      "demographic_groups": [
+        {
+          "id": "p004-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.7829, "ryu": 0.2171 }
+        }
+      ]
+    },
+    {
+      "id": "p005",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": -6 },
+      "total_population": 1385,
+      "initial_district_id": "d2",
+      "name": "Exurb (4,-6)",
+      "demographic_groups": [
+        {
+          "id": "p005-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.8037, "ryu": 0.1963 }
+        }
+      ]
+    },
+    {
+      "id": "p006",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 5, "r": -6 },
+      "total_population": 1378,
+      "initial_district_id": "d2",
+      "name": "Exurb (5,-6)",
+      "demographic_groups": [
+        {
+          "id": "p006-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.7616, "ryu": 0.2384 }
+        }
+      ]
+    },
+    {
+      "id": "p007",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 6, "r": -6 },
+      "total_population": 1403,
+      "initial_district_id": "d2",
+      "name": "Exurb (6,-6)",
+      "demographic_groups": [
+        {
+          "id": "p007-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.8125, "ryu": 0.1875 }
+        }
+      ]
+    },
+    {
+      "id": "p008",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -1, "r": -5 },
+      "total_population": 1420,
+      "initial_district_id": "d1",
+      "name": "Exurb (-1,-5)",
+      "demographic_groups": [
+        {
+          "id": "p008-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.8080, "ryu": 0.1920 }
+        }
+      ]
+    },
+    {
+      "id": "p009",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 0, "r": -5 },
+      "total_population": 1466,
+      "initial_district_id": "d1",
+      "name": "Exurb (0,-5)",
+      "demographic_groups": [
+        {
+          "id": "p009-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.7732, "ryu": 0.2268 }
+        }
+      ]
+    },
+    {
+      "id": "p010",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 1, "r": -5 },
+      "total_population": 1614,
+      "initial_district_id": "d1",
+      "name": "Exurb (1,-5)",
+      "demographic_groups": [
+        {
+          "id": "p010-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.8320, "ryu": 0.1680 }
+        }
+      ]
+    },
+    {
+      "id": "p011",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 2, "r": -5 },
+      "total_population": 1584,
+      "initial_district_id": "d2",
+      "name": "Exurb (2,-5)",
+      "demographic_groups": [
+        {
+          "id": "p011-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.7924, "ryu": 0.2076 }
+        }
+      ]
+    },
+    {
+      "id": "p012",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 3, "r": -5 },
+      "total_population": 1593,
+      "initial_district_id": "d2",
+      "name": "Exurb (3,-5)",
+      "demographic_groups": [
+        {
+          "id": "p012-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.8240, "ryu": 0.1760 }
+        }
+      ]
+    },
+    {
+      "id": "p013",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": -5 },
+      "total_population": 1608,
+      "initial_district_id": "d2",
+      "name": "Exurb (4,-5)",
+      "demographic_groups": [
+        {
+          "id": "p013-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.8287, "ryu": 0.1713 }
+        }
+      ]
+    },
+    {
+      "id": "p014",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 5, "r": -5 },
+      "total_population": 1406,
+      "initial_district_id": "d2",
+      "name": "Exurb (5,-5)",
+      "demographic_groups": [
+        {
+          "id": "p014-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.7852, "ryu": 0.2148 }
+        }
+      ]
+    },
+    {
+      "id": "p015",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 6, "r": -5 },
+      "total_population": 1511,
+      "initial_district_id": "d2",
+      "name": "Exurb (6,-5)",
+      "demographic_groups": [
+        {
+          "id": "p015-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.8252, "ryu": 0.1748 }
+        }
+      ]
+    },
+    {
+      "id": "p016",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -2, "r": -4 },
+      "total_population": 1596,
+      "initial_district_id": "d1",
+      "name": "Exurb (-2,-4)",
+      "demographic_groups": [
+        {
+          "id": "p016-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.7990, "ryu": 0.2010 }
+        }
+      ]
+    },
+    {
+      "id": "p017",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -1, "r": -4 },
+      "total_population": 1379,
+      "initial_district_id": "d1",
+      "name": "Exurb (-1,-4)",
+      "demographic_groups": [
+        {
+          "id": "p017-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.8235, "ryu": 0.1765 }
+        }
+      ]
+    },
+    {
+      "id": "p018",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 0, "r": -4 },
+      "total_population": 1397,
+      "initial_district_id": "d1",
+      "name": "Suburb (0,-4)",
+      "demographic_groups": [
+        {
+          "id": "p018-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4926, "ryu": 0.5074 }
+        }
+      ]
+    },
+    {
+      "id": "p019",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 1, "r": -4 },
+      "total_population": 1584,
+      "initial_district_id": "d2",
+      "name": "Suburb (1,-4)",
+      "demographic_groups": [
+        {
+          "id": "p019-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4682, "ryu": 0.5318 }
+        }
+      ]
+    },
+    {
+      "id": "p020",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 2, "r": -4 },
+      "total_population": 1566,
+      "initial_district_id": "d2",
+      "name": "Suburb (2,-4)",
+      "demographic_groups": [
+        {
+          "id": "p020-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5300, "ryu": 0.4700 }
+        }
+      ]
+    },
+    {
+      "id": "p021",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 3, "r": -4 },
+      "total_population": 1629,
+      "initial_district_id": "d2",
+      "name": "Suburb (3,-4)",
+      "demographic_groups": [
+        {
+          "id": "p021-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5226, "ryu": 0.4774 }
+        }
+      ]
+    },
+    {
+      "id": "p022",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": -4 },
+      "total_population": 1538,
+      "initial_district_id": "d2",
+      "name": "Suburb (4,-4)",
+      "demographic_groups": [
+        {
+          "id": "p022-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5241, "ryu": 0.4759 }
+        }
+      ]
+    },
+    {
+      "id": "p023",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 5, "r": -4 },
+      "total_population": 1491,
+      "initial_district_id": "d2",
+      "name": "Exurb (5,-4)",
+      "demographic_groups": [
+        {
+          "id": "p023-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.8322, "ryu": 0.1678 }
+        }
+      ]
+    },
+    {
+      "id": "p024",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 6, "r": -4 },
+      "total_population": 1645,
+      "initial_district_id": "d2",
+      "name": "Exurb (6,-4)",
+      "demographic_groups": [
+        {
+          "id": "p024-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.7650, "ryu": 0.2350 }
+        }
+      ]
+    },
+    {
+      "id": "p025",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -3, "r": -3 },
+      "total_population": 1623,
+      "initial_district_id": "d1",
+      "name": "Exurb (-3,-3)",
+      "demographic_groups": [
+        {
+          "id": "p025-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.7881, "ryu": 0.2119 }
+        }
+      ]
+    },
+    {
+      "id": "p026",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -2, "r": -3 },
+      "total_population": 1578,
+      "initial_district_id": "d1",
+      "name": "Exurb (-2,-3)",
+      "demographic_groups": [
+        {
+          "id": "p026-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.7953, "ryu": 0.2047 }
+        }
+      ]
+    },
+    {
+      "id": "p027",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -1, "r": -3 },
+      "total_population": 1611,
+      "initial_district_id": "d1",
+      "name": "Suburb (-1,-3)",
+      "demographic_groups": [
+        {
+          "id": "p027-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4869, "ryu": 0.5131 }
+        }
+      ]
+    },
+    {
+      "id": "p028",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 0, "r": -3 },
+      "total_population": 1462,
+      "initial_district_id": "d1",
+      "name": "Suburb (0,-3)",
+      "demographic_groups": [
+        {
+          "id": "p028-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4713, "ryu": 0.5287 }
+        }
+      ]
+    },
+    {
+      "id": "p029",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 1, "r": -3 },
+      "total_population": 1548,
+      "initial_district_id": "d2",
+      "name": "Suburb (1,-3)",
+      "demographic_groups": [
+        {
+          "id": "p029-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5174, "ryu": 0.4826 }
+        }
+      ]
+    },
+    {
+      "id": "p030",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 2, "r": -3 },
+      "total_population": 1389,
+      "initial_district_id": "d2",
+      "name": "Suburb (2,-3)",
+      "demographic_groups": [
+        {
+          "id": "p030-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4906, "ryu": 0.5094 }
+        }
+      ]
+    },
+    {
+      "id": "p031",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 3, "r": -3 },
+      "total_population": 1632,
+      "initial_district_id": "d2",
+      "name": "Suburb (3,-3)",
+      "demographic_groups": [
+        {
+          "id": "p031-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4627, "ryu": 0.5373 }
+        }
+      ]
+    },
+    {
+      "id": "p032",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": -3 },
+      "total_population": 1490,
+      "initial_district_id": "d2",
+      "name": "Suburb (4,-3)",
+      "demographic_groups": [
+        {
+          "id": "p032-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5286, "ryu": 0.4714 }
+        }
+      ]
+    },
+    {
+      "id": "p033",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 5, "r": -3 },
+      "total_population": 1528,
+      "initial_district_id": "d2",
+      "name": "Exurb (5,-3)",
+      "demographic_groups": [
+        {
+          "id": "p033-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.8332, "ryu": 0.1668 }
+        }
+      ]
+    },
+    {
+      "id": "p034",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 6, "r": -3 },
+      "total_population": 1426,
+      "initial_district_id": "d3",
+      "name": "Exurb (6,-3)",
+      "demographic_groups": [
+        {
+          "id": "p034-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.7668, "ryu": 0.2332 }
+        }
+      ]
+    },
+    {
+      "id": "p035",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": -2 },
+      "total_population": 1584,
+      "initial_district_id": "d1",
+      "name": "Exurb (-4,-2)",
+      "demographic_groups": [
+        {
+          "id": "p035-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.7631, "ryu": 0.2369 }
+        }
+      ]
+    },
+    {
+      "id": "p036",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -3, "r": -2 },
+      "total_population": 1517,
+      "initial_district_id": "d1",
+      "name": "Exurb (-3,-2)",
+      "demographic_groups": [
+        {
+          "id": "p036-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.8218, "ryu": 0.1782 }
+        }
+      ]
+    },
+    {
+      "id": "p037",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -2, "r": -2 },
+      "total_population": 1372,
+      "initial_district_id": "d1",
+      "name": "Suburb (-2,-2)",
+      "demographic_groups": [
+        {
+          "id": "p037-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5282, "ryu": 0.4718 }
+        }
+      ]
+    },
+    {
+      "id": "p038",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -1, "r": -2 },
+      "total_population": 1572,
+      "initial_district_id": "d1",
+      "name": "Suburb (-1,-2)",
+      "demographic_groups": [
+        {
+          "id": "p038-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5160, "ryu": 0.4840 }
+        }
+      ]
+    },
+    {
+      "id": "p039",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 0, "r": -2 },
+      "total_population": 1598,
+      "initial_district_id": "d1",
+      "name": "Core (0,-2)",
+      "demographic_groups": [
+        {
+          "id": "p039-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.1707, "ryu": 0.8293 }
+        }
+      ]
+    },
+    {
+      "id": "p040",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 1, "r": -2 },
+      "total_population": 1353,
+      "initial_district_id": "d2",
+      "name": "Core (1,-2)",
+      "demographic_groups": [
+        {
+          "id": "p040-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.2341, "ryu": 0.7659 }
+        }
+      ]
+    },
+    {
+      "id": "p041",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 2, "r": -2 },
+      "total_population": 1382,
+      "initial_district_id": "d2",
+      "name": "Core (2,-2)",
+      "demographic_groups": [
+        {
+          "id": "p041-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.2236, "ryu": 0.7764 }
+        }
+      ]
+    },
+    {
+      "id": "p042",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 3, "r": -2 },
+      "total_population": 1422,
+      "initial_district_id": "d2",
+      "name": "Suburb (3,-2)",
+      "demographic_groups": [
+        {
+          "id": "p042-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4769, "ryu": 0.5231 }
+        }
+      ]
+    },
+    {
+      "id": "p043",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": -2 },
+      "total_population": 1559,
+      "initial_district_id": "d3",
+      "name": "Suburb (4,-2)",
+      "demographic_groups": [
+        {
+          "id": "p043-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4931, "ryu": 0.5069 }
+        }
+      ]
+    },
+    {
+      "id": "p044",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 5, "r": -2 },
+      "total_population": 1393,
+      "initial_district_id": "d3",
+      "name": "Exurb (5,-2)",
+      "demographic_groups": [
+        {
+          "id": "p044-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.7875, "ryu": 0.2125 }
+        }
+      ]
+    },
+    {
+      "id": "p045",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 6, "r": -2 },
+      "total_population": 1477,
+      "initial_district_id": "d3",
+      "name": "Exurb (6,-2)",
+      "demographic_groups": [
+        {
+          "id": "p045-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.7984, "ryu": 0.2016 }
+        }
+      ]
+    },
+    {
+      "id": "p046",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -5, "r": -1 },
+      "total_population": 1621,
+      "initial_district_id": "d1",
+      "name": "Exurb (-5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p046-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.7764, "ryu": 0.2236 }
+        }
+      ]
+    },
+    {
+      "id": "p047",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": -1 },
+      "total_population": 1539,
+      "initial_district_id": "d1",
+      "name": "Exurb (-4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p047-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.8395, "ryu": 0.1605 }
+        }
+      ]
+    },
+    {
+      "id": "p048",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -3, "r": -1 },
+      "total_population": 1587,
+      "initial_district_id": "d1",
+      "name": "Suburb (-3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p048-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4876, "ryu": 0.5124 }
+        }
+      ]
+    },
+    {
+      "id": "p049",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -2, "r": -1 },
+      "total_population": 1507,
+      "initial_district_id": "d1",
+      "name": "Suburb (-2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p049-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4822, "ryu": 0.5178 }
+        }
+      ]
+    },
+    {
+      "id": "p050",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -1, "r": -1 },
+      "total_population": 1541,
+      "initial_district_id": "d1",
+      "name": "Core (-1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p050-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.1920, "ryu": 0.8080 }
+        }
+      ]
+    },
+    {
+      "id": "p051",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 0, "r": -1 },
+      "total_population": 1600,
+      "initial_district_id": "d1",
+      "name": "Core (0,-1)",
+      "demographic_groups": [
+        {
+          "id": "p051-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.2398, "ryu": 0.7602 }
+        }
+      ]
+    },
+    {
+      "id": "p052",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 1, "r": -1 },
+      "total_population": 1503,
+      "initial_district_id": "d2",
+      "name": "Core (1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p052-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.1668, "ryu": 0.8332 }
+        }
+      ]
+    },
+    {
+      "id": "p053",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 2, "r": -1 },
+      "total_population": 1535,
+      "initial_district_id": "d3",
+      "name": "Core (2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p053-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.2151, "ryu": 0.7849 }
+        }
+      ]
+    },
+    {
+      "id": "p054",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 3, "r": -1 },
+      "total_population": 1371,
+      "initial_district_id": "d3",
+      "name": "Suburb (3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p054-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.4848, "ryu": 0.5152 }
+        }
+      ]
+    },
+    {
+      "id": "p055",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": -1 },
+      "total_population": 1513,
+      "initial_district_id": "d3",
+      "name": "Suburb (4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p055-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4899, "ryu": 0.5101 }
+        }
+      ]
+    },
+    {
+      "id": "p056",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 5, "r": -1 },
+      "total_population": 1394,
+      "initial_district_id": "d3",
+      "name": "Exurb (5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p056-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.8039, "ryu": 0.1961 }
+        }
+      ]
+    },
+    {
+      "id": "p057",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 6, "r": -1 },
+      "total_population": 1376,
+      "initial_district_id": "d3",
+      "name": "Exurb (6,-1)",
+      "demographic_groups": [
+        {
+          "id": "p057-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.7962, "ryu": 0.2038 }
+        }
+      ]
+    },
+    {
+      "id": "p058",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -6, "r": 0 },
+      "total_population": 1519,
+      "initial_district_id": "d5",
+      "name": "Exurb (-6,0)",
+      "demographic_groups": [
+        {
+          "id": "p058-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.8071, "ryu": 0.1929 }
+        }
+      ]
+    },
+    {
+      "id": "p059",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -5, "r": 0 },
+      "total_population": 1465,
+      "initial_district_id": "d5",
+      "name": "Exurb (-5,0)",
+      "demographic_groups": [
+        {
+          "id": "p059-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.8237, "ryu": 0.1763 }
+        }
+      ]
+    },
+    {
+      "id": "p060",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": 0 },
+      "total_population": 1457,
+      "initial_district_id": "d5",
+      "name": "Suburb (-4,0)",
+      "demographic_groups": [
+        {
+          "id": "p060-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4601, "ryu": 0.5399 }
+        }
+      ]
+    },
+    {
+      "id": "p061",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -3, "r": 0 },
+      "total_population": 1525,
+      "initial_district_id": "d5",
+      "name": "Suburb (-3,0)",
+      "demographic_groups": [
+        {
+          "id": "p061-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4871, "ryu": 0.5129 }
+        }
+      ]
+    },
+    {
+      "id": "p062",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -2, "r": 0 },
+      "total_population": 1596,
+      "initial_district_id": "d5",
+      "name": "Core (-2,0)",
+      "demographic_groups": [
+        {
+          "id": "p062-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.2160, "ryu": 0.7840 }
+        }
+      ]
+    },
+    {
+      "id": "p063",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -1, "r": 0 },
+      "total_population": 1411,
+      "initial_district_id": "d5",
+      "name": "Core (-1,0)",
+      "demographic_groups": [
+        {
+          "id": "p063-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.2033, "ryu": 0.7967 }
+        }
+      ]
+    },
+    {
+      "id": "p064",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 0, "r": 0 },
+      "total_population": 1401,
+      "initial_district_id": "d3",
+      "name": "Core (0,0)",
+      "demographic_groups": [
+        {
+          "id": "p064-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.1659, "ryu": 0.8341 }
+        }
+      ]
+    },
+    {
+      "id": "p065",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 1, "r": 0 },
+      "total_population": 1640,
+      "initial_district_id": "d3",
+      "name": "Core (1,0)",
+      "demographic_groups": [
+        {
+          "id": "p065-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.1736, "ryu": 0.8264 }
+        }
+      ]
+    },
+    {
+      "id": "p066",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 2, "r": 0 },
+      "total_population": 1585,
+      "initial_district_id": "d3",
+      "name": "Core (2,0)",
+      "demographic_groups": [
+        {
+          "id": "p066-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.1687, "ryu": 0.8313 }
+        }
+      ]
+    },
+    {
+      "id": "p067",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 3, "r": 0 },
+      "total_population": 1535,
+      "initial_district_id": "d3",
+      "name": "Suburb (3,0)",
+      "demographic_groups": [
+        {
+          "id": "p067-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4793, "ryu": 0.5207 }
+        }
+      ]
+    },
+    {
+      "id": "p068",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": 0 },
+      "total_population": 1405,
+      "initial_district_id": "d3",
+      "name": "Suburb (4,0)",
+      "demographic_groups": [
+        {
+          "id": "p068-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5145, "ryu": 0.4855 }
+        }
+      ]
+    },
+    {
+      "id": "p069",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 5, "r": 0 },
+      "total_population": 1519,
+      "initial_district_id": "d3",
+      "name": "Exurb (5,0)",
+      "demographic_groups": [
+        {
+          "id": "p069-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.7859, "ryu": 0.2141 }
+        }
+      ]
+    },
+    {
+      "id": "p070",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 6, "r": 0 },
+      "total_population": 1457,
+      "initial_district_id": "d3",
+      "name": "Exurb (6,0)",
+      "demographic_groups": [
+        {
+          "id": "p070-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.8210, "ryu": 0.1790 }
+        }
+      ]
+    },
+    {
+      "id": "p071",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -6, "r": 1 },
+      "total_population": 1405,
+      "initial_district_id": "d5",
+      "name": "Exurb (-6,1)",
+      "demographic_groups": [
+        {
+          "id": "p071-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.8396, "ryu": 0.1604 }
+        }
+      ]
+    },
+    {
+      "id": "p072",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -5, "r": 1 },
+      "total_population": 1354,
+      "initial_district_id": "d5",
+      "name": "Exurb (-5,1)",
+      "demographic_groups": [
+        {
+          "id": "p072-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.7726, "ryu": 0.2274 }
+        }
+      ]
+    },
+    {
+      "id": "p073",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": 1 },
+      "total_population": 1551,
+      "initial_district_id": "d5",
+      "name": "Suburb (-4,1)",
+      "demographic_groups": [
+        {
+          "id": "p073-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4660, "ryu": 0.5340 }
+        }
+      ]
+    },
+    {
+      "id": "p074",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -3, "r": 1 },
+      "total_population": 1372,
+      "initial_district_id": "d5",
+      "name": "Suburb (-3,1)",
+      "demographic_groups": [
+        {
+          "id": "p074-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5323, "ryu": 0.4677 }
+        }
+      ]
+    },
+    {
+      "id": "p075",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -2, "r": 1 },
+      "total_population": 1646,
+      "initial_district_id": "d5",
+      "name": "Core (-2,1)",
+      "demographic_groups": [
+        {
+          "id": "p075-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.1772, "ryu": 0.8228 }
+        }
+      ]
+    },
+    {
+      "id": "p076",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -1, "r": 1 },
+      "total_population": 1603,
+      "initial_district_id": "d5",
+      "name": "Core (-1,1)",
+      "demographic_groups": [
+        {
+          "id": "p076-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.2061, "ryu": 0.7939 }
+        }
+      ]
+    },
+    {
+      "id": "p077",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 0, "r": 1 },
+      "total_population": 1501,
+      "initial_district_id": "d4",
+      "name": "Core (0,1)",
+      "demographic_groups": [
+        {
+          "id": "p077-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.1682, "ryu": 0.8318 }
+        }
+      ]
+    },
+    {
+      "id": "p078",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 1, "r": 1 },
+      "total_population": 1547,
+      "initial_district_id": "d3",
+      "name": "Core (1,1)",
+      "demographic_groups": [
+        {
+          "id": "p078-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.2205, "ryu": 0.7795 }
+        }
+      ]
+    },
+    {
+      "id": "p079",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 2, "r": 1 },
+      "total_population": 1647,
+      "initial_district_id": "d3",
+      "name": "Suburb (2,1)",
+      "demographic_groups": [
+        {
+          "id": "p079-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4935, "ryu": 0.5065 }
+        }
+      ]
+    },
+    {
+      "id": "p080",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 3, "r": 1 },
+      "total_population": 1650,
+      "initial_district_id": "d3",
+      "name": "Suburb (3,1)",
+      "demographic_groups": [
+        {
+          "id": "p080-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5006, "ryu": 0.4994 }
+        }
+      ]
+    },
+    {
+      "id": "p081",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": 1 },
+      "total_population": 1613,
+      "initial_district_id": "d3",
+      "name": "Exurb (4,1)",
+      "demographic_groups": [
+        {
+          "id": "p081-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.7872, "ryu": 0.2128 }
+        }
+      ]
+    },
+    {
+      "id": "p082",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 5, "r": 1 },
+      "total_population": 1521,
+      "initial_district_id": "d3",
+      "name": "Exurb (5,1)",
+      "demographic_groups": [
+        {
+          "id": "p082-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.7693, "ryu": 0.2307 }
+        }
+      ]
+    },
+    {
+      "id": "p083",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -6, "r": 2 },
+      "total_population": 1362,
+      "initial_district_id": "d5",
+      "name": "Exurb (-6,2)",
+      "demographic_groups": [
+        {
+          "id": "p083-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.7696, "ryu": 0.2304 }
+        }
+      ]
+    },
+    {
+      "id": "p084",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -5, "r": 2 },
+      "total_population": 1576,
+      "initial_district_id": "d5",
+      "name": "Exurb (-5,2)",
+      "demographic_groups": [
+        {
+          "id": "p084-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.8320, "ryu": 0.1680 }
+        }
+      ]
+    },
+    {
+      "id": "p085",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": 2 },
+      "total_population": 1650,
+      "initial_district_id": "d5",
+      "name": "Suburb (-4,2)",
+      "demographic_groups": [
+        {
+          "id": "p085-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.4965, "ryu": 0.5035 }
+        }
+      ]
+    },
+    {
+      "id": "p086",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -3, "r": 2 },
+      "total_population": 1583,
+      "initial_district_id": "d5",
+      "name": "Suburb (-3,2)",
+      "demographic_groups": [
+        {
+          "id": "p086-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4893, "ryu": 0.5107 }
+        }
+      ]
+    },
+    {
+      "id": "p087",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -2, "r": 2 },
+      "total_population": 1561,
+      "initial_district_id": "d5",
+      "name": "Core (-2,2)",
+      "demographic_groups": [
+        {
+          "id": "p087-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.1892, "ryu": 0.8108 }
+        }
+      ]
+    },
+    {
+      "id": "p088",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -1, "r": 2 },
+      "total_population": 1350,
+      "initial_district_id": "d4",
+      "name": "Core (-1,2)",
+      "demographic_groups": [
+        {
+          "id": "p088-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.2301, "ryu": 0.7699 }
+        }
+      ]
+    },
+    {
+      "id": "p089",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 0, "r": 2 },
+      "total_population": 1619,
+      "initial_district_id": "d4",
+      "name": "Core (0,2)",
+      "demographic_groups": [
+        {
+          "id": "p089-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.1622, "ryu": 0.8378 }
+        }
+      ]
+    },
+    {
+      "id": "p090",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 1, "r": 2 },
+      "total_population": 1559,
+      "initial_district_id": "d4",
+      "name": "Suburb (1,2)",
+      "demographic_groups": [
+        {
+          "id": "p090-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5188, "ryu": 0.4812 }
+        }
+      ]
+    },
+    {
+      "id": "p091",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 2, "r": 2 },
+      "total_population": 1430,
+      "initial_district_id": "d3",
+      "name": "Suburb (2,2)",
+      "demographic_groups": [
+        {
+          "id": "p091-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4686, "ryu": 0.5314 }
+        }
+      ]
+    },
+    {
+      "id": "p092",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 3, "r": 2 },
+      "total_population": 1591,
+      "initial_district_id": "d3",
+      "name": "Exurb (3,2)",
+      "demographic_groups": [
+        {
+          "id": "p092-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.8334, "ryu": 0.1666 }
+        }
+      ]
+    },
+    {
+      "id": "p093",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 4, "r": 2 },
+      "total_population": 1434,
+      "initial_district_id": "d3",
+      "name": "Exurb (4,2)",
+      "demographic_groups": [
+        {
+          "id": "p093-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.8335, "ryu": 0.1665 }
+        }
+      ]
+    },
+    {
+      "id": "p094",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -6, "r": 3 },
+      "total_population": 1443,
+      "initial_district_id": "d5",
+      "name": "Exurb (-6,3)",
+      "demographic_groups": [
+        {
+          "id": "p094-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.8006, "ryu": 0.1994 }
+        }
+      ]
+    },
+    {
+      "id": "p095",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -5, "r": 3 },
+      "total_population": 1456,
+      "initial_district_id": "d5",
+      "name": "Exurb (-5,3)",
+      "demographic_groups": [
+        {
+          "id": "p095-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.7824, "ryu": 0.2176 }
+        }
+      ]
+    },
+    {
+      "id": "p096",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": 3 },
+      "total_population": 1357,
+      "initial_district_id": "d5",
+      "name": "Suburb (-4,3)",
+      "demographic_groups": [
+        {
+          "id": "p096-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4863, "ryu": 0.5137 }
+        }
+      ]
+    },
+    {
+      "id": "p097",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -3, "r": 3 },
+      "total_population": 1437,
+      "initial_district_id": "d5",
+      "name": "Suburb (-3,3)",
+      "demographic_groups": [
+        {
+          "id": "p097-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5243, "ryu": 0.4757 }
+        }
+      ]
+    },
+    {
+      "id": "p098",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -2, "r": 3 },
+      "total_population": 1500,
+      "initial_district_id": "d4",
+      "name": "Suburb (-2,3)",
+      "demographic_groups": [
+        {
+          "id": "p098-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4737, "ryu": 0.5263 }
+        }
+      ]
+    },
+    {
+      "id": "p099",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": -1, "r": 3 },
+      "total_population": 1565,
+      "initial_district_id": "d4",
+      "name": "Suburb (-1,3)",
+      "demographic_groups": [
+        {
+          "id": "p099-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5177, "ryu": 0.4823 }
+        }
+      ]
+    },
+    {
+      "id": "p100",
+      "editable": true,
+      "county_id": "accord_central",
+      "position": { "q": 0, "r": 3 },
+      "total_population": 1542,
+      "initial_district_id": "d4",
+      "name": "Suburb (0,3)",
+      "demographic_groups": [
+        {
+          "id": "p100-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4661, "ryu": 0.5339 }
+        }
+      ]
+    },
+    {
+      "id": "p101",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 1, "r": 3 },
+      "total_population": 1609,
+      "initial_district_id": "d4",
+      "name": "Suburb (1,3)",
+      "demographic_groups": [
+        {
+          "id": "p101-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5360, "ryu": 0.4640 }
+        }
+      ]
+    },
+    {
+      "id": "p102",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 2, "r": 3 },
+      "total_population": 1554,
+      "initial_district_id": "d4",
+      "name": "Exurb (2,3)",
+      "demographic_groups": [
+        {
+          "id": "p102-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.8137, "ryu": 0.1863 }
+        }
+      ]
+    },
+    {
+      "id": "p103",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 3, "r": 3 },
+      "total_population": 1491,
+      "initial_district_id": "d3",
+      "name": "Exurb (3,3)",
+      "demographic_groups": [
+        {
+          "id": "p103-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.8131, "ryu": 0.1869 }
+        }
+      ]
+    },
+    {
+      "id": "p104",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -6, "r": 4 },
+      "total_population": 1392,
+      "initial_district_id": "d5",
+      "name": "Exurb (-6,4)",
+      "demographic_groups": [
+        {
+          "id": "p104-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.8246, "ryu": 0.1754 }
+        }
+      ]
+    },
+    {
+      "id": "p105",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -5, "r": 4 },
+      "total_population": 1384,
+      "initial_district_id": "d5",
+      "name": "Exurb (-5,4)",
+      "demographic_groups": [
+        {
+          "id": "p105-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.8052, "ryu": 0.1948 }
+        }
+      ]
+    },
+    {
+      "id": "p106",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": 4 },
+      "total_population": 1467,
+      "initial_district_id": "d5",
+      "name": "Suburb (-4,4)",
+      "demographic_groups": [
+        {
+          "id": "p106-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.5380, "ryu": 0.4620 }
+        }
+      ]
+    },
+    {
+      "id": "p107",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -3, "r": 4 },
+      "total_population": 1480,
+      "initial_district_id": "d4",
+      "name": "Suburb (-3,4)",
+      "demographic_groups": [
+        {
+          "id": "p107-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4609, "ryu": 0.5391 }
+        }
+      ]
+    },
+    {
+      "id": "p108",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -2, "r": 4 },
+      "total_population": 1350,
+      "initial_district_id": "d4",
+      "name": "Suburb (-2,4)",
+      "demographic_groups": [
+        {
+          "id": "p108-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4792, "ryu": 0.5208 }
+        }
+      ]
+    },
+    {
+      "id": "p109",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -1, "r": 4 },
+      "total_population": 1456,
+      "initial_district_id": "d4",
+      "name": "Suburb (-1,4)",
+      "demographic_groups": [
+        {
+          "id": "p109-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4838, "ryu": 0.5162 }
+        }
+      ]
+    },
+    {
+      "id": "p110",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 0, "r": 4 },
+      "total_population": 1559,
+      "initial_district_id": "d4",
+      "name": "Suburb (0,4)",
+      "demographic_groups": [
+        {
+          "id": "p110-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4795, "ryu": 0.5205 }
+        }
+      ]
+    },
+    {
+      "id": "p111",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 1, "r": 4 },
+      "total_population": 1501,
+      "initial_district_id": "d4",
+      "name": "Exurb (1,4)",
+      "demographic_groups": [
+        {
+          "id": "p111-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.7607, "ryu": 0.2393 }
+        }
+      ]
+    },
+    {
+      "id": "p112",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 2, "r": 4 },
+      "total_population": 1490,
+      "initial_district_id": "d4",
+      "name": "Exurb (2,4)",
+      "demographic_groups": [
+        {
+          "id": "p112-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.7992, "ryu": 0.2008 }
+        }
+      ]
+    },
+    {
+      "id": "p113",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -6, "r": 5 },
+      "total_population": 1544,
+      "initial_district_id": "d5",
+      "name": "Exurb (-6,5)",
+      "demographic_groups": [
+        {
+          "id": "p113-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.8268, "ryu": 0.1732 }
+        }
+      ]
+    },
+    {
+      "id": "p114",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -5, "r": 5 },
+      "total_population": 1602,
+      "initial_district_id": "d5",
+      "name": "Exurb (-5,5)",
+      "demographic_groups": [
+        {
+          "id": "p114-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.8331, "ryu": 0.1669 }
+        }
+      ]
+    },
+    {
+      "id": "p115",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": 5 },
+      "total_population": 1612,
+      "initial_district_id": "d5",
+      "name": "Exurb (-4,5)",
+      "demographic_groups": [
+        {
+          "id": "p115-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.7630, "ryu": 0.2370 }
+        }
+      ]
+    },
+    {
+      "id": "p116",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -3, "r": 5 },
+      "total_population": 1482,
+      "initial_district_id": "d4",
+      "name": "Exurb (-3,5)",
+      "demographic_groups": [
+        {
+          "id": "p116-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.7740, "ryu": 0.2260 }
+        }
+      ]
+    },
+    {
+      "id": "p117",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -2, "r": 5 },
+      "total_population": 1535,
+      "initial_district_id": "d4",
+      "name": "Exurb (-2,5)",
+      "demographic_groups": [
+        {
+          "id": "p117-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.8105, "ryu": 0.1895 }
+        }
+      ]
+    },
+    {
+      "id": "p118",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -1, "r": 5 },
+      "total_population": 1471,
+      "initial_district_id": "d4",
+      "name": "Exurb (-1,5)",
+      "demographic_groups": [
+        {
+          "id": "p118-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.7782, "ryu": 0.2218 }
+        }
+      ]
+    },
+    {
+      "id": "p119",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 0, "r": 5 },
+      "total_population": 1416,
+      "initial_district_id": "d4",
+      "name": "Exurb (0,5)",
+      "demographic_groups": [
+        {
+          "id": "p119-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.8302, "ryu": 0.1698 }
+        }
+      ]
+    },
+    {
+      "id": "p120",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 1, "r": 5 },
+      "total_population": 1416,
+      "initial_district_id": "d4",
+      "name": "Exurb (1,5)",
+      "demographic_groups": [
+        {
+          "id": "p120-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.8360, "ryu": 0.1640 }
+        }
+      ]
+    },
+    {
+      "id": "p121",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -6, "r": 6 },
+      "total_population": 1454,
+      "initial_district_id": "d5",
+      "name": "Exurb (-6,6)",
+      "demographic_groups": [
+        {
+          "id": "p121-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.7811, "ryu": 0.2189 }
+        }
+      ]
+    },
+    {
+      "id": "p122",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -5, "r": 6 },
+      "total_population": 1508,
+      "initial_district_id": "d5",
+      "name": "Exurb (-5,6)",
+      "demographic_groups": [
+        {
+          "id": "p122-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.8059, "ryu": 0.1941 }
+        }
+      ]
+    },
+    {
+      "id": "p123",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -4, "r": 6 },
+      "total_population": 1452,
+      "initial_district_id": "d4",
+      "name": "Exurb (-4,6)",
+      "demographic_groups": [
+        {
+          "id": "p123-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.8352, "ryu": 0.1648 }
+        }
+      ]
+    },
+    {
+      "id": "p124",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -3, "r": 6 },
+      "total_population": 1436,
+      "initial_district_id": "d4",
+      "name": "Exurb (-3,6)",
+      "demographic_groups": [
+        {
+          "id": "p124-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.7609, "ryu": 0.2391 }
+        }
+      ]
+    },
+    {
+      "id": "p125",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -2, "r": 6 },
+      "total_population": 1541,
+      "initial_district_id": "d4",
+      "name": "Exurb (-2,6)",
+      "demographic_groups": [
+        {
+          "id": "p125-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.8389, "ryu": 0.1611 }
+        }
+      ]
+    },
+    {
+      "id": "p126",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": -1, "r": 6 },
+      "total_population": 1487,
+      "initial_district_id": "d4",
+      "name": "Exurb (-1,6)",
+      "demographic_groups": [
+        {
+          "id": "p126-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.7753, "ryu": 0.2247 }
+        }
+      ]
+    },
+    {
+      "id": "p127",
+      "editable": true,
+      "county_id": "accord_outer",
+      "position": { "q": 0, "r": 6 },
+      "total_population": 1431,
+      "initial_district_id": "d4",
+      "name": "Exurb (0,6)",
+      "demographic_groups": [
+        {
+          "id": "p127-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.8263, "ryu": 0.1737 }
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All five districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All five districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-compactness",
+      "required": true,
+      "description": "All districts must be reasonably compact — no long tentacles or thin strips (compactness ≥ 40%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.40
+      }
+    },
+    {
+      "id": "sc-efficiency-gap",
+      "required": false,
+      "description": "How close to zero can you get the efficiency gap on a purely neutral map? (≤ 10%).",
+      "criterion": {
+        "type": "efficiency_gap",
+        "operator": "lte",
+        "threshold": 0.10
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Independent Commissioner, Accord County Redistricting Commission",
+      "motivation": "After years of partisan warfare over district lines, both parties agreed to something remarkable: an independent commission with binding authority. The rules are strict — equal population, geographic compactness, contiguous districts. No partisan data allowed. Both sides signed off on the criteria. Now you draw the map."
+    },
+    "intro_slides": [
+      {
+        "heading": "The Accord",
+        "body": "It took two years of negotiations, three failed bills, and a court order, but both parties finally agreed: an independent commission would draw the new map using strictly neutral criteria.\n\nNo partisan registration data. No incumbent addresses. Just geometry: equal population, compact districts, no disconnected pieces. Both parties signed the agreement. Both parties praised it publicly."
+      },
+      {
+        "heading": "The Problem with Perfect Neutrality",
+        "body": "Here's what both parties understood privately, even as they signed: neutral rules don't produce neutral outcomes. They produce outcomes driven by geography.\n\nIn Accord County, geography has a lean. Ryu voters cluster tightly in the urban core. Ken voters spread across the suburbs and exurbs. Any compact map will reflect that geography — not because anyone drew it that way, but because that's where people live."
+      },
+      {
+        "heading": "A Fair Process, An Unfair Outcome?",
+        "body": "Draw the most geometrically neutral map you can. Then submit it and look at the results.\n\nBoth parties will complain. Ryu will say the compact map packed their voters unfairly. Ken will say their geographic spread deserves more representation. Both arguments will have merit.\n\nThis is not a bug in your map. It's a feature of representative democracy that no one has solved."
+      }
+    ],
+    "objective": "Apply the agreed neutral criteria. Draw a compact, population-balanced map. Watch both sides declare the process rigged."
+  }
+}

--- a/game/scenarios/scenario-009.json
+++ b/game/scenarios/scenario-009.json
@@ -1,0 +1,2384 @@
+{
+  "format_version": "1",
+  "id": "scenario-009",
+  "title": "Cats vs. Dogs",
+  "election_type": "state_house",
+  "region": {
+    "id": "pawprint_county",
+    "name": "Pawprint County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "cat", "name": "Cat Party", "abbreviation": "CAT" },
+    { "id": "dog", "name": "Dog Party", "abbreviation": "DOG" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" },
+    { "id": "d5", "name": "District 5" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+    {
+      "id": "p001",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 0, "r": -6 },
+      "total_population": 1644,
+      "initial_district_id": "d5",
+      "name": "Dogdale (0,-6)",
+      "demographic_groups": [
+        {
+          "id": "p001-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.4103, "dog": 0.5897 }
+        }
+      ]
+    },
+    {
+      "id": "p002",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 1, "r": -6 },
+      "total_population": 1593,
+      "initial_district_id": "d5",
+      "name": "Dogdale (1,-6)",
+      "demographic_groups": [
+        {
+          "id": "p002-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "cat": 0.4495, "dog": 0.5505 }
+        }
+      ]
+    },
+    {
+      "id": "p003",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 2, "r": -6 },
+      "total_population": 1580,
+      "initial_district_id": "d5",
+      "name": "Dogdale (2,-6)",
+      "demographic_groups": [
+        {
+          "id": "p003-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "cat": 0.4298, "dog": 0.5702 }
+        }
+      ]
+    },
+    {
+      "id": "p004",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 3, "r": -6 },
+      "total_population": 1556,
+      "initial_district_id": "d5",
+      "name": "Dogdale (3,-6)",
+      "demographic_groups": [
+        {
+          "id": "p004-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.4472, "dog": 0.5528 }
+        }
+      ]
+    },
+    {
+      "id": "p005",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": -6 },
+      "total_population": 1591,
+      "initial_district_id": "d5",
+      "name": "Dogdale (4,-6)",
+      "demographic_groups": [
+        {
+          "id": "p005-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "cat": 0.4211, "dog": 0.5789 }
+        }
+      ]
+    },
+    {
+      "id": "p006",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 5, "r": -6 },
+      "total_population": 1589,
+      "initial_district_id": "d5",
+      "name": "Dogdale (5,-6)",
+      "demographic_groups": [
+        {
+          "id": "p006-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.4526, "dog": 0.5474 }
+        }
+      ]
+    },
+    {
+      "id": "p007",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 6, "r": -6 },
+      "total_population": 1590,
+      "initial_district_id": "d5",
+      "name": "Dogdale (6,-6)",
+      "demographic_groups": [
+        {
+          "id": "p007-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.3991, "dog": 0.6009 }
+        }
+      ]
+    },
+    {
+      "id": "p008",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -1, "r": -5 },
+      "total_population": 1455,
+      "initial_district_id": "d5",
+      "name": "Dogdale (-1,-5)",
+      "demographic_groups": [
+        {
+          "id": "p008-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "cat": 0.4331, "dog": 0.5669 }
+        }
+      ]
+    },
+    {
+      "id": "p009",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 0, "r": -5 },
+      "total_population": 1567,
+      "initial_district_id": "d5",
+      "name": "Dogdale (0,-5)",
+      "demographic_groups": [
+        {
+          "id": "p009-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "cat": 0.4492, "dog": 0.5508 }
+        }
+      ]
+    },
+    {
+      "id": "p010",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 1, "r": -5 },
+      "total_population": 1465,
+      "initial_district_id": "d5",
+      "name": "Dogdale (1,-5)",
+      "demographic_groups": [
+        {
+          "id": "p010-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.4582, "dog": 0.5418 }
+        }
+      ]
+    },
+    {
+      "id": "p011",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 2, "r": -5 },
+      "total_population": 1649,
+      "initial_district_id": "d5",
+      "name": "Dogdale (2,-5)",
+      "demographic_groups": [
+        {
+          "id": "p011-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.4166, "dog": 0.5834 }
+        }
+      ]
+    },
+    {
+      "id": "p012",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 3, "r": -5 },
+      "total_population": 1358,
+      "initial_district_id": "d5",
+      "name": "Dogdale (3,-5)",
+      "demographic_groups": [
+        {
+          "id": "p012-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.3894, "dog": 0.6106 }
+        }
+      ]
+    },
+    {
+      "id": "p013",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": -5 },
+      "total_population": 1408,
+      "initial_district_id": "d5",
+      "name": "Dogdale (4,-5)",
+      "demographic_groups": [
+        {
+          "id": "p013-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "cat": 0.4240, "dog": 0.5760 }
+        }
+      ]
+    },
+    {
+      "id": "p014",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 5, "r": -5 },
+      "total_population": 1611,
+      "initial_district_id": "d5",
+      "name": "Dogdale (5,-5)",
+      "demographic_groups": [
+        {
+          "id": "p014-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.4310, "dog": 0.5690 }
+        }
+      ]
+    },
+    {
+      "id": "p015",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 6, "r": -5 },
+      "total_population": 1618,
+      "initial_district_id": "d5",
+      "name": "Dogdale (6,-5)",
+      "demographic_groups": [
+        {
+          "id": "p015-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "cat": 0.3900, "dog": 0.6100 }
+        }
+      ]
+    },
+    {
+      "id": "p016",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -2, "r": -4 },
+      "total_population": 1562,
+      "initial_district_id": "d5",
+      "name": "Dogdale (-2,-4)",
+      "demographic_groups": [
+        {
+          "id": "p016-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.3937, "dog": 0.6063 }
+        }
+      ]
+    },
+    {
+      "id": "p017",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -1, "r": -4 },
+      "total_population": 1529,
+      "initial_district_id": "d5",
+      "name": "Dogdale (-1,-4)",
+      "demographic_groups": [
+        {
+          "id": "p017-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "cat": 0.4510, "dog": 0.5490 }
+        }
+      ]
+    },
+    {
+      "id": "p018",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 0, "r": -4 },
+      "total_population": 1625,
+      "initial_district_id": "d5",
+      "name": "Midtown (0,-4)",
+      "demographic_groups": [
+        {
+          "id": "p018-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.7402, "dog": 0.2598 }
+        }
+      ]
+    },
+    {
+      "id": "p019",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 1, "r": -4 },
+      "total_population": 1409,
+      "initial_district_id": "d5",
+      "name": "Midtown (1,-4)",
+      "demographic_groups": [
+        {
+          "id": "p019-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.7114, "dog": 0.2886 }
+        }
+      ]
+    },
+    {
+      "id": "p020",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 2, "r": -4 },
+      "total_population": 1463,
+      "initial_district_id": "d5",
+      "name": "Midtown (2,-4)",
+      "demographic_groups": [
+        {
+          "id": "p020-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "cat": 0.7080, "dog": 0.2920 }
+        }
+      ]
+    },
+    {
+      "id": "p021",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 3, "r": -4 },
+      "total_population": 1631,
+      "initial_district_id": "d5",
+      "name": "Midtown (3,-4)",
+      "demographic_groups": [
+        {
+          "id": "p021-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.6944, "dog": 0.3056 }
+        }
+      ]
+    },
+    {
+      "id": "p022",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": -4 },
+      "total_population": 1474,
+      "initial_district_id": "d5",
+      "name": "Midtown (4,-4)",
+      "demographic_groups": [
+        {
+          "id": "p022-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "cat": 0.7167, "dog": 0.2833 }
+        }
+      ]
+    },
+    {
+      "id": "p023",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 5, "r": -4 },
+      "total_population": 1376,
+      "initial_district_id": "d5",
+      "name": "Dogdale (5,-4)",
+      "demographic_groups": [
+        {
+          "id": "p023-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.4283, "dog": 0.5717 }
+        }
+      ]
+    },
+    {
+      "id": "p024",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 6, "r": -4 },
+      "total_population": 1471,
+      "initial_district_id": "d5",
+      "name": "Dogdale (6,-4)",
+      "demographic_groups": [
+        {
+          "id": "p024-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "cat": 0.4109, "dog": 0.5891 }
+        }
+      ]
+    },
+    {
+      "id": "p025",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -3, "r": -3 },
+      "total_population": 1421,
+      "initial_district_id": "d5",
+      "name": "Dogdale (-3,-3)",
+      "demographic_groups": [
+        {
+          "id": "p025-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "cat": 0.4101, "dog": 0.5899 }
+        }
+      ]
+    },
+    {
+      "id": "p026",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -2, "r": -3 },
+      "total_population": 1548,
+      "initial_district_id": "d5",
+      "name": "Dogdale (-2,-3)",
+      "demographic_groups": [
+        {
+          "id": "p026-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.4232, "dog": 0.5768 }
+        }
+      ]
+    },
+    {
+      "id": "p027",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -1, "r": -3 },
+      "total_population": 1360,
+      "initial_district_id": "d5",
+      "name": "Midtown (-1,-3)",
+      "demographic_groups": [
+        {
+          "id": "p027-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.7388, "dog": 0.2612 }
+        }
+      ]
+    },
+    {
+      "id": "p028",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 0, "r": -3 },
+      "total_population": 1549,
+      "initial_district_id": "d5",
+      "name": "Midtown (0,-3)",
+      "demographic_groups": [
+        {
+          "id": "p028-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.6884, "dog": 0.3116 }
+        }
+      ]
+    },
+    {
+      "id": "p029",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 1, "r": -3 },
+      "total_population": 1466,
+      "initial_district_id": "d5",
+      "name": "Midtown (1,-3)",
+      "demographic_groups": [
+        {
+          "id": "p029-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "cat": 0.7259, "dog": 0.2741 }
+        }
+      ]
+    },
+    {
+      "id": "p030",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 2, "r": -3 },
+      "total_population": 1644,
+      "initial_district_id": "d5",
+      "name": "Midtown (2,-3)",
+      "demographic_groups": [
+        {
+          "id": "p030-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.7409, "dog": 0.2591 }
+        }
+      ]
+    },
+    {
+      "id": "p031",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 3, "r": -3 },
+      "total_population": 1643,
+      "initial_district_id": "d5",
+      "name": "Midtown (3,-3)",
+      "demographic_groups": [
+        {
+          "id": "p031-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "cat": 0.7198, "dog": 0.2802 }
+        }
+      ]
+    },
+    {
+      "id": "p032",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": -3 },
+      "total_population": 1535,
+      "initial_district_id": "d5",
+      "name": "Midtown (4,-3)",
+      "demographic_groups": [
+        {
+          "id": "p032-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "cat": 0.7575, "dog": 0.2425 }
+        }
+      ]
+    },
+    {
+      "id": "p033",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 5, "r": -3 },
+      "total_population": 1361,
+      "initial_district_id": "d5",
+      "name": "Dogdale (5,-3)",
+      "demographic_groups": [
+        {
+          "id": "p033-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.4359, "dog": 0.5641 }
+        }
+      ]
+    },
+    {
+      "id": "p034",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 6, "r": -3 },
+      "total_population": 1503,
+      "initial_district_id": "d5",
+      "name": "Dogdale (6,-3)",
+      "demographic_groups": [
+        {
+          "id": "p034-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.4408, "dog": 0.5592 }
+        }
+      ]
+    },
+    {
+      "id": "p035",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": -2 },
+      "total_population": 1551,
+      "initial_district_id": "d4",
+      "name": "Dogdale (-4,-2)",
+      "demographic_groups": [
+        {
+          "id": "p035-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "cat": 0.4240, "dog": 0.5760 }
+        }
+      ]
+    },
+    {
+      "id": "p036",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -3, "r": -2 },
+      "total_population": 1584,
+      "initial_district_id": "d4",
+      "name": "Dogdale (-3,-2)",
+      "demographic_groups": [
+        {
+          "id": "p036-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.4072, "dog": 0.5928 }
+        }
+      ]
+    },
+    {
+      "id": "p037",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -2, "r": -2 },
+      "total_population": 1600,
+      "initial_district_id": "d4",
+      "name": "Midtown (-2,-2)",
+      "demographic_groups": [
+        {
+          "id": "p037-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "cat": 0.7146, "dog": 0.2854 }
+        }
+      ]
+    },
+    {
+      "id": "p038",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -1, "r": -2 },
+      "total_population": 1382,
+      "initial_district_id": "d4",
+      "name": "Midtown (-1,-2)",
+      "demographic_groups": [
+        {
+          "id": "p038-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "cat": 0.7443, "dog": 0.2557 }
+        }
+      ]
+    },
+    {
+      "id": "p039",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 0, "r": -2 },
+      "total_population": 1509,
+      "initial_district_id": "d4",
+      "name": "Catville (0,-2)",
+      "demographic_groups": [
+        {
+          "id": "p039-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.8261, "dog": 0.1739 }
+        }
+      ]
+    },
+    {
+      "id": "p040",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 1, "r": -2 },
+      "total_population": 1489,
+      "initial_district_id": "d4",
+      "name": "Catville (1,-2)",
+      "demographic_groups": [
+        {
+          "id": "p040-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.8174, "dog": 0.1826 }
+        }
+      ]
+    },
+    {
+      "id": "p041",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 2, "r": -2 },
+      "total_population": 1598,
+      "initial_district_id": "d4",
+      "name": "Catville (2,-2)",
+      "demographic_groups": [
+        {
+          "id": "p041-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.8159, "dog": 0.1841 }
+        }
+      ]
+    },
+    {
+      "id": "p042",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 3, "r": -2 },
+      "total_population": 1385,
+      "initial_district_id": "d4",
+      "name": "Midtown (3,-2)",
+      "demographic_groups": [
+        {
+          "id": "p042-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.7162, "dog": 0.2838 }
+        }
+      ]
+    },
+    {
+      "id": "p043",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": -2 },
+      "total_population": 1350,
+      "initial_district_id": "d4",
+      "name": "Midtown (4,-2)",
+      "demographic_groups": [
+        {
+          "id": "p043-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.7432, "dog": 0.2568 }
+        }
+      ]
+    },
+    {
+      "id": "p044",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 5, "r": -2 },
+      "total_population": 1371,
+      "initial_district_id": "d4",
+      "name": "Dogdale (5,-2)",
+      "demographic_groups": [
+        {
+          "id": "p044-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "cat": 0.4213, "dog": 0.5787 }
+        }
+      ]
+    },
+    {
+      "id": "p045",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 6, "r": -2 },
+      "total_population": 1379,
+      "initial_district_id": "d4",
+      "name": "Dogdale (6,-2)",
+      "demographic_groups": [
+        {
+          "id": "p045-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.4561, "dog": 0.5439 }
+        }
+      ]
+    },
+    {
+      "id": "p046",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -5, "r": -1 },
+      "total_population": 1358,
+      "initial_district_id": "d4",
+      "name": "Dogdale (-5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p046-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.3911, "dog": 0.6089 }
+        }
+      ]
+    },
+    {
+      "id": "p047",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": -1 },
+      "total_population": 1550,
+      "initial_district_id": "d4",
+      "name": "Dogdale (-4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p047-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "cat": 0.4011, "dog": 0.5989 }
+        }
+      ]
+    },
+    {
+      "id": "p048",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -3, "r": -1 },
+      "total_population": 1421,
+      "initial_district_id": "d4",
+      "name": "Midtown (-3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p048-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.6999, "dog": 0.3001 }
+        }
+      ]
+    },
+    {
+      "id": "p049",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -2, "r": -1 },
+      "total_population": 1569,
+      "initial_district_id": "d4",
+      "name": "Midtown (-2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p049-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "cat": 0.6894, "dog": 0.3106 }
+        }
+      ]
+    },
+    {
+      "id": "p050",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -1, "r": -1 },
+      "total_population": 1590,
+      "initial_district_id": "d4",
+      "name": "Catville (-1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p050-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "cat": 0.8496, "dog": 0.1504 }
+        }
+      ]
+    },
+    {
+      "id": "p051",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 0, "r": -1 },
+      "total_population": 1456,
+      "initial_district_id": "d4",
+      "name": "Catville (0,-1)",
+      "demographic_groups": [
+        {
+          "id": "p051-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.8542, "dog": 0.1458 }
+        }
+      ]
+    },
+    {
+      "id": "p052",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 1, "r": -1 },
+      "total_population": 1387,
+      "initial_district_id": "d4",
+      "name": "Catville (1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p052-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.8411, "dog": 0.1589 }
+        }
+      ]
+    },
+    {
+      "id": "p053",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 2, "r": -1 },
+      "total_population": 1427,
+      "initial_district_id": "d4",
+      "name": "Catville (2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p053-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.7836, "dog": 0.2164 }
+        }
+      ]
+    },
+    {
+      "id": "p054",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 3, "r": -1 },
+      "total_population": 1526,
+      "initial_district_id": "d4",
+      "name": "Midtown (3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p054-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.6801, "dog": 0.3199 }
+        }
+      ]
+    },
+    {
+      "id": "p055",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": -1 },
+      "total_population": 1368,
+      "initial_district_id": "d4",
+      "name": "Midtown (4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p055-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "cat": 0.7413, "dog": 0.2587 }
+        }
+      ]
+    },
+    {
+      "id": "p056",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 5, "r": -1 },
+      "total_population": 1626,
+      "initial_district_id": "d4",
+      "name": "Dogdale (5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p056-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "cat": 0.4595, "dog": 0.5405 }
+        }
+      ]
+    },
+    {
+      "id": "p057",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 6, "r": -1 },
+      "total_population": 1469,
+      "initial_district_id": "d4",
+      "name": "Dogdale (6,-1)",
+      "demographic_groups": [
+        {
+          "id": "p057-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.3958, "dog": 0.6042 }
+        }
+      ]
+    },
+    {
+      "id": "p058",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -6, "r": 0 },
+      "total_population": 1645,
+      "initial_district_id": "d3",
+      "name": "Dogdale (-6,0)",
+      "demographic_groups": [
+        {
+          "id": "p058-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.4465, "dog": 0.5535 }
+        }
+      ]
+    },
+    {
+      "id": "p059",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -5, "r": 0 },
+      "total_population": 1376,
+      "initial_district_id": "d3",
+      "name": "Dogdale (-5,0)",
+      "demographic_groups": [
+        {
+          "id": "p059-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.3853, "dog": 0.6147 }
+        }
+      ]
+    },
+    {
+      "id": "p060",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": 0 },
+      "total_population": 1398,
+      "initial_district_id": "d3",
+      "name": "Midtown (-4,0)",
+      "demographic_groups": [
+        {
+          "id": "p060-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "cat": 0.7413, "dog": 0.2587 }
+        }
+      ]
+    },
+    {
+      "id": "p061",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -3, "r": 0 },
+      "total_population": 1625,
+      "initial_district_id": "d3",
+      "name": "Midtown (-3,0)",
+      "demographic_groups": [
+        {
+          "id": "p061-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.7555, "dog": 0.2445 }
+        }
+      ]
+    },
+    {
+      "id": "p062",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -2, "r": 0 },
+      "total_population": 1438,
+      "initial_district_id": "d3",
+      "name": "Catville (-2,0)",
+      "demographic_groups": [
+        {
+          "id": "p062-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.8476, "dog": 0.1524 }
+        }
+      ]
+    },
+    {
+      "id": "p063",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -1, "r": 0 },
+      "total_population": 1450,
+      "initial_district_id": "d3",
+      "name": "Catville (-1,0)",
+      "demographic_groups": [
+        {
+          "id": "p063-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "cat": 0.8053, "dog": 0.1947 }
+        }
+      ]
+    },
+    {
+      "id": "p064",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 0, "r": 0 },
+      "total_population": 1586,
+      "initial_district_id": "d3",
+      "name": "Catville (0,0)",
+      "demographic_groups": [
+        {
+          "id": "p064-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.8304, "dog": 0.1696 }
+        }
+      ]
+    },
+    {
+      "id": "p065",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 1, "r": 0 },
+      "total_population": 1384,
+      "initial_district_id": "d3",
+      "name": "Catville (1,0)",
+      "demographic_groups": [
+        {
+          "id": "p065-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.7926, "dog": 0.2074 }
+        }
+      ]
+    },
+    {
+      "id": "p066",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 2, "r": 0 },
+      "total_population": 1541,
+      "initial_district_id": "d3",
+      "name": "Catville (2,0)",
+      "demographic_groups": [
+        {
+          "id": "p066-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.8196, "dog": 0.1804 }
+        }
+      ]
+    },
+    {
+      "id": "p067",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 3, "r": 0 },
+      "total_population": 1434,
+      "initial_district_id": "d3",
+      "name": "Midtown (3,0)",
+      "demographic_groups": [
+        {
+          "id": "p067-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.6923, "dog": 0.3077 }
+        }
+      ]
+    },
+    {
+      "id": "p068",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": 0 },
+      "total_population": 1503,
+      "initial_district_id": "d3",
+      "name": "Midtown (4,0)",
+      "demographic_groups": [
+        {
+          "id": "p068-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.7418, "dog": 0.2582 }
+        }
+      ]
+    },
+    {
+      "id": "p069",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 5, "r": 0 },
+      "total_population": 1434,
+      "initial_district_id": "d3",
+      "name": "Dogdale (5,0)",
+      "demographic_groups": [
+        {
+          "id": "p069-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.4003, "dog": 0.5997 }
+        }
+      ]
+    },
+    {
+      "id": "p070",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 6, "r": 0 },
+      "total_population": 1410,
+      "initial_district_id": "d3",
+      "name": "Dogdale (6,0)",
+      "demographic_groups": [
+        {
+          "id": "p070-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.4212, "dog": 0.5788 }
+        }
+      ]
+    },
+    {
+      "id": "p071",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -6, "r": 1 },
+      "total_population": 1597,
+      "initial_district_id": "d2",
+      "name": "Dogdale (-6,1)",
+      "demographic_groups": [
+        {
+          "id": "p071-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "cat": 0.4008, "dog": 0.5992 }
+        }
+      ]
+    },
+    {
+      "id": "p072",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -5, "r": 1 },
+      "total_population": 1375,
+      "initial_district_id": "d2",
+      "name": "Dogdale (-5,1)",
+      "demographic_groups": [
+        {
+          "id": "p072-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.4545, "dog": 0.5455 }
+        }
+      ]
+    },
+    {
+      "id": "p073",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": 1 },
+      "total_population": 1604,
+      "initial_district_id": "d2",
+      "name": "Midtown (-4,1)",
+      "demographic_groups": [
+        {
+          "id": "p073-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.6933, "dog": 0.3067 }
+        }
+      ]
+    },
+    {
+      "id": "p074",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -3, "r": 1 },
+      "total_population": 1466,
+      "initial_district_id": "d2",
+      "name": "Midtown (-3,1)",
+      "demographic_groups": [
+        {
+          "id": "p074-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.7340, "dog": 0.2660 }
+        }
+      ]
+    },
+    {
+      "id": "p075",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -2, "r": 1 },
+      "total_population": 1546,
+      "initial_district_id": "d2",
+      "name": "Catville (-2,1)",
+      "demographic_groups": [
+        {
+          "id": "p075-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "cat": 0.8314, "dog": 0.1686 }
+        }
+      ]
+    },
+    {
+      "id": "p076",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -1, "r": 1 },
+      "total_population": 1374,
+      "initial_district_id": "d2",
+      "name": "Catville (-1,1)",
+      "demographic_groups": [
+        {
+          "id": "p076-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "cat": 0.7821, "dog": 0.2179 }
+        }
+      ]
+    },
+    {
+      "id": "p077",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 0, "r": 1 },
+      "total_population": 1649,
+      "initial_district_id": "d2",
+      "name": "Catville (0,1)",
+      "demographic_groups": [
+        {
+          "id": "p077-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.7951, "dog": 0.2049 }
+        }
+      ]
+    },
+    {
+      "id": "p078",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 1, "r": 1 },
+      "total_population": 1357,
+      "initial_district_id": "d2",
+      "name": "Catville (1,1)",
+      "demographic_groups": [
+        {
+          "id": "p078-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.8493, "dog": 0.1507 }
+        }
+      ]
+    },
+    {
+      "id": "p079",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 2, "r": 1 },
+      "total_population": 1577,
+      "initial_district_id": "d2",
+      "name": "Midtown (2,1)",
+      "demographic_groups": [
+        {
+          "id": "p079-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "cat": 0.7038, "dog": 0.2962 }
+        }
+      ]
+    },
+    {
+      "id": "p080",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 3, "r": 1 },
+      "total_population": 1552,
+      "initial_district_id": "d2",
+      "name": "Midtown (3,1)",
+      "demographic_groups": [
+        {
+          "id": "p080-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.7483, "dog": 0.2517 }
+        }
+      ]
+    },
+    {
+      "id": "p081",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": 1 },
+      "total_population": 1552,
+      "initial_district_id": "d2",
+      "name": "Dogdale (4,1)",
+      "demographic_groups": [
+        {
+          "id": "p081-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.4513, "dog": 0.5487 }
+        }
+      ]
+    },
+    {
+      "id": "p082",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 5, "r": 1 },
+      "total_population": 1497,
+      "initial_district_id": "d2",
+      "name": "Dogdale (5,1)",
+      "demographic_groups": [
+        {
+          "id": "p082-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.4341, "dog": 0.5659 }
+        }
+      ]
+    },
+    {
+      "id": "p083",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -6, "r": 2 },
+      "total_population": 1496,
+      "initial_district_id": "d2",
+      "name": "Dogdale (-6,2)",
+      "demographic_groups": [
+        {
+          "id": "p083-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "cat": 0.3831, "dog": 0.6169 }
+        }
+      ]
+    },
+    {
+      "id": "p084",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -5, "r": 2 },
+      "total_population": 1540,
+      "initial_district_id": "d2",
+      "name": "Dogdale (-5,2)",
+      "demographic_groups": [
+        {
+          "id": "p084-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.4485, "dog": 0.5515 }
+        }
+      ]
+    },
+    {
+      "id": "p085",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": 2 },
+      "total_population": 1371,
+      "initial_district_id": "d2",
+      "name": "Midtown (-4,2)",
+      "demographic_groups": [
+        {
+          "id": "p085-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.6988, "dog": 0.3012 }
+        }
+      ]
+    },
+    {
+      "id": "p086",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -3, "r": 2 },
+      "total_population": 1638,
+      "initial_district_id": "d2",
+      "name": "Midtown (-3,2)",
+      "demographic_groups": [
+        {
+          "id": "p086-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.6847, "dog": 0.3153 }
+        }
+      ]
+    },
+    {
+      "id": "p087",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -2, "r": 2 },
+      "total_population": 1451,
+      "initial_district_id": "d2",
+      "name": "Catville (-2,2)",
+      "demographic_groups": [
+        {
+          "id": "p087-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "cat": 0.8403, "dog": 0.1597 }
+        }
+      ]
+    },
+    {
+      "id": "p088",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -1, "r": 2 },
+      "total_population": 1522,
+      "initial_district_id": "d2",
+      "name": "Catville (-1,2)",
+      "demographic_groups": [
+        {
+          "id": "p088-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.7935, "dog": 0.2065 }
+        }
+      ]
+    },
+    {
+      "id": "p089",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 0, "r": 2 },
+      "total_population": 1561,
+      "initial_district_id": "d2",
+      "name": "Catville (0,2)",
+      "demographic_groups": [
+        {
+          "id": "p089-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "cat": 0.7935, "dog": 0.2065 }
+        }
+      ]
+    },
+    {
+      "id": "p090",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 1, "r": 2 },
+      "total_population": 1446,
+      "initial_district_id": "d2",
+      "name": "Midtown (1,2)",
+      "demographic_groups": [
+        {
+          "id": "p090-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "cat": 0.7424, "dog": 0.2576 }
+        }
+      ]
+    },
+    {
+      "id": "p091",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 2, "r": 2 },
+      "total_population": 1433,
+      "initial_district_id": "d2",
+      "name": "Midtown (2,2)",
+      "demographic_groups": [
+        {
+          "id": "p091-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.7109, "dog": 0.2891 }
+        }
+      ]
+    },
+    {
+      "id": "p092",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 3, "r": 2 },
+      "total_population": 1621,
+      "initial_district_id": "d2",
+      "name": "Dogdale (3,2)",
+      "demographic_groups": [
+        {
+          "id": "p092-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "cat": 0.3896, "dog": 0.6104 }
+        }
+      ]
+    },
+    {
+      "id": "p093",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 4, "r": 2 },
+      "total_population": 1582,
+      "initial_district_id": "d2",
+      "name": "Dogdale (4,2)",
+      "demographic_groups": [
+        {
+          "id": "p093-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "cat": 0.3854, "dog": 0.6146 }
+        }
+      ]
+    },
+    {
+      "id": "p094",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -6, "r": 3 },
+      "total_population": 1646,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-6,3)",
+      "demographic_groups": [
+        {
+          "id": "p094-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "cat": 0.4549, "dog": 0.5451 }
+        }
+      ]
+    },
+    {
+      "id": "p095",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -5, "r": 3 },
+      "total_population": 1554,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-5,3)",
+      "demographic_groups": [
+        {
+          "id": "p095-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.4483, "dog": 0.5517 }
+        }
+      ]
+    },
+    {
+      "id": "p096",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": 3 },
+      "total_population": 1529,
+      "initial_district_id": "d1",
+      "name": "Midtown (-4,3)",
+      "demographic_groups": [
+        {
+          "id": "p096-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.7204, "dog": 0.2796 }
+        }
+      ]
+    },
+    {
+      "id": "p097",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -3, "r": 3 },
+      "total_population": 1548,
+      "initial_district_id": "d1",
+      "name": "Midtown (-3,3)",
+      "demographic_groups": [
+        {
+          "id": "p097-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.7177, "dog": 0.2823 }
+        }
+      ]
+    },
+    {
+      "id": "p098",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -2, "r": 3 },
+      "total_population": 1537,
+      "initial_district_id": "d1",
+      "name": "Midtown (-2,3)",
+      "demographic_groups": [
+        {
+          "id": "p098-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "cat": 0.7094, "dog": 0.2906 }
+        }
+      ]
+    },
+    {
+      "id": "p099",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": -1, "r": 3 },
+      "total_population": 1400,
+      "initial_district_id": "d1",
+      "name": "Midtown (-1,3)",
+      "demographic_groups": [
+        {
+          "id": "p099-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "cat": 0.7119, "dog": 0.2881 }
+        }
+      ]
+    },
+    {
+      "id": "p100",
+      "editable": true,
+      "county_id": "catville",
+      "position": { "q": 0, "r": 3 },
+      "total_population": 1534,
+      "initial_district_id": "d1",
+      "name": "Midtown (0,3)",
+      "demographic_groups": [
+        {
+          "id": "p100-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.7359, "dog": 0.2641 }
+        }
+      ]
+    },
+    {
+      "id": "p101",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 1, "r": 3 },
+      "total_population": 1393,
+      "initial_district_id": "d1",
+      "name": "Midtown (1,3)",
+      "demographic_groups": [
+        {
+          "id": "p101-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.6982, "dog": 0.3018 }
+        }
+      ]
+    },
+    {
+      "id": "p102",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 2, "r": 3 },
+      "total_population": 1423,
+      "initial_district_id": "d1",
+      "name": "Dogdale (2,3)",
+      "demographic_groups": [
+        {
+          "id": "p102-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.4050, "dog": 0.5950 }
+        }
+      ]
+    },
+    {
+      "id": "p103",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 3, "r": 3 },
+      "total_population": 1374,
+      "initial_district_id": "d1",
+      "name": "Dogdale (3,3)",
+      "demographic_groups": [
+        {
+          "id": "p103-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.4138, "dog": 0.5862 }
+        }
+      ]
+    },
+    {
+      "id": "p104",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -6, "r": 4 },
+      "total_population": 1368,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-6,4)",
+      "demographic_groups": [
+        {
+          "id": "p104-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.3816, "dog": 0.6184 }
+        }
+      ]
+    },
+    {
+      "id": "p105",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -5, "r": 4 },
+      "total_population": 1407,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-5,4)",
+      "demographic_groups": [
+        {
+          "id": "p105-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "cat": 0.4039, "dog": 0.5961 }
+        }
+      ]
+    },
+    {
+      "id": "p106",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": 4 },
+      "total_population": 1536,
+      "initial_district_id": "d1",
+      "name": "Midtown (-4,4)",
+      "demographic_groups": [
+        {
+          "id": "p106-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.6912, "dog": 0.3088 }
+        }
+      ]
+    },
+    {
+      "id": "p107",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -3, "r": 4 },
+      "total_population": 1612,
+      "initial_district_id": "d1",
+      "name": "Midtown (-3,4)",
+      "demographic_groups": [
+        {
+          "id": "p107-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.7022, "dog": 0.2978 }
+        }
+      ]
+    },
+    {
+      "id": "p108",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -2, "r": 4 },
+      "total_population": 1585,
+      "initial_district_id": "d1",
+      "name": "Midtown (-2,4)",
+      "demographic_groups": [
+        {
+          "id": "p108-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.7191, "dog": 0.2809 }
+        }
+      ]
+    },
+    {
+      "id": "p109",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -1, "r": 4 },
+      "total_population": 1479,
+      "initial_district_id": "d1",
+      "name": "Midtown (-1,4)",
+      "demographic_groups": [
+        {
+          "id": "p109-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "cat": 0.6883, "dog": 0.3117 }
+        }
+      ]
+    },
+    {
+      "id": "p110",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 0, "r": 4 },
+      "total_population": 1405,
+      "initial_district_id": "d1",
+      "name": "Midtown (0,4)",
+      "demographic_groups": [
+        {
+          "id": "p110-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "cat": 0.7302, "dog": 0.2698 }
+        }
+      ]
+    },
+    {
+      "id": "p111",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 1, "r": 4 },
+      "total_population": 1400,
+      "initial_district_id": "d1",
+      "name": "Dogdale (1,4)",
+      "demographic_groups": [
+        {
+          "id": "p111-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "cat": 0.4177, "dog": 0.5823 }
+        }
+      ]
+    },
+    {
+      "id": "p112",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 2, "r": 4 },
+      "total_population": 1635,
+      "initial_district_id": "d1",
+      "name": "Dogdale (2,4)",
+      "demographic_groups": [
+        {
+          "id": "p112-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.4576, "dog": 0.5424 }
+        }
+      ]
+    },
+    {
+      "id": "p113",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -6, "r": 5 },
+      "total_population": 1435,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-6,5)",
+      "demographic_groups": [
+        {
+          "id": "p113-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "cat": 0.4473, "dog": 0.5527 }
+        }
+      ]
+    },
+    {
+      "id": "p114",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -5, "r": 5 },
+      "total_population": 1510,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-5,5)",
+      "demographic_groups": [
+        {
+          "id": "p114-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "cat": 0.4518, "dog": 0.5482 }
+        }
+      ]
+    },
+    {
+      "id": "p115",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": 5 },
+      "total_population": 1409,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-4,5)",
+      "demographic_groups": [
+        {
+          "id": "p115-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.4437, "dog": 0.5563 }
+        }
+      ]
+    },
+    {
+      "id": "p116",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -3, "r": 5 },
+      "total_population": 1570,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-3,5)",
+      "demographic_groups": [
+        {
+          "id": "p116-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "cat": 0.4152, "dog": 0.5848 }
+        }
+      ]
+    },
+    {
+      "id": "p117",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -2, "r": 5 },
+      "total_population": 1617,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-2,5)",
+      "demographic_groups": [
+        {
+          "id": "p117-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "cat": 0.4470, "dog": 0.5530 }
+        }
+      ]
+    },
+    {
+      "id": "p118",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -1, "r": 5 },
+      "total_population": 1534,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-1,5)",
+      "demographic_groups": [
+        {
+          "id": "p118-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "cat": 0.3920, "dog": 0.6080 }
+        }
+      ]
+    },
+    {
+      "id": "p119",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 0, "r": 5 },
+      "total_population": 1408,
+      "initial_district_id": "d1",
+      "name": "Dogdale (0,5)",
+      "demographic_groups": [
+        {
+          "id": "p119-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.4032, "dog": 0.5968 }
+        }
+      ]
+    },
+    {
+      "id": "p120",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 1, "r": 5 },
+      "total_population": 1546,
+      "initial_district_id": "d1",
+      "name": "Dogdale (1,5)",
+      "demographic_groups": [
+        {
+          "id": "p120-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.4409, "dog": 0.5591 }
+        }
+      ]
+    },
+    {
+      "id": "p121",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -6, "r": 6 },
+      "total_population": 1541,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-6,6)",
+      "demographic_groups": [
+        {
+          "id": "p121-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "cat": 0.3943, "dog": 0.6057 }
+        }
+      ]
+    },
+    {
+      "id": "p122",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -5, "r": 6 },
+      "total_population": 1607,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-5,6)",
+      "demographic_groups": [
+        {
+          "id": "p122-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.3944, "dog": 0.6056 }
+        }
+      ]
+    },
+    {
+      "id": "p123",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -4, "r": 6 },
+      "total_population": 1553,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-4,6)",
+      "demographic_groups": [
+        {
+          "id": "p123-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "cat": 0.4460, "dog": 0.5540 }
+        }
+      ]
+    },
+    {
+      "id": "p124",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -3, "r": 6 },
+      "total_population": 1399,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-3,6)",
+      "demographic_groups": [
+        {
+          "id": "p124-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "cat": 0.3854, "dog": 0.6146 }
+        }
+      ]
+    },
+    {
+      "id": "p125",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -2, "r": 6 },
+      "total_population": 1390,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-2,6)",
+      "demographic_groups": [
+        {
+          "id": "p125-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "cat": 0.4053, "dog": 0.5947 }
+        }
+      ]
+    },
+    {
+      "id": "p126",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": -1, "r": 6 },
+      "total_population": 1596,
+      "initial_district_id": "d1",
+      "name": "Dogdale (-1,6)",
+      "demographic_groups": [
+        {
+          "id": "p126-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "cat": 0.4066, "dog": 0.5934 }
+        }
+      ]
+    },
+    {
+      "id": "p127",
+      "editable": true,
+      "county_id": "dogdale",
+      "position": { "q": 0, "r": 6 },
+      "total_population": 1446,
+      "initial_district_id": "d1",
+      "name": "Dogdale (0,6)",
+      "demographic_groups": [
+        {
+          "id": "p127-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "cat": 0.4523, "dog": 0.5477 }
+        }
+      ]
+    }
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All five districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All five districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-compactness",
+      "required": true,
+      "description": "Districts must be geographically compact — no sprawling fur-balls (compactness ≥ 40%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.40
+      }
+    },
+    {
+      "id": "sc-safe-seats-cat",
+      "required": true,
+      "description": "The Cat Party must lock in at least 3 safe districts (winning margin ≥ 15 points).",
+      "criterion": {
+        "type": "safe_seats",
+        "party": "cat",
+        "margin": 0.15,
+        "min_count": 3
+      }
+    },
+    {
+      "id": "sc-safe-seats-dog",
+      "required": false,
+      "description": "Even dogs deserve one safe seat — can you give the Dog Party at least 1 district won by 15+ points?",
+      "criterion": {
+        "type": "safe_seats",
+        "party": "dog",
+        "margin": 0.15,
+        "min_count": 1
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Chief Map Strategist, Cat Party",
+      "motivation": "The Cat Party has controlled Pawprint County's legislature for years and intends to keep it that way. The census just came in. The lines need redrawing. Your job: make sure the Cats win at least three unlosable districts. The dogs are loud, but they don't have to be numerous."
+    },
+    "intro_slides": [
+      {
+        "heading": "It's a Dog-Eat-Cat World",
+        "body": "The Cat Party has held the majority in Pawprint County for years. The Dog Party has been nipping at their heels.\n\nThe census data is in. Boundaries must be redrawn. The Cat Party leadership has called you in for one reason: make it stick."
+      },
+      {
+        "heading": "The Math",
+        "body": "Cats make up about 60% of Pawprint County's voters — a comfortable majority in the urban core, but the outer precincts are more competitive.\n\nLeft to chance, those outer districts could swing either way. Your job is to take chance out of the equation. Draw lines that turn a majority into a durable map."
+      },
+      {
+        "heading": "Same Game, Different Fur",
+        "body": "You've seen this before — packing, cracking, population balance, compactness. The tools are the same whether you're drawing for Cats, Dogs, Ken, Ryu, or anyone else.\n\nThe rules of redistricting don't care about the players. Only the lines matter."
+      }
+    ],
+    "objective": "Draw a compact, population-balanced map that locks in at least 3 safe Cat Party districts (winning margin ≥ 15 points). Bonus: leave the dogs one safe seat to chew on."
+  }
+}

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -357,3 +357,207 @@ test("scenario-005 winnability: consolidating the valley into one district passe
   await expect(page.locator("#result-screen")).toBeVisible();
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
 });
+
+// ─── scenario-006: "Harden the Map" ─────────────────────────────────────────
+
+test("scenario-006 smoke: loads and renders 120 precincts", async ({ page }) => {
+  await page.goto("/?s=scenario-006");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+  expect(await page.locator("path.hex").count()).toBe(120);
+});
+
+test("scenario-006 smoke: intro shows bipartisan consultant role", async ({ page }) => {
+  await page.goto("/?s=scenario-006");
+  await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("#char-role")).toContainText("Bipartisan Redistricting Consultant");
+  await expect(page.locator("#objective-text")).toContainText("safe seats");
+});
+
+test("scenario-006 winnability: separating partisan flanks into safe districts passes", async ({ page }) => {
+  /**
+   * Geography: q=0-5 Ken flank (~62%); q=6-9 Ryu flank (~62% Ryu).
+   * Winning: vertical 2-col strips — D1=q0-1, D2=q2-3, D3=q4-5 (Ken safe x3),
+   *          D4=q6-7, D5=q8-9 (Ryu safe x2). All margins ~24% > 15% threshold.
+   */
+  await loadScenario(page, "scenario-006");
+
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], district: number) => void;
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found on window");
+    const { paintStroke } = store.getState();
+    const numQ = 10, numR = 12;
+    for (let d = 0; d < 5; d++) {
+      const ids: number[] = [];
+      for (let r = 0; r < numR; r++) {
+        ids.push(r * numQ + d * 2);
+        ids.push(r * numQ + d * 2 + 1);
+      }
+      paintStroke(ids, d + 1);
+    }
+  });
+
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+});
+
+// ─── scenario-007: "The Reform Map" ─────────────────────────────────────────
+
+test("scenario-007 smoke: loads and renders 127 precincts", async ({ page }) => {
+  await page.goto("/?s=scenario-007");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+  expect(await page.locator("path.hex").count()).toBe(127);
+});
+
+test("scenario-007 smoke: intro shows reform commissioner role", async ({ page }) => {
+  await page.goto("/?s=scenario-007");
+  await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("#char-role")).toContainText("Reform Commissioner");
+  await expect(page.locator("#objective-text")).toContainText("compact");
+});
+
+test("scenario-007 winnability: five compact blobs pass reform criteria", async ({ page }) => {
+  /**
+   * Hex-of-hexes R=6: 127 precincts sorted by (r, q).
+   * Initial: diagonal strips (k=q+r) — non-compact, population-imbalanced → submit disabled.
+   * Winning: 5 compact Voronoi-like blobs grown from seeds at d=4 (~72° apart).
+   *   Sizes: 26, 26, 25, 25, 25 — all within ±10% of target (25.4).
+   *   Compactness: 0.81–0.83 — well above the 0.40 threshold.
+   *
+   * Precomputed via Voronoi BFS from seeds:
+   *   D1 seed (4,0)  ~0°,   D2 seed (-1,4) ~74°,  D3 seed (-4,2) ~150°,
+   *   D4 seed (-2,-2) ~210°, D5 seed (3,-4) ~286°.
+   */
+  await loadScenario(page, "scenario-007");
+
+  await expect(page.locator("#btn-submit")).toBeDisabled();
+
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], district: number) => void;
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found on window");
+    const { paintStroke } = store.getState();
+
+    // Precomputed compact balanced assignment (indices into hexes sorted by (r, q))
+    const assignment: number[][] = [
+      [33,42,43,44,52,53,54,55,56,63,64,65,66,67,68,69,77,78,79,80,81,90,91,92,101,102],
+      [76,87,88,89,97,98,99,100,106,107,108,109,110,111,114,115,116,117,118,119,121,122,123,124,125,126],
+      [59,60,61,62,70,71,72,73,74,75,82,83,84,85,86,93,94,95,96,103,104,105,112,113,120],
+      [0,1,7,8,9,15,16,17,24,25,26,27,34,35,36,37,38,45,46,47,48,49,50,57,58],
+      [2,3,4,5,6,10,11,12,13,14,18,19,20,21,22,23,28,29,30,31,32,39,40,41,51],
+    ];
+    assignment.forEach((ids, d) => paintStroke(ids, d + 1));
+  });
+
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+});
+
+// ─── scenario-008: "Both Sides Unhappy" ─────────────────────────────────────
+
+test("scenario-008 smoke: loads and renders 127 precincts", async ({ page }) => {
+  await page.goto("/?s=scenario-008");
+  await expect(page.locator("path.hex")).toHaveCount(127);
+});
+
+test("scenario-008 smoke: intro shows independent commissioner role", async ({ page }) => {
+  await page.goto("/?s=scenario-008");
+  await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("#char-role")).toContainText("Independent Commissioner");
+  await expect(page.locator("#objective-text")).toContainText("compact");
+});
+
+test("scenario-008 winnability: compact Voronoi blobs pass neutral criteria", async ({ page }) => {
+  /**
+   * Same hex-of-hexes R=6, 127 precincts. Same Voronoi BFS assignment as
+   * scenario-007 (geometry-only criteria: compactness, population balance).
+   * Efficiency gap criterion is optional — doesn't block pass.
+   */
+  await loadScenario(page, "scenario-008");
+
+  await expect(page.locator("#btn-submit")).toBeDisabled();
+
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], district: number) => void;
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found on window");
+    const { paintStroke } = store.getState();
+
+    const assignment: number[][] = [
+      [33,42,43,44,52,53,54,55,56,63,64,65,66,67,68,69,77,78,79,80,81,90,91,92,101,102],
+      [76,87,88,89,97,98,99,100,106,107,108,109,110,111,114,115,116,117,118,119,121,122,123,124,125,126],
+      [59,60,61,62,70,71,72,73,74,75,82,83,84,85,86,93,94,95,96,103,104,105,112,113,120],
+      [0,1,7,8,9,15,16,17,24,25,26,27,34,35,36,37,38,45,46,47,48,49,50,57,58],
+      [2,3,4,5,6,10,11,12,13,14,18,19,20,21,22,23,28,29,30,31,32,39,40,41,51],
+    ];
+    assignment.forEach((ids, d) => paintStroke(ids, d + 1));
+  });
+
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+});
+
+// ─── scenario-009: "Cats vs. Dogs" ──────────────────────────────────────────
+
+test("scenario-009 smoke: loads and renders 127 precincts", async ({ page }) => {
+  await page.goto("/?s=scenario-009");
+  await expect(page.locator("path.hex")).toHaveCount(127);
+});
+
+test("scenario-009 smoke: intro shows Cat Party strategist role", async ({ page }) => {
+  await page.goto("/?s=scenario-009");
+  await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("#char-role")).toContainText("Cat Party");
+  await expect(page.locator("#objective-text")).toContainText("Cat Party");
+});
+
+test("scenario-009 winnability: ring-based split gives 3 Cat-safe districts", async ({ page }) => {
+  /**
+   * Hex-of-hexes R=6, 127 precincts. Ring-based Cat geography (inner = Cat
+   * stronghold, outer = competitive). Ring-based assignment gives:
+   *   D1 (inner): ~78% Cat → safe; D2-D3 (middle): ~60-64% Cat → safe;
+   *   D4-D5 (outer): ~48% Cat → competitive/Dog.
+   * 3 Cat-safe seats (margin ≥ 15%) passes the required criterion.
+   */
+  await loadScenario(page, "scenario-009");
+
+  await expect(page.locator("#btn-submit")).toBeDisabled();
+
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], district: number) => void;
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found on window");
+    const { paintStroke } = store.getState();
+
+    // Ring-based: D1=inner core, D2-D3=middle+some outer, D4-D5=outer sectors
+    const assignment: number[][] = [
+      [27,28,29,30,37,38,39,40,41,49,50,51,52,61,62,63,64,65,74,75,76,77,86,87,88],
+      [55,66,67,68,72,73,78,79,80,83,84,85,89,90,95,96,97,98,99,100,105,106,107,108,109],
+      [8,9,10,11,12,13,16,17,18,19,20,21,22,25,26,31,32,36,42,47,48,53,54,59,60],
+      [82,91,92,93,94,101,102,103,104,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126],
+      [0,1,2,3,4,5,6,7,14,15,23,24,33,34,35,43,44,45,46,56,57,58,69,70,71,81],
+    ];
+    assignment.forEach((ids, d) => paintStroke(ids, d + 1));
+  });
+
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+});

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -43,6 +43,10 @@ const SCENARIO_MANIFEST = [
 	{ id: "scenario-003", title: "Riverport: The Packing Problem" },
 	{ id: "scenario-004", title: "Lakeview: Cracking the Opposition" },
 	{ id: "scenario-005", title: "Valle Verde: A Voice for the Valley" },
+	{ id: "scenario-006", title: "Harden the Map" },
+	{ id: "scenario-007", title: "The Reform Map" },
+	{ id: "scenario-008", title: "Both Sides Unhappy" },
+	{ id: "scenario-009", title: "Cats vs. Dogs" },
 ] as const;
 
 type ManifestEntry = (typeof SCENARIO_MANIFEST)[number];

--- a/game/web/src/model/adapter.ts
+++ b/game/web/src/model/adapter.ts
@@ -5,7 +5,7 @@
  * Strategy:
  *  - Stable numeric IDs from array position (precincts[i].id = i)
  *  - District IDs: 1-based integers (scenario.districts[i] → i+1)
- *  - partyShare: population-weighted vote shares; ken→R, ryu→D; L/G/I=0
+ *  - partyShare: population-weighted vote shares; first party→R, second→D; L/G/I=0
  *  - neighbors: computed from hex axial positions via HEX_DIRECTIONS
  *  - center: hexToPixel(q, r)
  *  - initial assignments from loader-filled initial_district_id
@@ -52,18 +52,20 @@ export function scenarioToSpike(scenario: Scenario): {
 		});
 
 		// Population-weighted vote shares (turnout ignored until Sprint 3)
-		let kenShare = 0;
-		let ryuShare = 0;
+		// Map first scenario party → R, second → D (matches partyIdToKey in main.ts)
+		const firstPartyId = scenario.parties[0]?.id as string | undefined;
+		const secondPartyId = scenario.parties[1]?.id as string | undefined;
+		let firstShare = 0;
+		let secondShare = 0;
 		for (const g of pc.demographic_groups) {
 			const vs = g.vote_shares as unknown as VoteShareRecord;
-			kenShare += g.population_share * (vs["ken"] ?? 0);
-			ryuShare += g.population_share * (vs["ryu"] ?? 0);
+			if (firstPartyId) firstShare += g.population_share * (vs[firstPartyId] ?? 0);
+			if (secondPartyId) secondShare += g.population_share * (vs[secondPartyId] ?? 0);
 		}
 
-		// Map to spike PartyShare: ken→R, ryu→D, minor parties=0
 		const partyShare = {
-			R: Math.round(kenShare * 1000) / 1000,
-			D: Math.round(ryuShare * 1000) / 1000,
+			R: Math.round(firstShare * 1000) / 1000,
+			D: Math.round(secondShare * 1000) / 1000,
 			L: 0,
 			G: 0,
 			I: 0,

--- a/thoughts/shared/tickets/DESIGN-008-geographic-features.md
+++ b/thoughts/shared/tickets/DESIGN-008-geographic-features.md
@@ -1,0 +1,73 @@
+---
+id: DESIGN-008
+title: Geographic features — lakes, mountains as decorative non-precinct tiles
+area: design, rendering
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+Add flavor/orientation geographic features (lakes, rivers, hills) to scenario maps as
+decorative non-precinct hex tiles. Features are purely cosmetic — they don't participate
+in population, simulation, or contiguity — but they:
+1. Make maps feel like real places (Civ/SimCity aesthetic)
+2. Break up the uniform hex field for player orientation
+3. Provide natural "holes" in hex-of-hexes regions (a lake in the center, etc.)
+
+## Design decisions (from 2026-04-27 session)
+
+- Feature tiles colored in grey (mountains/hills) or aqua/teal (lakes/water)
+- Animated texture: wave pattern for water, hatching/bump for terrain
+- Colors must not overlap with the district color palette (currently 5-8 colors for parties)
+- Features block adjacency for contiguity: a precinct separated from its district only
+  by a feature tile is NOT contiguous with it (feature = physical barrier)
+- Features are static per scenario (not editable by player)
+
+## Scenario format change
+
+Add optional `features` array to scenario JSON:
+```json
+"features": [
+  { "position": { "q": 0, "r": 0 }, "type": "lake" },
+  { "position": { "q": 1, "r": -1 }, "type": "lake" },
+  { "position": { "q": 0, "r": 2 }, "type": "mountain" }
+]
+```
+
+Feature types (v1): `lake`, `mountain`. Renderer maps type → color + texture.
+
+## Renderer changes
+
+- Feature tiles rendered as filled hexes with type-specific color + animated texture
+  - `lake`: aqua/teal (`#4fa3bf` or similar), animated wave SVG pattern
+  - `mountain`: grey (`#8a9bb0` or similar), static hatching
+- Feature tiles are NOT `path.hex` elements — use a separate SVG layer below hex layer
+- Feature tile positions excluded from neighbor calculation in contiguity BFS
+
+## Loader changes
+
+- Parse optional `features` array; validate positions don't overlap with precinct positions
+- Feature positions included in neighbor graph as "blocking" nodes (not passable)
+
+## Goals / Acceptance Criteria
+
+- [ ] Scenario format: optional `features` array with position + type
+- [ ] Loader: parses features; validates no overlap with precincts
+- [ ] Renderer: feature layer below hex layer; lake = aqua + wave; mountain = grey + hatch
+- [ ] Contiguity: feature positions block adjacency (BFS treats them as walls)
+- [ ] At least one scenario (new or retrofitted) includes a lake feature
+- [ ] e2e: feature tiles visible in map; correct color; don't affect precinct painting
+
+## Out of scope (v1)
+
+- Rivers (linear features spanning edges rather than cells)
+- Named features with labels
+- Player-visible feature interaction
+- Elevation/terrain affecting population density
+
+## References
+
+- GAME-027 — hex-of-hexes shape (implement first; features go inside hex region)
+- GAME-028 — backport (coordinate features with backport if adding to old scenarios)
+- Visual aesthetic: `thoughts/shared/research/` — Civ/SimCity dark HUD, map-first

--- a/thoughts/shared/tickets/GAME-027-hex-map-shape.md
+++ b/thoughts/shared/tickets/GAME-027-hex-map-shape.md
@@ -1,0 +1,71 @@
+---
+id: GAME-027
+title: Hex-of-hexes map shape for new scenarios
+area: game, content
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+Current scenario generators produce rectangular `q × r` grids which render as
+rhomboid/parallelogram shapes in hex axial coordinates — visually wrong for a
+game map. New scenarios (007+) should use a hex-of-hexes region: a true hexagonal
+arrangement of hexes centered at the origin. This is purely a generator change;
+no TypeScript or renderer changes are needed.
+
+Backporting to scenarios 002–006 is a separate ticket (GAME-028).
+
+## Current State
+
+Scenarios 002–006 use rectangular nested loops (`for r in 0..NUM_R, for q in 0..NUM_Q`)
+producing parallelogram-shaped maps. The hex axial renderer handles arbitrary q,r
+positions, including negatives, so hex-of-hexes coordinates work without engine changes.
+
+## Hex-of-hexes formula
+
+For radius R, valid positions satisfy: `|q| ≤ R && |r| ≤ R && |q+r| ≤ R`
+Precinct count = `3R² + 3R + 1`
+
+| R | Precincts | Districts of 25 | Districts of 24 |
+|---|---|---|---|
+| 5 | 91 | — | — |
+| 6 | 127 | 5 (×25, +2 spare) | 5 (×25-26) |
+| 7 | 169 | — | 7 (×24) |
+
+For 5-district scenarios: use R=6 (127 hexes). Districts get ~25-26 precincts each;
+population balance is by population totals, not precinct count, so uneven splits fine.
+
+Generator pattern:
+```kotlin
+val R = 6
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(q to r) }
+    }
+}.sortedWith(compareBy({ it.second }, { it.first }))
+```
+
+Coordinates are centered at (0,0) — natural axial, including negatives.
+
+## Goals / Acceptance Criteria
+
+- [x] Scenario-007 generator uses hex-of-hexes (R=6, 127 hexes)
+- [x] Scenario-008 generator uses hex-of-hexes (R=6, 127 hexes)
+- [x] Scenario-009 generator uses hex-of-hexes (R=6, 127 hexes)
+- [x] All three scenarios load without validation errors
+- [x] All three scenarios render as recognizable hexagonal map shapes
+- [x] e2e tests pass for all three
+
+## Test Coverage
+
+- [x] e2e: each scenario renders expected precinct count (127)
+- [x] e2e: winnability tests use hex-coordinate-aware precinct index calculations
+
+## References
+
+- GAME-028 — backport hex shape to scenarios 002–006
+- DESIGN-008 — geographic features (lakes, mountains) as decorative non-precinct tiles
+- `thoughts/shared/decisions/2026-04-27-game-name.md` — naming context

--- a/thoughts/shared/tickets/GAME-028-hex-shape-backport.md
+++ b/thoughts/shared/tickets/GAME-028-hex-shape-backport.md
@@ -1,0 +1,47 @@
+---
+id: GAME-028
+title: Backport hex-of-hexes map shape to scenarios 002–006
+area: game, content
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+Scenarios 002–006 use rectangular grid generators producing rhomboid/parallelogram
+map shapes. Once GAME-027 establishes the hex-of-hexes pattern in scenarios 007–009,
+backport that shape to all earlier scenarios. Requires regenerating scenario JSON files,
+rewriting e2e winnability tests (precinct indices change), and updating generators.
+
+## Scenarios to retrofit
+
+| Scenario | Grid | Precincts | Target shape |
+|---|---|---|---|
+| tutorial-001 | 6×5 = 30 | 30 | hex R=3 (37) — or keep small for tutorial |
+| tutorial-002 | ~14×14 = 196 | 196 | hex R=8 (217) or R=7 (169) |
+| scenario-002 | 8×12 = 96 | 96 | hex R=5 (91) or R=6 (127, subset) |
+| scenario-003 | 10×12 = 120 | 120 | hex R=6 (127) |
+| scenario-004 | 10×12 = 120 | 120 | hex R=6 (127) |
+| scenario-005 | 10×12 = 120 | 120 | hex R=6 (127) |
+| scenario-006 | 10×12 = 120 | 120 | hex R=6 (127) |
+
+## Goals / Acceptance Criteria
+
+- [ ] All generators updated to hex-of-hexes coordinate generation
+- [ ] All scenario JSON files regenerated
+- [ ] All e2e winnability tests updated with new precinct coordinate logic
+- [ ] `bazel test //web:e2e_test` passes after all changes
+- [ ] Maps render as recognizable hexagonal/circular shapes in browser
+
+## Notes
+
+- Tutorial-001 is a guided walkthrough with specific named precincts in narrative text —
+  verify narrative still makes sense after coordinate change
+- Winnability tests that use specific precinct indices (paintPrecinct by id) need to be
+  rewritten to use hex-coordinate-aware index lookup or paintStroke API
+- Do this after GAME-027 is merged so the pattern is established and stable
+
+## References
+
+- GAME-027 — hex-of-hexes for new scenarios (implement first)
+- DESIGN-008 — geographic features (implement after shape is stable)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -94,6 +94,9 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-007-dimensional-dot-map-demographic-overlay.md` | design, rendering | Dimensional dot map: demographic dimension switching (Option B adaptive encoding) + sorted placement toggle |
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
 | `GAME-020-last-scenario-wrap-up-screen.md` | game, UX | Wrap-up/congratulations screen after completing the final scenario (instead of dead-end select screen) |
+| `GAME-027-hex-map-shape.md` | game, content | Hex-of-hexes map shape (R=6, 127 hexes) for new scenarios 007–009; replaces rhomboid rectangular grid |
+| `GAME-028-hex-shape-backport.md` | game, content | Backport hex-of-hexes shape to scenarios 002–006 + tutorial; regenerate JSON + rewrite e2e indices |
+| `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary
- Hex-of-hexes map shape (R=6, 127 precincts) for scenarios 007-009: generators, JSON, manifest entries, and 9 e2e tests (3 per scenario: 2 smoke + 1 winnability)
- Fix adapter.ts to read party IDs dynamically from the scenario's `parties` array instead of hardcoding `"ken"` and `"ryu"`, enabling arbitrary party names (e.g. `"cat"`/`"dog"` in scenario-009)
- Fix scenario-007 winnability e2e test: angular sectors caused population imbalance (30 vs 23 hexes per sector); replaced with precomputed Voronoi BFS assignment (25-26 hexes each, compactness 0.81+)

## Validation performed
- [x] `bazel test //web/...` — 11/11 targets pass (68 e2e tests, unit tests, type checks)
- [x] All three new scenarios load, render 127 hex precincts, show correct intro text
- [x] Winnability tests verify end-to-end pass for each scenario's success criteria
- [ ] kubectl dry-run passed (N/A — no k8s)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services
- None — game content + adapter fix only

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- see GAME-027

## Rollback
- Revert the merge commit; no runtime state affected
