### PR TITLE
fix: redirect unknown/locked scenario URLs to scenario picker

### DIFF
--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -245,7 +245,11 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	);
 
 	let entryToLoad: ManifestEntry;
-	if (requestedEntry !== undefined) {
+	if (requestedId !== "" && requestedEntry === undefined) {
+		// Unknown scenario ID in URL — redirect to select screen
+		showScenarioSelect();
+		return;
+	} else if (requestedEntry !== undefined) {
 		// Check unlock: scenario must be first, or previous scenario completed (unless debug)
 		const idx = SCENARIO_MANIFEST.indexOf(requestedEntry);
 		const locked = idx > 0 && !isCompleted(progress, SCENARIO_MANIFEST[idx - 1]?.id ?? "");


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Navigating to a non-existent scenario ID (e.g. `?s=tutorial-004`) now redirects to the scenario select screen instead of showing a blank/broken page
- Same behavior for locked scenarios (already existed, now the unknown-ID case is handled too)

## Validation performed
- [x] `bazel test //web:e2e_test` — passes
- [x] Manual: `?s=tutorial-004` → scenario picker shown
- [ ] kubectl dry-run passed (N/A — no k8s)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- No formal ticket — demo feedback fix

## Rollback
- Revert merge commit
