### PR TITLE
feat(GAME-020): wrap-up screen after completing final scenario

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -645,3 +645,46 @@ test("lock gate: debug param bypasses lock on locked scenario", async ({ page })
   // Should load the scenario, not redirect
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
 });
+
+// ─── GAME-020: Wrap-up screen after final scenario ──────────────────────────
+
+test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", async ({ page }) => {
+  // Seed all but scenario-009 as complete
+  await page.goto("/");
+  const allButLast = [
+    "tutorial-002", "scenario-002", "scenario-003", "scenario-004",
+    "scenario-005", "scenario-006", "scenario-007", "scenario-008",
+  ];
+  await page.evaluate((ids) => {
+    localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ids }));
+  }, allButLast);
+  // Load scenario-009 and complete it
+  await loadScenario(page, "scenario-009");
+  // Use paintStroke to apply the known winning assignment
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], district: number) => void;
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found on window");
+    const { paintStroke } = store.getState();
+    const assignment: number[][] = [
+      [27,28,29,30,37,38,39,40,41,49,50,51,52,61,62,63,64,65,74,75,76,77,86,87,88],
+      [55,66,67,68,72,73,78,79,80,83,84,85,89,90,95,96,97,98,99,100,105,106,107,108,109],
+      [8,9,10,11,12,13,16,17,18,19,20,21,22,25,26,31,32,36,42,47,48,53,54,59,60],
+      [82,91,92,93,94,101,102,103,104,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126],
+      [0,1,2,3,4,5,6,7,14,15,23,24,33,34,35,43,44,45,46,56,57,58,69,70,71,81],
+    ];
+    assignment.forEach((ids, d) => paintStroke(ids, d + 1));
+  });
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+  // Click "Next Scenario" — should show wrap-up, not select screen
+  await page.locator("#btn-next-scenario").click();
+  await expect(page.locator("#wrap-up-screen")).toBeVisible({ timeout: 5_000 });
+  await expect(page.locator("#wrap-up-screen")).toContainText("Congratulations");
+  // Select screen should NOT be visible
+  await expect(page.locator("#scenario-select")).not.toBeVisible();
+});
+
+// (GAME-029 about page tests will be added in a separate PR)

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -421,6 +421,29 @@
 
       /* ── Result screen (GAME-017) ────────────────────────────────────────── */
 
+      /* ── Wrap-up screen (GAME-020) ─────────────────────────────────────── */
+      #wrap-up-screen {
+        position: fixed; inset: 0;
+        background: #0d1b2e;
+        display: flex; align-items: center; justify-content: center;
+        z-index: 95;
+      }
+      #wrap-up-screen.hidden { display: none; }
+      #wrap-up-card {
+        background: #16213e; border: 1px solid #0f3460;
+        border-radius: 10px; padding: 40px 44px;
+        max-width: 560px; width: 90%; text-align: center;
+        color: #c0d0e8;
+      }
+      #wrap-up-card h1 {
+        font-size: 1.6rem; color: #4caf80; margin-bottom: 16px;
+      }
+      #btn-wrap-up-replay {
+        background: #1a3a5c; color: #c0d0e8; border: 1px solid #2a5a8c;
+        padding: 10px 24px; border-radius: 6px; cursor: pointer; font-size: 1rem;
+      }
+      #btn-wrap-up-replay:hover { background: #1a4a7a; }
+
       #result-screen {
         position: fixed;
         inset: 0;
@@ -732,6 +755,18 @@
         <div id="result-actions">
           <button id="btn-keep-drawing">← Keep Drawing</button>
           <button id="btn-next-scenario" style="display:none">Next Scenario →</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Wrap-up screen (GAME-020) ─────────────────────────────────────── -->
+    <div id="wrap-up-screen" class="hidden">
+      <div id="wrap-up-card">
+        <h1>Congratulations</h1>
+        <p id="wrap-up-text">You've completed every scenario. You've drawn maps that packed voters, cracked communities, protected incumbents, satisfied reformers, and proven that no set of rules can make redistricting apolitical.</p>
+        <p style="color:#8898b0;margin-top:12px;">The lines always matter. Now you know why.</p>
+        <div style="display:flex;gap:12px;justify-content:center;margin-top:24px;">
+          <button id="btn-wrap-up-replay">Play Again</button>
         </div>
       </div>
     </div>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -210,6 +210,7 @@ if (
 			clearWip();
 			renderScenarioCards();
 		});
+
 	}
 
 	// ── Startup routing (GAME-021) ────────────────────────────────────────────
@@ -588,9 +589,19 @@ if (
 		window.location.assign("/");
 	});
 
-	// "Next Scenario" → navigate back to root so routing re-evaluates with
-	// updated progress and shows the select screen (or next unlocked scenario).
+	// "Next Scenario" → if all scenarios complete, show wrap-up; else select screen.
 	btnNextScenario!.addEventListener("click", () => {
+		const allComplete = SCENARIO_MANIFEST.every((e) => isCompleted(progress, e.id));
+		if (allComplete) {
+			resultScreen!.classList.add("hidden");
+			document.getElementById("wrap-up-screen")?.classList.remove("hidden");
+		} else {
+			window.location.assign("/");
+		}
+	});
+
+	// Wrap-up "Play Again" → back to select screen
+	document.getElementById("btn-wrap-up-replay")?.addEventListener("click", () => {
 		window.location.assign("/");
 	});
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Wrap-up/congratulations screen shown when player clicks "Next Scenario" after completing the final scenario in the manifest
- Closing text summarizes the game's arc; "Play Again" button returns to select screen
- Distinct from result screen; does not trigger when non-final scenarios are completed

## Validation performed
- [x] `bazel test //web/...` — 11/11 targets pass
- [x] e2e test: seeds all-but-last complete, wins last via paintStroke, asserts wrap-up visible
- [ ] kubectl dry-run passed (N/A — no k8s)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services
- None — UI feature only

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- see GAME-020

## Rollback
- Revert merge commit
