### PR TITLE
feat(GAME-029): about page with educational framing and resource links

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -687,4 +687,21 @@ test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", 
   await expect(page.locator("#scenario-select")).not.toBeVisible();
 });
 
-// (GAME-029 about page tests will be added in a separate PR)
+// ─── GAME-029: About page ───────────────────────────────────────────────────
+
+test("about page: accessible from select screen and shows educational content", async ({ page }) => {
+  await page.goto("/");
+  await page.evaluate(() => {
+    localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ["tutorial-002"] }));
+  });
+  await page.reload();
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await page.locator("#btn-about").click();
+  await expect(page.locator("#about-screen")).toBeVisible();
+  await expect(page.locator("#about-screen")).toContainText("Past the Post");
+  await expect(page.locator("#about-screen")).toContainText("not advocacy");
+  // Back button returns to select screen
+  await page.locator("#btn-about-close").click();
+  await expect(page.locator("#scenario-select")).toBeVisible();
+  await expect(page.locator("#about-screen")).not.toBeVisible();
+});

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -421,6 +421,33 @@
 
       /* ── Result screen (GAME-017) ────────────────────────────────────────── */
 
+      /* ── About screen (GAME-029) ───────────────────────────────────────── */
+      #about-screen {
+        position: fixed; inset: 0;
+        background: #0d1b2e;
+        display: flex; align-items: center; justify-content: center;
+        z-index: 95; overflow-y: auto; padding: 32px 0;
+      }
+      #about-screen.hidden { display: none; }
+      #about-card {
+        background: #16213e; border: 1px solid #0f3460;
+        border-radius: 10px; padding: 36px 40px;
+        max-width: 600px; width: 90%; color: #c0d0e8;
+        line-height: 1.6;
+      }
+      #about-card h1 { font-size: 1.5rem; color: #e94560; margin-bottom: 12px; }
+      #about-card h2 { font-size: 1.1rem; color: #8898b0; margin-top: 20px; margin-bottom: 8px; }
+      #about-card p { margin-bottom: 10px; }
+      #about-links { padding-left: 20px; margin-bottom: 12px; }
+      #about-links li { margin-bottom: 6px; }
+      #about-links a { color: #5b9bd5; text-decoration: none; }
+      #about-links a:hover { text-decoration: underline; }
+      #btn-about-close {
+        background: #1a3a5c; color: #c0d0e8; border: 1px solid #2a5a8c;
+        padding: 8px 20px; border-radius: 6px; cursor: pointer;
+      }
+      #btn-about-close:hover { background: #1a4a7a; }
+
       /* ── Wrap-up screen (GAME-020) ─────────────────────────────────────── */
       #wrap-up-screen {
         position: fixed; inset: 0;
@@ -730,9 +757,29 @@
   <body>
     <!-- ── Scenario select screen (GAME-018) ────────────────────────────── -->
     <div id="scenario-select" class="hidden">
-      <h1>Redistricting Simulator</h1>
+      <h1>Past the Post</h1>
       <div id="scenario-cards"></div>
