### PR TITLE
fix: name credit, wrap-up via force-win, sticky debug, GAME-030 ticket

### DIFF
--- a/game/web/index.html
+++ b/game/web/index.html
@@ -777,7 +777,7 @@
           <li><a href="https://redistricting.lls.edu/" target="_blank" rel="noopener">Loyola Law School — All About Redistricting</a></li>
           <li><a href="https://www.fairvote.org/redistricting" target="_blank" rel="noopener">FairVote — Redistricting</a></li>
         </ul>
-        <p style="color:#606878;font-size:0.8rem;margin-top:16px;">Designed by Christian Gruber. Built with Claude.</p>
+        <p style="color:#606878;font-size:0.8rem;margin-top:16px;">Designed, architected, and co-developed by Christian Edward Jackson-Gruber and Claude.</p>
         <button id="btn-about-close" style="margin-top:16px;">← Back</button>
       </div>
     </div>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -116,6 +116,19 @@ if (
 	throw new Error("Required DOM elements not found");
 }
 
+// ─── Debug mode: sticky via sessionStorage ───────────────────────────────────
+// Once ?debug is used, it stays active for the tab session so navigations
+// (force-win → select → next scenario) don't lose it.
+const DEBUG_KEY = "redistricting-sim-debug";
+const debugParam = new URLSearchParams(window.location.search).get("debug");
+if (debugParam === "off") {
+	try { sessionStorage.removeItem(DEBUG_KEY); } catch { /* ignore */ }
+} else if (debugParam !== null) {
+	try { sessionStorage.setItem(DEBUG_KEY, "1"); } catch { /* ignore */ }
+}
+const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
+	sessionStorage.getItem(DEBUG_KEY) === "1";
+
 // ─── Async init ───────────────────────────────────────────────────────────────
 
 (async () => {
@@ -232,12 +245,11 @@ if (
 	);
 
 	let entryToLoad: ManifestEntry;
-	const isDebug = urlParams.has("debug");
 	if (requestedEntry !== undefined) {
 		// Check unlock: scenario must be first, or previous scenario completed (unless debug)
 		const idx = SCENARIO_MANIFEST.indexOf(requestedEntry);
 		const locked = idx > 0 && !isCompleted(progress, SCENARIO_MANIFEST[idx - 1]?.id ?? "");
-		if (locked && !isDebug) {
+		if (locked && !IS_DEBUG) {
 			showScenarioSelect();
 			return;
 		}
@@ -578,13 +590,18 @@ if (
 
 	// ── Debug force-win: visible only with ?debug in URL ─────────────────────
 	const btnDebugWin = document.getElementById("btn-debug-win") as HTMLButtonElement | null;
-	if (btnDebugWin && new URLSearchParams(window.location.search).has("debug")) {
+	if (btnDebugWin && IS_DEBUG) {
 		btnDebugWin.style.display = "";
 		btnDebugWin.addEventListener("click", () => {
 			progress = markCompleted(progress, scenario.id);
 			saveProgress(progress);
 			clearWip();
-			window.location.assign("/");
+			const allComplete = SCENARIO_MANIFEST.every((e) => isCompleted(progress, e.id));
+			if (allComplete) {
+				document.getElementById("wrap-up-screen")?.classList.remove("hidden");
+			} else {
+				window.location.assign("/");
+			}
 		});
 	}
 

--- a/thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md
+++ b/thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md
@@ -1,0 +1,79 @@
+---
+id: GAME-030
+title: Main menu, campaign model, and navigation overhaul
+area: game, UX, architecture
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+Replace the current scenario-select-as-home-screen with a proper main menu,
+campaign model, and layered navigation. The game should feel like a real game
+with a title screen, not a scenario picker that doubles as everything.
+
+## Current State
+
+The scenario select screen serves as the home screen — it's the first thing
+returning players see. There is no title screen, no campaign concept, no
+settings, and the "About" and "Reset Campaign" buttons are tacked on.
+Scenarios are hardcoded in SCENARIO_MANIFEST.
+
+## Design
+
+### Main Menu Screen
+- Full-screen with game art/logo ("Past the Post")
+- Vertical menu on the left:
+  - **Continue** (visible only when a campaign is in progress)
+  - **New Campaign**
+  - **Load** (greyed out until save/load feature is ready)
+  - **Settings** (greyed out until settings feature is ready)
+  - **About** (opens existing about page)
+
+### Campaign Model
+- A campaign is a named collection of scenarios with ordering
+- The v1 educational campaign is the only campaign; others are future
+- Campaign data structure: `{ id, title, description, scenarioIds: string[] }`
+- Campaign completion tracked per-campaign in localStorage
+
+### Campaign Select Screen
+- Shows available campaigns (initially just the one educational campaign)
+- Each campaign card: title, description, progress indicator
+- Back button returns to main menu
+- Clicking a campaign opens the scenario select screen
+
+### Scenario Select Screen
+- No longer the home screen — accessed through a campaign
+- Scenario list generated from the campaign's `scenarioIds`, not hardcoded
+- Back button returns to campaign select (not main menu)
+
+### In-Game Navigation
+- The "← Scenarios" button becomes a menu with:
+  - "Return to Scenarios" (back to scenario select within current campaign)
+  - "Return to Main Menu" (back to main menu)
+
+## Goals / Acceptance Criteria
+
+- [ ] Main menu screen with art/logo and vertical navigation
+- [ ] Campaign data model: id, title, description, scenarioIds
+- [ ] Campaign select screen showing available campaigns
+- [ ] Scenario select screen driven by campaign data (not hardcoded manifest)
+- [ ] In-game menu with "Return to Scenarios" and "Return to Main Menu" options
+- [ ] Continue button on main menu when a campaign is in progress
+- [ ] Load and Settings buttons present but greyed out / disabled
+- [ ] About opens existing about page
+- [ ] All existing e2e tests pass (may need updates for new navigation flow)
+
+## Test Coverage
+
+- [ ] e2e: main menu visible on fresh load; About/New Campaign buttons work
+- [ ] e2e: New Campaign → campaign select → scenario select flow
+- [ ] e2e: in-game menu navigation back to scenarios and main menu
+- [ ] e2e: Continue button appears when campaign in progress
+
+## References
+
+- Game vision §MENU: "New Game | Continue | Custom Level | Settings | About"
+- GAME-029 — about page (already implemented; move into main menu navigation)
+- GAME-018 — scenario select + progression (refactored, not replaced)
+- `game/web/src/main.ts` — current SCENARIO_MANIFEST and routing

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -95,6 +95,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-020-last-scenario-wrap-up-screen.md` | game, UX | Wrap-up/congratulations screen after completing the final scenario (instead of dead-end select screen) |
 | `GAME-028-hex-shape-backport.md` | game, content | Backport hex-of-hexes shape to scenarios 002–006 + tutorial; regenerate JSON + rewrite e2e indices |
 | `GAME-029-about-page.md` | game, UX | About page: educational framing, designer intent, non-partisan stance, resource links |
+| `GAME-030-main-menu-and-campaigns.md` | game, UX, architecture | Main menu, campaign model, campaign select, layered navigation; replaces scenario-select-as-home |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
 
 ---


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Fix about page credit: Christian Edward Jackson-Gruber (not Gruber)
- Force-win now shows wrap-up screen when all scenarios complete (previously went to select)
- Debug mode sticky via sessionStorage: `?debug` turns on for the tab, `?debug=off` turns off
- File GAME-030 ticket: main menu, campaign model, layered navigation (future sprint)

## Validation performed
- [x] `bazel test //web/...` — 11/11 targets pass
- [x] Manual: force-win through all 9 → wrap-up screen shown
- [x] Manual: `?debug` persists across navigations; `?debug=off` clears it
- [ ] kubectl dry-run passed (N/A — no k8s)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- GAME-020 (wrap-up fix), GAME-029 (credit fix), GAME-030 (ticket filed)

## Rollback
- Revert merge commit
