### PR TITLE
fix: demo feedback — responsive select, demographics, debug win, save/restore UX

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -19,12 +19,12 @@ import { test, expect } from "@playwright/test";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Navigate to a scenario, skip intro, wait for hex grid. */
+/** Navigate to a scenario, skip intro, wait for hex grid. Uses &debug to bypass lock gate. */
 async function loadScenario(
   page: import("@playwright/test").Page,
   id: string,
 ): Promise<void> {
-  await page.goto(`/?s=${id}`);
+  await page.goto(`/?s=${id}&debug`);
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -58,7 +58,7 @@ async function selectDistrict(
 // ─── scenario-002: "Give the Governor a Win" ─────────────────────────────────
 
 test("scenario-002 smoke: loads and renders 96 precincts", async ({ page }) => {
-  await page.goto("/?s=scenario-002");
+  await page.goto("/?s=scenario-002&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -69,7 +69,7 @@ test("scenario-002 smoke: loads and renders 96 precincts", async ({ page }) => {
 });
 
 test("scenario-002 smoke: intro shows correct character and objective", async ({ page }) => {
-  await page.goto("/?s=scenario-002");
+  await page.goto("/?s=scenario-002&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Ken Party");
   await expect(page.locator("#objective-text")).toContainText("Ken Party wins at least 3 seats");
@@ -124,7 +124,7 @@ test("scenario-002 winnability: gerrymandering 3/4 Ken districts passes the map"
 // ─── scenario-003: "The Packing Problem" ─────────────────────────────────────
 
 test("scenario-003 smoke: loads and renders 120 precincts", async ({ page }) => {
-  await page.goto("/?s=scenario-003");
+  await page.goto("/?s=scenario-003&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -135,7 +135,7 @@ test("scenario-003 smoke: loads and renders 120 precincts", async ({ page }) => 
 });
 
 test("scenario-003 smoke: intro shows packing character and objective", async ({ page }) => {
-  await page.goto("/?s=scenario-003");
+  await page.goto("/?s=scenario-003&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Ken Party");
   await expect(page.locator("#objective-text")).toContainText("4 of the 5 seats");
@@ -203,7 +203,7 @@ test("scenario-003 winnability: packing urban core into one district passes the 
 // ─── scenario-004: "Cracking the Opposition" ─────────────────────────────────
 
 test("scenario-004 smoke: loads and renders 120 precincts", async ({ page }) => {
-  await page.goto("/?s=scenario-004");
+  await page.goto("/?s=scenario-004&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -214,7 +214,7 @@ test("scenario-004 smoke: loads and renders 120 precincts", async ({ page }) => 
 });
 
 test("scenario-004 smoke: intro references cracking tactic and prior scenario", async ({ page }) => {
-  await page.goto("/?s=scenario-004");
+  await page.goto("/?s=scenario-004&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Ken Party");
   await expect(page.locator("#objective-text")).toContainText("Ken Party wins every seat");
@@ -277,7 +277,7 @@ test("scenario-004 winnability: cracking the corridor across all 5 districts pas
 // ─── scenario-005: "Valle Verde: A Voice for the Valley" ─────────────────────
 
 test("scenario-005 smoke: loads and renders 120 precincts", async ({ page }) => {
-  await page.goto("/?s=scenario-005");
+  await page.goto("/?s=scenario-005&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -288,7 +288,7 @@ test("scenario-005 smoke: loads and renders 120 precincts", async ({ page }) => 
 });
 
 test("scenario-005 smoke: intro shows VRA character and objective", async ({ page }) => {
-  await page.goto("/?s=scenario-005");
+  await page.goto("/?s=scenario-005&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Redistricting Coordinator");
   await expect(page.locator("#objective-text")).toContainText("majority-Latino district");
@@ -361,7 +361,7 @@ test("scenario-005 winnability: consolidating the valley into one district passe
 // ─── scenario-006: "Harden the Map" ─────────────────────────────────────────
 
 test("scenario-006 smoke: loads and renders 120 precincts", async ({ page }) => {
-  await page.goto("/?s=scenario-006");
+  await page.goto("/?s=scenario-006&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -370,7 +370,7 @@ test("scenario-006 smoke: loads and renders 120 precincts", async ({ page }) => 
 });
 
 test("scenario-006 smoke: intro shows bipartisan consultant role", async ({ page }) => {
-  await page.goto("/?s=scenario-006");
+  await page.goto("/?s=scenario-006&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Bipartisan Redistricting Consultant");
   await expect(page.locator("#objective-text")).toContainText("safe seats");
@@ -410,7 +410,7 @@ test("scenario-006 winnability: separating partisan flanks into safe districts p
 // ─── scenario-007: "The Reform Map" ─────────────────────────────────────────
 
 test("scenario-007 smoke: loads and renders 127 precincts", async ({ page }) => {
-  await page.goto("/?s=scenario-007");
+  await page.goto("/?s=scenario-007&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -419,7 +419,7 @@ test("scenario-007 smoke: loads and renders 127 precincts", async ({ page }) => 
 });
 
 test("scenario-007 smoke: intro shows reform commissioner role", async ({ page }) => {
-  await page.goto("/?s=scenario-007");
+  await page.goto("/?s=scenario-007&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Reform Commissioner");
   await expect(page.locator("#objective-text")).toContainText("compact");
@@ -468,12 +468,12 @@ test("scenario-007 winnability: five compact blobs pass reform criteria", async 
 // ─── scenario-008: "Both Sides Unhappy" ─────────────────────────────────────
 
 test("scenario-008 smoke: loads and renders 127 precincts", async ({ page }) => {
-  await page.goto("/?s=scenario-008");
+  await page.goto("/?s=scenario-008&debug");
   await expect(page.locator("path.hex")).toHaveCount(127);
 });
 
 test("scenario-008 smoke: intro shows independent commissioner role", async ({ page }) => {
-  await page.goto("/?s=scenario-008");
+  await page.goto("/?s=scenario-008&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Independent Commissioner");
   await expect(page.locator("#objective-text")).toContainText("compact");
@@ -515,12 +515,12 @@ test("scenario-008 winnability: compact Voronoi blobs pass neutral criteria", as
 // ─── scenario-009: "Cats vs. Dogs" ──────────────────────────────────────────
 
 test("scenario-009 smoke: loads and renders 127 precincts", async ({ page }) => {
-  await page.goto("/?s=scenario-009");
+  await page.goto("/?s=scenario-009&debug");
   await expect(page.locator("path.hex")).toHaveCount(127);
 });
 
 test("scenario-009 smoke: intro shows Cat Party strategist role", async ({ page }) => {
-  await page.goto("/?s=scenario-009");
+  await page.goto("/?s=scenario-009&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Cat Party");
   await expect(page.locator("#objective-text")).toContainText("Cat Party");
@@ -560,4 +560,88 @@ test("scenario-009 winnability: ring-based split gives 3 Cat-safe districts", as
   await page.locator("#btn-submit").click();
   await expect(page.locator("#result-screen")).toBeVisible();
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+});
+
+// ─── Cross-cutting: demo feedback fixes ─────────────────────────────────────
+
+test("scenario select: all cards visible and scrollable", async ({ page }) => {
+  // Navigate first so localStorage is accessible, then seed progress and reload
+  await page.goto("/");
+  await page.evaluate(() => {
+    localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ["tutorial-002"] }));
+  });
+  await page.reload();
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  const cards = page.locator(".scenario-card");
+  const count = await cards.count();
+  expect(count).toBeGreaterThanOrEqual(9);
+  // The last card should be scrollable into view, not clipped
+  const lastCard = cards.last();
+  await lastCard.scrollIntoViewIfNeeded();
+  await expect(lastCard).toBeVisible();
+});
+
+test("scenario-005 precinct hover shows demographic group breakdown", async ({ page }) => {
+  await loadScenario(page, "scenario-005");
+  const hex = page.locator("path.hex").first();
+  await hex.hover();
+  const infoPanel = page.locator("#precinct-info");
+  await expect(infoPanel).toContainText("%", { timeout: 3_000 });
+  // Multiple % signs = lean + per-group breakdown (Valle Verde has 3+ groups)
+  const text = await infoPanel.textContent();
+  const percentCount = (text?.match(/%/g) ?? []).length;
+  expect(percentCount).toBeGreaterThanOrEqual(3);
+});
+
+test("debug force-win button: visible with ?debug param, marks scenario complete", async ({ page }) => {
+  await page.goto("/?s=tutorial-002&debug");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+  const debugBtn = page.locator("#btn-debug-win");
+  await expect(debugBtn).toBeVisible();
+  await debugBtn.click();
+  // Should navigate to select screen after force-win
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  const completed = await page.evaluate(() => {
+    const raw = localStorage.getItem("redistricting-sim-progress");
+    return raw ? JSON.parse(raw) : null;
+  });
+  expect(completed?.completed).toContain("tutorial-002");
+});
+
+test("debug force-win button: hidden without ?debug param", async ({ page }) => {
+  // Navigate WITHOUT &debug (can't use loadScenario which adds it)
+  await page.goto("/?s=tutorial-002");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+  const debugBtn = page.locator("#btn-debug-win");
+  await expect(debugBtn).not.toBeVisible();
+});
+
+test("lock gate: direct URL to locked scenario redirects to select screen", async ({ page }) => {
+  // Ensure no progress — scenario-002 requires tutorial-002 completed
+  await page.goto("/");
+  await page.evaluate(() => {
+    localStorage.removeItem("redistricting-sim-progress");
+    localStorage.removeItem("redistricting-sim-wip");
+  });
+  await page.goto("/?s=scenario-002");
+  // Should NOT show the intro or hex grid — should show the select screen
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("path.hex")).toHaveCount(0);
+});
+
+test("lock gate: debug param bypasses lock on locked scenario", async ({ page }) => {
+  await page.goto("/");
+  await page.evaluate(() => {
+    localStorage.removeItem("redistricting-sim-progress");
+    localStorage.removeItem("redistricting-sim-wip");
+  });
+  await page.goto("/?s=scenario-002&debug");
+  // Should load the scenario, not redirect
+  await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
 });

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -317,18 +317,42 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        justify-content: center;
         gap: 32px;
+        padding: 32px 0;
+        overflow-y: auto;
         z-index: 85;
       }
 
       #scenario-select.hidden { display: none; }
+
+      /* ── WIP discard warning modal ──────────────────────────────────────── */
+      #wip-warning-modal {
+        position: fixed; inset: 0;
+        background: rgba(0,0,0,0.7);
+        display: flex; align-items: center; justify-content: center;
+        z-index: 200;
+      }
+      #wip-warning-modal.hidden { display: none; }
+      #wip-warning-card {
+        background: #162a45; border: 1px solid #e94560;
+        border-radius: 10px; padding: 24px 32px;
+        max-width: 420px; text-align: center; color: #c0d0e8;
+      }
+      #wip-warning-confirm {
+        background: #e94560; color: #fff; border: none;
+        padding: 8px 20px; border-radius: 6px; cursor: pointer;
+      }
+      #wip-warning-cancel {
+        background: #1a3a5c; color: #c0d0e8; border: 1px solid #2a5a8c;
+        padding: 8px 20px; border-radius: 6px; cursor: pointer;
+      }
 
       #scenario-select h1 {
         font-size: 1.6rem;
         font-weight: 700;
         color: #e94560;
         letter-spacing: 0.03em;
+        flex-shrink: 0;
       }
 
       #scenario-cards {
@@ -336,8 +360,9 @@
         gap: 20px;
         flex-wrap: wrap;
         justify-content: center;
-        max-width: 800px;
+        max-width: 1200px;
         padding: 0 16px;
+        flex-shrink: 0;
       }
 
       .scenario-card {
@@ -684,6 +709,18 @@
     <div id="scenario-select" class="hidden">
       <h1>Redistricting Simulator</h1>
       <div id="scenario-cards"></div>
+      <button id="btn-reset-campaign" style="margin-top:16px;background:none;border:1px solid #555;color:#888;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:0.75rem;">Reset Campaign</button>
+    </div>
+
+    <!-- ── WIP discard warning modal ──────────────────────────────────── -->
+    <div id="wip-warning-modal" class="hidden">
+      <div id="wip-warning-card">
+        <p id="wip-warning-text"></p>
+        <div style="display:flex;gap:12px;justify-content:center;margin-top:16px;">
+          <button id="wip-warning-confirm">Switch Scenario</button>
+          <button id="wip-warning-cancel">Cancel</button>
+        </div>
+      </div>
     </div>
 
     <!-- ── Result screen (GAME-017) ─────────────────────────────────────── -->
@@ -726,6 +763,7 @@
     </div>
 
     <header id="app-header" style="display:none">
+      <button id="btn-back-to-scenarios" style="background:none;border:1px solid #2a5a8c;color:#8898b0;padding:4px 12px;border-radius:4px;cursor:pointer;font-size:0.8rem;">← Scenarios</button>
       <h1>Redistricting Simulator</h1>
       <div id="controls">
         <span style="font-size:0.8rem;color:#888;">Draw district:</span>
@@ -735,6 +773,7 @@
         <button id="btn-view-toggle">Switch to Partisan Lean</button>
         <button id="btn-county-toggle">Show County Borders</button>
         <button id="btn-submit" disabled>Submit Map</button>
+        <button id="btn-debug-win" style="display:none;background:#8b4513;color:#ffa;">⚡ Force Win (debug)</button>
         <button id="btn-reset">Reset</button>
         <span id="reset-confirm">
           Reset to start?

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -134,7 +134,7 @@ if (
 			const completed = isCompleted(progress, entry.id);
 			const unlocked = i === 0 || isCompleted(progress, SCENARIO_MANIFEST[i - 1]?.id ?? "");
 			const locked = !unlocked;
-			const inProgress = !completed && wip?.scenarioId === entry.id;
+			const inProgress = wip?.scenarioId === entry.id;
 
 			const card = document.createElement("div");
 			card.className = `scenario-card${locked ? " locked" : ""}`;
@@ -144,18 +144,24 @@ if (
 			titleEl.textContent = entry.title;
 
 			const statusEl = document.createElement("div");
-			const statusLabel = completed ? "Completed" : inProgress ? "In Progress" : unlocked ? "Ready" : "Locked";
-			const statusClass = completed ? "completed" : inProgress ? "in-progress" : unlocked ? "unlocked" : "locked";
+			const statusLabel = inProgress ? "In Progress" : completed ? "Completed" : unlocked ? "Ready" : "Locked";
+			const statusClass = inProgress ? "in-progress" : completed ? "completed" : unlocked ? "unlocked" : "locked";
 			statusEl.className = `sc-status ${statusClass}`;
 			statusEl.textContent = statusLabel;
 
 			const playBtn = document.createElement("button");
-			playBtn.className = `sc-play-btn ${completed ? "replay" : inProgress ? "continue" : unlocked ? "play" : "locked-btn"}`;
-			playBtn.textContent = completed ? "Play Again" : inProgress ? "Continue" : unlocked ? "Play" : "Locked";
+			playBtn.className = `sc-play-btn ${inProgress ? "continue" : completed ? "replay" : unlocked ? "play" : "locked-btn"}`;
+			playBtn.textContent = inProgress ? "Continue" : completed ? "Play Again" : unlocked ? "Play" : "Locked";
 			playBtn.disabled = locked;
 			if (!locked) {
 				playBtn.addEventListener("click", () => {
-					window.location.assign(`/?s=${entry.id}`);
+					const currentWip = loadWip();
+					if (currentWip && currentWip.scenarioId !== entry.id) {
+						// Warn: switching will discard in-progress work on a different scenario
+						showWipWarning(currentWip.scenarioId, entry.id);
+					} else {
+						window.location.assign(`/?s=${entry.id}`);
+					}
 				});
 			}
 
@@ -166,9 +172,44 @@ if (
 		});
 	}
 
+	function showWipWarning(wipScenarioId: string, targetId: string) {
+		const modal = document.getElementById("wip-warning-modal");
+		const text = document.getElementById("wip-warning-text");
+		const confirmBtn = document.getElementById("wip-warning-confirm");
+		const cancelBtn = document.getElementById("wip-warning-cancel");
+		if (!modal || !text || !confirmBtn || !cancelBtn) return;
+		const wipTitle = SCENARIO_MANIFEST.find((e) => e.id === wipScenarioId)?.title ?? wipScenarioId;
+		text.textContent = `You have unsaved progress in "${wipTitle}". Switching scenarios will discard it.`;
+		modal.classList.remove("hidden");
+		const onConfirm = () => {
+			cleanup();
+			clearWip();
+			window.location.assign(`/?s=${targetId}`);
+		};
+		const onCancel = () => {
+			cleanup();
+			modal.classList.add("hidden");
+		};
+		function cleanup() {
+			confirmBtn!.removeEventListener("click", onConfirm);
+			cancelBtn!.removeEventListener("click", onCancel);
+		}
+		confirmBtn.addEventListener("click", onConfirm);
+		cancelBtn.addEventListener("click", onCancel);
+	}
+
 	function showScenarioSelect() {
 		renderScenarioCards();
 		scenarioSelectEl?.classList.remove("hidden");
+
+		// Reset campaign button — clears all progress and WIP
+		document.getElementById("btn-reset-campaign")?.addEventListener("click", () => {
+			if (!confirm("Reset all progress? This will erase completion status and any in-progress work.")) return;
+			progress = { completed: [] };
+			saveProgress(progress);
+			clearWip();
+			renderScenarioCards();
+		});
 	}
 
 	// ── Startup routing (GAME-021) ────────────────────────────────────────────
@@ -181,8 +222,15 @@ if (
 	);
 
 	let entryToLoad: ManifestEntry;
+	const isDebug = urlParams.has("debug");
 	if (requestedEntry !== undefined) {
-		// Explicit scenario requested via URL — play it directly
+		// Check unlock: scenario must be first, or previous scenario completed (unless debug)
+		const idx = SCENARIO_MANIFEST.indexOf(requestedEntry);
+		const locked = idx > 0 && !isCompleted(progress, SCENARIO_MANIFEST[idx - 1]?.id ?? "");
+		if (locked && !isDebug) {
+			showScenarioSelect();
+			return;
+		}
 		entryToLoad = requestedEntry;
 	} else if (progress.completed.length > 0 || loadWip() !== null) {
 		// Returning player (has completed or in-progress scenario) — show select screen
@@ -255,22 +303,28 @@ if (
 		temporalStore.getState().clear();
 		isRestoringWip = false;
 	}
+	function flushWipSave() {
+		if (wipTimer !== null) clearTimeout(wipTimer);
+		wipTimer = null;
+		const { assignments, activeDistrict } = store.getState();
+		const assignmentsRecord: Record<string, number> = {};
+		for (const [k, v] of assignments) {
+			if (v !== null) assignmentsRecord[String(k)] = v;
+		}
+		const wip: WipState = {
+			scenarioId: scenario.id,
+			assignments: assignmentsRecord,
+			activeDistrict,
+		};
+		saveWip(wip);
+	}
+
 	function scheduleWipSave() {
 		if (isRestoringWip) return;
 		if (wipTimer !== null) clearTimeout(wipTimer);
 		wipTimer = setTimeout(() => {
 			wipTimer = null;
-			const { assignments, activeDistrict } = store.getState();
-			const assignmentsRecord: Record<string, number> = {};
-			for (const [k, v] of assignments) {
-				if (v !== null) assignmentsRecord[String(k)] = v;
-			}
-			const wip: WipState = {
-				scenarioId: scenario.id,
-				assignments: assignmentsRecord,
-				activeDistrict,
-			};
-			saveWip(wip);
+			flushWipSave();
 		}, 800);
 	}
 
@@ -512,8 +566,26 @@ if (
 		showResultScreen();
 	});
 
+	// ── Debug force-win: visible only with ?debug in URL ─────────────────────
+	const btnDebugWin = document.getElementById("btn-debug-win") as HTMLButtonElement | null;
+	if (btnDebugWin && new URLSearchParams(window.location.search).has("debug")) {
+		btnDebugWin.style.display = "";
+		btnDebugWin.addEventListener("click", () => {
+			progress = markCompleted(progress, scenario.id);
+			saveProgress(progress);
+			clearWip();
+			window.location.assign("/");
+		});
+	}
+
 	btnKeepDrawing!.addEventListener("click", () => {
 		resultScreen!.classList.add("hidden");
+	});
+
+	// "← Scenarios" button → flush WIP then return to scenario select
+	document.getElementById("btn-back-to-scenarios")?.addEventListener("click", () => {
+		flushWipSave();
+		window.location.assign("/");
 	});
 
 	// "Next Scenario" → navigate back to root so routing re-evaluates with

--- a/game/web/src/model/adapter.ts
+++ b/game/web/src/model/adapter.ts
@@ -86,6 +86,16 @@ export function scenarioToSpike(scenario: Scenario): {
 		};
 		if (pc.name !== undefined) spikePrecinct.name = pc.name;
 		if (pc.county_id !== undefined) spikePrecinct.county_id = pc.county_id;
+		if (pc.demographic_groups.length > 1) {
+			spikePrecinct.groupShares = pc.demographic_groups.map((g) => {
+				const entry: { name: string; share: number; dimensions?: Record<string, string> } = {
+					name: g.name ?? g.id,
+					share: g.population_share,
+				};
+				if (g.dimensions) entry.dimensions = g.dimensions as Record<string, string>;
+				return entry;
+			});
+		}
 		return spikePrecinct;
 	});
 

--- a/game/web/src/model/types.ts
+++ b/game/web/src/model/types.ts
@@ -69,6 +69,8 @@ export interface Precinct {
 	previousResult: PreviousResult;
 	/** Demographic breakdown */
 	demographics: Demographics;
+	/** Per-group population shares from scenario demographic_groups (for info panel) */
+	groupShares?: { name: string; share: number; dimensions?: Record<string, string> }[];
 }
 
 /** A district is identified by a 1-based integer index */

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -456,12 +456,20 @@ export class SvgMapRenderer implements MapRenderer {
 						d.partyShare[a] > d.partyShare[b] ? a : b,
 					);
 					const leanLabel = `${PARTY_LABELS[topParty]} (${(d.partyShare[topParty] * 100).toFixed(1)}%)`;
+					let groupsHtml = "";
+					if (d.groupShares && d.groupShares.length > 1) {
+						const lines = d.groupShares.map(
+							(g) => `${g.name}: ${(g.share * 100).toFixed(0)}%`,
+						);
+						groupsHtml = `<br><span style="color:#8898b0">` + lines.join("<br>") + `</span>`;
+					}
 					infoPanel.innerHTML =
 						`<div class="precinct-name">${precinctLabel}</div>` +
 						`<div class="precinct-detail">` +
 						`${distLabel}<br>` +
 						`Pop: ${d.population.toLocaleString()}<br>` +
 						`Lean: ${leanLabel}` +
+						groupsHtml +
 						`</div>`;
 				}
 			}


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary
- Demo feedback fixes: responsive scenario select (scroll + wrap), demographic group display in precinct hover, debug force-win button (`?debug`), WIP discard warning modal, synchronous WIP flush before navigation, back-to-scenarios button, reset campaign button, URL lock gate for locked scenarios, Continue button priority over Play Again when WIP exists
- 8 new e2e tests covering these features; existing e2e tests updated to use `&debug` bypass

## Validation performed
- [x] `bazel test //web/...` — 11/11 targets pass (74 e2e tests + unit + type checks)
- [x] Manual testing in browser: scroll, demographics hover, debug win, WIP warning, back button, reset campaign, lock gate
- [ ] kubectl dry-run passed (N/A — no k8s)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services
- None — UI fixes only

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- Demo feedback from 2026-04-27 session (no formal ticket)

## Rollback
- Revert the merge commit