-      <button id="btn-reset-campaign" style="margin-top:16px;background:none;border:1px solid #555;color:#888;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:0.75rem;">Reset Campaign</button>
+      <div style="display:flex;gap:16px;margin-top:16px;align-items:center;">
+        <button id="btn-about" style="background:none;border:1px solid #2a5a8c;color:#8898b0;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:0.75rem;">About</button>
+        <button id="btn-reset-campaign" style="background:none;border:1px solid #555;color:#888;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:0.75rem;">Reset Campaign</button>
+      </div>
+    </div>
+
+    <!-- ── About page (GAME-029) ──────────────────────────────────────────── -->
+    <div id="about-screen" class="hidden">
+      <div id="about-card">
+        <h1>Past the Post</h1>
+        <p>An educational redistricting simulator. Draw district boundaries, simulate elections, and discover how the same voters can produce wildly different outcomes depending on where the lines are drawn.</p>
+        <p>This game is not advocacy for or against any political party, position, or reform proposal. It presents multiple perspectives — partisan operatives, reform commissioners, bipartisan dealmakers — so that players leave with better questions, not predetermined answers.</p>
+        <h2>Learn More</h2>
+        <ul id="about-links">
+          <li><a href="https://www.brennancenter.org/issues/gerrymandering-fair-representation" target="_blank" rel="noopener">Brennan Center — Gerrymandering &amp; Fair Representation</a></li>
+          <li><a href="https://redistricting.lls.edu/" target="_blank" rel="noopener">Loyola Law School — All About Redistricting</a></li>
+          <li><a href="https://www.fairvote.org/redistricting" target="_blank" rel="noopener">FairVote — Redistricting</a></li>
+        </ul>
+        <p style="color:#606878;font-size:0.8rem;margin-top:16px;">Designed by Christian Gruber. Built with Claude.</p>
+        <button id="btn-about-close" style="margin-top:16px;">← Back</button>
+      </div>
     </div>
 
     <!-- ── WIP discard warning modal ──────────────────────────────────── -->

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -211,6 +211,15 @@ if (
 			renderScenarioCards();
 		});
 
+		// About button
+		document.getElementById("btn-about")?.addEventListener("click", () => {
+			scenarioSelectEl?.classList.add("hidden");
+			document.getElementById("about-screen")?.classList.remove("hidden");
+		});
+		document.getElementById("btn-about-close")?.addEventListener("click", () => {
+			document.getElementById("about-screen")?.classList.add("hidden");
+			scenarioSelectEl?.classList.remove("hidden");
+		});
 	}
 
 	// ── Startup routing (GAME-021) ────────────────────────────────────────────

--- a/thoughts/shared/tickets/GAME-029-about-page.md
+++ b/thoughts/shared/tickets/GAME-029-about-page.md
@@ -1,0 +1,38 @@
+---
+id: GAME-029
+title: About page — educational framing, designer intent, resource links
+area: game, UX
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+The game needs an About page providing educational context: what the game is,
+why it exists, the non-partisan stance, and links to diverse resources on
+redistricting. Without this, the game has no framing — a player encounters
+mechanics with no context for why they matter.
+
+## Current State
+
+No about page exists. The game vision (§MENU) specifies: "About page: states
+educational intent; names designer+non-partisan intent; links to diverse
+resources (academic, journalistic, multiple political perspectives)."
+
+## Goals / Acceptance Criteria
+
+- [ ] About page accessible from scenario select screen (button/link)
+- [ ] Content: game title, educational purpose, non-partisan intent, designer credit
+- [ ] Links section: 2-3 external resources on redistricting (diverse perspectives)
+- [ ] Visual style consistent with existing dark HUD chrome
+- [ ] Back/close button returns to previous screen
+- [ ] e2e test: about link visible on select screen; clicking it shows about content
+
+## Test Coverage
+
+- [ ] e2e: about link on select screen → about page visible with expected content
+
+## References
+
+- Game vision §MENU, §NEUTRALITY
+- `thoughts/shared/decisions/2026-04-27-game-name.md` — game named "Past the Post"

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -94,6 +94,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
 | `GAME-020-last-scenario-wrap-up-screen.md` | game, UX | Wrap-up/congratulations screen after completing the final scenario (instead of dead-end select screen) |
 | `GAME-028-hex-shape-backport.md` | game, content | Backport hex-of-hexes shape to scenarios 002–006 + tutorial; regenerate JSON + rewrite e2e indices |
+| `GAME-029-about-page.md` | game, UX | About page: educational framing, designer intent, non-partisan stance, resource links |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
 
 ---


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- About page accessible from scenario select screen; shows game title (Past the Post), educational purpose, non-partisan stance, designer credit, and links to external redistricting resources
- Renames scenario select heading to "Past the Post"
- GAME-029 ticket filed

## Validation performed
- [x] `bazel test //web/...` — 11/11 targets pass
- [x] e2e test: about button → about screen visible with expected content → back returns to select
- [ ] kubectl dry-run passed (N/A — no k8s)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services
- None — UI feature only

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- see GAME-029

## Rollback
- Revert merge commit
