### PR TITLE
feat(GAME-028): backport hex-of-hexes to scenarios 002-006 + tutorial-002

### DIFF
--- a/game/scenarios/gen-scenario-002.main.kts
+++ b/game/scenarios/gen-scenario-002.main.kts
@@ -2,26 +2,29 @@
 /**
  * Generator for scenario-002.json: "Give the Governor a Win"
  *
- * Layout: 8 columns (q=0..7) × 12 rows (r=0..11) = 96 precincts, 4 districts of 24.
+ * Lesson: Basic partisan gerrymandering — redraw to give one party more seats.
  *
- * Zones:
- *   North     (r=0..5, all q):    60% Ken / 40% Ryu — Ken-leaning
- *   Southwest (q=0..3, r=6..11):  52% Ken / 48% Ryu — competitive Ken-lean
- *   Southeast (q=4..7, r=6..11):  25% Ken / 75% Ryu — strong Ryu
+ * Shape: hex-of-hexes, radius 5 → 91 precincts, 4 districts of ~22-23.
+ * Coordinates: axial, centered at (0,0); range q,r in [-5,5].
  *
- * Initial assignment (vertical 2-column strips):
- *   D1=q0-1, D2=q2-3, D3=q4-5, D4=q6-7
+ * Partisan geography (angle-based, three zones):
+ *   North  (r < 0 or r=0 and q<0, roughly upper half): ~60% Ken — Ken-leaning
+ *   Southwest (q ≤ 0 and r > 0): ~52% Ken — competitive Ken-lean
+ *   Southeast (q > 0 and r > 0): ~25% Ken — strong Ryu stronghold
  *
- * Initial outcome:
- *   D1,D2 each get north+SW → ~56% Ken → KEN wins
- *   D3,D4 each get north+SE → ~42% Ken → RYU wins
- *   Result: 2 Ken / 2 Ryu (fails the ≥3 Ken criterion)
+ * Initial assignment: diagonal strips (k=q+r constant).
+ *   Each strip crosses all three zones → D1,D2 get north+SW (~56% Ken → Ken wins),
+ *   D3,D4 get north+SE (~42% Ken → Ryu wins).
+ *   Result: 2 Ken / 2 Ryu — fails ≥3 Ken criterion.
  *
- * Winning gerrymander (what player must discover):
- *   D1=q0-1 all rows,  D2=q2-3 all rows  → 56% Ken each
- *   D3=q4-7 r=0-5      (all-north band)   → 60% Ken
- *   D4=q4-7 r=6-11     (all-SE band)      → 25% Ken (Ryu sacrificed district)
+ * Winning gerrymander: pack the southeast Ryu stronghold into one district.
+ *   3 districts from north+southwest (Ken-majority) → 3 Ken ✓
+ *   1 district absorbs the southeast Ryu bloc → Ryu sacrifice
  *   Result: 3 Ken / 1 Ryu ✓
+ *
+ * Success criteria:
+ *   Required: district_count, population_balance (±10%), Ken ≥ 3 seats
+ *   Optional: compactness ≥ 0.40
  *
  * Run from repo root:
  *   kotlin game/scenarios/gen-scenario-002.main.kts
@@ -31,62 +34,81 @@ import kotlin.math.abs
 import kotlin.random.Random
 
 val rng = Random(42)
-val NUM_Q = 8
-val NUM_R = 12
-val BASE_POP = 1500
+val R = 5
 
-fun zone(q: Int, r: Int) = when {
-    r <= 5 -> "north"
-    q <= 3 -> "southwest"
-    else   -> "southeast"
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
+
+// Two zones: most of the hex is Ken territory, but a compact Ryu stronghold
+// occupies the inner-east region (q ≥ 1, d ≤ 3, ~18 hexes). The surrounding
+// area leans Ken, creating a natural "pack the Ryu bloc" puzzle.
+fun baseKenShare(q: Int, r: Int): Double {
+    val d = hexDist(q, r)
+    return when {
+        q >= 1 && d <= 3 -> 0.25  // inner-east: strong Ryu stronghold (~18 hexes)
+        q >= 1           -> 0.52  // outer-east: competitive, slight Ken
+        else             -> 0.62  // west: reliable Ken territory
+    }
 }
 
-fun initialDistrict(q: Int, r: Int) = when {
-    q <= 1 -> "d1"
-    q <= 3 -> "d2"
-    q <= 5 -> "d3"
-    else   -> "d4"
+// Initial: diagonal strips (k = q+r constant) — mixes zones.
+//   k ≤ -3: d1, k=-2..-1: d2, k=0..1: d3, k≥2: d4
+fun initialDistrict(q: Int, r: Int): String {
+    val k = q + r
+    return when {
+        k <= -3 -> "d1"
+        k <= -1 -> "d2"
+        k <= 1  -> "d3"
+        else    -> "d4"
+    }
 }
 
-fun countyId(q: Int, r: Int) = when {
-    r <= 5 -> "clearwater_north"
-    q <= 3 -> "clearwater_west"
-    else   -> "clearwater_east"
+fun countyId(q: Int, r: Int): String = when {
+    q >= 1 && hexDist(q, r) <= 3 -> "clearwater_east"
+    q <= 0                       -> "clearwater_west"
+    else                         -> "clearwater_central"
 }
-
-fun colLetter(q: Int) = "ABCDEFGH"[q].toString()
 
 fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+data class Hex(val q: Int, val r: Int)
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+val BASE_POP = 1500
 
 val precincts = StringBuilder()
 var first = true
 
-for (r in 0 until NUM_R) {
-    for (q in 0 until NUM_Q) {
-        val idx = r * NUM_Q + q
-        val pid = "p%03d".format(idx + 1)
-        val z = zone(q, r)
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
 
-        val baseKen = when (z) {
-            "north"     -> 0.60
-            "southwest" -> 0.52
-            else        -> 0.25
-        }
-        val delta = rng.nextDouble(-0.03, 0.03)
-        val kenShare = (baseKen + delta).coerceIn(0.05, 0.95)
-        val ryuShare = 1.0 - kenShare
+    val pop = BASE_POP + rng.nextInt(-150, 151)
 
-        val pop = BASE_POP + rng.nextInt(-100, 101)
-        val turnout = rng.nextDouble(0.52, 0.62)
-        val districtId = initialDistrict(q, r)
-        val county = countyId(q, r)
-        val zoneName = z.split("_").joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
-        val name = "$zoneName ${colLetter(q)}${r + 1}"
+    val kenShare = (baseKenShare(q, r) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+    val kenStr = kenShare.fmt(4)
+    val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
+    val turnout = rng.nextDouble(0.55, 0.70)
 
-        if (!first) precincts.append(",\n")
-        first = false
+    val districtId = initialDistrict(q, r)
+    val county = countyId(q, r)
+    val d = hexDist(q, r)
+    val zoneName = when {
+        q >= 1 && d <= 3 -> "East"
+        q <= 0           -> "West"
+        else             -> "Central"
+    }
+    val name = "$zoneName ($q,$r)"
 
-        precincts.append("""    {
+    if (!first) precincts.append(",\n")
+    first = false
+
+    precincts.append("""    {
       "id": "$pid",
       "editable": true,
       "county_id": "$county",
@@ -96,15 +118,14 @@ for (r in 0 until NUM_R) {
       "name": "$name",
       "demographic_groups": [
         {
-          "id": "${pid}-base",
-          "name": "Registered voters",
+          "id": "${pid}-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": ${turnout.fmt(2)},
-          "vote_shares": { "ken": ${kenShare.fmt(4)}, "ryu": ${ryuShare.fmt(4)} }
+          "vote_shares": { "ken": $kenStr, "ryu": $ryuStr }
         }
       ]
     }""")
-    }
 }
 
 val json = """{
@@ -152,7 +173,7 @@ $precincts
     {
       "id": "sc-ken-seats",
       "required": true,
-      "description": "The Ken Party wins at least 3 of the 4 districts.",
+      "description": "The governor's Ken Party wins at least 3 of the 4 districts.",
       "criterion": {
         "type": "seat_count",
         "party": "ken",
@@ -161,37 +182,41 @@ $precincts
       }
     },
     {
-      "id": "sc-compact",
+      "id": "sc-compactness",
       "required": false,
-      "description": "Districts have compact, reasonable shapes — a clean gerrymander.",
+      "description": "All districts are reasonably compact (≥ 40%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
-        "threshold": 0.4
+        "threshold": 0.40
       }
     }
   ],
   "narrative": {
     "character": {
       "name": "You",
-      "role": "Campaign Strategist, Ken Party State Committee",
-      "motivation": "The Governor's party needs a State House majority. The votes are there — if the lines are drawn right."
+      "role": "Ken Party Campaign Strategist, Clearwater County",
+      "motivation": "The governor wants a reliable majority in Clearwater County. The current map splits the vote evenly — two Ken, two Ryu. That's not good enough. You've been brought in to redraw the lines so Ken wins three of four seats."
     },
     "intro_slides": [
       {
-        "heading": "The Governor Needs a Win",
-        "body": "Clearwater County is up for redistricting. The current map gives each party two of the four seats — a stalemate.\n\nThe Governor's party, the Ken Party, wants three seats. Your job: draw the lines to make it happen."
+        "heading": "The Governor's Problem",
+        "body": "Clearwater County elects four representatives. Right now, the map gives each party two seats. The governor — a Ken partisan — wants three.\n\nThe population hasn't changed. The voters haven't changed. But the lines can change."
       },
       {
-        "heading": "Same Votes. Different Lines.",
-        "body": "The county's voters haven't changed. But where you draw the district boundaries determines which party wins each seat.\n\nThe north leans Ken. The southeast leans Ryu. The trick is deciding which precincts end up together — and who gets packed into a losing district."
+        "heading": "How Redistricting Works",
+        "body": "Every ten years, district boundaries are redrawn. The official reason is to reflect population changes. The real reason, often, is to change who wins.\n\nYou're looking at a map of precincts — small geographic units with known voting patterns. Your job is to group them into districts that favor the Ken Party."
+      },
+      {
+        "heading": "Your First Gerrymander",
+        "body": "Look at the map. The southeast corner votes heavily Ryu. The north and southwest lean Ken.\n\nIf you can contain the Ryu stronghold in one district and spread Ken voters across the other three, the governor gets the majority. The tools are simple — the consequences are not."
       }
     ],
-    "objective": "Draw 4 districts so the Ken Party wins at least 3 seats."
+    "objective": "Redraw the map so the Ken Party wins at least 3 of 4 districts."
   }
 }
 """
 
 val outFile = java.io.File("game/scenarios/scenario-002.json")
 outFile.writeText(json)
-println("Wrote ${NUM_Q * NUM_R} precincts to ${outFile.path}")
+println("Wrote ${hexes.size} precincts to ${outFile.path}")

--- a/game/scenarios/gen-scenario-003.main.kts
+++ b/game/scenarios/gen-scenario-003.main.kts
@@ -2,114 +2,132 @@
 /**
  * Generator for scenario-003.json: "The Packing Problem"
  *
- * Layout: 10 columns (q=0..9) × 12 rows (r=0..11) = 120 precincts, 5 districts of 24.
+ * Lesson: Packing — concentrate opposition voters into as few districts as
+ * possible, wasting their votes in landslide wins.
  *
- * Zones:
- *   Urban core   (q=3..6, r=3..8): 15% Ken / 85% Ryu — dense Ryu stronghold to pack
- *   Suburban     (one step outside core, approx q=2..7 excl. core OR r=2..9 excl. core):
- *                                   42% Ken / 58% Ryu — competitive Ryu-lean
- *   Rural        (everything else): 65% Ken / 35% Ryu — reliable Ken
+ * Shape: hex-of-hexes, radius 6 → 127 precincts, 5 districts of ~25-26.
+ * Coordinates: axial, centered at (0,0); range q,r in [-6,6].
  *
- * Initial assignment (vertical 2-column strips):
- *   D1=q0-1, D2=q2-3, D3=q4-5, D4=q6-7, D5=q8-9
+ * Partisan geography (concentric):
+ *   Urban core (d ≤ 2, 19 hexes): ~15% Ken / 85% Ryu — dense Ryu stronghold
+ *   Suburban   (d = 3-4, 42 hexes): ~42% Ken / 58% Ryu — competitive Ryu-lean
+ *   Rural      (d = 5-6, 66 hexes): ~65% Ken / 35% Ryu — reliable Ken
  *
- * Initial outcome: each district has a slice of urban core + suburbs + rural.
- *   Urban core slice → each district ~4-5 Ryu precincts out of 24 → not enough to flip most.
- *   Actually the core is 4 cols × 6 rows = 24 precincts = entire D3 could be packed.
- *   With vertical strips: D2 gets q=2-3∩core (r=3-8 for q=3 only → 6 precincts),
- *                         D3 gets q=4-5∩core (r=3-8 → 12 precincts),
- *                         D4 gets q=6-7∩core (r=3-8 for q=6 only → 6 precincts).
- *   D2: 6 urban + 18 rural/suburban → enough rural to pull Ken over 50%? Roughly:
- *     suburban ≈ 8 precincts, rural ≈ 10 precincts
- *     avg ≈ (6×0.15 + 8×0.42 + 10×0.65)/24 ≈ (0.9+3.36+6.5)/24 ≈ 10.76/24 ≈ 0.45 → RYU wins
- *   D3: 12 urban + 12 rural/suburban → avg ≈ (12×0.15 + 6×0.42 + 6×0.65)/24 ≈ (1.8+2.52+3.9)/24
- *     ≈ 8.22/24 ≈ 0.34 → RYU wins
- *   D4: similar to D2 → 0.45 → RYU wins
- *   D1, D5: no urban core → mostly rural + outer suburban → ~62% Ken → KEN wins
- *   Result: 2 Ken / 3 Ryu (fails ≥3 Ken required criterion)
+ * Urban voters have higher turnout (65-75%) vs. rural/suburban (50-60%).
  *
- * Winning gerrymander (pack the urban core):
- *   Pack all urban core (q=3..6, r=3..8) into D3 = 24 precincts, all Ryu → D3 is the sacrifice
- *   Remaining 4 districts share: rural + suburban only → all Ken-majority → 4 Ken / 1 Ryu ✓
- *   But q=3..6 r=3..8 = 4×6 = 24 precincts exactly — one full district.
- *   Need to move: q=3∩non-core from D2 → swap with some of D3's non-core precincts.
- *   Simpler approach: player paints q=3-6, r=3-8 into D3 (the core), then rebalances D2 and D4.
+ * Initial assignment: 5 angular wedge sectors from center to edge.
+ *   Each sector spans all three zones → mixes urban+suburban+rural.
+ *   D2/D3/D4 each get some urban core → ~45% Ken → Ryu wins.
+ *   D1/D5 get mostly rural → ~62% Ken → Ken wins.
+ *   Result: 2 Ken / 3 Ryu — fails ≥4 Ken seats criterion.
+ *
+ * Winning gerrymander: pack the urban core into one district.
+ *   Pack all d ≤ 2 (19 hexes) + 6 nearby suburban hexes into D3 = 25 hexes.
+ *   D3 → ~20% Ken → Ryu landslide (the sacrifice district).
+ *   Remaining 4 districts: suburban + rural only → all Ken-majority.
+ *   Result: 4 Ken / 1 Ryu ✓.
+ *
+ * Success criteria:
+ *   Required: district_count, population_balance (±10%), seat_count Ken ≥ 4
+ *   Optional: efficiency_gap ≤ 15%
  *
  * Run from repo root:
  *   kotlin game/scenarios/gen-scenario-003.main.kts
  */
 
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.PI
 import kotlin.random.Random
 
 val rng = Random(43)
-val NUM_Q = 10
-val NUM_R = 12
-val BASE_POP = 1500
+val R = 6
 
-fun isUrbanCore(q: Int, r: Int) = q in 3..6 && r in 3..8
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
 
-fun isSuburban(q: Int, r: Int): Boolean {
-    if (isUrbanCore(q, r)) return false
-    // One hex ring outside the core bounding box
-    return q in 2..7 && r in 2..9
+fun baseKenShare(q: Int, r: Int): Double {
+    val d = hexDist(q, r)
+    return when {
+        d <= 2 -> 0.15  // urban core: strong Ryu
+        d <= 4 -> 0.42  // suburban: competitive Ryu-lean
+        else   -> 0.65  // rural: reliable Ken
+    }
 }
 
-fun zone(q: Int, r: Int) = when {
-    isUrbanCore(q, r) -> "urban"
-    isSuburban(q, r)  -> "suburban"
-    else              -> "rural"
+fun baseTurnout(q: Int, r: Int): Double {
+    val d = hexDist(q, r)
+    return when {
+        d <= 2 -> 0.70  // urban: higher turnout
+        d <= 4 -> 0.55  // suburban
+        else   -> 0.55  // rural
+    }
 }
 
-fun initialDistrict(q: Int, r: Int) = when {
-    q <= 1 -> "d1"
-    q <= 3 -> "d2"
-    q <= 5 -> "d3"
-    q <= 7 -> "d4"
-    else   -> "d5"
+// Initial: 5 angular wedge sectors — each spans all zones → mixed results.
+fun initialDistrict(q: Int, r: Int): String {
+    if (q == 0 && r == 0) return "d3"
+    val x = q.toDouble() + r.toDouble() * 0.5
+    val y = r.toDouble() * 0.8660254
+    val norm = (atan2(y, x) + PI) / (2.0 * PI)
+    return when ((norm * 5).toInt().coerceIn(0, 4)) {
+        0 -> "d1"
+        1 -> "d2"
+        2 -> "d3"
+        3 -> "d4"
+        else -> "d5"
+    }
 }
 
-fun countyId(q: Int, r: Int) = when {
-    isUrbanCore(q, r) -> "riverport_city"
-    isSuburban(q, r)  -> "riverport_suburbs"
-    else              -> "riverport_rural"
+fun countyId(q: Int, r: Int): String {
+    val d = hexDist(q, r)
+    return when {
+        d <= 2 -> "riverport_city"
+        d <= 4 -> "riverport_suburbs"
+        else   -> "greenfield_county"
+    }
 }
-
-fun colLetter(q: Int) = "ABCDEFGHIJ"[q].toString()
 
 fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+data class Hex(val q: Int, val r: Int)
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+val BASE_POP = 1500
 
 val precincts = StringBuilder()
 var first = true
 
-for (r in 0 until NUM_R) {
-    for (q in 0 until NUM_Q) {
-        val idx = r * NUM_Q + q
-        val pid = "p%03d".format(idx + 1)
-        val z = zone(q, r)
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
 
-        val baseKen = when (z) {
-            "urban"    -> 0.15
-            "suburban" -> 0.42
-            else       -> 0.65
-        }
-        val delta = rng.nextDouble(-0.03, 0.03)
-        val kenShare = (baseKen + delta).coerceIn(0.05, 0.95)
-        val ryuShare = 1.0 - kenShare
+    val pop = BASE_POP + rng.nextInt(-150, 151)
 
-        val pop = BASE_POP + rng.nextInt(-100, 101)
-        val turnout = when (z) {
-            "urban" -> rng.nextDouble(0.65, 0.75)  // higher urban turnout
-            else    -> rng.nextDouble(0.50, 0.60)
-        }
-        val districtId = initialDistrict(q, r)
-        val county = countyId(q, r)
-        val zoneName = z.replaceFirstChar { it.uppercase() }
-        val name = "$zoneName ${colLetter(q)}${r + 1}"
+    val kenShare = (baseKenShare(q, r) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+    val kenStr = kenShare.fmt(4)
+    val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
+    val turnout = baseTurnout(q, r) + rng.nextDouble(-0.05, 0.05)
 
-        if (!first) precincts.append(",\n")
-        first = false
+    val districtId = initialDistrict(q, r)
+    val county = countyId(q, r)
+    val d = hexDist(q, r)
+    val zoneName = when {
+        d <= 2 -> "Downtown"
+        d <= 4 -> "Suburbs"
+        else   -> "Rural"
+    }
+    val name = "$zoneName ($q,$r)"
 
-        precincts.append("""    {
+    if (!first) precincts.append(",\n")
+    first = false
+
+    precincts.append("""    {
       "id": "$pid",
       "editable": true,
       "county_id": "$county",
@@ -119,15 +137,14 @@ for (r in 0 until NUM_R) {
       "name": "$name",
       "demographic_groups": [
         {
-          "id": "${pid}-base",
-          "name": "Registered voters",
+          "id": "${pid}-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": ${turnout.fmt(2)},
-          "vote_shares": { "ken": ${kenShare.fmt(4)}, "ryu": ${ryuShare.fmt(4)} }
+          "vote_shares": { "ken": $kenStr, "ryu": $ryuStr }
         }
       ]
     }""")
-    }
 }
 
 val json = """{
@@ -136,8 +153,8 @@ val json = """{
   "title": "Riverport: The Packing Problem",
   "election_type": "state_house",
   "region": {
-    "id": "riverport_county",
-    "name": "Riverport County"
+    "id": "riverport_metro",
+    "name": "Riverport Metro Area"
   },
   "geometry": { "type": "hex_axial" },
   "parties": [
@@ -176,7 +193,7 @@ $precincts
     {
       "id": "sc-ken-seats",
       "required": true,
-      "description": "The Ken Party wins at least 4 of the 5 districts.",
+      "description": "Ken Party wins at least 4 of the 5 districts.",
       "criterion": {
         "type": "seat_count",
         "party": "ken",
@@ -187,7 +204,7 @@ $precincts
     {
       "id": "sc-efficiency-gap",
       "required": false,
-      "description": "The efficiency gap is 15% or less — a statistically efficient gerrymander.",
+      "description": "Packing creates a large efficiency gap — can you keep it under 15%?",
       "criterion": {
         "type": "efficiency_gap",
         "operator": "lte",
@@ -198,24 +215,28 @@ $precincts
   "narrative": {
     "character": {
       "name": "You",
-      "role": "Redistricting Consultant, Ken Party Majority Caucus",
-      "motivation": "Riverport has a large urban core that votes overwhelmingly Ryu. Your job is to contain that bloc — concentrate it into one district, and let Ken dominate the rest."
+      "role": "Ken Party Campaign Strategist, Riverport Metro",
+      "motivation": "The Ken Party controls the state legislature but is losing ground in Riverport's urban core. The Ryu Party's voters are concentrated downtown — a liability if you know how to exploit it. Your job: draw a map that locks in 4 of 5 seats by packing their voters into one unwinnable district."
     },
     "intro_slides": [
       {
-        "heading": "The City Votes Ryu",
-        "body": "Riverport's urban core is a Ryu stronghold. In the current map, that bloc is spread across three districts — pulling each one toward Ryu.\n\nYour job: stop spreading those votes around."
+        "heading": "The Urban Problem",
+        "body": "Riverport's downtown is a Ryu stronghold — dense, politically active, and growing. If you let those voters spread across multiple districts, they could flip seats.\n\nBut concentration is a weakness. If all those Ryu voters end up in the same district, they win it by a landslide — and waste thousands of votes that could have helped them elsewhere."
       },
       {
-        "heading": "Pack Them In",
-        "body": "Packing means drawing one district to absorb as many opposition voters as possible.\n\nWhen you pack Ryu voters into a single district, they win it by a landslide — but all those extra votes are wasted. The other four districts become safe Ken territory."
+        "heading": "The Packing Play",
+        "body": "Packing means drawing one district that your opponents win overwhelmingly — 80%, 85%, even 90%. Every vote above 50%+1 is wasted. Meanwhile, you spread your own voters efficiently across the remaining districts, winning each by a comfortable but not wasteful margin.\n\nThe result: they win one seat by a landslide. You win four seats by steady margins."
+      },
+      {
+        "heading": "The Efficiency Gap",
+        "body": "Political scientists measure this with the efficiency gap — the difference in wasted votes between the two parties. A packed map has a huge efficiency gap: the opposition wastes votes in their landslide district, while the mapmaker wastes very few.\n\nDraw your map. Then look at the efficiency gap and see what packing costs."
       }
     ],
-    "objective": "Pack the Ryu stronghold into one district so the Ken Party wins at least 4 of the 5 seats."
+    "objective": "Pack Ryu voters into as few districts as possible. Ken Party must win at least 4 of 5 seats."
   }
 }
 """
 
 val outFile = java.io.File("game/scenarios/scenario-003.json")
 outFile.writeText(json)
-println("Wrote ${NUM_Q * NUM_R} precincts to ${outFile.path}")
+println("Wrote ${hexes.size} precincts to ${outFile.path}")

--- a/game/scenarios/gen-scenario-004.main.kts
+++ b/game/scenarios/gen-scenario-004.main.kts
@@ -2,156 +2,104 @@
 /**
  * Generator for scenario-004.json: "Cracking the Opposition"
  *
- * Layout: 10 columns (q=0..9) × 12 rows (r=0..11) = 120 precincts, 5 districts of 24.
+ * Lesson: Cracking — dilute a concentrated opposition group by splitting
+ * it across multiple districts so it can't form a majority anywhere.
  *
- * Zones:
- *   Opposition corridor (r=5..6, all q): 18% Ken / 82% Ryu — a horizontal Ryu band
- *   Upper band  (r=0..4, all q):          65% Ken / 35% Ryu — reliable Ken
- *   Lower band  (r=7..11, all q):         65% Ken / 35% Ryu — reliable Ken
+ * Shape: hex-of-hexes, radius 6 → 127 precincts, 5 districts of ~25-26.
+ * Coordinates: axial, centered at (0,0); range q,r in [-6,6].
  *
- * Initial assignment (vertical 2-column strips):
- *   D1=q0-1, D2=q2-3, D3=q4-5, D4=q6-7, D5=q8-9
+ * Partisan geography (corridor through center):
+ *   Corridor (r = 0, 13 hexes): ~18% Ken / 82% Ryu — narrow Ryu band
+ *   Upper/lower (r ≠ 0, 114 hexes): ~65% Ken / 35% Ryu — Ken territory
  *
- * Each initial district spans all rows → each gets 4 corridor precincts (r=5-6) out of 24.
- *   Corridor weight: (4×0.18 + 20×0.65)/24 ≈ (0.72+13)/24 ≈ 57.2% Ken → KEN wins all 5
- *   That's too easy — initial state already passes. Need different initial to make it a puzzle.
+ * Initial assignment: horizontal r-band slabs that consolidate the corridor.
+ *   D3 gets r=-1..1 (37 hexes) — too many, but contains the corridor → Ryu wins.
+ *   D1,D2,D4,D5 are upper/lower bands → Ken wins.
+ *   Result: 4 Ken / 1 Ryu — fails the ≥5 Ken (all seats) criterion.
+ *   Also fails population_balance (37 vs 11 hexes per slab).
  *
- * Alternative initial: horizontal strips (row bands)
- *   D1=r=0-1 all cols    (2×10=20 precincts — too few, need 24)
- *   Better: D1=r=0..2 + 4 from r=3 (uneven, hard to reason about)
+ * Winning gerrymander: crack the corridor across all 5 districts.
+ *   Vertical-ish strips or angular sectors: each crosses the corridor,
+ *   picking up only ~7 Ryu precincts out of ~25.
+ *   Average Ken per district ≈ (7×0.18 + 18×0.65)/25 ≈ 52% → Ken wins all 5.
  *
- * Cleaner approach: use 5 horizontal bands of r width 2.4 — not integer.
- * Simplest: group into horizontal bands with slight overlap:
- *   D1=r=0..2 (all q, 30 precincts — too many)
- *
- * Best approach: make corridor wider (r=4..7, 4 rows × 10 cols = 40 precincts).
- * 5 districts of 24: if each district gets 8 corridor precincts → corridor swamps them:
- *   (8×0.18 + 16×0.65)/24 ≈ (1.44+10.4)/24 ≈ 49.3% Ken → RYU wins all 5 (too many Ryu)
- *
- * Best design: corridor r=5..6 (2 rows, 20 precincts total).
- * Initial = horizontal bands:
- *   D1 = r=0..1 all q   = 20 precincts → need 4 more → add r=2, q=0..3 = 4 precincts → 24 ✓
- *   D2 = r=2,q=4..9 + r=3 all q = 6+10 = 16 → + r=4,q=0..7 = 8 → 24 ✓
- *   D3 = r=4,q=8..9 + r=5..6 all q + r=7,q=0..1 = 2+20+2 = 24 ✓
- *   D4 = r=7,q=2..9 + r=8..9 all q = 8+20 = 28 → too many
- *
- * This is getting complex. Let's just go with vertical strips as initial (so the puzzle is to
- * switch to horizontal to crack), and make the corridor wide enough that vertical strips lead
- * to a losing initial outcome.
- *
- * Design revision: corridor r=4..7 (4 rows × 10 cols = 40 precincts, 1/3 of the map).
- * 5 districts of 24 with vertical strips:
- *   Each district (2 cols) gets: r=4-7 = 4 rows × 2 cols = 8 corridor precincts
- *   Avg Ken = (8×0.18 + 16×0.65)/24 = (1.44+10.4)/24 = 0.493 → ~49.3% → RYU wins (barely)
- *   Result: 0 Ken / 5 Ryu → too extreme, no challenge
- *
- * Final design: corridor r=5..6 (narrow), initial = horizontal bands creating 3 Ken + 2 Ryu,
- * and the winning crack moves to vertical strips. But then vertical strips give 5 Ken (all win).
- *
- * Simplest coherent design:
- *   Corridor r=5..6, 20 precincts total (Ryu-heavy).
- *   Initial = 3 horizontal bands + corridor isolated:
- *     D1 = r=0..2 all q = 30 → too many
- *
- * Let's just use: initial = horizontal band districts where the corridor forms D3 (all Ryu),
- * and upper + lower bands are D1,D2 (upper) and D4,D5 (lower), all Ken.
- * That's initial 4 Ken / 1 Ryu → already wins. Not a puzzle.
- *
- * FINAL FINAL DESIGN: Make it genuinely difficult.
- * Opposition corridor: r=5..6 (2 rows × 10 cols = 20 precincts, 80% Ryu).
- * Non-corridor: 100 precincts, 65% Ken.
- * 5 districts of 24 precincts each.
- *
- * Initial (horizontal bands, deliberately unhelpful):
- *   D1 = r=0..1, all q            = 20 precincts
- *   Add r=2, q=0..3               = 4 precincts → D1 total = 24 ✓ (all upper → 65% Ken → KEN)
- *   D2 = r=2,q=4..9 + r=3 all q  = 6+10 = 16 + r=4,q=0..7 = 8 → 24 ✓ (upper → 65% Ken → KEN)
- *   D3 = r=4,q=8..9 + r=5..6 all q + r=7,q=0..1 = 2+20+2 = 24 ✓ (corridor-heavy → 30% Ken → RYU)
- *   D4 = r=7,q=2..9 + r=8..9 all q = 8+20 = 28 → need to remove 4
- *        Use r=7,q=2..7 + r=8..9 all q = 6+20 = 26 → still 2 too many
- *        Use r=7,q=2..5 + r=8..9 all q = 4+20 = 24 ✓ (lower → 65% Ken → KEN)
- *   D5 = r=7,q=6..9 + r=10..11 all q = 4+20 = 24 ✓ (lower → 65% Ken → KEN)
- *
- * Initial outcome: D1 KEN, D2 KEN, D3 RYU, D4 KEN, D5 KEN → 4 Ken / 1 Ryu. Already wins!
- *
- * I need the initial to fail the "opposition wins zero districts" criterion. Let me use a
- * different required criterion: Ken wins ALL 5 seats.
- * Initial 4/5 → fails ≥5. Player must crack the corridor to win all 5.
- *
- * Winning crack: vertical strips (each district crosses the corridor):
- *   D1=q0-1 all rows: 4 corridor + 20 non-corridor → (4×0.18+20×0.65)/24 ≈ 57% Ken → KEN ✓
- *   Same for all 5 vertical strips.
- *   Result: 5 Ken / 0 Ryu ✓
+ * Success criteria:
+ *   Required: district_count, population_balance (±10%), seat_count Ken = 5
+ *   Optional: mean_median ≤ 10%
  *
  * Run from repo root:
  *   kotlin game/scenarios/gen-scenario-004.main.kts
  */
 
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.PI
 import kotlin.random.Random
 
 val rng = Random(44)
-val NUM_Q = 10
-val NUM_R = 12
-val BASE_POP = 1500
+val R = 6
 
-fun isCorridor(q: Int, r: Int) = r in 5..6
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
 
-fun zone(q: Int, r: Int) = if (isCorridor(q, r)) "corridor" else if (r <= 4) "upper" else "lower"
+fun isCorridor(q: Int, r: Int): Boolean = r == 0 && hexDist(q, r) <= R
 
-// Initial horizontal-band assignment (deliberately non-cracking so player must discover crack)
+fun baseKenShare(q: Int, r: Int): Double = when {
+    isCorridor(q, r) -> 0.18  // corridor: strong Ryu
+    else              -> 0.65  // upper/lower: reliable Ken
+}
+
+// Initial: horizontal r-band slabs that consolidate the corridor into D3.
 fun initialDistrict(q: Int, r: Int): String = when {
-    r <= 1                          -> "d1"
-    r == 2 && q <= 3                -> "d1"
-    r == 2 && q >= 4                -> "d2"
-    r == 3                          -> "d2"
-    r == 4 && q <= 7                -> "d2"
-    r == 4 && q >= 8                -> "d3"
-    r in 5..6                       -> "d3"
-    r == 7 && q <= 1                -> "d3"
-    r == 7 && q in 2..5             -> "d4"
-    r in 8..9                       -> "d4"
-    r == 7 && q >= 6                -> "d5"
-    else                            -> "d5"   // r=10..11
+    r >= 3  -> "d1"
+    r == 2  -> "d2"
+    r >= -1 -> "d3"
+    r == -2 -> "d4"
+    else    -> "d5"
 }
 
-fun countyId(q: Int, r: Int) = when {
-    isCorridor(q, r) -> "lakeview_city"
-    r <= 4           -> "lakeview_north"
-    else             -> "lakeview_south"
+fun countyId(q: Int, r: Int): String = when {
+    abs(r) <= 1 -> "lakeview_central"
+    r > 0       -> "lakeview_north"
+    else        -> "lakeview_south"
 }
-
-fun colLetter(q: Int) = "ABCDEFGHIJ"[q].toString()
 
 fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+data class Hex(val q: Int, val r: Int)
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+val BASE_POP = 1500
 
 val precincts = StringBuilder()
 var first = true
 
-for (r in 0 until NUM_R) {
-    for (q in 0 until NUM_Q) {
-        val idx = r * NUM_Q + q
-        val pid = "p%03d".format(idx + 1)
-        val z = zone(q, r)
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
 
-        val baseKen = when (z) {
-            "corridor" -> 0.18
-            else       -> 0.65
-        }
-        val delta = rng.nextDouble(-0.03, 0.03)
-        val kenShare = (baseKen + delta).coerceIn(0.05, 0.95)
-        val ryuShare = 1.0 - kenShare
+    val pop = BASE_POP + rng.nextInt(-150, 151)
 
-        val pop = BASE_POP + rng.nextInt(-100, 101)
-        val turnout = rng.nextDouble(0.52, 0.62)
-        val districtId = initialDistrict(q, r)
-        val county = countyId(q, r)
-        val zoneName = z.replaceFirstChar { it.uppercase() }
-        val name = "$zoneName ${colLetter(q)}${r + 1}"
+    val kenShare = (baseKenShare(q, r) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+    val kenStr = kenShare.fmt(4)
+    val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
+    val turnout = rng.nextDouble(0.55, 0.70)
 
-        if (!first) precincts.append(",\n")
-        first = false
+    val districtId = initialDistrict(q, r)
+    val county = countyId(q, r)
+    val corridor = isCorridor(q, r)
+    val zoneName = if (corridor) "Lakeshore" else if (r > 0) "North" else "South"
+    val name = "$zoneName ($q,$r)"
 
-        precincts.append("""    {
+    if (!first) precincts.append(",\n")
+    first = false
+
+    precincts.append("""    {
       "id": "$pid",
       "editable": true,
       "county_id": "$county",
@@ -161,15 +109,14 @@ for (r in 0 until NUM_R) {
       "name": "$name",
       "demographic_groups": [
         {
-          "id": "${pid}-base",
-          "name": "Registered voters",
+          "id": "${pid}-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": ${turnout.fmt(2)},
-          "vote_shares": { "ken": ${kenShare.fmt(4)}, "ryu": ${ryuShare.fmt(4)} }
+          "vote_shares": { "ken": $kenStr, "ryu": $ryuStr }
         }
       ]
     }""")
-    }
 }
 
 val json = """{
@@ -216,9 +163,9 @@ $precincts
       "criterion": { "type": "population_balance" }
     },
     {
-      "id": "sc-ken-seats",
+      "id": "sc-ken-all-seats",
       "required": true,
-      "description": "The Ken Party wins all 5 districts — leave the Ryu corridor nowhere to win.",
+      "description": "Ken Party wins every seat — all 5 districts.",
       "criterion": {
         "type": "seat_count",
         "party": "ken",
@@ -229,7 +176,7 @@ $precincts
     {
       "id": "sc-mean-median",
       "required": false,
-      "description": "Mean-median difference is 10% or less — a statistically uniform crack.",
+      "description": "How skewed is your map? Mean-median gap ≤ 10%.",
       "criterion": {
         "type": "mean_median",
         "party": "ken",
@@ -241,24 +188,28 @@ $precincts
   "narrative": {
     "character": {
       "name": "You",
-      "role": "Political Director, Ken Party Legislative Caucus",
-      "motivation": "Last time you packed the opposition into one district. This time, the goal is different — dilute them so thoroughly they can't win anywhere."
+      "role": "Ken Party Redistricting Director, Lakeview County",
+      "motivation": "Last cycle, the Ryu Party won a seat in Lakeview by concentrating their voters along the lakeshore corridor. The Ken Party wants that seat back — and every other seat too. Your job: split the corridor so Ryu voters can't form a majority anywhere."
     },
     "intro_slides": [
       {
-        "heading": "The Ryu Corridor",
-        "body": "A band of Ryu-leaning precincts runs through the middle of Lakeview County. In the current map, they're grouped together — and they win District 3.\n\nYour job: make sure that never happens."
+        "heading": "The Corridor",
+        "body": "A narrow band of Ryu voters runs through the center of Lakeview County — along the lakeshore, where the apartments are dense and the politics lean hard Ryu.\n\nRight now, if those voters are in one district, they win it. Your predecessor let that happen. You won't."
       },
       {
-        "heading": "Crack the Bloc",
-        "body": "Cracking means splitting a concentrated voting bloc across multiple districts — diluting their power so they can't win any of them.\n\nDraw lines that cut across the corridor. Give each district a slice of Ryu voters — too few to tip any district Ryu, but just enough to waste their votes."
+        "heading": "The Cracking Play",
+        "body": "Cracking is the opposite of packing. Instead of concentrating the opposition, you split them. Draw district lines that cut through the corridor, dividing Ryu voters across multiple districts.\n\nIn each district, the corridor's Ryu precincts are outnumbered by the surrounding Ken territory. Ryu voters still vote — but they lose everywhere."
+      },
+      {
+        "heading": "The Disappearing Voice",
+        "body": "Notice what happens: a community that could win one seat now wins zero. Their total vote count hasn't changed. Their turnout hasn't dropped. But the lines moved, and their voice vanished.\n\nThis is what cracking does. It doesn't silence voters — it dilutes them until they don't matter."
       }
     ],
-    "objective": "Crack the Ryu corridor across all 5 districts so the Ken Party wins every seat."
+    "objective": "Crack the Ryu corridor across all 5 districts. Ken Party must win every seat."
   }
 }
 """
 
 val outFile = java.io.File("game/scenarios/scenario-004.json")
 outFile.writeText(json)
-println("Wrote ${NUM_Q * NUM_R} precincts to ${outFile.path}")
+println("Wrote ${hexes.size} precincts to ${outFile.path}")

--- a/game/scenarios/gen-scenario-005.main.kts
+++ b/game/scenarios/gen-scenario-005.main.kts
@@ -4,28 +4,25 @@
  *
  * Lesson: Voting Rights Act (VRA) / majority-minority districts.
  *
- * Layout: 10 columns (q=0..9) × 12 rows (r=0..11) = 120 precincts, 5 districts of 24.
+ * Shape: hex-of-hexes, radius 6 → 127 precincts, 5 districts of ~25-26.
+ * Coordinates: axial, centered at (0,0); range q,r in [-6,6].
  *
- * Zones:
- *   Valley (q=3..8, r=5..8): 6 cols × 4 rows = 24 precincts — Latino-concentrated
- *     Latino share: ~70%; Anglo share: ~30%
- *     Ken-leaning community (~78% Ken)
- *   Rim (everything else): 96 precincts — Anglo-majority
- *     Latino share: ~20%; Anglo share: ~80%
- *     Ryu-leaning (~62% Ryu)
+ * Partisan geography:
+ *   Valley (compact hex cluster offset from center, ~25 hexes):
+ *     ~70% Latino, ~30% Anglo. Latino community votes ~78% Ken.
+ *   Rim (everything else, ~102 hexes):
+ *     ~20% Latino, ~80% Anglo. Anglo community leans Ryu (~62% Ryu).
  *
- * Initial assignment: vertical 2-column strips (q=0–1, q=2–3, q=4–5, q=6–7, q=8–9)
- *   Cracks the valley across D2, D3, D4, D5 — no district reaches 50% Latino:
- *     D1 (q=0–1): 0 valley pcts   → ~20% Latino   ← fails VRA ✓
- *     D2 (q=2–3): 4 valley pcts   → ~28% Latino   ← fails VRA ✓
- *     D3 (q=4–5): 8 valley pcts   → ~37% Latino   ← fails VRA ✓
- *     D4 (q=6–7): 8 valley pcts   → ~37% Latino   ← fails VRA ✓
- *     D5 (q=8–9): 4 valley pcts   → ~28% Latino   ← fails VRA ✓
+ * Valley definition: hexes where q ∈ [1,5] AND r ∈ [-2,1] AND hexDist ≤ 6.
+ *   This creates a compact cluster in the east, roughly 24 hexes.
  *
- * Winning solution: consolidate the valley into one district (q=3..8, r=5..8)
+ * Initial assignment: diagonal strips (k=q+r constant).
+ *   Cracks the valley across multiple districts — no district reaches 50% Latino.
+ *
+ * Winning solution: consolidate the valley into one district.
  *   → 70% Latino → majority-minority criterion satisfied ✓
- *   Educational note: this also packs Ken votes into one district — the remaining
- *   four districts become more Ryu-leaning. VRA compliance creates a tradeoff.
+ *   Educational note: packs Ken votes into one district; remaining four
+ *   become more Ryu-leaning. VRA compliance creates a partisan tradeoff.
  *
  * demographic_groups schema:
  *   group_schema: { dimensions: { ethnicity: [latino, anglo] } }
@@ -36,77 +33,89 @@
  *   kotlin game/scenarios/gen-scenario-005.main.kts
  */
 
+import kotlin.math.abs
 import kotlin.random.Random
 
 val rng = Random(55)
-val NUM_Q = 10
-val NUM_R = 12
-val BASE_POP = 1500
+val R = 6
 
-fun isValley(q: Int, r: Int) = q in 3..8 && r in 5..8
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
 
-// Initial assignment: vertical 2-column strips
-fun initialDistrict(q: Int, r: Int): String = when {
-    q <= 1 -> "d1"
-    q <= 3 -> "d2"
-    q <= 5 -> "d3"
-    q <= 7 -> "d4"
-    else   -> "d5"
+// Valley: a compact cluster in the eastern part of the hex
+fun isValley(q: Int, r: Int): Boolean =
+    q in 1..5 && r in -2..1 && hexDist(q, r) <= R
+
+// Initial: diagonal strips (k = q+r constant) — cracks the valley.
+//   k ≤ -3: d1, k=-2..-1: d2, k=0: d3, k=1..2: d4, k≥3: d5
+fun initialDistrict(q: Int, r: Int): String {
+    val k = q + r
+    return when {
+        k <= -3 -> "d1"
+        k <= -1 -> "d2"
+        k == 0  -> "d3"
+        k <= 2  -> "d4"
+        else    -> "d5"
+    }
 }
 
 fun countyId(q: Int, r: Int) = when {
-    isValley(q, r) -> "valle_verde_valley"
-    r <= 4         -> "valle_verde_north"
-    else           -> "valle_verde_south"
+    isValley(q, r)  -> "valle_verde_valley"
+    hexDist(q, r) <= 3 -> "valle_verde_central"
+    else            -> "valle_verde_rim"
 }
 
-fun colLetter(q: Int) = "ABCDEFGHIJ"[q].toString()
-
 fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+data class Hex(val q: Int, val r: Int)
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+val BASE_POP = 1500
 
 val precincts = StringBuilder()
 var first = true
 
-for (r in 0 until NUM_R) {
-    for (q in 0 until NUM_Q) {
-        val idx = r * NUM_Q + q
-        val pid = "p%03d".format(idx + 1)
-        val valley = isValley(q, r)
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
+    val valley = isValley(q, r)
 
-        val pop = BASE_POP + rng.nextInt(-150, 151)
+    val pop = BASE_POP + rng.nextInt(-150, 151)
 
-        // Latino population share (of total_population)
-        val latinoShare = if (valley) {
-            (0.70 + rng.nextDouble(-0.04, 0.04)).coerceIn(0.60, 0.80)
-        } else {
-            (0.20 + rng.nextDouble(-0.04, 0.04)).coerceIn(0.10, 0.32)
-        }
-        // Ensure shares sum exactly to 1.0 (avoid floating-point accumulation in loader)
-        val latinoShareStr = latinoShare.fmt(4)
-        val angloShare = 1.0 - latinoShareStr.toDouble()
-        val angloShareStr = angloShare.fmt(4)
+    val latinoShare = if (valley) {
+        (0.70 + rng.nextDouble(-0.04, 0.04)).coerceIn(0.60, 0.80)
+    } else {
+        (0.20 + rng.nextDouble(-0.04, 0.04)).coerceIn(0.10, 0.32)
+    }
+    val latinoShareStr = latinoShare.fmt(4)
+    val angloShare = 1.0 - latinoShareStr.toDouble()
+    val angloShareStr = angloShare.fmt(4)
 
-        // Vote shares: Latino community strongly Ken-leaning; Anglo community leans Ryu
-        val latinoKen = (0.78 + rng.nextDouble(-0.03, 0.03)).coerceIn(0.05, 0.95)
-        val latinoKenStr = latinoKen.fmt(4)
-        val latinoRyuStr = (1.0 - latinoKenStr.toDouble()).fmt(4)
+    val latinoKen = (0.78 + rng.nextDouble(-0.03, 0.03)).coerceIn(0.05, 0.95)
+    val latinoKenStr = latinoKen.fmt(4)
+    val latinoRyuStr = (1.0 - latinoKenStr.toDouble()).fmt(4)
 
-        val angloKen = (0.38 + rng.nextDouble(-0.03, 0.03)).coerceIn(0.05, 0.95)
-        val angloKenStr = angloKen.fmt(4)
-        val angloRyuStr = (1.0 - angloKenStr.toDouble()).fmt(4)
+    val angloKen = (0.38 + rng.nextDouble(-0.03, 0.03)).coerceIn(0.05, 0.95)
+    val angloKenStr = angloKen.fmt(4)
+    val angloRyuStr = (1.0 - angloKenStr.toDouble()).fmt(4)
 
-        val latinoTurnout = rng.nextDouble(0.52, 0.62)
-        val angloTurnout = rng.nextDouble(0.58, 0.68)
+    val latinoTurnout = rng.nextDouble(0.52, 0.62)
+    val angloTurnout = rng.nextDouble(0.58, 0.68)
 
-        val districtId = initialDistrict(q, r)
-        val county = countyId(q, r)
-        val zoneName = if (valley) "Valley" else "Rim"
-        val name = "$zoneName ${colLetter(q)}${r + 1}"
+    val districtId = initialDistrict(q, r)
+    val county = countyId(q, r)
+    val zoneName = if (valley) "Valley" else "Rim"
+    val name = "$zoneName ($q,$r)"
 
-        if (!first) precincts.append(",\n")
-        first = false
+    if (!first) precincts.append(",\n")
+    first = false
 
-        precincts.append("""    {
+    precincts.append("""    {
       "id": "$pid",
       "editable": true,
       "county_id": "$county",
@@ -133,8 +142,9 @@ for (r in 0 until NUM_R) {
         }
       ]
     }""")
-    }
 }
+
+val valleyCount = hexes.count { isValley(it.q, it.r) }
 
 val json = """{
   "format_version": "1",
@@ -209,12 +219,12 @@ $precincts
     "character": {
       "name": "You",
       "role": "Court-Appointed Redistricting Coordinator, Valle Verde County",
-      "motivation": "A federal court found that the current district map violates the Voting Rights Act. The Valley's Latino community has been cracked across four districts — diluted so thoroughly that they cannot elect their preferred candidate anywhere. You must draw a new map that complies with the law."
+      "motivation": "A federal court found that the current district map violates the Voting Rights Act. The Valley's Latino community has been cracked across multiple districts — diluted so thoroughly that they cannot elect their preferred candidate anywhere. You must draw a new map that complies with the law."
     },
     "intro_slides": [
       {
         "heading": "The Valley Grows",
-        "body": "Over the past decade, Valle Verde County's Valley has seen significant population growth. The Latino community, concentrated in this area, now makes up a meaningful share of the county's total population.\n\nBut on the current map, drawn ten years ago, the Valley is sliced into four strips — each one a piece of a different district, none large enough to matter."
+        "body": "Over the past decade, Valle Verde County's Valley has seen significant population growth. The Latino community, concentrated in this area, now makes up a meaningful share of the county's total population.\n\nBut on the current map, drawn ten years ago, the Valley is sliced across multiple districts — each one a piece of a different district, none large enough to matter."
       },
       {
         "heading": "The Voting Rights Act",
@@ -232,4 +242,4 @@ $precincts
 
 val outFile = java.io.File("game/scenarios/scenario-005.json")
 outFile.writeText(json)
-println("Wrote ${NUM_Q * NUM_R} precincts to ${outFile.path}")
+println("Wrote ${hexes.size} precincts ($valleyCount valley) to ${outFile.path}")

--- a/game/scenarios/gen-scenario-006.main.kts
+++ b/game/scenarios/gen-scenario-006.main.kts
@@ -4,26 +4,20 @@
  *
  * Lesson: Incumbency protection — the bipartisan gerrymander.
  *
- * Layout: 10 columns (q=0..9) × 12 rows (r=0..11) = 120 precincts, 5 districts of 24.
+ * Shape: hex-of-hexes, radius 6 → 127 precincts, 5 districts of ~25-26.
+ * Coordinates: axial, centered at (0,0); range q,r in [-6,6].
  *
- * Partisan geography:
- *   Left flank  (q=0..5): ~62% Ken (6 cols × 12 rows = 72 precincts = 3 districts exactly)
- *   Right flank (q=6..9): ~38% Ken / ~62% Ryu (4 cols × 12 rows = 48 = 2 districts exactly)
+ * Partisan geography (left/right split via q coordinate):
+ *   Left flank  (q ≤ 0, ~70 hexes): ~62% Ken
+ *   Right flank (q ≥ 1, ~57 hexes): ~38% Ken / ~62% Ryu
  *
- * Initial assignment: "mirror pair" — each district pairs one left col with one right col.
- *   D1: q=0 + q=9 → (62%+38%)/2 = 50% Ken → margin ≈0% → COMPETITIVE
- *   D2: q=1 + q=8 → same → COMPETITIVE
- *   D3: q=2 + q=7 → same → COMPETITIVE
- *   D4: q=3 + q=6 → same → COMPETITIVE
- *   D5: q=4 + q=5 → (62%+62%)/2 = 62% Ken → safe for Ken only (1 safe seat)
- *   → safe_seats_ken criterion (≥3) fails; safe_seats_ryu (≥2) fails ✓
+ * Initial assignment: angular wedge sectors that mix left and right flanks.
+ *   Each sector spans from center to edge, crossing the partisan divide.
+ *   Average ≈ 50% Ken → all districts competitive → fails safe_seats criteria.
  *
- * Winning solution: vertical strips — separate the flanks
- *   D1: q=0-1, all rows (62% Ken → margin ~24% → SAFE Ken ✓)
- *   D2: q=2-3, all rows (62% Ken → SAFE Ken ✓)
- *   D3: q=4-5, all rows (62% Ken → SAFE Ken ✓)
- *   D4: q=6-7, all rows (62% Ryu → SAFE Ryu ✓)
- *   D5: q=8-9, all rows (62% Ryu → SAFE Ryu ✓)
+ * Winning solution: separate the flanks into vertical-ish blocks.
+ *   3 districts from left flank (62% Ken → safe Ken ✓)
+ *   2 districts from right flank (62% Ryu → safe Ryu ✓)
  *   → Ken: 3 safe seats ✓; Ryu: 2 safe seats ✓
  *
  * safe_seats margin threshold: 0.15 (winner needs ≥57.5% to qualify as "safe")
@@ -32,53 +26,76 @@
  *   kotlin game/scenarios/gen-scenario-006.main.kts
  */
 
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.PI
 import kotlin.random.Random
 
 val rng = Random(66)
-val NUM_Q = 10
-val NUM_R = 12
-val BASE_POP = 1500
+val R = 6
 
-// Partisan geography: clean left/right split, no battleground column
-fun baseKenShare(q: Int): Double = if (q <= 5) 0.62 else 0.38
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
 
-// Initial: mirror pairs — each district gets one col from each flank
-fun initialDistrict(q: Int): String = when (q) {
-    0, 9 -> "d1"
-    1, 8 -> "d2"
-    2, 7 -> "d3"
-    3, 6 -> "d4"
-    else -> "d5"  // q=4, q=5
+// Left = Ken territory, right = Ryu territory
+fun baseKenShare(q: Int, r: Int): Double = when {
+    q <= 0 -> 0.62  // left flank: Ken-majority
+    else   -> 0.38  // right flank: Ryu-majority
 }
 
-fun countyId(q: Int): String = if (q <= 5) "westbrook" else "eastbrook"
-fun colLetter(q: Int) = "ABCDEFGHIJ"[q].toString()
+// Initial: 5 angular wedge sectors — each mixes left and right flanks.
+// All districts end up competitive (~50% Ken) → fails safe_seats for both parties.
+fun initialDistrict(q: Int, r: Int): String {
+    if (q == 0 && r == 0) return "d3"
+    val x = q.toDouble() + r.toDouble() * 0.5
+    val y = r.toDouble() * 0.8660254
+    val norm = (atan2(y, x) + PI) / (2.0 * PI)
+    return when ((norm * 5).toInt().coerceIn(0, 4)) {
+        0 -> "d1"
+        1 -> "d2"
+        2 -> "d3"
+        3 -> "d4"
+        else -> "d5"
+    }
+}
+
+fun countyId(q: Int, r: Int): String = if (q <= 0) "westbrook" else "eastbrook"
+
 fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+data class Hex(val q: Int, val r: Int)
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+val BASE_POP = 1500
 
 val precincts = StringBuilder()
 var first = true
 
-for (r in 0 until NUM_R) {
-    for (q in 0 until NUM_Q) {
-        val idx = r * NUM_Q + q
-        val pid = "p%03d".format(idx + 1)
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
 
-        val pop = BASE_POP + rng.nextInt(-150, 151)
+    val pop = BASE_POP + rng.nextInt(-150, 151)
 
-        val kenShare = (baseKenShare(q) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
-        val kenStr = kenShare.fmt(4)
-        val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
-        val turnout = rng.nextDouble(0.55, 0.70)
+    val kenShare = (baseKenShare(q, r) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+    val kenStr = kenShare.fmt(4)
+    val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
+    val turnout = rng.nextDouble(0.55, 0.70)
 
-        val districtId = initialDistrict(q)
-        val county = countyId(q)
-        val side = if (q <= 5) "West" else "East"
-        val name = "$side ${colLetter(q)}${r + 1}"
+    val districtId = initialDistrict(q, r)
+    val county = countyId(q, r)
+    val side = if (q <= 0) "West" else "East"
+    val name = "$side ($q,$r)"
 
-        if (!first) precincts.append(",\n")
-        first = false
+    if (!first) precincts.append(",\n")
+    first = false
 
-        precincts.append("""    {
+    precincts.append("""    {
       "id": "$pid",
       "editable": true,
       "county_id": "$county",
@@ -96,7 +113,6 @@ for (r in 0 until NUM_R) {
         }
       ]
     }""")
-    }
 }
 
 val json = """{
@@ -202,4 +218,4 @@ $precincts
 
 val outFile = java.io.File("game/scenarios/scenario-006.json")
 outFile.writeText(json)
-println("Wrote ${NUM_Q * NUM_R} precincts to ${outFile.path}")
+println("Wrote ${hexes.size} precincts to ${outFile.path}")

--- a/game/scenarios/gen-tutorial-002.main.kts
+++ b/game/scenarios/gen-tutorial-002.main.kts
@@ -1,0 +1,225 @@
+#!/usr/bin/env kotlin
+/**
+ * Generator for tutorial-002.json: "Millbrook County: Three-District Challenge"
+ *
+ * Shape: hex-of-hexes R=8 (217 positions) trimmed to 196 by removing the
+ * outermost corner hexes. This gives a roughly circular hex shape at the
+ * same precinct count as the original 14×14 rectangular grid.
+ *
+ * Trimming rule: remove hexes where hexDist == 8 AND the hex is at one of
+ * the 6 corner directions (where two of |q|,|r|,|q+r| equal 8). This
+ * removes 6 hexes from d=8 ring, leaving 217-6=211. Need to remove 15
+ * more: trim hexes at d=8 that are closest to corners (highest max(|q|,|r|,|q+r|)).
+ *
+ * Simpler approach: include all hexes with hexDist ≤ 7 (169) + enough d=8
+ * hexes to reach 196. The d=8 ring has 48 hexes; we need 27 of them.
+ * Take the 27 hexes from the d=8 ring that are furthest from corners
+ * (i.e., closest to the 6 edge midpoints).
+ *
+ * Districts: 3 districts of ~65 precincts each.
+ * Counties: north (r < -2), central (|r| ≤ 2), south (r > 2).
+ *
+ * Geography: gentle partisan lean by county.
+ *   North: ~55% Ken — slight Ken lean
+ *   Central: ~50% — competitive
+ *   South: ~45% Ken — slight Ryu lean
+ *
+ * Initial assignment: county-aligned (north→d1, central→d2, south→d3).
+ *   Population imbalanced by design → submit disabled.
+ *   Player must move a few boundary precincts to balance populations.
+ *
+ * Run from repo root:
+ *   kotlin game/scenarios/gen-tutorial-002.main.kts
+ */
+
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.random.Random
+
+val rng = Random(202)
+val R = 8
+val TARGET_COUNT = 196
+
+fun hexDist(q: Int, r: Int): Int = (abs(q) + abs(r) + abs(q + r)) / 2
+
+// Build full R=8 hex, then trim to 196
+data class Hex(val q: Int, val r: Int)
+
+val allHexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) { add(Hex(q, r)) }
+    }
+}
+
+// All d≤7 hexes (169) + d=8 hexes sorted by "distance from nearest corner"
+// Corner hexes at d=8 have max(|q|,|r|,|q+r|) = 8 for two coordinates.
+// Edge-midpoint hexes have the coordinates more spread out.
+// Sort d=8 ring by how "corner-like" they are (higher = more corner-like).
+val inner = allHexes.filter { hexDist(it.q, it.r) <= 7 }  // 169
+val outerRing = allHexes.filter { hexDist(it.q, it.r) == 8 }  // 48
+val need = TARGET_COUNT - inner.size  // 27
+
+// Corner-likeness: max of |q|, |r|, |q+r| — corners have this = 8
+val outerSorted = outerRing.sortedBy { max(abs(it.q), max(abs(it.r), abs(it.q + it.r))) }
+// Take the 27 LEAST corner-like (closest to edge midpoints)
+val selectedOuter = outerSorted.take(need)
+
+val hexes = (inner + selectedOuter).sortedWith(compareBy({ it.r }, { it.q }))
+val hexIndex = hexes.withIndex().associate { (i, h) -> h to i }
+
+println("Total: ${hexes.size} (inner ${inner.size} + ${selectedOuter.size} outer)")
+
+// Counties by r position
+fun countyId(q: Int, r: Int): String = when {
+    r < -2  -> "north"
+    r <= 2  -> "central"
+    else    -> "south"
+}
+
+// Partisan lean by county
+fun baseKenShare(q: Int, r: Int): Double = when {
+    r < -2  -> 0.55  // north: slight Ken
+    r <= 2  -> 0.50  // central: competitive
+    else    -> 0.45  // south: slight Ryu
+}
+
+// Initial: county-aligned districts (population imbalanced)
+fun initialDistrict(q: Int, r: Int): String = when {
+    r < -2  -> "d1"  // north
+    r <= 2  -> "d2"  // central
+    else    -> "d3"  // south
+}
+
+val BASE_POP = 3000  // higher per-precinct pop for tutorial scale
+
+fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+val precincts = StringBuilder()
+var first = true
+
+for ((idx, hex) in hexes.withIndex()) {
+    val (q, r) = hex
+    val pid = "p%03d".format(idx + 1)
+
+    val pop = BASE_POP + rng.nextInt(-300, 301)
+
+    val kenShare = (baseKenShare(q, r) + rng.nextDouble(-0.06, 0.06)).coerceIn(0.05, 0.95)
+    val kenStr = kenShare.fmt(4)
+    val ryuStr = (1.0 - kenStr.toDouble()).fmt(4)
+    val turnout = rng.nextDouble(0.55, 0.70)
+
+    val districtId = initialDistrict(q, r)
+    val county = countyId(q, r)
+    val zoneName = when {
+        r < -2  -> "North"
+        r <= 2  -> "Central"
+        else    -> "South"
+    }
+    val name = "$zoneName ($q,$r)"
+
+    if (!first) precincts.append(",\n")
+    first = false
+
+    precincts.append("""    {
+      "id": "$pid",
+      "editable": true,
+      "county_id": "$county",
+      "position": { "q": $q, "r": $r },
+      "total_population": $pop,
+      "initial_district_id": "$districtId",
+      "name": "$name",
+      "demographic_groups": [
+        {
+          "id": "${pid}-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": ${turnout.fmt(2)},
+          "vote_shares": { "ken": $kenStr, "ryu": $ryuStr }
+        }
+      ]
+    }""")
+}
+
+// Count per initial district
+val d1Count = hexes.count { initialDistrict(it.q, it.r) == "d1" }
+val d2Count = hexes.count { initialDistrict(it.q, it.r) == "d2" }
+val d3Count = hexes.count { initialDistrict(it.q, it.r) == "d3" }
+
+val json = """{
+  "format_version": "1",
+  "id": "tutorial-002",
+  "title": "Millbrook County: Three-District Challenge",
+  "election_type": "state_house",
+  "region": {
+    "id": "millbrook_county",
+    "name": "Millbrook County"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
+    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+$precincts
+  ],
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All three districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All three districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    },
+    {
+      "id": "sc-compactness",
+      "required": false,
+      "description": "All districts are reasonably compact (compactness ≥ 40%).",
+      "criterion": {
+        "type": "compactness",
+        "operator": "gte",
+        "threshold": 0.40
+      }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "Redistricting Commissioner, Millbrook County",
+      "motivation": "Millbrook County needs new district boundaries. The three counties — North, Central, and South — each have different populations. Your job is to draw three districts with roughly equal population. The current county-aligned map is out of balance."
+    },
+    "intro_slides": [
+      {
+        "heading": "Welcome to Millbrook County",
+        "body": "This is a larger map than the tutorial. Millbrook County has three regions: North, Central, and South. The current district boundaries follow county lines — but the populations aren't equal.\n\nYour job: adjust the boundaries so all three districts have roughly the same number of people."
+      },
+      {
+        "heading": "The Tools",
+        "body": "Select a district from the toolbar, then paint precincts to assign them. You don't need to redraw the entire map — just move a few boundary precincts to balance the populations.\n\nWatch the population balance indicator in the sidebar. When all three districts are within 10% of the target, the Submit button will activate."
+      }
+    ],
+    "objective": "Balance the three districts so each has roughly equal population (within 10%). Move boundary precincts between districts to fix the imbalance."
+  }
+}
+"""
+
+val outFile = java.io.File("game/scenarios/tutorial-002.json")
+outFile.writeText(json)
+println("Wrote ${hexes.size} precincts to ${outFile.path} (d1=$d1Count, d2=$d2Count, d3=$d3Count)")

--- a/game/scenarios/scenario-002.json
+++ b/game/scenarios/scenario-002.json
@@ -23,573 +23,789 @@
     {
       "id": "p001",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 0, "r": 0 },
-      "total_population": 1585,
+      "county_id": "clearwater_west",
+      "position": { "q": 0, "r": -5 },
+      "total_population": 1538,
       "initial_district_id": "d1",
-      "name": "North A1",
+      "name": "West (0,-5)",
       "demographic_groups": [
         {
-          "id": "p001-base",
-          "name": "Registered voters",
+          "id": "p001-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5836, "ryu": 0.4164 }
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6124, "ryu": 0.3876 }
         }
       ]
     },
     {
       "id": "p002",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 1, "r": 0 },
-      "total_population": 1402,
+      "county_id": "clearwater_central",
+      "position": { "q": 1, "r": -5 },
+      "total_population": 1508,
       "initial_district_id": "d1",
-      "name": "North B1",
+      "name": "Central (1,-5)",
       "demographic_groups": [
         {
-          "id": "p002-base",
-          "name": "Registered voters",
+          "id": "p002-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.5791, "ryu": 0.4209 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.5576, "ryu": 0.4424 }
         }
       ]
     },
     {
       "id": "p003",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 2, "r": 0 },
-      "total_population": 1407,
-      "initial_district_id": "d2",
-      "name": "North C1",
+      "county_id": "clearwater_central",
+      "position": { "q": 2, "r": -5 },
+      "total_population": 1550,
+      "initial_district_id": "d1",
+      "name": "Central (2,-5)",
       "demographic_groups": [
         {
-          "id": "p003-base",
-          "name": "Registered voters",
+          "id": "p003-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6056, "ryu": 0.3944 }
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5338, "ryu": 0.4662 }
         }
       ]
     },
     {
       "id": "p004",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 3, "r": 0 },
-      "total_population": 1413,
+      "county_id": "clearwater_central",
+      "position": { "q": 3, "r": -5 },
+      "total_population": 1425,
       "initial_district_id": "d2",
-      "name": "North D1",
+      "name": "Central (3,-5)",
       "demographic_groups": [
         {
-          "id": "p004-base",
-          "name": "Registered voters",
+          "id": "p004-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6266, "ryu": 0.3734 }
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5274, "ryu": 0.4726 }
         }
       ]
     },
     {
       "id": "p005",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 4, "r": 0 },
-      "total_population": 1511,
-      "initial_district_id": "d3",
-      "name": "North E1",
+      "county_id": "clearwater_central",
+      "position": { "q": 4, "r": -5 },
+      "total_population": 1479,
+      "initial_district_id": "d2",
+      "name": "Central (4,-5)",
       "demographic_groups": [
         {
-          "id": "p005-base",
-          "name": "Registered voters",
+          "id": "p005-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6081, "ryu": 0.3919 }
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5185, "ryu": 0.4815 }
         }
       ]
     },
     {
       "id": "p006",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 5, "r": 0 },
-      "total_population": 1596,
+      "county_id": "clearwater_central",
+      "position": { "q": 5, "r": -5 },
+      "total_population": 1600,
       "initial_district_id": "d3",
-      "name": "North F1",
+      "name": "Central (5,-5)",
       "demographic_groups": [
         {
-          "id": "p006-base",
-          "name": "Registered voters",
+          "id": "p006-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5990, "ryu": 0.4010 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5054, "ryu": 0.4946 }
         }
       ]
     },
     {
       "id": "p007",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 6, "r": 0 },
-      "total_population": 1513,
-      "initial_district_id": "d4",
-      "name": "North G1",
+      "county_id": "clearwater_west",
+      "position": { "q": -1, "r": -4 },
+      "total_population": 1357,
+      "initial_district_id": "d1",
+      "name": "West (-1,-4)",
       "demographic_groups": [
         {
-          "id": "p007-base",
-          "name": "Registered voters",
+          "id": "p007-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.5966, "ryu": 0.4034 }
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6164, "ryu": 0.3836 }
         }
       ]
     },
     {
       "id": "p008",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 7, "r": 0 },
-      "total_population": 1575,
-      "initial_district_id": "d4",
-      "name": "North H1",
+      "county_id": "clearwater_west",
+      "position": { "q": 0, "r": -4 },
+      "total_population": 1580,
+      "initial_district_id": "d1",
+      "name": "West (0,-4)",
       "demographic_groups": [
         {
-          "id": "p008-base",
-          "name": "Registered voters",
+          "id": "p008-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6245, "ryu": 0.3755 }
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5977, "ryu": 0.4023 }
         }
       ]
     },
     {
       "id": "p009",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 0, "r": 1 },
-      "total_population": 1496,
+      "county_id": "clearwater_central",
+      "position": { "q": 1, "r": -4 },
+      "total_population": 1477,
       "initial_district_id": "d1",
-      "name": "North A2",
+      "name": "Central (1,-4)",
       "demographic_groups": [
         {
-          "id": "p009-base",
-          "name": "Registered voters",
+          "id": "p009-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6007, "ryu": 0.3993 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5423, "ryu": 0.4577 }
         }
       ]
     },
     {
       "id": "p010",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 1, "r": 1 },
-      "total_population": 1430,
-      "initial_district_id": "d1",
-      "name": "North B2",
+      "county_id": "clearwater_central",
+      "position": { "q": 2, "r": -4 },
+      "total_population": 1367,
+      "initial_district_id": "d2",
+      "name": "Central (2,-4)",
       "demographic_groups": [
         {
-          "id": "p010-base",
-          "name": "Registered voters",
+          "id": "p010-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6286, "ryu": 0.3714 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5276, "ryu": 0.4724 }
         }
       ]
     },
     {
       "id": "p011",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 2, "r": 1 },
-      "total_population": 1501,
+      "county_id": "clearwater_central",
+      "position": { "q": 3, "r": -4 },
+      "total_population": 1487,
       "initial_district_id": "d2",
-      "name": "North C2",
+      "name": "Central (3,-4)",
       "demographic_groups": [
         {
-          "id": "p011-base",
-          "name": "Registered voters",
+          "id": "p011-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6260, "ryu": 0.3740 }
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5588, "ryu": 0.4412 }
         }
       ]
     },
     {
       "id": "p012",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 3, "r": 1 },
-      "total_population": 1508,
-      "initial_district_id": "d2",
-      "name": "North D2",
+      "county_id": "clearwater_central",
+      "position": { "q": 4, "r": -4 },
+      "total_population": 1602,
+      "initial_district_id": "d3",
+      "name": "Central (4,-4)",
       "demographic_groups": [
         {
-          "id": "p012-base",
-          "name": "Registered voters",
+          "id": "p012-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.5942, "ryu": 0.4058 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.5111, "ryu": 0.4889 }
         }
       ]
     },
     {
       "id": "p013",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 4, "r": 1 },
-      "total_population": 1582,
+      "county_id": "clearwater_central",
+      "position": { "q": 5, "r": -4 },
+      "total_population": 1352,
       "initial_district_id": "d3",
-      "name": "North E2",
+      "name": "Central (5,-4)",
       "demographic_groups": [
         {
-          "id": "p013-base",
-          "name": "Registered voters",
+          "id": "p013-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6273, "ryu": 0.3727 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5120, "ryu": 0.4880 }
         }
       ]
     },
     {
       "id": "p014",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 5, "r": 1 },
-      "total_population": 1448,
-      "initial_district_id": "d3",
-      "name": "North F2",
+      "county_id": "clearwater_west",
+      "position": { "q": -2, "r": -3 },
+      "total_population": 1598,
+      "initial_district_id": "d1",
+      "name": "West (-2,-3)",
       "demographic_groups": [
         {
-          "id": "p014-base",
-          "name": "Registered voters",
+          "id": "p014-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6186, "ryu": 0.3814 }
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6233, "ryu": 0.3767 }
         }
       ]
     },
     {
       "id": "p015",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 6, "r": 1 },
-      "total_population": 1562,
-      "initial_district_id": "d4",
-      "name": "North G2",
+      "county_id": "clearwater_west",
+      "position": { "q": -1, "r": -3 },
+      "total_population": 1482,
+      "initial_district_id": "d1",
+      "name": "West (-1,-3)",
       "demographic_groups": [
         {
-          "id": "p015-base",
-          "name": "Registered voters",
+          "id": "p015-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6055, "ryu": 0.3945 }
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5974, "ryu": 0.4026 }
         }
       ]
     },
     {
       "id": "p016",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 7, "r": 1 },
-      "total_population": 1433,
-      "initial_district_id": "d4",
-      "name": "North H2",
+      "county_id": "clearwater_west",
+      "position": { "q": 0, "r": -3 },
+      "total_population": 1377,
+      "initial_district_id": "d1",
+      "name": "West (0,-3)",
       "demographic_groups": [
         {
-          "id": "p016-base",
-          "name": "Registered voters",
+          "id": "p016-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5824, "ryu": 0.4176 }
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6123, "ryu": 0.3877 }
         }
       ]
     },
     {
       "id": "p017",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 0, "r": 2 },
-      "total_population": 1552,
-      "initial_district_id": "d1",
-      "name": "North A3",
+      "county_id": "clearwater_east",
+      "position": { "q": 1, "r": -3 },
+      "total_population": 1490,
+      "initial_district_id": "d2",
+      "name": "East (1,-3)",
       "demographic_groups": [
         {
-          "id": "p017-base",
-          "name": "Registered voters",
+          "id": "p017-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6295, "ryu": 0.3705 }
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.2770, "ryu": 0.7230 }
         }
       ]
     },
     {
       "id": "p018",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 1, "r": 2 },
-      "total_population": 1475,
-      "initial_district_id": "d1",
-      "name": "North B3",
+      "county_id": "clearwater_east",
+      "position": { "q": 2, "r": -3 },
+      "total_population": 1629,
+      "initial_district_id": "d2",
+      "name": "East (2,-3)",
       "demographic_groups": [
         {
-          "id": "p018-base",
-          "name": "Registered voters",
+          "id": "p018-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6074, "ryu": 0.3926 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.2468, "ryu": 0.7532 }
         }
       ]
     },
     {
       "id": "p019",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 2, "r": 2 },
-      "total_population": 1510,
-      "initial_district_id": "d2",
-      "name": "North C3",
+      "county_id": "clearwater_east",
+      "position": { "q": 3, "r": -3 },
+      "total_population": 1375,
+      "initial_district_id": "d3",
+      "name": "East (3,-3)",
       "demographic_groups": [
         {
-          "id": "p019-base",
-          "name": "Registered voters",
+          "id": "p019-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6225, "ryu": 0.3775 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.2624, "ryu": 0.7376 }
         }
       ]
     },
     {
       "id": "p020",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 3, "r": 2 },
-      "total_population": 1590,
-      "initial_district_id": "d2",
-      "name": "North D3",
+      "county_id": "clearwater_central",
+      "position": { "q": 4, "r": -3 },
+      "total_population": 1574,
+      "initial_district_id": "d3",
+      "name": "Central (4,-3)",
       "demographic_groups": [
         {
-          "id": "p020-base",
-          "name": "Registered voters",
+          "id": "p020-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6067, "ryu": 0.3933 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5308, "ryu": 0.4692 }
         }
       ]
     },
     {
       "id": "p021",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 4, "r": 2 },
-      "total_population": 1598,
-      "initial_district_id": "d3",
-      "name": "North E3",
+      "county_id": "clearwater_central",
+      "position": { "q": 5, "r": -3 },
+      "total_population": 1630,
+      "initial_district_id": "d4",
+      "name": "Central (5,-3)",
       "demographic_groups": [
         {
-          "id": "p021-base",
-          "name": "Registered voters",
+          "id": "p021-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5896, "ryu": 0.4104 }
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5291, "ryu": 0.4709 }
         }
       ]
     },
     {
       "id": "p022",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 5, "r": 2 },
-      "total_population": 1515,
-      "initial_district_id": "d3",
-      "name": "North F3",
+      "county_id": "clearwater_west",
+      "position": { "q": -3, "r": -2 },
+      "total_population": 1618,
+      "initial_district_id": "d1",
+      "name": "West (-3,-2)",
       "demographic_groups": [
         {
-          "id": "p022-base",
-          "name": "Registered voters",
+          "id": "p022-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5849, "ryu": 0.4151 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6033, "ryu": 0.3967 }
         }
       ]
     },
     {
       "id": "p023",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 6, "r": 2 },
-      "total_population": 1570,
-      "initial_district_id": "d4",
-      "name": "North G3",
+      "county_id": "clearwater_west",
+      "position": { "q": -2, "r": -2 },
+      "total_population": 1617,
+      "initial_district_id": "d1",
+      "name": "West (-2,-2)",
       "demographic_groups": [
         {
-          "id": "p023-base",
-          "name": "Registered voters",
+          "id": "p023-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6168, "ryu": 0.3832 }
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6203, "ryu": 0.3797 }
         }
       ]
     },
     {
       "id": "p024",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 7, "r": 2 },
-      "total_population": 1474,
-      "initial_district_id": "d4",
-      "name": "North H3",
+      "county_id": "clearwater_west",
+      "position": { "q": -1, "r": -2 },
+      "total_population": 1554,
+      "initial_district_id": "d1",
+      "name": "West (-1,-2)",
       "demographic_groups": [
         {
-          "id": "p024-base",
-          "name": "Registered voters",
+          "id": "p024-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5734, "ryu": 0.4266 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5832, "ryu": 0.4168 }
         }
       ]
     },
     {
       "id": "p025",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 0, "r": 3 },
-      "total_population": 1575,
-      "initial_district_id": "d1",
-      "name": "North A4",
+      "county_id": "clearwater_west",
+      "position": { "q": 0, "r": -2 },
+      "total_population": 1640,
+      "initial_district_id": "d2",
+      "name": "West (0,-2)",
       "demographic_groups": [
         {
-          "id": "p025-base",
-          "name": "Registered voters",
+          "id": "p025-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6098, "ryu": 0.3902 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6577, "ryu": 0.3423 }
         }
       ]
     },
     {
       "id": "p026",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 1, "r": 3 },
-      "total_population": 1402,
-      "initial_district_id": "d1",
-      "name": "North B4",
+      "county_id": "clearwater_east",
+      "position": { "q": 1, "r": -2 },
+      "total_population": 1364,
+      "initial_district_id": "d2",
+      "name": "East (1,-2)",
       "demographic_groups": [
         {
-          "id": "p026-base",
-          "name": "Registered voters",
+          "id": "p026-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6115, "ryu": 0.3885 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.2298, "ryu": 0.7702 }
         }
       ]
     },
     {
       "id": "p027",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 2, "r": 3 },
-      "total_population": 1529,
-      "initial_district_id": "d2",
-      "name": "North C4",
+      "county_id": "clearwater_east",
+      "position": { "q": 2, "r": -2 },
+      "total_population": 1540,
+      "initial_district_id": "d3",
+      "name": "East (2,-2)",
       "demographic_groups": [
         {
-          "id": "p027-base",
-          "name": "Registered voters",
+          "id": "p027-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6193, "ryu": 0.3807 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.2471, "ryu": 0.7529 }
         }
       ]
     },
     {
       "id": "p028",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 3, "r": 3 },
-      "total_population": 1460,
-      "initial_district_id": "d2",
-      "name": "North D4",
+      "county_id": "clearwater_east",
+      "position": { "q": 3, "r": -2 },
+      "total_population": 1520,
+      "initial_district_id": "d3",
+      "name": "East (3,-2)",
       "demographic_groups": [
         {
-          "id": "p028-base",
-          "name": "Registered voters",
+          "id": "p028-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5920, "ryu": 0.4080 }
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.2465, "ryu": 0.7535 }
         }
       ]
     },
     {
       "id": "p029",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 4, "r": 3 },
-      "total_population": 1579,
-      "initial_district_id": "d3",
-      "name": "North E4",
+      "county_id": "clearwater_central",
+      "position": { "q": 4, "r": -2 },
+      "total_population": 1498,
+      "initial_district_id": "d4",
+      "name": "Central (4,-2)",
       "demographic_groups": [
         {
-          "id": "p029-base",
-          "name": "Registered voters",
+          "id": "p029-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6086, "ryu": 0.3914 }
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4864, "ryu": 0.5136 }
         }
       ]
     },
     {
       "id": "p030",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 5, "r": 3 },
-      "total_population": 1409,
-      "initial_district_id": "d3",
-      "name": "North F4",
+      "county_id": "clearwater_central",
+      "position": { "q": 5, "r": -2 },
+      "total_population": 1527,
+      "initial_district_id": "d4",
+      "name": "Central (5,-2)",
       "demographic_groups": [
         {
-          "id": "p030-base",
-          "name": "Registered voters",
+          "id": "p030-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5793, "ryu": 0.4207 }
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4962, "ryu": 0.5038 }
         }
       ]
     },
     {
       "id": "p031",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 6, "r": 3 },
-      "total_population": 1440,
-      "initial_district_id": "d4",
-      "name": "North G4",
+      "county_id": "clearwater_west",
+      "position": { "q": -4, "r": -1 },
+      "total_population": 1554,
+      "initial_district_id": "d1",
+      "name": "West (-4,-1)",
       "demographic_groups": [
         {
-          "id": "p031-base",
-          "name": "Registered voters",
+          "id": "p031-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6160, "ryu": 0.3840 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5931, "ryu": 0.4069 }
         }
       ]
     },
     {
       "id": "p032",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 7, "r": 3 },
-      "total_population": 1548,
-      "initial_district_id": "d4",
-      "name": "North H4",
+      "county_id": "clearwater_west",
+      "position": { "q": -3, "r": -1 },
+      "total_population": 1371,
+      "initial_district_id": "d1",
+      "name": "West (-3,-1)",
       "demographic_groups": [
         {
-          "id": "p032-base",
-          "name": "Registered voters",
+          "id": "p032-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6110, "ryu": 0.3890 }
+        }
+      ]
+    },
+    {
+      "id": "p033",
+      "editable": true,
+      "county_id": "clearwater_west",
+      "position": { "q": -2, "r": -1 },
+      "total_population": 1370,
+      "initial_district_id": "d1",
+      "name": "West (-2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p033-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6268, "ryu": 0.3732 }
+        }
+      ]
+    },
+    {
+      "id": "p034",
+      "editable": true,
+      "county_id": "clearwater_west",
+      "position": { "q": -1, "r": -1 },
+      "total_population": 1379,
+      "initial_district_id": "d2",
+      "name": "West (-1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p034-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6596, "ryu": 0.3404 }
+        }
+      ]
+    },
+    {
+      "id": "p035",
+      "editable": true,
+      "county_id": "clearwater_west",
+      "position": { "q": 0, "r": -1 },
+      "total_population": 1371,
+      "initial_district_id": "d2",
+      "name": "West (0,-1)",
+      "demographic_groups": [
+        {
+          "id": "p035-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5999, "ryu": 0.4001 }
+        }
+      ]
+    },
+    {
+      "id": "p036",
+      "editable": true,
+      "county_id": "clearwater_east",
+      "position": { "q": 1, "r": -1 },
+      "total_population": 1575,
+      "initial_district_id": "d3",
+      "name": "East (1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p036-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.2402, "ryu": 0.7598 }
+        }
+      ]
+    },
+    {
+      "id": "p037",
+      "editable": true,
+      "county_id": "clearwater_east",
+      "position": { "q": 2, "r": -1 },
+      "total_population": 1648,
+      "initial_district_id": "d3",
+      "name": "East (2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p037-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.2313, "ryu": 0.7687 }
+        }
+      ]
+    },
+    {
+      "id": "p038",
+      "editable": true,
+      "county_id": "clearwater_east",
+      "position": { "q": 3, "r": -1 },
+      "total_population": 1512,
+      "initial_district_id": "d4",
+      "name": "East (3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p038-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.2696, "ryu": 0.7304 }
+        }
+      ]
+    },
+    {
+      "id": "p039",
+      "editable": true,
+      "county_id": "clearwater_central",
+      "position": { "q": 4, "r": -1 },
+      "total_population": 1641,
+      "initial_district_id": "d4",
+      "name": "Central (4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p039-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5384, "ryu": 0.4616 }
+        }
+      ]
+    },
+    {
+      "id": "p040",
+      "editable": true,
+      "county_id": "clearwater_central",
+      "position": { "q": 5, "r": -1 },
+      "total_population": 1412,
+      "initial_district_id": "d4",
+      "name": "Central (5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p040-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4875, "ryu": 0.5125 }
+        }
+      ]
+    },
+    {
+      "id": "p041",
+      "editable": true,
+      "county_id": "clearwater_west",
+      "position": { "q": -5, "r": 0 },
+      "total_population": 1410,
+      "initial_district_id": "d1",
+      "name": "West (-5,0)",
+      "demographic_groups": [
+        {
+          "id": "p041-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6486, "ryu": 0.3514 }
+        }
+      ]
+    },
+    {
+      "id": "p042",
+      "editable": true,
+      "county_id": "clearwater_west",
+      "position": { "q": -4, "r": 0 },
+      "total_population": 1559,
+      "initial_district_id": "d1",
+      "name": "West (-4,0)",
+      "demographic_groups": [
+        {
+          "id": "p042-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6384, "ryu": 0.3616 }
+        }
+      ]
+    },
+    {
+      "id": "p043",
+      "editable": true,
+      "county_id": "clearwater_west",
+      "position": { "q": -3, "r": 0 },
+      "total_population": 1531,
+      "initial_district_id": "d1",
+      "name": "West (-3,0)",
+      "demographic_groups": [
+        {
+          "id": "p043-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6156, "ryu": 0.3844 }
+        }
+      ]
+    },
+    {
+      "id": "p044",
+      "editable": true,
+      "county_id": "clearwater_west",
+      "position": { "q": -2, "r": 0 },
+      "total_population": 1617,
+      "initial_district_id": "d2",
+      "name": "West (-2,0)",
+      "demographic_groups": [
+        {
+          "id": "p044-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
           "vote_shares": { "ken": 0.5828, "ryu": 0.4172 }
@@ -597,344 +813,128 @@
       ]
     },
     {
-      "id": "p033",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 0, "r": 4 },
-      "total_population": 1495,
-      "initial_district_id": "d1",
-      "name": "North A5",
-      "demographic_groups": [
-        {
-          "id": "p033-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.5763, "ryu": 0.4237 }
-        }
-      ]
-    },
-    {
-      "id": "p034",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 1, "r": 4 },
-      "total_population": 1492,
-      "initial_district_id": "d1",
-      "name": "North B5",
-      "demographic_groups": [
-        {
-          "id": "p034-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5717, "ryu": 0.4283 }
-        }
-      ]
-    },
-    {
-      "id": "p035",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 2, "r": 4 },
-      "total_population": 1536,
-      "initial_district_id": "d2",
-      "name": "North C5",
-      "demographic_groups": [
-        {
-          "id": "p035-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5869, "ryu": 0.4131 }
-        }
-      ]
-    },
-    {
-      "id": "p036",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 3, "r": 4 },
-      "total_population": 1468,
-      "initial_district_id": "d2",
-      "name": "North D5",
-      "demographic_groups": [
-        {
-          "id": "p036-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5793, "ryu": 0.4207 }
-        }
-      ]
-    },
-    {
-      "id": "p037",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 4, "r": 4 },
-      "total_population": 1411,
-      "initial_district_id": "d3",
-      "name": "North E5",
-      "demographic_groups": [
-        {
-          "id": "p037-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5786, "ryu": 0.4214 }
-        }
-      ]
-    },
-    {
-      "id": "p038",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 5, "r": 4 },
-      "total_population": 1407,
-      "initial_district_id": "d3",
-      "name": "North F5",
-      "demographic_groups": [
-        {
-          "id": "p038-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6099, "ryu": 0.3901 }
-        }
-      ]
-    },
-    {
-      "id": "p039",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 6, "r": 4 },
-      "total_population": 1597,
-      "initial_district_id": "d4",
-      "name": "North G5",
-      "demographic_groups": [
-        {
-          "id": "p039-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.5994, "ryu": 0.4006 }
-        }
-      ]
-    },
-    {
-      "id": "p040",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 7, "r": 4 },
-      "total_population": 1553,
-      "initial_district_id": "d4",
-      "name": "North H5",
-      "demographic_groups": [
-        {
-          "id": "p040-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5970, "ryu": 0.4030 }
-        }
-      ]
-    },
-    {
-      "id": "p041",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 0, "r": 5 },
-      "total_population": 1548,
-      "initial_district_id": "d1",
-      "name": "North A6",
-      "demographic_groups": [
-        {
-          "id": "p041-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5928, "ryu": 0.4072 }
-        }
-      ]
-    },
-    {
-      "id": "p042",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 1, "r": 5 },
-      "total_population": 1569,
-      "initial_district_id": "d1",
-      "name": "North B6",
-      "demographic_groups": [
-        {
-          "id": "p042-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6017, "ryu": 0.3983 }
-        }
-      ]
-    },
-    {
-      "id": "p043",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 2, "r": 5 },
-      "total_population": 1538,
-      "initial_district_id": "d2",
-      "name": "North C6",
-      "demographic_groups": [
-        {
-          "id": "p043-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6164, "ryu": 0.3836 }
-        }
-      ]
-    },
-    {
-      "id": "p044",
-      "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 3, "r": 5 },
-      "total_population": 1488,
-      "initial_district_id": "d2",
-      "name": "North D6",
-      "demographic_groups": [
-        {
-          "id": "p044-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.5736, "ryu": 0.4264 }
-        }
-      ]
-    },
-    {
       "id": "p045",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 4, "r": 5 },
-      "total_population": 1547,
-      "initial_district_id": "d3",
-      "name": "North E6",
+      "county_id": "clearwater_west",
+      "position": { "q": -1, "r": 0 },
+      "total_population": 1534,
+      "initial_district_id": "d2",
+      "name": "West (-1,0)",
       "demographic_groups": [
         {
-          "id": "p045-base",
-          "name": "Registered voters",
+          "id": "p045-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6266, "ryu": 0.3734 }
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6087, "ryu": 0.3913 }
         }
       ]
     },
     {
       "id": "p046",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 5, "r": 5 },
-      "total_population": 1455,
+      "county_id": "clearwater_west",
+      "position": { "q": 0, "r": 0 },
+      "total_population": 1517,
       "initial_district_id": "d3",
-      "name": "North F6",
+      "name": "West (0,0)",
       "demographic_groups": [
         {
-          "id": "p046-base",
-          "name": "Registered voters",
+          "id": "p046-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5985, "ryu": 0.4015 }
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6239, "ryu": 0.3761 }
         }
       ]
     },
     {
       "id": "p047",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 6, "r": 5 },
-      "total_population": 1493,
-      "initial_district_id": "d4",
-      "name": "North G6",
+      "county_id": "clearwater_east",
+      "position": { "q": 1, "r": 0 },
+      "total_population": 1637,
+      "initial_district_id": "d3",
+      "name": "East (1,0)",
       "demographic_groups": [
         {
-          "id": "p047-base",
-          "name": "Registered voters",
+          "id": "p047-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5975, "ryu": 0.4025 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.2449, "ryu": 0.7551 }
         }
       ]
     },
     {
       "id": "p048",
       "editable": true,
-      "county_id": "clearwater_north",
-      "position": { "q": 7, "r": 5 },
-      "total_population": 1411,
+      "county_id": "clearwater_east",
+      "position": { "q": 2, "r": 0 },
+      "total_population": 1358,
       "initial_district_id": "d4",
-      "name": "North H6",
+      "name": "East (2,0)",
       "demographic_groups": [
         {
-          "id": "p048-base",
-          "name": "Registered voters",
+          "id": "p048-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6182, "ryu": 0.3818 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.2309, "ryu": 0.7691 }
         }
       ]
     },
     {
       "id": "p049",
       "editable": true,
-      "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 6 },
-      "total_population": 1554,
-      "initial_district_id": "d1",
-      "name": "Southwest A7",
+      "county_id": "clearwater_east",
+      "position": { "q": 3, "r": 0 },
+      "total_population": 1415,
+      "initial_district_id": "d4",
+      "name": "East (3,0)",
       "demographic_groups": [
         {
-          "id": "p049-base",
-          "name": "Registered voters",
+          "id": "p049-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5079, "ryu": 0.4921 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.2353, "ryu": 0.7647 }
         }
       ]
     },
     {
       "id": "p050",
       "editable": true,
-      "county_id": "clearwater_west",
-      "position": { "q": 1, "r": 6 },
-      "total_population": 1566,
-      "initial_district_id": "d1",
-      "name": "Southwest B7",
+      "county_id": "clearwater_central",
+      "position": { "q": 4, "r": 0 },
+      "total_population": 1389,
+      "initial_district_id": "d4",
+      "name": "Central (4,0)",
       "demographic_groups": [
         {
-          "id": "p050-base",
-          "name": "Registered voters",
+          "id": "p050-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5190, "ryu": 0.4810 }
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5460, "ryu": 0.4540 }
         }
       ]
     },
     {
       "id": "p051",
       "editable": true,
-      "county_id": "clearwater_west",
-      "position": { "q": 2, "r": 6 },
-      "total_population": 1554,
-      "initial_district_id": "d2",
-      "name": "Southwest C7",
+      "county_id": "clearwater_central",
+      "position": { "q": 5, "r": 0 },
+      "total_population": 1536,
+      "initial_district_id": "d4",
+      "name": "Central (5,0)",
       "demographic_groups": [
         {
-          "id": "p051-base",
-          "name": "Registered voters",
+          "id": "p051-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5015, "ryu": 0.4985 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5271, "ryu": 0.4729 }
         }
       ]
     },
@@ -942,89 +942,89 @@
       "id": "p052",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 3, "r": 6 },
-      "total_population": 1498,
-      "initial_district_id": "d2",
-      "name": "Southwest D7",
+      "position": { "q": -5, "r": 1 },
+      "total_population": 1359,
+      "initial_district_id": "d1",
+      "name": "West (-5,1)",
       "demographic_groups": [
         {
-          "id": "p052-base",
-          "name": "Registered voters",
+          "id": "p052-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.5095, "ryu": 0.4905 }
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6219, "ryu": 0.3781 }
         }
       ]
     },
     {
       "id": "p053",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 4, "r": 6 },
-      "total_population": 1439,
-      "initial_district_id": "d3",
-      "name": "Southeast E7",
+      "county_id": "clearwater_west",
+      "position": { "q": -4, "r": 1 },
+      "total_population": 1579,
+      "initial_district_id": "d1",
+      "name": "West (-4,1)",
       "demographic_groups": [
         {
-          "id": "p053-base",
-          "name": "Registered voters",
+          "id": "p053-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.2254, "ryu": 0.7746 }
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6077, "ryu": 0.3923 }
         }
       ]
     },
     {
       "id": "p054",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 5, "r": 6 },
-      "total_population": 1478,
-      "initial_district_id": "d3",
-      "name": "Southeast F7",
+      "county_id": "clearwater_west",
+      "position": { "q": -3, "r": 1 },
+      "total_population": 1444,
+      "initial_district_id": "d2",
+      "name": "West (-3,1)",
       "demographic_groups": [
         {
-          "id": "p054-base",
-          "name": "Registered voters",
+          "id": "p054-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.2267, "ryu": 0.7733 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6264, "ryu": 0.3736 }
         }
       ]
     },
     {
       "id": "p055",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 6, "r": 6 },
-      "total_population": 1492,
-      "initial_district_id": "d4",
-      "name": "Southeast G7",
+      "county_id": "clearwater_west",
+      "position": { "q": -2, "r": 1 },
+      "total_population": 1551,
+      "initial_district_id": "d2",
+      "name": "West (-2,1)",
       "demographic_groups": [
         {
-          "id": "p055-base",
-          "name": "Registered voters",
+          "id": "p055-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.2772, "ryu": 0.7228 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6488, "ryu": 0.3512 }
         }
       ]
     },
     {
       "id": "p056",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 7, "r": 6 },
-      "total_population": 1437,
-      "initial_district_id": "d4",
-      "name": "Southeast H7",
+      "county_id": "clearwater_west",
+      "position": { "q": -1, "r": 1 },
+      "total_population": 1504,
+      "initial_district_id": "d3",
+      "name": "West (-1,1)",
       "demographic_groups": [
         {
-          "id": "p056-base",
-          "name": "Registered voters",
+          "id": "p056-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.2216, "ryu": 0.7784 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5938, "ryu": 0.4062 }
         }
       ]
     },
@@ -1032,143 +1032,143 @@
       "id": "p057",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 7 },
-      "total_population": 1437,
-      "initial_district_id": "d1",
-      "name": "Southwest A8",
+      "position": { "q": 0, "r": 1 },
+      "total_population": 1496,
+      "initial_district_id": "d3",
+      "name": "West (0,1)",
       "demographic_groups": [
         {
-          "id": "p057-base",
-          "name": "Registered voters",
+          "id": "p057-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5382, "ryu": 0.4618 }
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6488, "ryu": 0.3512 }
         }
       ]
     },
     {
       "id": "p058",
       "editable": true,
-      "county_id": "clearwater_west",
-      "position": { "q": 1, "r": 7 },
-      "total_population": 1567,
-      "initial_district_id": "d1",
-      "name": "Southwest B8",
+      "county_id": "clearwater_east",
+      "position": { "q": 1, "r": 1 },
+      "total_population": 1415,
+      "initial_district_id": "d4",
+      "name": "East (1,1)",
       "demographic_groups": [
         {
-          "id": "p058-base",
-          "name": "Registered voters",
+          "id": "p058-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5383, "ryu": 0.4617 }
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.2563, "ryu": 0.7437 }
         }
       ]
     },
     {
       "id": "p059",
       "editable": true,
-      "county_id": "clearwater_west",
-      "position": { "q": 2, "r": 7 },
-      "total_population": 1449,
-      "initial_district_id": "d2",
-      "name": "Southwest C8",
+      "county_id": "clearwater_east",
+      "position": { "q": 2, "r": 1 },
+      "total_population": 1362,
+      "initial_district_id": "d4",
+      "name": "East (2,1)",
       "demographic_groups": [
         {
-          "id": "p059-base",
-          "name": "Registered voters",
+          "id": "p059-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4911, "ryu": 0.5089 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.2819, "ryu": 0.7181 }
         }
       ]
     },
     {
       "id": "p060",
       "editable": true,
-      "county_id": "clearwater_west",
-      "position": { "q": 3, "r": 7 },
-      "total_population": 1547,
-      "initial_district_id": "d2",
-      "name": "Southwest D8",
+      "county_id": "clearwater_central",
+      "position": { "q": 3, "r": 1 },
+      "total_population": 1467,
+      "initial_district_id": "d4",
+      "name": "Central (3,1)",
       "demographic_groups": [
         {
-          "id": "p060-base",
-          "name": "Registered voters",
+          "id": "p060-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5223, "ryu": 0.4777 }
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5301, "ryu": 0.4699 }
         }
       ]
     },
     {
       "id": "p061",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 4, "r": 7 },
-      "total_population": 1516,
-      "initial_district_id": "d3",
-      "name": "Southeast E8",
+      "county_id": "clearwater_central",
+      "position": { "q": 4, "r": 1 },
+      "total_population": 1523,
+      "initial_district_id": "d4",
+      "name": "Central (4,1)",
       "demographic_groups": [
         {
-          "id": "p061-base",
-          "name": "Registered voters",
+          "id": "p061-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2425, "ryu": 0.7575 }
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4909, "ryu": 0.5091 }
         }
       ]
     },
     {
       "id": "p062",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 5, "r": 7 },
-      "total_population": 1433,
-      "initial_district_id": "d3",
-      "name": "Southeast F8",
+      "county_id": "clearwater_west",
+      "position": { "q": -5, "r": 2 },
+      "total_population": 1619,
+      "initial_district_id": "d1",
+      "name": "West (-5,2)",
       "demographic_groups": [
         {
-          "id": "p062-base",
-          "name": "Registered voters",
+          "id": "p062-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.2312, "ryu": 0.7688 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6217, "ryu": 0.3783 }
         }
       ]
     },
     {
       "id": "p063",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 6, "r": 7 },
-      "total_population": 1546,
-      "initial_district_id": "d4",
-      "name": "Southeast G8",
+      "county_id": "clearwater_west",
+      "position": { "q": -4, "r": 2 },
+      "total_population": 1396,
+      "initial_district_id": "d2",
+      "name": "West (-4,2)",
       "demographic_groups": [
         {
-          "id": "p063-base",
-          "name": "Registered voters",
+          "id": "p063-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.2594, "ryu": 0.7406 }
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6447, "ryu": 0.3553 }
         }
       ]
     },
     {
       "id": "p064",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 7, "r": 7 },
-      "total_population": 1545,
-      "initial_district_id": "d4",
-      "name": "Southeast H8",
+      "county_id": "clearwater_west",
+      "position": { "q": -3, "r": 2 },
+      "total_population": 1556,
+      "initial_district_id": "d2",
+      "name": "West (-3,2)",
       "demographic_groups": [
         {
-          "id": "p064-base",
-          "name": "Registered voters",
+          "id": "p064-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.2427, "ryu": 0.7573 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6441, "ryu": 0.3559 }
         }
       ]
     },
@@ -1176,17 +1176,17 @@
       "id": "p065",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 8 },
-      "total_population": 1579,
-      "initial_district_id": "d1",
-      "name": "Southwest A9",
+      "position": { "q": -2, "r": 2 },
+      "total_population": 1467,
+      "initial_district_id": "d3",
+      "name": "West (-2,2)",
       "demographic_groups": [
         {
-          "id": "p065-base",
-          "name": "Registered voters",
+          "id": "p065-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5445, "ryu": 0.4555 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5824, "ryu": 0.4176 }
         }
       ]
     },
@@ -1194,17 +1194,17 @@
       "id": "p066",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 1, "r": 8 },
-      "total_population": 1506,
-      "initial_district_id": "d1",
-      "name": "Southwest B9",
+      "position": { "q": -1, "r": 2 },
+      "total_population": 1581,
+      "initial_district_id": "d3",
+      "name": "West (-1,2)",
       "demographic_groups": [
         {
-          "id": "p066-base",
-          "name": "Registered voters",
+          "id": "p066-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4916, "ryu": 0.5084 }
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6107, "ryu": 0.3893 }
         }
       ]
     },
@@ -1212,107 +1212,107 @@
       "id": "p067",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 2, "r": 8 },
-      "total_population": 1600,
-      "initial_district_id": "d2",
-      "name": "Southwest C9",
+      "position": { "q": 0, "r": 2 },
+      "total_population": 1530,
+      "initial_district_id": "d4",
+      "name": "West (0,2)",
       "demographic_groups": [
         {
-          "id": "p067-base",
-          "name": "Registered voters",
+          "id": "p067-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5366, "ryu": 0.4634 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6259, "ryu": 0.3741 }
         }
       ]
     },
     {
       "id": "p068",
       "editable": true,
-      "county_id": "clearwater_west",
-      "position": { "q": 3, "r": 8 },
-      "total_population": 1596,
-      "initial_district_id": "d2",
-      "name": "Southwest D9",
+      "county_id": "clearwater_east",
+      "position": { "q": 1, "r": 2 },
+      "total_population": 1412,
+      "initial_district_id": "d4",
+      "name": "East (1,2)",
       "demographic_groups": [
         {
-          "id": "p068-base",
-          "name": "Registered voters",
+          "id": "p068-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5245, "ryu": 0.4755 }
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.2793, "ryu": 0.7207 }
         }
       ]
     },
     {
       "id": "p069",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 4, "r": 8 },
-      "total_population": 1492,
-      "initial_district_id": "d3",
-      "name": "Southeast E9",
+      "county_id": "clearwater_central",
+      "position": { "q": 2, "r": 2 },
+      "total_population": 1555,
+      "initial_district_id": "d4",
+      "name": "Central (2,2)",
       "demographic_groups": [
         {
-          "id": "p069-base",
-          "name": "Registered voters",
+          "id": "p069-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.2292, "ryu": 0.7708 }
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5498, "ryu": 0.4502 }
         }
       ]
     },
     {
       "id": "p070",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 5, "r": 8 },
-      "total_population": 1583,
-      "initial_district_id": "d3",
-      "name": "Southeast F9",
+      "county_id": "clearwater_central",
+      "position": { "q": 3, "r": 2 },
+      "total_population": 1559,
+      "initial_district_id": "d4",
+      "name": "Central (3,2)",
       "demographic_groups": [
         {
-          "id": "p070-base",
-          "name": "Registered voters",
+          "id": "p070-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.2328, "ryu": 0.7672 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5482, "ryu": 0.4518 }
         }
       ]
     },
     {
       "id": "p071",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 6, "r": 8 },
-      "total_population": 1423,
-      "initial_district_id": "d4",
-      "name": "Southeast G9",
+      "county_id": "clearwater_west",
+      "position": { "q": -5, "r": 3 },
+      "total_population": 1403,
+      "initial_district_id": "d2",
+      "name": "West (-5,3)",
       "demographic_groups": [
         {
-          "id": "p071-base",
-          "name": "Registered voters",
+          "id": "p071-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.2362, "ryu": 0.7638 }
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6480, "ryu": 0.3520 }
         }
       ]
     },
     {
       "id": "p072",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 7, "r": 8 },
-      "total_population": 1482,
-      "initial_district_id": "d4",
-      "name": "Southeast H9",
+      "county_id": "clearwater_west",
+      "position": { "q": -4, "r": 3 },
+      "total_population": 1412,
+      "initial_district_id": "d2",
+      "name": "West (-4,3)",
       "demographic_groups": [
         {
-          "id": "p072-base",
-          "name": "Registered voters",
+          "id": "p072-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2783, "ryu": 0.7217 }
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6025, "ryu": 0.3975 }
         }
       ]
     },
@@ -1320,17 +1320,17 @@
       "id": "p073",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 9 },
-      "total_population": 1446,
-      "initial_district_id": "d1",
-      "name": "Southwest A10",
+      "position": { "q": -3, "r": 3 },
+      "total_population": 1369,
+      "initial_district_id": "d3",
+      "name": "West (-3,3)",
       "demographic_groups": [
         {
-          "id": "p073-base",
-          "name": "Registered voters",
+          "id": "p073-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4937, "ryu": 0.5063 }
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6023, "ryu": 0.3977 }
         }
       ]
     },
@@ -1338,17 +1338,17 @@
       "id": "p074",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 1, "r": 9 },
-      "total_population": 1472,
-      "initial_district_id": "d1",
-      "name": "Southwest B10",
+      "position": { "q": -2, "r": 3 },
+      "total_population": 1523,
+      "initial_district_id": "d3",
+      "name": "West (-2,3)",
       "demographic_groups": [
         {
-          "id": "p074-base",
-          "name": "Registered voters",
+          "id": "p074-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4996, "ryu": 0.5004 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6395, "ryu": 0.3605 }
         }
       ]
     },
@@ -1356,17 +1356,17 @@
       "id": "p075",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 2, "r": 9 },
-      "total_population": 1457,
-      "initial_district_id": "d2",
-      "name": "Southwest C10",
+      "position": { "q": -1, "r": 3 },
+      "total_population": 1631,
+      "initial_district_id": "d4",
+      "name": "West (-1,3)",
       "demographic_groups": [
         {
-          "id": "p075-base",
-          "name": "Registered voters",
+          "id": "p075-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5360, "ryu": 0.4640 }
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6426, "ryu": 0.3574 }
         }
       ]
     },
@@ -1374,89 +1374,89 @@
       "id": "p076",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 3, "r": 9 },
-      "total_population": 1558,
-      "initial_district_id": "d2",
-      "name": "Southwest D10",
+      "position": { "q": 0, "r": 3 },
+      "total_population": 1393,
+      "initial_district_id": "d4",
+      "name": "West (0,3)",
       "demographic_groups": [
         {
-          "id": "p076-base",
-          "name": "Registered voters",
+          "id": "p076-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5259, "ryu": 0.4741 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6460, "ryu": 0.3540 }
         }
       ]
     },
     {
       "id": "p077",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 4, "r": 9 },
-      "total_population": 1590,
-      "initial_district_id": "d3",
-      "name": "Southeast E10",
+      "county_id": "clearwater_central",
+      "position": { "q": 1, "r": 3 },
+      "total_population": 1566,
+      "initial_district_id": "d4",
+      "name": "Central (1,3)",
       "demographic_groups": [
         {
-          "id": "p077-base",
-          "name": "Registered voters",
+          "id": "p077-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.2372, "ryu": 0.7628 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5476, "ryu": 0.4524 }
         }
       ]
     },
     {
       "id": "p078",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 5, "r": 9 },
-      "total_population": 1510,
-      "initial_district_id": "d3",
-      "name": "Southeast F10",
+      "county_id": "clearwater_central",
+      "position": { "q": 2, "r": 3 },
+      "total_population": 1456,
+      "initial_district_id": "d4",
+      "name": "Central (2,3)",
       "demographic_groups": [
         {
-          "id": "p078-base",
-          "name": "Registered voters",
+          "id": "p078-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.2222, "ryu": 0.7778 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4831, "ryu": 0.5169 }
         }
       ]
     },
     {
       "id": "p079",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 6, "r": 9 },
-      "total_population": 1502,
-      "initial_district_id": "d4",
-      "name": "Southeast G10",
+      "county_id": "clearwater_west",
+      "position": { "q": -5, "r": 4 },
+      "total_population": 1576,
+      "initial_district_id": "d2",
+      "name": "West (-5,4)",
       "demographic_groups": [
         {
-          "id": "p079-base",
-          "name": "Registered voters",
+          "id": "p079-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.2298, "ryu": 0.7702 }
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6533, "ryu": 0.3467 }
         }
       ]
     },
     {
       "id": "p080",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 7, "r": 9 },
-      "total_population": 1453,
-      "initial_district_id": "d4",
-      "name": "Southeast H10",
+      "county_id": "clearwater_west",
+      "position": { "q": -4, "r": 4 },
+      "total_population": 1522,
+      "initial_district_id": "d3",
+      "name": "West (-4,4)",
       "demographic_groups": [
         {
-          "id": "p080-base",
-          "name": "Registered voters",
+          "id": "p080-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.2395, "ryu": 0.7605 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6396, "ryu": 0.3604 }
         }
       ]
     },
@@ -1464,17 +1464,17 @@
       "id": "p081",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 10 },
-      "total_population": 1455,
-      "initial_district_id": "d1",
-      "name": "Southwest A11",
+      "position": { "q": -3, "r": 4 },
+      "total_population": 1576,
+      "initial_district_id": "d3",
+      "name": "West (-3,4)",
       "demographic_groups": [
         {
-          "id": "p081-base",
-          "name": "Registered voters",
+          "id": "p081-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5179, "ryu": 0.4821 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5868, "ryu": 0.4132 }
         }
       ]
     },
@@ -1482,17 +1482,17 @@
       "id": "p082",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 1, "r": 10 },
-      "total_population": 1492,
-      "initial_district_id": "d1",
-      "name": "Southwest B11",
+      "position": { "q": -2, "r": 4 },
+      "total_population": 1622,
+      "initial_district_id": "d4",
+      "name": "West (-2,4)",
       "demographic_groups": [
         {
-          "id": "p082-base",
-          "name": "Registered voters",
+          "id": "p082-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5017, "ryu": 0.4983 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6040, "ryu": 0.3960 }
         }
       ]
     },
@@ -1500,17 +1500,17 @@
       "id": "p083",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 2, "r": 10 },
-      "total_population": 1441,
-      "initial_district_id": "d2",
-      "name": "Southwest C11",
+      "position": { "q": -1, "r": 4 },
+      "total_population": 1493,
+      "initial_district_id": "d4",
+      "name": "West (-1,4)",
       "demographic_groups": [
         {
-          "id": "p083-base",
-          "name": "Registered voters",
+          "id": "p083-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.5264, "ryu": 0.4736 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6168, "ryu": 0.3832 }
         }
       ]
     },
@@ -1518,89 +1518,89 @@
       "id": "p084",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 3, "r": 10 },
-      "total_population": 1455,
-      "initial_district_id": "d2",
-      "name": "Southwest D11",
+      "position": { "q": 0, "r": 4 },
+      "total_population": 1618,
+      "initial_district_id": "d4",
+      "name": "West (0,4)",
       "demographic_groups": [
         {
-          "id": "p084-base",
-          "name": "Registered voters",
+          "id": "p084-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5004, "ryu": 0.4996 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6373, "ryu": 0.3627 }
         }
       ]
     },
     {
       "id": "p085",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 4, "r": 10 },
-      "total_population": 1415,
-      "initial_district_id": "d3",
-      "name": "Southeast E11",
+      "county_id": "clearwater_central",
+      "position": { "q": 1, "r": 4 },
+      "total_population": 1360,
+      "initial_district_id": "d4",
+      "name": "Central (1,4)",
       "demographic_groups": [
         {
-          "id": "p085-base",
-          "name": "Registered voters",
+          "id": "p085-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.2756, "ryu": 0.7244 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5046, "ryu": 0.4954 }
         }
       ]
     },
     {
       "id": "p086",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 5, "r": 10 },
-      "total_population": 1585,
+      "county_id": "clearwater_west",
+      "position": { "q": -5, "r": 5 },
+      "total_population": 1497,
       "initial_district_id": "d3",
-      "name": "Southeast F11",
+      "name": "West (-5,5)",
       "demographic_groups": [
         {
-          "id": "p086-base",
-          "name": "Registered voters",
+          "id": "p086-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.2751, "ryu": 0.7249 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5915, "ryu": 0.4085 }
         }
       ]
     },
     {
       "id": "p087",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 6, "r": 10 },
-      "total_population": 1431,
-      "initial_district_id": "d4",
-      "name": "Southeast G11",
+      "county_id": "clearwater_west",
+      "position": { "q": -4, "r": 5 },
+      "total_population": 1454,
+      "initial_district_id": "d3",
+      "name": "West (-4,5)",
       "demographic_groups": [
         {
-          "id": "p087-base",
-          "name": "Registered voters",
+          "id": "p087-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2236, "ryu": 0.7764 }
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6170, "ryu": 0.3830 }
         }
       ]
     },
     {
       "id": "p088",
       "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 7, "r": 10 },
-      "total_population": 1432,
+      "county_id": "clearwater_west",
+      "position": { "q": -3, "r": 5 },
+      "total_population": 1615,
       "initial_district_id": "d4",
-      "name": "Southeast H11",
+      "name": "West (-3,5)",
       "demographic_groups": [
         {
-          "id": "p088-base",
-          "name": "Registered voters",
+          "id": "p088-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.2462, "ryu": 0.7538 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6357, "ryu": 0.3643 }
         }
       ]
     },
@@ -1608,17 +1608,17 @@
       "id": "p089",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 11 },
-      "total_population": 1457,
-      "initial_district_id": "d1",
-      "name": "Southwest A12",
+      "position": { "q": -2, "r": 5 },
+      "total_population": 1426,
+      "initial_district_id": "d4",
+      "name": "West (-2,5)",
       "demographic_groups": [
         {
-          "id": "p089-base",
-          "name": "Registered voters",
+          "id": "p089-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5397, "ryu": 0.4603 }
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6468, "ryu": 0.3532 }
         }
       ]
     },
@@ -1626,17 +1626,17 @@
       "id": "p090",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 1, "r": 11 },
-      "total_population": 1457,
-      "initial_district_id": "d1",
-      "name": "Southwest B12",
+      "position": { "q": -1, "r": 5 },
+      "total_population": 1363,
+      "initial_district_id": "d4",
+      "name": "West (-1,5)",
       "demographic_groups": [
         {
-          "id": "p090-base",
-          "name": "Registered voters",
+          "id": "p090-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5186, "ryu": 0.4814 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6305, "ryu": 0.3695 }
         }
       ]
     },
@@ -1644,107 +1644,17 @@
       "id": "p091",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 2, "r": 11 },
-      "total_population": 1491,
-      "initial_district_id": "d2",
-      "name": "Southwest C12",
-      "demographic_groups": [
-        {
-          "id": "p091-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5375, "ryu": 0.4625 }
-        }
-      ]
-    },
-    {
-      "id": "p092",
-      "editable": true,
-      "county_id": "clearwater_west",
-      "position": { "q": 3, "r": 11 },
-      "total_population": 1498,
-      "initial_district_id": "d2",
-      "name": "Southwest D12",
-      "demographic_groups": [
-        {
-          "id": "p092-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5261, "ryu": 0.4739 }
-        }
-      ]
-    },
-    {
-      "id": "p093",
-      "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 4, "r": 11 },
-      "total_population": 1539,
-      "initial_district_id": "d3",
-      "name": "Southeast E12",
-      "demographic_groups": [
-        {
-          "id": "p093-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2674, "ryu": 0.7326 }
-        }
-      ]
-    },
-    {
-      "id": "p094",
-      "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 5, "r": 11 },
-      "total_population": 1557,
-      "initial_district_id": "d3",
-      "name": "Southeast F12",
-      "demographic_groups": [
-        {
-          "id": "p094-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.2648, "ryu": 0.7352 }
-        }
-      ]
-    },
-    {
-      "id": "p095",
-      "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 6, "r": 11 },
-      "total_population": 1476,
+      "position": { "q": 0, "r": 5 },
+      "total_population": 1563,
       "initial_district_id": "d4",
-      "name": "Southeast G12",
+      "name": "West (0,5)",
       "demographic_groups": [
         {
-          "id": "p095-base",
-          "name": "Registered voters",
+          "id": "p091-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.2307, "ryu": 0.7693 }
-        }
-      ]
-    },
-    {
-      "id": "p096",
-      "editable": true,
-      "county_id": "clearwater_east",
-      "position": { "q": 7, "r": 11 },
-      "total_population": 1562,
-      "initial_district_id": "d4",
-      "name": "Southeast H12",
-      "demographic_groups": [
-        {
-          "id": "p096-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.2412, "ryu": 0.7588 }
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6323, "ryu": 0.3677 }
         }
       ]
     }
@@ -1770,7 +1680,7 @@
     {
       "id": "sc-ken-seats",
       "required": true,
-      "description": "The Ken Party wins at least 3 of the 4 districts.",
+      "description": "The governor's Ken Party wins at least 3 of the 4 districts.",
       "criterion": {
         "type": "seat_count",
         "party": "ken",
@@ -1779,32 +1689,36 @@
       }
     },
     {
-      "id": "sc-compact",
+      "id": "sc-compactness",
       "required": false,
-      "description": "Districts have compact, reasonable shapes — a clean gerrymander.",
+      "description": "All districts are reasonably compact (≥ 40%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
-        "threshold": 0.4
+        "threshold": 0.40
       }
     }
   ],
   "narrative": {
     "character": {
       "name": "You",
-      "role": "Campaign Strategist, Ken Party State Committee",
-      "motivation": "The Governor's party needs a State House majority. The votes are there — if the lines are drawn right."
+      "role": "Ken Party Campaign Strategist, Clearwater County",
+      "motivation": "The governor wants a reliable majority in Clearwater County. The current map splits the vote evenly — two Ken, two Ryu. That's not good enough. You've been brought in to redraw the lines so Ken wins three of four seats."
     },
     "intro_slides": [
       {
-        "heading": "The Governor Needs a Win",
-        "body": "Clearwater County is up for redistricting. The current map gives each party two of the four seats — a stalemate.\n\nThe Governor's party, the Ken Party, wants three seats. Your job: draw the lines to make it happen."
+        "heading": "The Governor's Problem",
+        "body": "Clearwater County elects four representatives. Right now, the map gives each party two seats. The governor — a Ken partisan — wants three.\n\nThe population hasn't changed. The voters haven't changed. But the lines can change."
       },
       {
-        "heading": "Same Votes. Different Lines.",
-        "body": "The county's voters haven't changed. But where you draw the district boundaries determines which party wins each seat.\n\nThe north leans Ken. The southeast leans Ryu. The trick is deciding which precincts end up together — and who gets packed into a losing district."
+        "heading": "How Redistricting Works",
+        "body": "Every ten years, district boundaries are redrawn. The official reason is to reflect population changes. The real reason, often, is to change who wins.\n\nYou're looking at a map of precincts — small geographic units with known voting patterns. Your job is to group them into districts that favor the Ken Party."
+      },
+      {
+        "heading": "Your First Gerrymander",
+        "body": "Look at the map. The southeast corner votes heavily Ryu. The north and southwest lean Ken.\n\nIf you can contain the Ryu stronghold in one district and spread Ken voters across the other three, the governor gets the majority. The tools are simple — the consequences are not."
       }
     ],
-    "objective": "Draw 4 districts so the Ken Party wins at least 3 seats."
+    "objective": "Redraw the map so the Ken Party wins at least 3 of 4 districts."
   }
 }

--- a/game/scenarios/scenario-003.json
+++ b/game/scenarios/scenario-003.json
@@ -4,8 +4,8 @@
   "title": "Riverport: The Packing Problem",
   "election_type": "state_house",
   "region": {
-    "id": "riverport_county",
-    "name": "Riverport County"
+    "id": "riverport_metro",
+    "name": "Riverport Metro Area"
   },
   "geometry": { "type": "hex_axial" },
   "parties": [
@@ -24,468 +24,468 @@
     {
       "id": "p001",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 0 },
-      "total_population": 1559,
+      "county_id": "greenfield_county",
+      "position": { "q": 0, "r": -6 },
+      "total_population": 1526,
       "initial_district_id": "d1",
-      "name": "Rural A1",
+      "name": "Rural (0,-6)",
       "demographic_groups": [
         {
-          "id": "p001-base",
-          "name": "Registered voters",
+          "id": "p001-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6545, "ryu": 0.3455 }
+          "vote_shares": { "ken": 0.6578, "ryu": 0.3422 }
         }
       ]
     },
     {
       "id": "p002",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 0 },
-      "total_population": 1509,
+      "county_id": "greenfield_county",
+      "position": { "q": 1, "r": -6 },
+      "total_population": 1370,
       "initial_district_id": "d1",
-      "name": "Rural B1",
+      "name": "Rural (1,-6)",
       "demographic_groups": [
         {
-          "id": "p002-base",
-          "name": "Registered voters",
+          "id": "p002-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6377, "ryu": 0.3623 }
+          "vote_shares": { "ken": 0.6114, "ryu": 0.3886 }
         }
       ]
     },
     {
       "id": "p003",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 2, "r": 0 },
-      "total_population": 1491,
+      "county_id": "greenfield_county",
+      "position": { "q": 2, "r": -6 },
+      "total_population": 1436,
       "initial_district_id": "d2",
-      "name": "Rural C1",
+      "name": "Rural (2,-6)",
       "demographic_groups": [
         {
-          "id": "p003-base",
-          "name": "Registered voters",
+          "id": "p003-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6718, "ryu": 0.3282 }
+          "vote_shares": { "ken": 0.6438, "ryu": 0.3562 }
         }
       ]
     },
     {
       "id": "p004",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 3, "r": 0 },
-      "total_population": 1434,
+      "county_id": "greenfield_county",
+      "position": { "q": 3, "r": -6 },
+      "total_population": 1607,
       "initial_district_id": "d2",
-      "name": "Rural D1",
+      "name": "Rural (3,-6)",
       "demographic_groups": [
         {
-          "id": "p004-base",
-          "name": "Registered voters",
+          "id": "p004-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6449, "ryu": 0.3551 }
+          "vote_shares": { "ken": 0.6493, "ryu": 0.3507 }
         }
       ]
     },
     {
       "id": "p005",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 4, "r": 0 },
-      "total_population": 1464,
-      "initial_district_id": "d3",
-      "name": "Rural E1",
+      "county_id": "greenfield_county",
+      "position": { "q": 4, "r": -6 },
+      "total_population": 1552,
+      "initial_district_id": "d2",
+      "name": "Rural (4,-6)",
       "demographic_groups": [
         {
-          "id": "p005-base",
-          "name": "Registered voters",
+          "id": "p005-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6575, "ryu": 0.3425 }
+          "vote_shares": { "ken": 0.6800, "ryu": 0.3200 }
         }
       ]
     },
     {
       "id": "p006",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 5, "r": 0 },
-      "total_population": 1499,
-      "initial_district_id": "d3",
-      "name": "Rural F1",
+      "county_id": "greenfield_county",
+      "position": { "q": 5, "r": -6 },
+      "total_population": 1622,
+      "initial_district_id": "d2",
+      "name": "Rural (5,-6)",
       "demographic_groups": [
         {
-          "id": "p006-base",
-          "name": "Registered voters",
+          "id": "p006-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.50,
-          "vote_shares": { "ken": 0.6269, "ryu": 0.3731 }
+          "vote_shares": { "ken": 0.6579, "ryu": 0.3421 }
         }
       ]
     },
     {
       "id": "p007",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 6, "r": 0 },
-      "total_population": 1539,
-      "initial_district_id": "d4",
-      "name": "Rural G1",
+      "county_id": "greenfield_county",
+      "position": { "q": 6, "r": -6 },
+      "total_population": 1512,
+      "initial_district_id": "d2",
+      "name": "Rural (6,-6)",
       "demographic_groups": [
         {
-          "id": "p007-base",
-          "name": "Registered voters",
+          "id": "p007-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6341, "ryu": 0.3659 }
+          "vote_shares": { "ken": 0.6457, "ryu": 0.3543 }
         }
       ]
     },
     {
       "id": "p008",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 7, "r": 0 },
-      "total_population": 1400,
-      "initial_district_id": "d4",
-      "name": "Rural H1",
+      "county_id": "greenfield_county",
+      "position": { "q": -1, "r": -5 },
+      "total_population": 1537,
+      "initial_district_id": "d1",
+      "name": "Rural (-1,-5)",
       "demographic_groups": [
         {
-          "id": "p008-base",
-          "name": "Registered voters",
+          "id": "p008-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6517, "ryu": 0.3483 }
+          "vote_shares": { "ken": 0.6410, "ryu": 0.3590 }
         }
       ]
     },
     {
       "id": "p009",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 0 },
-      "total_population": 1499,
-      "initial_district_id": "d5",
-      "name": "Rural I1",
+      "county_id": "greenfield_county",
+      "position": { "q": 0, "r": -5 },
+      "total_population": 1534,
+      "initial_district_id": "d1",
+      "name": "Rural (0,-5)",
       "demographic_groups": [
         {
-          "id": "p009-base",
-          "name": "Registered voters",
+          "id": "p009-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6776, "ryu": 0.3224 }
+          "vote_shares": { "ken": 0.6354, "ryu": 0.3646 }
         }
       ]
     },
     {
       "id": "p010",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 0 },
-      "total_population": 1594,
-      "initial_district_id": "d5",
-      "name": "Rural J1",
+      "county_id": "greenfield_county",
+      "position": { "q": 1, "r": -5 },
+      "total_population": 1564,
+      "initial_district_id": "d1",
+      "name": "Rural (1,-5)",
       "demographic_groups": [
         {
-          "id": "p010-base",
-          "name": "Registered voters",
+          "id": "p010-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6372, "ryu": 0.3628 }
+          "vote_shares": { "ken": 0.6770, "ryu": 0.3230 }
         }
       ]
     },
     {
       "id": "p011",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 1 },
-      "total_population": 1569,
-      "initial_district_id": "d1",
-      "name": "Rural A2",
+      "county_id": "greenfield_county",
+      "position": { "q": 2, "r": -5 },
+      "total_population": 1504,
+      "initial_district_id": "d2",
+      "name": "Rural (2,-5)",
       "demographic_groups": [
         {
-          "id": "p011-base",
-          "name": "Registered voters",
+          "id": "p011-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6663, "ryu": 0.3337 }
+          "vote_shares": { "ken": 0.6789, "ryu": 0.3211 }
         }
       ]
     },
     {
       "id": "p012",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 1 },
-      "total_population": 1434,
-      "initial_district_id": "d1",
-      "name": "Rural B2",
+      "county_id": "greenfield_county",
+      "position": { "q": 3, "r": -5 },
+      "total_population": 1643,
+      "initial_district_id": "d2",
+      "name": "Rural (3,-5)",
       "demographic_groups": [
         {
-          "id": "p012-base",
-          "name": "Registered voters",
+          "id": "p012-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6516, "ryu": 0.3484 }
+          "vote_shares": { "ken": 0.6879, "ryu": 0.3121 }
         }
       ]
     },
     {
       "id": "p013",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 2, "r": 1 },
-      "total_population": 1428,
+      "county_id": "greenfield_county",
+      "position": { "q": 4, "r": -5 },
+      "total_population": 1606,
       "initial_district_id": "d2",
-      "name": "Rural C2",
+      "name": "Rural (4,-5)",
       "demographic_groups": [
         {
-          "id": "p013-base",
-          "name": "Registered voters",
+          "id": "p013-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6646, "ryu": 0.3354 }
+          "vote_shares": { "ken": 0.6402, "ryu": 0.3598 }
         }
       ]
     },
     {
       "id": "p014",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 3, "r": 1 },
-      "total_population": 1460,
+      "county_id": "greenfield_county",
+      "position": { "q": 5, "r": -5 },
+      "total_population": 1421,
       "initial_district_id": "d2",
-      "name": "Rural D2",
+      "name": "Rural (5,-5)",
       "demographic_groups": [
         {
-          "id": "p014-base",
-          "name": "Registered voters",
+          "id": "p014-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6770, "ryu": 0.3230 }
+          "vote_shares": { "ken": 0.6239, "ryu": 0.3761 }
         }
       ]
     },
     {
       "id": "p015",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 4, "r": 1 },
-      "total_population": 1565,
-      "initial_district_id": "d3",
-      "name": "Rural E2",
+      "county_id": "greenfield_county",
+      "position": { "q": 6, "r": -5 },
+      "total_population": 1607,
+      "initial_district_id": "d2",
+      "name": "Rural (6,-5)",
       "demographic_groups": [
         {
-          "id": "p015-base",
-          "name": "Registered voters",
+          "id": "p015-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6440, "ryu": 0.3560 }
+          "vote_shares": { "ken": 0.6265, "ryu": 0.3735 }
         }
       ]
     },
     {
       "id": "p016",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 5, "r": 1 },
-      "total_population": 1517,
-      "initial_district_id": "d3",
-      "name": "Rural F2",
+      "county_id": "greenfield_county",
+      "position": { "q": -2, "r": -4 },
+      "total_population": 1456,
+      "initial_district_id": "d1",
+      "name": "Rural (-2,-4)",
       "demographic_groups": [
         {
-          "id": "p016-base",
-          "name": "Registered voters",
+          "id": "p016-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6273, "ryu": 0.3727 }
+          "vote_shares": { "ken": 0.6604, "ryu": 0.3396 }
         }
       ]
     },
     {
       "id": "p017",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 6, "r": 1 },
-      "total_population": 1431,
-      "initial_district_id": "d4",
-      "name": "Rural G2",
+      "county_id": "greenfield_county",
+      "position": { "q": -1, "r": -4 },
+      "total_population": 1609,
+      "initial_district_id": "d1",
+      "name": "Rural (-1,-4)",
       "demographic_groups": [
         {
-          "id": "p017-base",
-          "name": "Registered voters",
+          "id": "p017-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6788, "ryu": 0.3212 }
+          "vote_shares": { "ken": 0.6329, "ryu": 0.3671 }
         }
       ]
     },
     {
       "id": "p018",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 7, "r": 1 },
-      "total_population": 1514,
-      "initial_district_id": "d4",
-      "name": "Rural H2",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 0, "r": -4 },
+      "total_population": 1400,
+      "initial_district_id": "d1",
+      "name": "Suburbs (0,-4)",
       "demographic_groups": [
         {
-          "id": "p018-base",
-          "name": "Registered voters",
+          "id": "p018-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6457, "ryu": 0.3543 }
+          "vote_shares": { "ken": 0.3992, "ryu": 0.6008 }
         }
       ]
     },
     {
       "id": "p019",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 1 },
-      "total_population": 1566,
-      "initial_district_id": "d5",
-      "name": "Rural I2",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 1, "r": -4 },
+      "total_population": 1477,
+      "initial_district_id": "d2",
+      "name": "Suburbs (1,-4)",
       "demographic_groups": [
         {
-          "id": "p019-base",
-          "name": "Registered voters",
+          "id": "p019-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6364, "ryu": 0.3636 }
+          "vote_shares": { "ken": 0.3977, "ryu": 0.6023 }
         }
       ]
     },
     {
       "id": "p020",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 1 },
-      "total_population": 1544,
-      "initial_district_id": "d5",
-      "name": "Rural J2",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 2, "r": -4 },
+      "total_population": 1450,
+      "initial_district_id": "d2",
+      "name": "Suburbs (2,-4)",
       "demographic_groups": [
         {
-          "id": "p020-base",
-          "name": "Registered voters",
+          "id": "p020-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6216, "ryu": 0.3784 }
+          "vote_shares": { "ken": 0.4207, "ryu": 0.5793 }
         }
       ]
     },
     {
       "id": "p021",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 2 },
-      "total_population": 1569,
-      "initial_district_id": "d1",
-      "name": "Rural A3",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 3, "r": -4 },
+      "total_population": 1419,
+      "initial_district_id": "d2",
+      "name": "Suburbs (3,-4)",
       "demographic_groups": [
         {
-          "id": "p021-base",
-          "name": "Registered voters",
+          "id": "p021-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6529, "ryu": 0.3471 }
+          "vote_shares": { "ken": 0.4326, "ryu": 0.5674 }
         }
       ]
     },
     {
       "id": "p022",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 2 },
-      "total_population": 1557,
-      "initial_district_id": "d1",
-      "name": "Rural B3",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 4, "r": -4 },
+      "total_population": 1474,
+      "initial_district_id": "d2",
+      "name": "Suburbs (4,-4)",
       "demographic_groups": [
         {
-          "id": "p022-base",
-          "name": "Registered voters",
+          "id": "p022-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6312, "ryu": 0.3688 }
+          "vote_shares": { "ken": 0.4187, "ryu": 0.5813 }
         }
       ]
     },
     {
       "id": "p023",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 2 },
-      "total_population": 1538,
+      "county_id": "greenfield_county",
+      "position": { "q": 5, "r": -4 },
+      "total_population": 1353,
       "initial_district_id": "d2",
-      "name": "Suburban C3",
+      "name": "Rural (5,-4)",
       "demographic_groups": [
         {
-          "id": "p023-base",
-          "name": "Registered voters",
+          "id": "p023-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.4472, "ryu": 0.5528 }
+          "vote_shares": { "ken": 0.6401, "ryu": 0.3599 }
         }
       ]
     },
     {
       "id": "p024",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 3, "r": 2 },
-      "total_population": 1592,
+      "county_id": "greenfield_county",
+      "position": { "q": 6, "r": -4 },
+      "total_population": 1446,
       "initial_district_id": "d2",
-      "name": "Suburban D3",
+      "name": "Rural (6,-4)",
       "demographic_groups": [
         {
-          "id": "p024-base",
-          "name": "Registered voters",
+          "id": "p024-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4004, "ryu": 0.5996 }
+          "vote_shares": { "ken": 0.6473, "ryu": 0.3527 }
         }
       ]
     },
     {
       "id": "p025",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 4, "r": 2 },
-      "total_population": 1501,
-      "initial_district_id": "d3",
-      "name": "Suburban E3",
+      "county_id": "greenfield_county",
+      "position": { "q": -3, "r": -3 },
+      "total_population": 1509,
+      "initial_district_id": "d1",
+      "name": "Rural (-3,-3)",
       "demographic_groups": [
         {
-          "id": "p025-base",
-          "name": "Registered voters",
+          "id": "p025-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.3995, "ryu": 0.6005 }
+          "vote_shares": { "ken": 0.6802, "ryu": 0.3198 }
         }
       ]
     },
     {
       "id": "p026",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 5, "r": 2 },
-      "total_population": 1490,
-      "initial_district_id": "d3",
-      "name": "Suburban F3",
+      "county_id": "greenfield_county",
+      "position": { "q": -2, "r": -3 },
+      "total_population": 1574,
+      "initial_district_id": "d1",
+      "name": "Rural (-2,-3)",
       "demographic_groups": [
         {
-          "id": "p026-base",
-          "name": "Registered voters",
+          "id": "p026-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.4191, "ryu": 0.5809 }
+          "vote_shares": { "ken": 0.6729, "ryu": 0.3271 }
         }
       ]
     },
@@ -493,17 +493,17 @@
       "id": "p027",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 6, "r": 2 },
-      "total_population": 1565,
-      "initial_district_id": "d4",
-      "name": "Suburban G3",
+      "position": { "q": -1, "r": -3 },
+      "total_population": 1632,
+      "initial_district_id": "d1",
+      "name": "Suburbs (-1,-3)",
       "demographic_groups": [
         {
-          "id": "p027-base",
-          "name": "Registered voters",
+          "id": "p027-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4446, "ryu": 0.5554 }
+          "vote_shares": { "ken": 0.4382, "ryu": 0.5618 }
         }
       ]
     },
@@ -511,179 +511,179 @@
       "id": "p028",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 7, "r": 2 },
-      "total_population": 1556,
-      "initial_district_id": "d4",
-      "name": "Suburban H3",
+      "position": { "q": 0, "r": -3 },
+      "total_population": 1649,
+      "initial_district_id": "d1",
+      "name": "Suburbs (0,-3)",
       "demographic_groups": [
         {
-          "id": "p028-base",
-          "name": "Registered voters",
+          "id": "p028-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4456, "ryu": 0.5544 }
+          "vote_shares": { "ken": 0.4442, "ryu": 0.5558 }
         }
       ]
     },
     {
       "id": "p029",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 2 },
-      "total_population": 1484,
-      "initial_district_id": "d5",
-      "name": "Rural I3",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 1, "r": -3 },
+      "total_population": 1641,
+      "initial_district_id": "d2",
+      "name": "Suburbs (1,-3)",
       "demographic_groups": [
         {
-          "id": "p029-base",
-          "name": "Registered voters",
+          "id": "p029-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6778, "ryu": 0.3222 }
+          "vote_shares": { "ken": 0.4498, "ryu": 0.5502 }
         }
       ]
     },
     {
       "id": "p030",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 2 },
-      "total_population": 1407,
-      "initial_district_id": "d5",
-      "name": "Rural J3",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 2, "r": -3 },
+      "total_population": 1548,
+      "initial_district_id": "d2",
+      "name": "Suburbs (2,-3)",
       "demographic_groups": [
         {
-          "id": "p030-base",
-          "name": "Registered voters",
+          "id": "p030-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6212, "ryu": 0.3788 }
+          "vote_shares": { "ken": 0.3977, "ryu": 0.6023 }
         }
       ]
     },
     {
       "id": "p031",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 3 },
-      "total_population": 1590,
-      "initial_district_id": "d1",
-      "name": "Rural A4",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 3, "r": -3 },
+      "total_population": 1581,
+      "initial_district_id": "d2",
+      "name": "Suburbs (3,-3)",
       "demographic_groups": [
         {
-          "id": "p031-base",
-          "name": "Registered voters",
+          "id": "p031-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6540, "ryu": 0.3460 }
+          "vote_shares": { "ken": 0.3840, "ryu": 0.6160 }
         }
       ]
     },
     {
       "id": "p032",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 3 },
-      "total_population": 1479,
-      "initial_district_id": "d1",
-      "name": "Rural B4",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 4, "r": -3 },
+      "total_population": 1520,
+      "initial_district_id": "d2",
+      "name": "Suburbs (4,-3)",
       "demographic_groups": [
         {
-          "id": "p032-base",
-          "name": "Registered voters",
+          "id": "p032-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6685, "ryu": 0.3315 }
+          "vote_shares": { "ken": 0.4171, "ryu": 0.5829 }
         }
       ]
     },
     {
       "id": "p033",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 3 },
-      "total_population": 1460,
+      "county_id": "greenfield_county",
+      "position": { "q": 5, "r": -3 },
+      "total_population": 1572,
       "initial_district_id": "d2",
-      "name": "Suburban C4",
+      "name": "Rural (5,-3)",
       "demographic_groups": [
         {
-          "id": "p033-base",
-          "name": "Registered voters",
+          "id": "p033-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4243, "ryu": 0.5757 }
+          "vote_shares": { "ken": 0.6820, "ryu": 0.3180 }
         }
       ]
     },
     {
       "id": "p034",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 3, "r": 3 },
-      "total_population": 1584,
-      "initial_district_id": "d2",
-      "name": "Urban D4",
+      "county_id": "greenfield_county",
+      "position": { "q": 6, "r": -3 },
+      "total_population": 1516,
+      "initial_district_id": "d3",
+      "name": "Rural (6,-3)",
       "demographic_groups": [
         {
-          "id": "p034-base",
-          "name": "Registered voters",
+          "id": "p034-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.73,
-          "vote_shares": { "ken": 0.1448, "ryu": 0.8552 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6321, "ryu": 0.3679 }
         }
       ]
     },
     {
       "id": "p035",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 4, "r": 3 },
-      "total_population": 1592,
-      "initial_district_id": "d3",
-      "name": "Urban E4",
+      "county_id": "greenfield_county",
+      "position": { "q": -4, "r": -2 },
+      "total_population": 1414,
+      "initial_district_id": "d1",
+      "name": "Rural (-4,-2)",
       "demographic_groups": [
         {
-          "id": "p035-base",
-          "name": "Registered voters",
+          "id": "p035-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.1412, "ryu": 0.8588 }
+          "turnout_rate": 0.52,
+          "vote_shares": { "ken": 0.6874, "ryu": 0.3126 }
         }
       ]
     },
     {
       "id": "p036",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 5, "r": 3 },
-      "total_population": 1424,
-      "initial_district_id": "d3",
-      "name": "Urban F4",
+      "county_id": "greenfield_county",
+      "position": { "q": -3, "r": -2 },
+      "total_population": 1572,
+      "initial_district_id": "d1",
+      "name": "Rural (-3,-2)",
       "demographic_groups": [
         {
-          "id": "p036-base",
-          "name": "Registered voters",
+          "id": "p036-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.1318, "ryu": 0.8682 }
+          "turnout_rate": 0.51,
+          "vote_shares": { "ken": 0.6648, "ryu": 0.3352 }
         }
       ]
     },
     {
       "id": "p037",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 6, "r": 3 },
-      "total_population": 1505,
-      "initial_district_id": "d4",
-      "name": "Urban G4",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -2, "r": -2 },
+      "total_population": 1554,
+      "initial_district_id": "d1",
+      "name": "Suburbs (-2,-2)",
       "demographic_groups": [
         {
-          "id": "p037-base",
-          "name": "Registered voters",
+          "id": "p037-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.1551, "ryu": 0.8449 }
+          "turnout_rate": 0.53,
+          "vote_shares": { "ken": 0.3894, "ryu": 0.6106 }
         }
       ]
     },
@@ -691,89 +691,89 @@
       "id": "p038",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 7, "r": 3 },
-      "total_population": 1570,
-      "initial_district_id": "d4",
-      "name": "Suburban H4",
+      "position": { "q": -1, "r": -2 },
+      "total_population": 1565,
+      "initial_district_id": "d1",
+      "name": "Suburbs (-1,-2)",
       "demographic_groups": [
         {
-          "id": "p038-base",
-          "name": "Registered voters",
+          "id": "p038-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.4144, "ryu": 0.5856 }
+          "vote_shares": { "ken": 0.4148, "ryu": 0.5852 }
         }
       ]
     },
     {
       "id": "p039",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 3 },
-      "total_population": 1583,
-      "initial_district_id": "d5",
-      "name": "Rural I4",
+      "county_id": "riverport_city",
+      "position": { "q": 0, "r": -2 },
+      "total_population": 1560,
+      "initial_district_id": "d1",
+      "name": "Downtown (0,-2)",
       "demographic_groups": [
         {
-          "id": "p039-base",
-          "name": "Registered voters",
+          "id": "p039-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6304, "ryu": 0.3696 }
+          "turnout_rate": 0.73,
+          "vote_shares": { "ken": 0.1815, "ryu": 0.8185 }
         }
       ]
     },
     {
       "id": "p040",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 3 },
-      "total_population": 1560,
-      "initial_district_id": "d5",
-      "name": "Rural J4",
+      "county_id": "riverport_city",
+      "position": { "q": 1, "r": -2 },
+      "total_population": 1570,
+      "initial_district_id": "d2",
+      "name": "Downtown (1,-2)",
       "demographic_groups": [
         {
-          "id": "p040-base",
-          "name": "Registered voters",
+          "id": "p040-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6486, "ryu": 0.3514 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.1152, "ryu": 0.8848 }
         }
       ]
     },
     {
       "id": "p041",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 4 },
-      "total_population": 1548,
-      "initial_district_id": "d1",
-      "name": "Rural A5",
+      "county_id": "riverport_city",
+      "position": { "q": 2, "r": -2 },
+      "total_population": 1572,
+      "initial_district_id": "d2",
+      "name": "Downtown (2,-2)",
       "demographic_groups": [
         {
-          "id": "p041-base",
-          "name": "Registered voters",
+          "id": "p041-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6330, "ryu": 0.3670 }
+          "turnout_rate": 0.72,
+          "vote_shares": { "ken": 0.1277, "ryu": 0.8723 }
         }
       ]
     },
     {
       "id": "p042",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 4 },
-      "total_population": 1596,
-      "initial_district_id": "d1",
-      "name": "Rural B5",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 3, "r": -2 },
+      "total_population": 1354,
+      "initial_district_id": "d2",
+      "name": "Suburbs (3,-2)",
       "demographic_groups": [
         {
-          "id": "p042-base",
-          "name": "Registered voters",
+          "id": "p042-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.50,
-          "vote_shares": { "ken": 0.6260, "ryu": 0.3740 }
+          "vote_shares": { "ken": 0.4146, "ryu": 0.5854 }
         }
       ]
     },
@@ -781,89 +781,89 @@
       "id": "p043",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 4 },
-      "total_population": 1541,
-      "initial_district_id": "d2",
-      "name": "Suburban C5",
+      "position": { "q": 4, "r": -2 },
+      "total_population": 1650,
+      "initial_district_id": "d3",
+      "name": "Suburbs (4,-2)",
       "demographic_groups": [
         {
-          "id": "p043-base",
-          "name": "Registered voters",
+          "id": "p043-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4483, "ryu": 0.5517 }
+          "vote_shares": { "ken": 0.4067, "ryu": 0.5933 }
         }
       ]
     },
     {
       "id": "p044",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 3, "r": 4 },
-      "total_population": 1437,
-      "initial_district_id": "d2",
-      "name": "Urban D5",
+      "county_id": "greenfield_county",
+      "position": { "q": 5, "r": -2 },
+      "total_population": 1624,
+      "initial_district_id": "d3",
+      "name": "Rural (5,-2)",
       "demographic_groups": [
         {
-          "id": "p044-base",
-          "name": "Registered voters",
+          "id": "p044-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.73,
-          "vote_shares": { "ken": 0.1248, "ryu": 0.8752 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6167, "ryu": 0.3833 }
         }
       ]
     },
     {
       "id": "p045",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 4, "r": 4 },
-      "total_population": 1594,
+      "county_id": "greenfield_county",
+      "position": { "q": 6, "r": -2 },
+      "total_population": 1410,
       "initial_district_id": "d3",
-      "name": "Urban E5",
+      "name": "Rural (6,-2)",
       "demographic_groups": [
         {
-          "id": "p045-base",
-          "name": "Registered voters",
+          "id": "p045-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.1558, "ryu": 0.8442 }
+          "turnout_rate": 0.51,
+          "vote_shares": { "ken": 0.6667, "ryu": 0.3333 }
         }
       ]
     },
     {
       "id": "p046",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 5, "r": 4 },
-      "total_population": 1538,
-      "initial_district_id": "d3",
-      "name": "Urban F5",
+      "county_id": "greenfield_county",
+      "position": { "q": -5, "r": -1 },
+      "total_population": 1528,
+      "initial_district_id": "d1",
+      "name": "Rural (-5,-1)",
       "demographic_groups": [
         {
-          "id": "p046-base",
-          "name": "Registered voters",
+          "id": "p046-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.74,
-          "vote_shares": { "ken": 0.1231, "ryu": 0.8769 }
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6105, "ryu": 0.3895 }
         }
       ]
     },
     {
       "id": "p047",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 6, "r": 4 },
-      "total_population": 1477,
-      "initial_district_id": "d4",
-      "name": "Urban G5",
+      "county_id": "greenfield_county",
+      "position": { "q": -4, "r": -1 },
+      "total_population": 1601,
+      "initial_district_id": "d1",
+      "name": "Rural (-4,-1)",
       "demographic_groups": [
         {
-          "id": "p047-base",
-          "name": "Registered voters",
+          "id": "p047-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.1404, "ryu": 0.8596 }
+          "turnout_rate": 0.53,
+          "vote_shares": { "ken": 0.6182, "ryu": 0.3818 }
         }
       ]
     },
@@ -871,287 +871,287 @@
       "id": "p048",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 7, "r": 4 },
-      "total_population": 1499,
-      "initial_district_id": "d4",
-      "name": "Suburban H5",
+      "position": { "q": -3, "r": -1 },
+      "total_population": 1520,
+      "initial_district_id": "d1",
+      "name": "Suburbs (-3,-1)",
       "demographic_groups": [
         {
-          "id": "p048-base",
-          "name": "Registered voters",
+          "id": "p048-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.4247, "ryu": 0.5753 }
+          "vote_shares": { "ken": 0.4169, "ryu": 0.5831 }
         }
       ]
     },
     {
       "id": "p049",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 4 },
-      "total_population": 1446,
-      "initial_district_id": "d5",
-      "name": "Rural I5",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -2, "r": -1 },
+      "total_population": 1560,
+      "initial_district_id": "d1",
+      "name": "Suburbs (-2,-1)",
       "demographic_groups": [
         {
-          "id": "p049-base",
-          "name": "Registered voters",
+          "id": "p049-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6305, "ryu": 0.3695 }
+          "vote_shares": { "ken": 0.4496, "ryu": 0.5504 }
         }
       ]
     },
     {
       "id": "p050",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 4 },
-      "total_population": 1569,
-      "initial_district_id": "d5",
-      "name": "Rural J5",
+      "county_id": "riverport_city",
+      "position": { "q": -1, "r": -1 },
+      "total_population": 1381,
+      "initial_district_id": "d1",
+      "name": "Downtown (-1,-1)",
       "demographic_groups": [
         {
-          "id": "p050-base",
-          "name": "Registered voters",
+          "id": "p050-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6460, "ryu": 0.3540 }
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.1796, "ryu": 0.8204 }
         }
       ]
     },
     {
       "id": "p051",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 5 },
-      "total_population": 1582,
+      "county_id": "riverport_city",
+      "position": { "q": 0, "r": -1 },
+      "total_population": 1569,
       "initial_district_id": "d1",
-      "name": "Rural A6",
+      "name": "Downtown (0,-1)",
       "demographic_groups": [
         {
-          "id": "p051-base",
-          "name": "Registered voters",
+          "id": "p051-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6506, "ryu": 0.3494 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.1885, "ryu": 0.8115 }
         }
       ]
     },
     {
       "id": "p052",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 5 },
-      "total_population": 1442,
-      "initial_district_id": "d1",
-      "name": "Rural B6",
+      "county_id": "riverport_city",
+      "position": { "q": 1, "r": -1 },
+      "total_population": 1597,
+      "initial_district_id": "d2",
+      "name": "Downtown (1,-1)",
       "demographic_groups": [
         {
-          "id": "p052-base",
-          "name": "Registered voters",
+          "id": "p052-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6537, "ryu": 0.3463 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.1399, "ryu": 0.8601 }
         }
       ]
     },
     {
       "id": "p053",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 5 },
-      "total_population": 1413,
-      "initial_district_id": "d2",
-      "name": "Suburban C6",
+      "county_id": "riverport_city",
+      "position": { "q": 2, "r": -1 },
+      "total_population": 1382,
+      "initial_district_id": "d3",
+      "name": "Downtown (2,-1)",
       "demographic_groups": [
         {
-          "id": "p053-base",
-          "name": "Registered voters",
+          "id": "p053-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4136, "ryu": 0.5864 }
+          "turnout_rate": 0.74,
+          "vote_shares": { "ken": 0.1383, "ryu": 0.8617 }
         }
       ]
     },
     {
       "id": "p054",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 3, "r": 5 },
-      "total_population": 1504,
-      "initial_district_id": "d2",
-      "name": "Urban D6",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 3, "r": -1 },
+      "total_population": 1474,
+      "initial_district_id": "d3",
+      "name": "Suburbs (3,-1)",
       "demographic_groups": [
         {
-          "id": "p054-base",
-          "name": "Registered voters",
+          "id": "p054-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.1569, "ryu": 0.8431 }
+          "turnout_rate": 0.53,
+          "vote_shares": { "ken": 0.4005, "ryu": 0.5995 }
         }
       ]
     },
     {
       "id": "p055",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 4, "r": 5 },
-      "total_population": 1512,
+      "county_id": "riverport_suburbs",
+      "position": { "q": 4, "r": -1 },
+      "total_population": 1525,
       "initial_district_id": "d3",
-      "name": "Urban E6",
+      "name": "Suburbs (4,-1)",
       "demographic_groups": [
         {
-          "id": "p055-base",
-          "name": "Registered voters",
+          "id": "p055-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.72,
-          "vote_shares": { "ken": 0.1729, "ryu": 0.8271 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.3968, "ryu": 0.6032 }
         }
       ]
     },
     {
       "id": "p056",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 5, "r": 5 },
-      "total_population": 1442,
+      "county_id": "greenfield_county",
+      "position": { "q": 5, "r": -1 },
+      "total_population": 1513,
       "initial_district_id": "d3",
-      "name": "Urban F6",
+      "name": "Rural (5,-1)",
       "demographic_groups": [
         {
-          "id": "p056-base",
-          "name": "Registered voters",
+          "id": "p056-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.1657, "ryu": 0.8343 }
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6471, "ryu": 0.3529 }
         }
       ]
     },
     {
       "id": "p057",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 6, "r": 5 },
-      "total_population": 1541,
-      "initial_district_id": "d4",
-      "name": "Urban G6",
+      "county_id": "greenfield_county",
+      "position": { "q": 6, "r": -1 },
+      "total_population": 1603,
+      "initial_district_id": "d3",
+      "name": "Rural (6,-1)",
       "demographic_groups": [
         {
-          "id": "p057-base",
-          "name": "Registered voters",
+          "id": "p057-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.75,
-          "vote_shares": { "ken": 0.1610, "ryu": 0.8390 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6332, "ryu": 0.3668 }
         }
       ]
     },
     {
       "id": "p058",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 7, "r": 5 },
-      "total_population": 1563,
-      "initial_district_id": "d4",
-      "name": "Suburban H6",
+      "county_id": "greenfield_county",
+      "position": { "q": -6, "r": 0 },
+      "total_population": 1505,
+      "initial_district_id": "d5",
+      "name": "Rural (-6,0)",
       "demographic_groups": [
         {
-          "id": "p058-base",
-          "name": "Registered voters",
+          "id": "p058-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.4080, "ryu": 0.5920 }
+          "vote_shares": { "ken": 0.6828, "ryu": 0.3172 }
         }
       ]
     },
     {
       "id": "p059",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 5 },
-      "total_population": 1569,
+      "county_id": "greenfield_county",
+      "position": { "q": -5, "r": 0 },
+      "total_population": 1401,
       "initial_district_id": "d5",
-      "name": "Rural I6",
+      "name": "Rural (-5,0)",
       "demographic_groups": [
         {
-          "id": "p059-base",
-          "name": "Registered voters",
+          "id": "p059-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6512, "ryu": 0.3488 }
+          "vote_shares": { "ken": 0.6726, "ryu": 0.3274 }
         }
       ]
     },
     {
       "id": "p060",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 5 },
-      "total_population": 1592,
+      "county_id": "riverport_suburbs",
+      "position": { "q": -4, "r": 0 },
+      "total_population": 1368,
       "initial_district_id": "d5",
-      "name": "Rural J6",
+      "name": "Suburbs (-4,0)",
       "demographic_groups": [
         {
-          "id": "p060-base",
-          "name": "Registered voters",
+          "id": "p060-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6641, "ryu": 0.3359 }
+          "vote_shares": { "ken": 0.4536, "ryu": 0.5464 }
         }
       ]
     },
     {
       "id": "p061",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 6 },
-      "total_population": 1593,
-      "initial_district_id": "d1",
-      "name": "Rural A7",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -3, "r": 0 },
+      "total_population": 1436,
+      "initial_district_id": "d5",
+      "name": "Suburbs (-3,0)",
       "demographic_groups": [
         {
-          "id": "p061-base",
-          "name": "Registered voters",
+          "id": "p061-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6301, "ryu": 0.3699 }
+          "vote_shares": { "ken": 0.4220, "ryu": 0.5780 }
         }
       ]
     },
     {
       "id": "p062",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 6 },
-      "total_population": 1538,
-      "initial_district_id": "d1",
-      "name": "Rural B7",
+      "county_id": "riverport_city",
+      "position": { "q": -2, "r": 0 },
+      "total_population": 1497,
+      "initial_district_id": "d5",
+      "name": "Downtown (-2,0)",
       "demographic_groups": [
         {
-          "id": "p062-base",
-          "name": "Registered voters",
+          "id": "p062-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6394, "ryu": 0.3606 }
+          "turnout_rate": 0.75,
+          "vote_shares": { "ken": 0.1333, "ryu": 0.8667 }
         }
       ]
     },
     {
       "id": "p063",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 6 },
-      "total_population": 1557,
-      "initial_district_id": "d2",
-      "name": "Suburban C7",
+      "county_id": "riverport_city",
+      "position": { "q": -1, "r": 0 },
+      "total_population": 1489,
+      "initial_district_id": "d5",
+      "name": "Downtown (-1,0)",
       "demographic_groups": [
         {
-          "id": "p063-base",
-          "name": "Registered voters",
+          "id": "p063-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4033, "ryu": 0.5967 }
+          "turnout_rate": 0.73,
+          "vote_shares": { "ken": 0.1730, "ryu": 0.8270 }
         }
       ]
     },
@@ -1159,17 +1159,17 @@
       "id": "p064",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 3, "r": 6 },
-      "total_population": 1431,
-      "initial_district_id": "d2",
-      "name": "Urban D7",
+      "position": { "q": 0, "r": 0 },
+      "total_population": 1551,
+      "initial_district_id": "d3",
+      "name": "Downtown (0,0)",
       "demographic_groups": [
         {
-          "id": "p064-base",
-          "name": "Registered voters",
+          "id": "p064-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.1652, "ryu": 0.8348 }
+          "vote_shares": { "ken": 0.1249, "ryu": 0.8751 }
         }
       ]
     },
@@ -1177,17 +1177,17 @@
       "id": "p065",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 4, "r": 6 },
-      "total_population": 1448,
+      "position": { "q": 1, "r": 0 },
+      "total_population": 1428,
       "initial_district_id": "d3",
-      "name": "Urban E7",
+      "name": "Downtown (1,0)",
       "demographic_groups": [
         {
-          "id": "p065-base",
-          "name": "Registered voters",
+          "id": "p065-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.1677, "ryu": 0.8323 }
+          "vote_shares": { "ken": 0.1535, "ryu": 0.8465 }
         }
       ]
     },
@@ -1195,35 +1195,35 @@
       "id": "p066",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 5, "r": 6 },
-      "total_population": 1410,
+      "position": { "q": 2, "r": 0 },
+      "total_population": 1424,
       "initial_district_id": "d3",
-      "name": "Urban F7",
+      "name": "Downtown (2,0)",
       "demographic_groups": [
         {
-          "id": "p066-base",
-          "name": "Registered voters",
+          "id": "p066-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.1345, "ryu": 0.8655 }
+          "vote_shares": { "ken": 0.1551, "ryu": 0.8449 }
         }
       ]
     },
     {
       "id": "p067",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 6, "r": 6 },
-      "total_population": 1538,
-      "initial_district_id": "d4",
-      "name": "Urban G7",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 3, "r": 0 },
+      "total_population": 1409,
+      "initial_district_id": "d3",
+      "name": "Suburbs (3,0)",
       "demographic_groups": [
         {
-          "id": "p067-base",
-          "name": "Registered voters",
+          "id": "p067-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.1396, "ryu": 0.8604 }
+          "turnout_rate": 0.53,
+          "vote_shares": { "ken": 0.3881, "ryu": 0.6119 }
         }
       ]
     },
@@ -1231,89 +1231,89 @@
       "id": "p068",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 7, "r": 6 },
-      "total_population": 1579,
-      "initial_district_id": "d4",
-      "name": "Suburban H7",
+      "position": { "q": 4, "r": 0 },
+      "total_population": 1369,
+      "initial_district_id": "d3",
+      "name": "Suburbs (4,0)",
       "demographic_groups": [
         {
-          "id": "p068-base",
-          "name": "Registered voters",
+          "id": "p068-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.3925, "ryu": 0.6075 }
+          "vote_shares": { "ken": 0.3938, "ryu": 0.6062 }
         }
       ]
     },
     {
       "id": "p069",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 6 },
-      "total_population": 1533,
-      "initial_district_id": "d5",
-      "name": "Rural I7",
+      "county_id": "greenfield_county",
+      "position": { "q": 5, "r": 0 },
+      "total_population": 1485,
+      "initial_district_id": "d3",
+      "name": "Rural (5,0)",
       "demographic_groups": [
         {
-          "id": "p069-base",
-          "name": "Registered voters",
+          "id": "p069-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6731, "ryu": 0.3269 }
+          "vote_shares": { "ken": 0.6307, "ryu": 0.3693 }
         }
       ]
     },
     {
       "id": "p070",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 6 },
-      "total_population": 1411,
-      "initial_district_id": "d5",
-      "name": "Rural J7",
+      "county_id": "greenfield_county",
+      "position": { "q": 6, "r": 0 },
+      "total_population": 1546,
+      "initial_district_id": "d3",
+      "name": "Rural (6,0)",
       "demographic_groups": [
         {
-          "id": "p070-base",
-          "name": "Registered voters",
+          "id": "p070-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6235, "ryu": 0.3765 }
+          "vote_shares": { "ken": 0.6138, "ryu": 0.3862 }
         }
       ]
     },
     {
       "id": "p071",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 7 },
-      "total_population": 1540,
-      "initial_district_id": "d1",
-      "name": "Rural A8",
+      "county_id": "greenfield_county",
+      "position": { "q": -6, "r": 1 },
+      "total_population": 1637,
+      "initial_district_id": "d5",
+      "name": "Rural (-6,1)",
       "demographic_groups": [
         {
-          "id": "p071-base",
-          "name": "Registered voters",
+          "id": "p071-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6536, "ryu": 0.3464 }
+          "vote_shares": { "ken": 0.6865, "ryu": 0.3135 }
         }
       ]
     },
     {
       "id": "p072",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 7 },
-      "total_population": 1419,
-      "initial_district_id": "d1",
-      "name": "Rural B8",
+      "county_id": "greenfield_county",
+      "position": { "q": -5, "r": 1 },
+      "total_population": 1548,
+      "initial_district_id": "d5",
+      "name": "Rural (-5,1)",
       "demographic_groups": [
         {
-          "id": "p072-base",
-          "name": "Registered voters",
+          "id": "p072-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+          "vote_shares": { "ken": 0.6452, "ryu": 0.3548 }
         }
       ]
     },
@@ -1321,35 +1321,35 @@
       "id": "p073",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 7 },
-      "total_population": 1588,
-      "initial_district_id": "d2",
-      "name": "Suburban C8",
+      "position": { "q": -4, "r": 1 },
+      "total_population": 1635,
+      "initial_district_id": "d5",
+      "name": "Suburbs (-4,1)",
       "demographic_groups": [
         {
-          "id": "p073-base",
-          "name": "Registered voters",
+          "id": "p073-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.4344, "ryu": 0.5656 }
+          "vote_shares": { "ken": 0.4199, "ryu": 0.5801 }
         }
       ]
     },
     {
       "id": "p074",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 3, "r": 7 },
-      "total_population": 1515,
-      "initial_district_id": "d2",
-      "name": "Urban D8",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -3, "r": 1 },
+      "total_population": 1509,
+      "initial_district_id": "d5",
+      "name": "Suburbs (-3,1)",
       "demographic_groups": [
         {
-          "id": "p074-base",
-          "name": "Registered voters",
+          "id": "p074-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.1312, "ryu": 0.8688 }
+          "turnout_rate": 0.52,
+          "vote_shares": { "ken": 0.3823, "ryu": 0.6177 }
         }
       ]
     },
@@ -1357,17 +1357,17 @@
       "id": "p075",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 4, "r": 7 },
-      "total_population": 1464,
-      "initial_district_id": "d3",
-      "name": "Urban E8",
+      "position": { "q": -2, "r": 1 },
+      "total_population": 1362,
+      "initial_district_id": "d5",
+      "name": "Downtown (-2,1)",
       "demographic_groups": [
         {
-          "id": "p075-base",
-          "name": "Registered voters",
+          "id": "p075-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.74,
-          "vote_shares": { "ken": 0.1676, "ryu": 0.8324 }
+          "vote_shares": { "ken": 0.1624, "ryu": 0.8376 }
         }
       ]
     },
@@ -1375,17 +1375,17 @@
       "id": "p076",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 5, "r": 7 },
-      "total_population": 1579,
-      "initial_district_id": "d3",
-      "name": "Urban F8",
+      "position": { "q": -1, "r": 1 },
+      "total_population": 1383,
+      "initial_district_id": "d5",
+      "name": "Downtown (-1,1)",
       "demographic_groups": [
         {
-          "id": "p076-base",
-          "name": "Registered voters",
+          "id": "p076-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.1291, "ryu": 0.8709 }
+          "vote_shares": { "ken": 0.1147, "ryu": 0.8853 }
         }
       ]
     },
@@ -1393,179 +1393,179 @@
       "id": "p077",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 6, "r": 7 },
-      "total_population": 1521,
+      "position": { "q": 0, "r": 1 },
+      "total_population": 1452,
       "initial_district_id": "d4",
-      "name": "Urban G8",
+      "name": "Downtown (0,1)",
       "demographic_groups": [
         {
-          "id": "p077-base",
-          "name": "Registered voters",
+          "id": "p077-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.74,
-          "vote_shares": { "ken": 0.1615, "ryu": 0.8385 }
+          "vote_shares": { "ken": 0.1830, "ryu": 0.8170 }
         }
       ]
     },
     {
       "id": "p078",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 7, "r": 7 },
-      "total_population": 1516,
-      "initial_district_id": "d4",
-      "name": "Suburban H8",
+      "county_id": "riverport_city",
+      "position": { "q": 1, "r": 1 },
+      "total_population": 1404,
+      "initial_district_id": "d3",
+      "name": "Downtown (1,1)",
       "demographic_groups": [
         {
-          "id": "p078-base",
-          "name": "Registered voters",
+          "id": "p078-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4398, "ryu": 0.5602 }
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.1418, "ryu": 0.8582 }
         }
       ]
     },
     {
       "id": "p079",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 7 },
-      "total_population": 1547,
-      "initial_district_id": "d5",
-      "name": "Rural I8",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 2, "r": 1 },
+      "total_population": 1405,
+      "initial_district_id": "d3",
+      "name": "Suburbs (2,1)",
       "demographic_groups": [
         {
-          "id": "p079-base",
-          "name": "Registered voters",
+          "id": "p079-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6406, "ryu": 0.3594 }
+          "vote_shares": { "ken": 0.4203, "ryu": 0.5797 }
         }
       ]
     },
     {
       "id": "p080",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 7 },
-      "total_population": 1420,
-      "initial_district_id": "d5",
-      "name": "Rural J8",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 3, "r": 1 },
+      "total_population": 1597,
+      "initial_district_id": "d3",
+      "name": "Suburbs (3,1)",
       "demographic_groups": [
         {
-          "id": "p080-base",
-          "name": "Registered voters",
+          "id": "p080-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6330, "ryu": 0.3670 }
+          "vote_shares": { "ken": 0.4054, "ryu": 0.5946 }
         }
       ]
     },
     {
       "id": "p081",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 8 },
-      "total_population": 1572,
-      "initial_district_id": "d1",
-      "name": "Rural A9",
+      "county_id": "greenfield_county",
+      "position": { "q": 4, "r": 1 },
+      "total_population": 1355,
+      "initial_district_id": "d3",
+      "name": "Rural (4,1)",
       "demographic_groups": [
         {
-          "id": "p081-base",
-          "name": "Registered voters",
+          "id": "p081-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6419, "ryu": 0.3581 }
+          "vote_shares": { "ken": 0.6631, "ryu": 0.3369 }
         }
       ]
     },
     {
       "id": "p082",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 8 },
-      "total_population": 1546,
-      "initial_district_id": "d1",
-      "name": "Rural B9",
+      "county_id": "greenfield_county",
+      "position": { "q": 5, "r": 1 },
+      "total_population": 1428,
+      "initial_district_id": "d3",
+      "name": "Rural (5,1)",
       "demographic_groups": [
         {
-          "id": "p082-base",
-          "name": "Registered voters",
+          "id": "p082-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6537, "ryu": 0.3463 }
+          "vote_shares": { "ken": 0.6204, "ryu": 0.3796 }
         }
       ]
     },
     {
       "id": "p083",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 8 },
-      "total_population": 1491,
-      "initial_district_id": "d2",
-      "name": "Suburban C9",
+      "county_id": "greenfield_county",
+      "position": { "q": -6, "r": 2 },
+      "total_population": 1585,
+      "initial_district_id": "d5",
+      "name": "Rural (-6,2)",
       "demographic_groups": [
         {
-          "id": "p083-base",
-          "name": "Registered voters",
+          "id": "p083-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.4474, "ryu": 0.5526 }
+          "vote_shares": { "ken": 0.6509, "ryu": 0.3491 }
         }
       ]
     },
     {
       "id": "p084",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 3, "r": 8 },
-      "total_population": 1430,
-      "initial_district_id": "d2",
-      "name": "Urban D9",
+      "county_id": "greenfield_county",
+      "position": { "q": -5, "r": 2 },
+      "total_population": 1399,
+      "initial_district_id": "d5",
+      "name": "Rural (-5,2)",
       "demographic_groups": [
         {
-          "id": "p084-base",
-          "name": "Registered voters",
+          "id": "p084-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.73,
-          "vote_shares": { "ken": 0.1624, "ryu": 0.8376 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6660, "ryu": 0.3340 }
         }
       ]
     },
     {
       "id": "p085",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 4, "r": 8 },
-      "total_population": 1437,
-      "initial_district_id": "d3",
-      "name": "Urban E9",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -4, "r": 2 },
+      "total_population": 1377,
+      "initial_district_id": "d5",
+      "name": "Suburbs (-4,2)",
       "demographic_groups": [
         {
-          "id": "p085-base",
-          "name": "Registered voters",
+          "id": "p085-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.71,
-          "vote_shares": { "ken": 0.1258, "ryu": 0.8742 }
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.4164, "ryu": 0.5836 }
         }
       ]
     },
     {
       "id": "p086",
       "editable": true,
-      "county_id": "riverport_city",
-      "position": { "q": 5, "r": 8 },
-      "total_population": 1540,
-      "initial_district_id": "d3",
-      "name": "Urban F9",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -3, "r": 2 },
+      "total_population": 1416,
+      "initial_district_id": "d5",
+      "name": "Suburbs (-3,2)",
       "demographic_groups": [
         {
-          "id": "p086-base",
-          "name": "Registered voters",
+          "id": "p086-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.71,
-          "vote_shares": { "ken": 0.1797, "ryu": 0.8203 }
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.3939, "ryu": 0.6061 }
         }
       ]
     },
@@ -1573,161 +1573,161 @@
       "id": "p087",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 6, "r": 8 },
-      "total_population": 1569,
-      "initial_district_id": "d4",
-      "name": "Urban G9",
+      "position": { "q": -2, "r": 2 },
+      "total_population": 1443,
+      "initial_district_id": "d5",
+      "name": "Downtown (-2,2)",
       "demographic_groups": [
         {
-          "id": "p087-base",
-          "name": "Registered voters",
+          "id": "p087-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.1298, "ryu": 0.8702 }
+          "vote_shares": { "ken": 0.1596, "ryu": 0.8404 }
         }
       ]
     },
     {
       "id": "p088",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 7, "r": 8 },
-      "total_population": 1450,
+      "county_id": "riverport_city",
+      "position": { "q": -1, "r": 2 },
+      "total_population": 1393,
       "initial_district_id": "d4",
-      "name": "Suburban H9",
+      "name": "Downtown (-1,2)",
       "demographic_groups": [
         {
-          "id": "p088-base",
-          "name": "Registered voters",
+          "id": "p088-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.4102, "ryu": 0.5898 }
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.1267, "ryu": 0.8733 }
         }
       ]
     },
     {
       "id": "p089",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 8 },
-      "total_population": 1465,
-      "initial_district_id": "d5",
-      "name": "Rural I9",
+      "county_id": "riverport_city",
+      "position": { "q": 0, "r": 2 },
+      "total_population": 1609,
+      "initial_district_id": "d4",
+      "name": "Downtown (0,2)",
       "demographic_groups": [
         {
-          "id": "p089-base",
-          "name": "Registered voters",
+          "id": "p089-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6507, "ryu": 0.3493 }
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.1464, "ryu": 0.8536 }
         }
       ]
     },
     {
       "id": "p090",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 8 },
-      "total_population": 1402,
-      "initial_district_id": "d5",
-      "name": "Rural J9",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 1, "r": 2 },
+      "total_population": 1444,
+      "initial_district_id": "d4",
+      "name": "Suburbs (1,2)",
       "demographic_groups": [
         {
-          "id": "p090-base",
-          "name": "Registered voters",
+          "id": "p090-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6615, "ryu": 0.3385 }
+          "vote_shares": { "ken": 0.4182, "ryu": 0.5818 }
         }
       ]
     },
     {
       "id": "p091",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 9 },
-      "total_population": 1401,
-      "initial_district_id": "d1",
-      "name": "Rural A10",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 2, "r": 2 },
+      "total_population": 1418,
+      "initial_district_id": "d3",
+      "name": "Suburbs (2,2)",
       "demographic_groups": [
         {
-          "id": "p091-base",
-          "name": "Registered voters",
+          "id": "p091-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6241, "ryu": 0.3759 }
+          "vote_shares": { "ken": 0.3833, "ryu": 0.6167 }
         }
       ]
     },
     {
       "id": "p092",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 9 },
-      "total_population": 1597,
-      "initial_district_id": "d1",
-      "name": "Rural B10",
+      "county_id": "greenfield_county",
+      "position": { "q": 3, "r": 2 },
+      "total_population": 1392,
+      "initial_district_id": "d3",
+      "name": "Rural (3,2)",
       "demographic_groups": [
         {
-          "id": "p092-base",
-          "name": "Registered voters",
+          "id": "p092-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6318, "ryu": 0.3682 }
+          "vote_shares": { "ken": 0.6207, "ryu": 0.3793 }
         }
       ]
     },
     {
       "id": "p093",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 9 },
-      "total_population": 1494,
-      "initial_district_id": "d2",
-      "name": "Suburban C10",
+      "county_id": "greenfield_county",
+      "position": { "q": 4, "r": 2 },
+      "total_population": 1488,
+      "initial_district_id": "d3",
+      "name": "Rural (4,2)",
       "demographic_groups": [
         {
-          "id": "p093-base",
-          "name": "Registered voters",
+          "id": "p093-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.4444, "ryu": 0.5556 }
+          "vote_shares": { "ken": 0.6255, "ryu": 0.3745 }
         }
       ]
     },
     {
       "id": "p094",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 3, "r": 9 },
-      "total_population": 1594,
-      "initial_district_id": "d2",
-      "name": "Suburban D10",
+      "county_id": "greenfield_county",
+      "position": { "q": -6, "r": 3 },
+      "total_population": 1374,
+      "initial_district_id": "d5",
+      "name": "Rural (-6,3)",
       "demographic_groups": [
         {
-          "id": "p094-base",
-          "name": "Registered voters",
+          "id": "p094-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.4075, "ryu": 0.5925 }
+          "vote_shares": { "ken": 0.6717, "ryu": 0.3283 }
         }
       ]
     },
     {
       "id": "p095",
       "editable": true,
-      "county_id": "riverport_suburbs",
-      "position": { "q": 4, "r": 9 },
-      "total_population": 1519,
-      "initial_district_id": "d3",
-      "name": "Suburban E10",
+      "county_id": "greenfield_county",
+      "position": { "q": -5, "r": 3 },
+      "total_population": 1367,
+      "initial_district_id": "d5",
+      "name": "Rural (-5,3)",
       "demographic_groups": [
         {
-          "id": "p095-base",
-          "name": "Registered voters",
+          "id": "p095-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4198, "ryu": 0.5802 }
+          "vote_shares": { "ken": 0.6893, "ryu": 0.3107 }
         }
       ]
     },
@@ -1735,17 +1735,17 @@
       "id": "p096",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 5, "r": 9 },
-      "total_population": 1504,
-      "initial_district_id": "d3",
-      "name": "Suburban F10",
+      "position": { "q": -4, "r": 3 },
+      "total_population": 1453,
+      "initial_district_id": "d5",
+      "name": "Suburbs (-4,3)",
       "demographic_groups": [
         {
-          "id": "p096-base",
-          "name": "Registered voters",
+          "id": "p096-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4279, "ryu": 0.5721 }
+          "vote_shares": { "ken": 0.4315, "ryu": 0.5685 }
         }
       ]
     },
@@ -1753,17 +1753,17 @@
       "id": "p097",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 6, "r": 9 },
-      "total_population": 1529,
-      "initial_district_id": "d4",
-      "name": "Suburban G10",
+      "position": { "q": -3, "r": 3 },
+      "total_population": 1525,
+      "initial_district_id": "d5",
+      "name": "Suburbs (-3,3)",
       "demographic_groups": [
         {
-          "id": "p097-base",
-          "name": "Registered voters",
+          "id": "p097-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.4299, "ryu": 0.5701 }
+          "vote_shares": { "ken": 0.4404, "ryu": 0.5596 }
         }
       ]
     },
@@ -1771,413 +1771,539 @@
       "id": "p098",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 7, "r": 9 },
-      "total_population": 1528,
+      "position": { "q": -2, "r": 3 },
+      "total_population": 1514,
       "initial_district_id": "d4",
-      "name": "Suburban H10",
+      "name": "Suburbs (-2,3)",
       "demographic_groups": [
         {
-          "id": "p098-base",
-          "name": "Registered voters",
+          "id": "p098-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4196, "ryu": 0.5804 }
+          "vote_shares": { "ken": 0.3818, "ryu": 0.6182 }
         }
       ]
     },
     {
       "id": "p099",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 9 },
-      "total_population": 1511,
-      "initial_district_id": "d5",
-      "name": "Rural I10",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -1, "r": 3 },
+      "total_population": 1616,
+      "initial_district_id": "d4",
+      "name": "Suburbs (-1,3)",
       "demographic_groups": [
         {
-          "id": "p099-base",
-          "name": "Registered voters",
+          "id": "p099-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6299, "ryu": 0.3701 }
+          "vote_shares": { "ken": 0.4409, "ryu": 0.5591 }
         }
       ]
     },
     {
       "id": "p100",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 9 },
-      "total_population": 1453,
-      "initial_district_id": "d5",
-      "name": "Rural J10",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 0, "r": 3 },
+      "total_population": 1490,
+      "initial_district_id": "d4",
+      "name": "Suburbs (0,3)",
       "demographic_groups": [
         {
-          "id": "p100-base",
-          "name": "Registered voters",
+          "id": "p100-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6323, "ryu": 0.3677 }
+          "vote_shares": { "ken": 0.3850, "ryu": 0.6150 }
         }
       ]
     },
     {
       "id": "p101",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 10 },
-      "total_population": 1595,
-      "initial_district_id": "d1",
-      "name": "Rural A11",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 1, "r": 3 },
+      "total_population": 1405,
+      "initial_district_id": "d4",
+      "name": "Suburbs (1,3)",
       "demographic_groups": [
         {
-          "id": "p101-base",
-          "name": "Registered voters",
+          "id": "p101-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6237, "ryu": 0.3763 }
+          "vote_shares": { "ken": 0.4034, "ryu": 0.5966 }
         }
       ]
     },
     {
       "id": "p102",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 10 },
-      "total_population": 1594,
-      "initial_district_id": "d1",
-      "name": "Rural B11",
+      "county_id": "greenfield_county",
+      "position": { "q": 2, "r": 3 },
+      "total_population": 1375,
+      "initial_district_id": "d4",
+      "name": "Rural (2,3)",
       "demographic_groups": [
         {
-          "id": "p102-base",
-          "name": "Registered voters",
+          "id": "p102-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6363, "ryu": 0.3637 }
+          "vote_shares": { "ken": 0.6121, "ryu": 0.3879 }
         }
       ]
     },
     {
       "id": "p103",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 2, "r": 10 },
-      "total_population": 1415,
-      "initial_district_id": "d2",
-      "name": "Rural C11",
+      "county_id": "greenfield_county",
+      "position": { "q": 3, "r": 3 },
+      "total_population": 1599,
+      "initial_district_id": "d3",
+      "name": "Rural (3,3)",
       "demographic_groups": [
         {
-          "id": "p103-base",
-          "name": "Registered voters",
+          "id": "p103-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6439, "ryu": 0.3561 }
+          "vote_shares": { "ken": 0.6549, "ryu": 0.3451 }
         }
       ]
     },
     {
       "id": "p104",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 3, "r": 10 },
-      "total_population": 1523,
-      "initial_district_id": "d2",
-      "name": "Rural D11",
+      "county_id": "greenfield_county",
+      "position": { "q": -6, "r": 4 },
+      "total_population": 1439,
+      "initial_district_id": "d5",
+      "name": "Rural (-6,4)",
       "demographic_groups": [
         {
-          "id": "p104-base",
-          "name": "Registered voters",
+          "id": "p104-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.50,
-          "vote_shares": { "ken": 0.6268, "ryu": 0.3732 }
+          "vote_shares": { "ken": 0.6132, "ryu": 0.3868 }
         }
       ]
     },
     {
       "id": "p105",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 4, "r": 10 },
-      "total_population": 1406,
-      "initial_district_id": "d3",
-      "name": "Rural E11",
+      "county_id": "greenfield_county",
+      "position": { "q": -5, "r": 4 },
+      "total_population": 1557,
+      "initial_district_id": "d5",
+      "name": "Rural (-5,4)",
       "demographic_groups": [
         {
-          "id": "p105-base",
-          "name": "Registered voters",
+          "id": "p105-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6350, "ryu": 0.3650 }
+          "vote_shares": { "ken": 0.6346, "ryu": 0.3654 }
         }
       ]
     },
     {
       "id": "p106",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 5, "r": 10 },
-      "total_population": 1544,
-      "initial_district_id": "d3",
-      "name": "Rural F11",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -4, "r": 4 },
+      "total_population": 1459,
+      "initial_district_id": "d5",
+      "name": "Suburbs (-4,4)",
       "demographic_groups": [
         {
-          "id": "p106-base",
-          "name": "Registered voters",
+          "id": "p106-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6454, "ryu": 0.3546 }
+          "vote_shares": { "ken": 0.4114, "ryu": 0.5886 }
         }
       ]
     },
     {
       "id": "p107",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 6, "r": 10 },
-      "total_population": 1511,
+      "county_id": "riverport_suburbs",
+      "position": { "q": -3, "r": 4 },
+      "total_population": 1358,
       "initial_district_id": "d4",
-      "name": "Rural G11",
+      "name": "Suburbs (-3,4)",
       "demographic_groups": [
         {
-          "id": "p107-base",
-          "name": "Registered voters",
+          "id": "p107-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6317, "ryu": 0.3683 }
+          "vote_shares": { "ken": 0.4391, "ryu": 0.5609 }
         }
       ]
     },
     {
       "id": "p108",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 7, "r": 10 },
-      "total_population": 1421,
+      "county_id": "riverport_suburbs",
+      "position": { "q": -2, "r": 4 },
+      "total_population": 1504,
       "initial_district_id": "d4",
-      "name": "Rural H11",
+      "name": "Suburbs (-2,4)",
       "demographic_groups": [
         {
-          "id": "p108-base",
-          "name": "Registered voters",
+          "id": "p108-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6664, "ryu": 0.3336 }
+          "vote_shares": { "ken": 0.4292, "ryu": 0.5708 }
         }
       ]
     },
     {
       "id": "p109",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 10 },
-      "total_population": 1562,
-      "initial_district_id": "d5",
-      "name": "Rural I11",
+      "county_id": "riverport_suburbs",
+      "position": { "q": -1, "r": 4 },
+      "total_population": 1647,
+      "initial_district_id": "d4",
+      "name": "Suburbs (-1,4)",
       "demographic_groups": [
         {
-          "id": "p109-base",
-          "name": "Registered voters",
+          "id": "p109-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6732, "ryu": 0.3268 }
+          "vote_shares": { "ken": 0.4112, "ryu": 0.5888 }
         }
       ]
     },
     {
       "id": "p110",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 10 },
-      "total_population": 1475,
-      "initial_district_id": "d5",
-      "name": "Rural J11",
+      "county_id": "riverport_suburbs",
+      "position": { "q": 0, "r": 4 },
+      "total_population": 1485,
+      "initial_district_id": "d4",
+      "name": "Suburbs (0,4)",
       "demographic_groups": [
         {
-          "id": "p110-base",
-          "name": "Registered voters",
+          "id": "p110-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6541, "ryu": 0.3459 }
+          "vote_shares": { "ken": 0.3862, "ryu": 0.6138 }
         }
       ]
     },
     {
       "id": "p111",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 0, "r": 11 },
-      "total_population": 1404,
-      "initial_district_id": "d1",
-      "name": "Rural A12",
+      "county_id": "greenfield_county",
+      "position": { "q": 1, "r": 4 },
+      "total_population": 1622,
+      "initial_district_id": "d4",
+      "name": "Rural (1,4)",
       "demographic_groups": [
         {
-          "id": "p111-base",
-          "name": "Registered voters",
+          "id": "p111-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6483, "ryu": 0.3517 }
+          "vote_shares": { "ken": 0.6810, "ryu": 0.3190 }
         }
       ]
     },
     {
       "id": "p112",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 1, "r": 11 },
-      "total_population": 1447,
-      "initial_district_id": "d1",
-      "name": "Rural B12",
+      "county_id": "greenfield_county",
+      "position": { "q": 2, "r": 4 },
+      "total_population": 1648,
+      "initial_district_id": "d4",
+      "name": "Rural (2,4)",
       "demographic_groups": [
         {
-          "id": "p112-base",
-          "name": "Registered voters",
+          "id": "p112-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6215, "ryu": 0.3785 }
+          "vote_shares": { "ken": 0.6368, "ryu": 0.3632 }
         }
       ]
     },
     {
       "id": "p113",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 2, "r": 11 },
-      "total_population": 1576,
-      "initial_district_id": "d2",
-      "name": "Rural C12",
+      "county_id": "greenfield_county",
+      "position": { "q": -6, "r": 5 },
+      "total_population": 1488,
+      "initial_district_id": "d5",
+      "name": "Rural (-6,5)",
       "demographic_groups": [
         {
-          "id": "p113-base",
-          "name": "Registered voters",
+          "id": "p113-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6278, "ryu": 0.3722 }
+          "vote_shares": { "ken": 0.6753, "ryu": 0.3247 }
         }
       ]
     },
     {
       "id": "p114",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 3, "r": 11 },
-      "total_population": 1567,
-      "initial_district_id": "d2",
-      "name": "Rural D12",
+      "county_id": "greenfield_county",
+      "position": { "q": -5, "r": 5 },
+      "total_population": 1427,
+      "initial_district_id": "d5",
+      "name": "Rural (-5,5)",
       "demographic_groups": [
         {
-          "id": "p114-base",
-          "name": "Registered voters",
+          "id": "p114-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6547, "ryu": 0.3453 }
+          "vote_shares": { "ken": 0.6112, "ryu": 0.3888 }
         }
       ]
     },
     {
       "id": "p115",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 4, "r": 11 },
-      "total_population": 1500,
-      "initial_district_id": "d3",
-      "name": "Rural E12",
+      "county_id": "greenfield_county",
+      "position": { "q": -4, "r": 5 },
+      "total_population": 1491,
+      "initial_district_id": "d5",
+      "name": "Rural (-4,5)",
       "demographic_groups": [
         {
-          "id": "p115-base",
-          "name": "Registered voters",
+          "id": "p115-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6417, "ryu": 0.3583 }
+          "vote_shares": { "ken": 0.6142, "ryu": 0.3858 }
         }
       ]
     },
     {
       "id": "p116",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 5, "r": 11 },
-      "total_population": 1493,
-      "initial_district_id": "d3",
-      "name": "Rural F12",
+      "county_id": "greenfield_county",
+      "position": { "q": -3, "r": 5 },
+      "total_population": 1387,
+      "initial_district_id": "d4",
+      "name": "Rural (-3,5)",
       "demographic_groups": [
         {
-          "id": "p116-base",
-          "name": "Registered voters",
+          "id": "p116-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6689, "ryu": 0.3311 }
+          "vote_shares": { "ken": 0.6679, "ryu": 0.3321 }
         }
       ]
     },
     {
       "id": "p117",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 6, "r": 11 },
-      "total_population": 1531,
+      "county_id": "greenfield_county",
+      "position": { "q": -2, "r": 5 },
+      "total_population": 1619,
       "initial_district_id": "d4",
-      "name": "Rural G12",
+      "name": "Rural (-2,5)",
       "demographic_groups": [
         {
-          "id": "p117-base",
-          "name": "Registered voters",
+          "id": "p117-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6490, "ryu": 0.3510 }
+          "vote_shares": { "ken": 0.6297, "ryu": 0.3703 }
         }
       ]
     },
     {
       "id": "p118",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 7, "r": 11 },
-      "total_population": 1557,
+      "county_id": "greenfield_county",
+      "position": { "q": -1, "r": 5 },
+      "total_population": 1626,
       "initial_district_id": "d4",
-      "name": "Rural H12",
+      "name": "Rural (-1,5)",
       "demographic_groups": [
         {
-          "id": "p118-base",
-          "name": "Registered voters",
+          "id": "p118-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6449, "ryu": 0.3551 }
+          "vote_shares": { "ken": 0.6831, "ryu": 0.3169 }
         }
       ]
     },
     {
       "id": "p119",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 8, "r": 11 },
-      "total_population": 1581,
-      "initial_district_id": "d5",
-      "name": "Rural I12",
+      "county_id": "greenfield_county",
+      "position": { "q": 0, "r": 5 },
+      "total_population": 1429,
+      "initial_district_id": "d4",
+      "name": "Rural (0,5)",
       "demographic_groups": [
         {
-          "id": "p119-base",
-          "name": "Registered voters",
+          "id": "p119-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6521, "ryu": 0.3479 }
+          "vote_shares": { "ken": 0.6846, "ryu": 0.3154 }
         }
       ]
     },
     {
       "id": "p120",
       "editable": true,
-      "county_id": "riverport_rural",
-      "position": { "q": 9, "r": 11 },
-      "total_population": 1430,
-      "initial_district_id": "d5",
-      "name": "Rural J12",
+      "county_id": "greenfield_county",
+      "position": { "q": 1, "r": 5 },
+      "total_population": 1499,
+      "initial_district_id": "d4",
+      "name": "Rural (1,5)",
       "demographic_groups": [
         {
-          "id": "p120-base",
-          "name": "Registered voters",
+          "id": "p120-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6723, "ryu": 0.3277 }
+          "vote_shares": { "ken": 0.6706, "ryu": 0.3294 }
+        }
+      ]
+    },
+    {
+      "id": "p121",
+      "editable": true,
+      "county_id": "greenfield_county",
+      "position": { "q": -6, "r": 6 },
+      "total_population": 1550,
+      "initial_district_id": "d5",
+      "name": "Rural (-6,6)",
+      "demographic_groups": [
+        {
+          "id": "p121-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6286, "ryu": 0.3714 }
+        }
+      ]
+    },
+    {
+      "id": "p122",
+      "editable": true,
+      "county_id": "greenfield_county",
+      "position": { "q": -5, "r": 6 },
+      "total_population": 1391,
+      "initial_district_id": "d5",
+      "name": "Rural (-5,6)",
+      "demographic_groups": [
+        {
+          "id": "p122-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6192, "ryu": 0.3808 }
+        }
+      ]
+    },
+    {
+      "id": "p123",
+      "editable": true,
+      "county_id": "greenfield_county",
+      "position": { "q": -4, "r": 6 },
+      "total_population": 1576,
+      "initial_district_id": "d4",
+      "name": "Rural (-4,6)",
+      "demographic_groups": [
+        {
+          "id": "p123-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6303, "ryu": 0.3697 }
+        }
+      ]
+    },
+    {
+      "id": "p124",
+      "editable": true,
+      "county_id": "greenfield_county",
+      "position": { "q": -3, "r": 6 },
+      "total_population": 1500,
+      "initial_district_id": "d4",
+      "name": "Rural (-3,6)",
+      "demographic_groups": [
+        {
+          "id": "p124-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.51,
+          "vote_shares": { "ken": 0.6721, "ryu": 0.3279 }
+        }
+      ]
+    },
+    {
+      "id": "p125",
+      "editable": true,
+      "county_id": "greenfield_county",
+      "position": { "q": -2, "r": 6 },
+      "total_population": 1589,
+      "initial_district_id": "d4",
+      "name": "Rural (-2,6)",
+      "demographic_groups": [
+        {
+          "id": "p125-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.51,
+          "vote_shares": { "ken": 0.6845, "ryu": 0.3155 }
+        }
+      ]
+    },
+    {
+      "id": "p126",
+      "editable": true,
+      "county_id": "greenfield_county",
+      "position": { "q": -1, "r": 6 },
+      "total_population": 1563,
+      "initial_district_id": "d4",
+      "name": "Rural (-1,6)",
+      "demographic_groups": [
+        {
+          "id": "p126-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.53,
+          "vote_shares": { "ken": 0.6529, "ryu": 0.3471 }
+        }
+      ]
+    },
+    {
+      "id": "p127",
+      "editable": true,
+      "county_id": "greenfield_county",
+      "position": { "q": 0, "r": 6 },
+      "total_population": 1514,
+      "initial_district_id": "d4",
+      "name": "Rural (0,6)",
+      "demographic_groups": [
+        {
+          "id": "p127-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.53,
+          "vote_shares": { "ken": 0.6446, "ryu": 0.3554 }
         }
       ]
     }
@@ -2203,7 +2329,7 @@
     {
       "id": "sc-ken-seats",
       "required": true,
-      "description": "The Ken Party wins at least 4 of the 5 districts.",
+      "description": "Ken Party wins at least 4 of the 5 districts.",
       "criterion": {
         "type": "seat_count",
         "party": "ken",
@@ -2214,7 +2340,7 @@
     {
       "id": "sc-efficiency-gap",
       "required": false,
-      "description": "The efficiency gap is 15% or less — a statistically efficient gerrymander.",
+      "description": "Packing creates a large efficiency gap — can you keep it under 15%?",
       "criterion": {
         "type": "efficiency_gap",
         "operator": "lte",
@@ -2225,19 +2351,23 @@
   "narrative": {
     "character": {
       "name": "You",
-      "role": "Redistricting Consultant, Ken Party Majority Caucus",
-      "motivation": "Riverport has a large urban core that votes overwhelmingly Ryu. Your job is to contain that bloc — concentrate it into one district, and let Ken dominate the rest."
+      "role": "Ken Party Campaign Strategist, Riverport Metro",
+      "motivation": "The Ken Party controls the state legislature but is losing ground in Riverport's urban core. The Ryu Party's voters are concentrated downtown — a liability if you know how to exploit it. Your job: draw a map that locks in 4 of 5 seats by packing their voters into one unwinnable district."
     },
     "intro_slides": [
       {
-        "heading": "The City Votes Ryu",
-        "body": "Riverport's urban core is a Ryu stronghold. In the current map, that bloc is spread across three districts — pulling each one toward Ryu.\n\nYour job: stop spreading those votes around."
+        "heading": "The Urban Problem",
+        "body": "Riverport's downtown is a Ryu stronghold — dense, politically active, and growing. If you let those voters spread across multiple districts, they could flip seats.\n\nBut concentration is a weakness. If all those Ryu voters end up in the same district, they win it by a landslide — and waste thousands of votes that could have helped them elsewhere."
       },
       {
-        "heading": "Pack Them In",
-        "body": "Packing means drawing one district to absorb as many opposition voters as possible.\n\nWhen you pack Ryu voters into a single district, they win it by a landslide — but all those extra votes are wasted. The other four districts become safe Ken territory."
+        "heading": "The Packing Play",
+        "body": "Packing means drawing one district that your opponents win overwhelmingly — 80%, 85%, even 90%. Every vote above 50%+1 is wasted. Meanwhile, you spread your own voters efficiently across the remaining districts, winning each by a comfortable but not wasteful margin.\n\nThe result: they win one seat by a landslide. You win four seats by steady margins."
+      },
+      {
+        "heading": "The Efficiency Gap",
+        "body": "Political scientists measure this with the efficiency gap — the difference in wasted votes between the two parties. A packed map has a huge efficiency gap: the opposition wastes votes in their landslide district, while the mapmaker wastes very few.\n\nDraw your map. Then look at the efficiency gap and see what packing costs."
       }
     ],
-    "objective": "Pack the Ryu stronghold into one district so the Ken Party wins at least 4 of the 5 seats."
+    "objective": "Pack Ryu voters into as few districts as possible. Ken Party must win at least 4 of 5 seats."
   }
 }

--- a/game/scenarios/scenario-004.json
+++ b/game/scenarios/scenario-004.json
@@ -24,411 +24,159 @@
     {
       "id": "p001",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 0 },
-      "total_population": 1508,
-      "initial_district_id": "d1",
-      "name": "Upper A1",
+      "county_id": "lakeview_south",
+      "position": { "q": 0, "r": -6 },
+      "total_population": 1488,
+      "initial_district_id": "d5",
+      "name": "South (0,-6)",
       "demographic_groups": [
         {
-          "id": "p001-base",
-          "name": "Registered voters",
+          "id": "p001-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6750, "ryu": 0.3250 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6287, "ryu": 0.3713 }
         }
       ]
     },
     {
       "id": "p002",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 0 },
-      "total_population": 1577,
-      "initial_district_id": "d1",
-      "name": "Upper B1",
+      "county_id": "lakeview_south",
+      "position": { "q": 1, "r": -6 },
+      "total_population": 1536,
+      "initial_district_id": "d5",
+      "name": "South (1,-6)",
       "demographic_groups": [
         {
-          "id": "p002-base",
-          "name": "Registered voters",
+          "id": "p002-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6704, "ryu": 0.3296 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6796, "ryu": 0.3204 }
         }
       ]
     },
     {
       "id": "p003",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 2, "r": 0 },
-      "total_population": 1525,
-      "initial_district_id": "d1",
-      "name": "Upper C1",
+      "county_id": "lakeview_south",
+      "position": { "q": 2, "r": -6 },
+      "total_population": 1500,
+      "initial_district_id": "d5",
+      "name": "South (2,-6)",
       "demographic_groups": [
         {
-          "id": "p003-base",
-          "name": "Registered voters",
+          "id": "p003-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6603, "ryu": 0.3397 }
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6293, "ryu": 0.3707 }
         }
       ]
     },
     {
       "id": "p004",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 3, "r": 0 },
-      "total_population": 1464,
-      "initial_district_id": "d1",
-      "name": "Upper D1",
+      "county_id": "lakeview_south",
+      "position": { "q": 3, "r": -6 },
+      "total_population": 1366,
+      "initial_district_id": "d5",
+      "name": "South (3,-6)",
       "demographic_groups": [
         {
-          "id": "p004-base",
-          "name": "Registered voters",
+          "id": "p004-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6548, "ryu": 0.3452 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6849, "ryu": 0.3151 }
         }
       ]
     },
     {
       "id": "p005",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 4, "r": 0 },
-      "total_population": 1427,
-      "initial_district_id": "d1",
-      "name": "Upper E1",
+      "county_id": "lakeview_south",
+      "position": { "q": 4, "r": -6 },
+      "total_population": 1520,
+      "initial_district_id": "d5",
+      "name": "South (4,-6)",
       "demographic_groups": [
         {
-          "id": "p005-base",
-          "name": "Registered voters",
+          "id": "p005-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6425, "ryu": 0.3575 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6725, "ryu": 0.3275 }
         }
       ]
     },
     {
       "id": "p006",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 5, "r": 0 },
-      "total_population": 1590,
-      "initial_district_id": "d1",
-      "name": "Upper F1",
+      "county_id": "lakeview_south",
+      "position": { "q": 5, "r": -6 },
+      "total_population": 1519,
+      "initial_district_id": "d5",
+      "name": "South (5,-6)",
       "demographic_groups": [
         {
-          "id": "p006-base",
-          "name": "Registered voters",
+          "id": "p006-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6612, "ryu": 0.3388 }
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6431, "ryu": 0.3569 }
         }
       ]
     },
     {
       "id": "p007",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 6, "r": 0 },
-      "total_population": 1580,
-      "initial_district_id": "d1",
-      "name": "Upper G1",
+      "county_id": "lakeview_south",
+      "position": { "q": 6, "r": -6 },
+      "total_population": 1450,
+      "initial_district_id": "d5",
+      "name": "South (6,-6)",
       "demographic_groups": [
         {
-          "id": "p007-base",
-          "name": "Registered voters",
+          "id": "p007-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6309, "ryu": 0.3691 }
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6496, "ryu": 0.3504 }
         }
       ]
     },
     {
       "id": "p008",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 7, "r": 0 },
-      "total_population": 1491,
-      "initial_district_id": "d1",
-      "name": "Upper H1",
+      "county_id": "lakeview_south",
+      "position": { "q": -1, "r": -5 },
+      "total_population": 1458,
+      "initial_district_id": "d5",
+      "name": "South (-1,-5)",
       "demographic_groups": [
         {
-          "id": "p008-base",
-          "name": "Registered voters",
+          "id": "p008-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6250, "ryu": 0.3750 }
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6523, "ryu": 0.3477 }
         }
       ]
     },
     {
       "id": "p009",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 8, "r": 0 },
-      "total_population": 1484,
-      "initial_district_id": "d1",
-      "name": "Upper I1",
+      "county_id": "lakeview_south",
+      "position": { "q": 0, "r": -5 },
+      "total_population": 1440,
+      "initial_district_id": "d5",
+      "name": "South (0,-5)",
       "demographic_groups": [
         {
-          "id": "p009-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6261, "ryu": 0.3739 }
-        }
-      ]
-    },
-    {
-      "id": "p010",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 9, "r": 0 },
-      "total_population": 1579,
-      "initial_district_id": "d1",
-      "name": "Upper J1",
-      "demographic_groups": [
-        {
-          "id": "p010-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6740, "ryu": 0.3260 }
-        }
-      ]
-    },
-    {
-      "id": "p011",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 1 },
-      "total_population": 1572,
-      "initial_district_id": "d1",
-      "name": "Upper A2",
-      "demographic_groups": [
-        {
-          "id": "p011-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6435, "ryu": 0.3565 }
-        }
-      ]
-    },
-    {
-      "id": "p012",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 1 },
-      "total_population": 1515,
-      "initial_district_id": "d1",
-      "name": "Upper B2",
-      "demographic_groups": [
-        {
-          "id": "p012-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6291, "ryu": 0.3709 }
-        }
-      ]
-    },
-    {
-      "id": "p013",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 2, "r": 1 },
-      "total_population": 1538,
-      "initial_district_id": "d1",
-      "name": "Upper C2",
-      "demographic_groups": [
-        {
-          "id": "p013-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6369, "ryu": 0.3631 }
-        }
-      ]
-    },
-    {
-      "id": "p014",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 3, "r": 1 },
-      "total_population": 1531,
-      "initial_district_id": "d1",
-      "name": "Upper D2",
-      "demographic_groups": [
-        {
-          "id": "p014-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6607, "ryu": 0.3393 }
-        }
-      ]
-    },
-    {
-      "id": "p015",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 4, "r": 1 },
-      "total_population": 1594,
-      "initial_district_id": "d1",
-      "name": "Upper E2",
-      "demographic_groups": [
-        {
-          "id": "p015-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6531, "ryu": 0.3469 }
-        }
-      ]
-    },
-    {
-      "id": "p016",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 5, "r": 1 },
-      "total_population": 1429,
-      "initial_district_id": "d1",
-      "name": "Upper F2",
-      "demographic_groups": [
-        {
-          "id": "p016-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6610, "ryu": 0.3390 }
-        }
-      ]
-    },
-    {
-      "id": "p017",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 6, "r": 1 },
-      "total_population": 1427,
-      "initial_district_id": "d1",
-      "name": "Upper G2",
-      "demographic_groups": [
-        {
-          "id": "p017-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6398, "ryu": 0.3602 }
-        }
-      ]
-    },
-    {
-      "id": "p018",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 7, "r": 1 },
-      "total_population": 1409,
-      "initial_district_id": "d1",
-      "name": "Upper H2",
-      "demographic_groups": [
-        {
-          "id": "p018-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6753, "ryu": 0.3247 }
-        }
-      ]
-    },
-    {
-      "id": "p019",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 8, "r": 1 },
-      "total_population": 1540,
-      "initial_district_id": "d1",
-      "name": "Upper I2",
-      "demographic_groups": [
-        {
-          "id": "p019-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6574, "ryu": 0.3426 }
-        }
-      ]
-    },
-    {
-      "id": "p020",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 9, "r": 1 },
-      "total_population": 1563,
-      "initial_district_id": "d1",
-      "name": "Upper J2",
-      "demographic_groups": [
-        {
-          "id": "p020-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6239, "ryu": 0.3761 }
-        }
-      ]
-    },
-    {
-      "id": "p021",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 2 },
-      "total_population": 1473,
-      "initial_district_id": "d1",
-      "name": "Upper A3",
-      "demographic_groups": [
-        {
-          "id": "p021-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6586, "ryu": 0.3414 }
-        }
-      ]
-    },
-    {
-      "id": "p022",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 2 },
-      "total_population": 1405,
-      "initial_district_id": "d1",
-      "name": "Upper B3",
-      "demographic_groups": [
-        {
-          "id": "p022-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6751, "ryu": 0.3249 }
-        }
-      ]
-    },
-    {
-      "id": "p023",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 2, "r": 2 },
-      "total_population": 1487,
-      "initial_district_id": "d1",
-      "name": "Upper C3",
-      "demographic_groups": [
-        {
-          "id": "p023-base",
-          "name": "Registered voters",
+          "id": "p009-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
           "vote_shares": { "ken": 0.6525, "ryu": 0.3475 }
@@ -436,359 +184,1961 @@
       ]
     },
     {
-      "id": "p024",
+      "id": "p010",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 3, "r": 2 },
-      "total_population": 1400,
-      "initial_district_id": "d1",
-      "name": "Upper D3",
+      "county_id": "lakeview_south",
+      "position": { "q": 1, "r": -5 },
+      "total_population": 1430,
+      "initial_district_id": "d5",
+      "name": "South (1,-5)",
       "demographic_groups": [
         {
-          "id": "p024-base",
-          "name": "Registered voters",
+          "id": "p010-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6342, "ryu": 0.3658 }
+        }
+      ]
+    },
+    {
+      "id": "p011",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 2, "r": -5 },
+      "total_population": 1581,
+      "initial_district_id": "d5",
+      "name": "South (2,-5)",
+      "demographic_groups": [
+        {
+          "id": "p011-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6581, "ryu": 0.3419 }
+        }
+      ]
+    },
+    {
+      "id": "p012",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 3, "r": -5 },
+      "total_population": 1523,
+      "initial_district_id": "d5",
+      "name": "South (3,-5)",
+      "demographic_groups": [
+        {
+          "id": "p012-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6661, "ryu": 0.3339 }
+        }
+      ]
+    },
+    {
+      "id": "p013",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 4, "r": -5 },
+      "total_population": 1572,
+      "initial_district_id": "d5",
+      "name": "South (4,-5)",
+      "demographic_groups": [
+        {
+          "id": "p013-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6678, "ryu": 0.3322 }
+        }
+      ]
+    },
+    {
+      "id": "p014",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 5, "r": -5 },
+      "total_population": 1634,
+      "initial_district_id": "d5",
+      "name": "South (5,-5)",
+      "demographic_groups": [
+        {
+          "id": "p014-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6639, "ryu": 0.3361 }
+        }
+      ]
+    },
+    {
+      "id": "p015",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 6, "r": -5 },
+      "total_population": 1417,
+      "initial_district_id": "d5",
+      "name": "South (6,-5)",
+      "demographic_groups": [
+        {
+          "id": "p015-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6570, "ryu": 0.3430 }
+          "vote_shares": { "ken": 0.6651, "ryu": 0.3349 }
+        }
+      ]
+    },
+    {
+      "id": "p016",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": -2, "r": -4 },
+      "total_population": 1536,
+      "initial_district_id": "d5",
+      "name": "South (-2,-4)",
+      "demographic_groups": [
+        {
+          "id": "p016-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6833, "ryu": 0.3167 }
+        }
+      ]
+    },
+    {
+      "id": "p017",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": -1, "r": -4 },
+      "total_population": 1555,
+      "initial_district_id": "d5",
+      "name": "South (-1,-4)",
+      "demographic_groups": [
+        {
+          "id": "p017-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6244, "ryu": 0.3756 }
+        }
+      ]
+    },
+    {
+      "id": "p018",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 0, "r": -4 },
+      "total_population": 1477,
+      "initial_district_id": "d5",
+      "name": "South (0,-4)",
+      "demographic_groups": [
+        {
+          "id": "p018-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6113, "ryu": 0.3887 }
+        }
+      ]
+    },
+    {
+      "id": "p019",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 1, "r": -4 },
+      "total_population": 1455,
+      "initial_district_id": "d5",
+      "name": "South (1,-4)",
+      "demographic_groups": [
+        {
+          "id": "p019-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6397, "ryu": 0.3603 }
+        }
+      ]
+    },
+    {
+      "id": "p020",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 2, "r": -4 },
+      "total_population": 1507,
+      "initial_district_id": "d5",
+      "name": "South (2,-4)",
+      "demographic_groups": [
+        {
+          "id": "p020-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6145, "ryu": 0.3855 }
+        }
+      ]
+    },
+    {
+      "id": "p021",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 3, "r": -4 },
+      "total_population": 1373,
+      "initial_district_id": "d5",
+      "name": "South (3,-4)",
+      "demographic_groups": [
+        {
+          "id": "p021-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6643, "ryu": 0.3357 }
+        }
+      ]
+    },
+    {
+      "id": "p022",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 4, "r": -4 },
+      "total_population": 1546,
+      "initial_district_id": "d5",
+      "name": "South (4,-4)",
+      "demographic_groups": [
+        {
+          "id": "p022-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6168, "ryu": 0.3832 }
+        }
+      ]
+    },
+    {
+      "id": "p023",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 5, "r": -4 },
+      "total_population": 1375,
+      "initial_district_id": "d5",
+      "name": "South (5,-4)",
+      "demographic_groups": [
+        {
+          "id": "p023-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6739, "ryu": 0.3261 }
+        }
+      ]
+    },
+    {
+      "id": "p024",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 6, "r": -4 },
+      "total_population": 1583,
+      "initial_district_id": "d5",
+      "name": "South (6,-4)",
+      "demographic_groups": [
+        {
+          "id": "p024-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6287, "ryu": 0.3713 }
         }
       ]
     },
     {
       "id": "p025",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 4, "r": 2 },
-      "total_population": 1537,
-      "initial_district_id": "d2",
-      "name": "Upper E3",
+      "county_id": "lakeview_south",
+      "position": { "q": -3, "r": -3 },
+      "total_population": 1549,
+      "initial_district_id": "d5",
+      "name": "South (-3,-3)",
       "demographic_groups": [
         {
-          "id": "p025-base",
-          "name": "Registered voters",
+          "id": "p025-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6226, "ryu": 0.3774 }
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6295, "ryu": 0.3705 }
         }
       ]
     },
     {
       "id": "p026",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 5, "r": 2 },
-      "total_population": 1531,
-      "initial_district_id": "d2",
-      "name": "Upper F3",
+      "county_id": "lakeview_south",
+      "position": { "q": -2, "r": -3 },
+      "total_population": 1555,
+      "initial_district_id": "d5",
+      "name": "South (-2,-3)",
       "demographic_groups": [
         {
-          "id": "p026-base",
-          "name": "Registered voters",
+          "id": "p026-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6477, "ryu": 0.3523 }
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6158, "ryu": 0.3842 }
         }
       ]
     },
     {
       "id": "p027",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 6, "r": 2 },
-      "total_population": 1431,
-      "initial_district_id": "d2",
-      "name": "Upper G3",
+      "county_id": "lakeview_south",
+      "position": { "q": -1, "r": -3 },
+      "total_population": 1569,
+      "initial_district_id": "d5",
+      "name": "South (-1,-3)",
       "demographic_groups": [
         {
-          "id": "p027-base",
-          "name": "Registered voters",
+          "id": "p027-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6260, "ryu": 0.3740 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6382, "ryu": 0.3618 }
         }
       ]
     },
     {
       "id": "p028",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 7, "r": 2 },
-      "total_population": 1424,
-      "initial_district_id": "d2",
-      "name": "Upper H3",
+      "county_id": "lakeview_south",
+      "position": { "q": 0, "r": -3 },
+      "total_population": 1621,
+      "initial_district_id": "d5",
+      "name": "South (0,-3)",
       "demographic_groups": [
         {
-          "id": "p028-base",
-          "name": "Registered voters",
+          "id": "p028-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6402, "ryu": 0.3598 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6687, "ryu": 0.3313 }
         }
       ]
     },
     {
       "id": "p029",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 8, "r": 2 },
-      "total_population": 1446,
-      "initial_district_id": "d2",
-      "name": "Upper I3",
+      "county_id": "lakeview_south",
+      "position": { "q": 1, "r": -3 },
+      "total_population": 1461,
+      "initial_district_id": "d5",
+      "name": "South (1,-3)",
       "demographic_groups": [
         {
-          "id": "p029-base",
-          "name": "Registered voters",
+          "id": "p029-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6756, "ryu": 0.3244 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6739, "ryu": 0.3261 }
         }
       ]
     },
     {
       "id": "p030",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 9, "r": 2 },
-      "total_population": 1414,
-      "initial_district_id": "d2",
-      "name": "Upper J3",
+      "county_id": "lakeview_south",
+      "position": { "q": 2, "r": -3 },
+      "total_population": 1598,
+      "initial_district_id": "d5",
+      "name": "South (2,-3)",
       "demographic_groups": [
         {
-          "id": "p030-base",
-          "name": "Registered voters",
+          "id": "p030-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6797, "ryu": 0.3203 }
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6365, "ryu": 0.3635 }
         }
       ]
     },
     {
       "id": "p031",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 3 },
-      "total_population": 1506,
-      "initial_district_id": "d2",
-      "name": "Upper A4",
+      "county_id": "lakeview_south",
+      "position": { "q": 3, "r": -3 },
+      "total_population": 1568,
+      "initial_district_id": "d5",
+      "name": "South (3,-3)",
       "demographic_groups": [
         {
-          "id": "p031-base",
-          "name": "Registered voters",
+          "id": "p031-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6498, "ryu": 0.3502 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6209, "ryu": 0.3791 }
         }
       ]
     },
     {
       "id": "p032",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 3 },
-      "total_population": 1562,
-      "initial_district_id": "d2",
-      "name": "Upper B4",
+      "county_id": "lakeview_south",
+      "position": { "q": 4, "r": -3 },
+      "total_population": 1541,
+      "initial_district_id": "d5",
+      "name": "South (4,-3)",
       "demographic_groups": [
         {
-          "id": "p032-base",
-          "name": "Registered voters",
+          "id": "p032-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6557, "ryu": 0.3443 }
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6554, "ryu": 0.3446 }
         }
       ]
     },
     {
       "id": "p033",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 2, "r": 3 },
-      "total_population": 1449,
-      "initial_district_id": "d2",
-      "name": "Upper C4",
+      "county_id": "lakeview_south",
+      "position": { "q": 5, "r": -3 },
+      "total_population": 1482,
+      "initial_district_id": "d5",
+      "name": "South (5,-3)",
       "demographic_groups": [
         {
-          "id": "p033-base",
-          "name": "Registered voters",
+          "id": "p033-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6546, "ryu": 0.3454 }
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6573, "ryu": 0.3427 }
         }
       ]
     },
     {
       "id": "p034",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 3, "r": 3 },
-      "total_population": 1463,
-      "initial_district_id": "d2",
-      "name": "Upper D4",
+      "county_id": "lakeview_south",
+      "position": { "q": 6, "r": -3 },
+      "total_population": 1393,
+      "initial_district_id": "d5",
+      "name": "South (6,-3)",
       "demographic_groups": [
         {
-          "id": "p034-base",
-          "name": "Registered voters",
+          "id": "p034-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6542, "ryu": 0.3458 }
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6535, "ryu": 0.3465 }
         }
       ]
     },
     {
       "id": "p035",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 4, "r": 3 },
-      "total_population": 1432,
-      "initial_district_id": "d2",
-      "name": "Upper E4",
+      "county_id": "lakeview_south",
+      "position": { "q": -4, "r": -2 },
+      "total_population": 1612,
+      "initial_district_id": "d4",
+      "name": "South (-4,-2)",
       "demographic_groups": [
         {
-          "id": "p035-base",
-          "name": "Registered voters",
+          "id": "p035-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6474, "ryu": 0.3526 }
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6493, "ryu": 0.3507 }
         }
       ]
     },
     {
       "id": "p036",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 5, "r": 3 },
-      "total_population": 1543,
-      "initial_district_id": "d2",
-      "name": "Upper F4",
+      "county_id": "lakeview_south",
+      "position": { "q": -3, "r": -2 },
+      "total_population": 1386,
+      "initial_district_id": "d4",
+      "name": "South (-3,-2)",
       "demographic_groups": [
         {
-          "id": "p036-base",
-          "name": "Registered voters",
+          "id": "p036-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6629, "ryu": 0.3371 }
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6118, "ryu": 0.3882 }
         }
       ]
     },
     {
       "id": "p037",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 6, "r": 3 },
-      "total_population": 1467,
-      "initial_district_id": "d2",
-      "name": "Upper G4",
+      "county_id": "lakeview_south",
+      "position": { "q": -2, "r": -2 },
+      "total_population": 1637,
+      "initial_district_id": "d4",
+      "name": "South (-2,-2)",
       "demographic_groups": [
         {
-          "id": "p037-base",
-          "name": "Registered voters",
+          "id": "p037-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6438, "ryu": 0.3562 }
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6433, "ryu": 0.3567 }
         }
       ]
     },
     {
       "id": "p038",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 7, "r": 3 },
-      "total_population": 1532,
-      "initial_district_id": "d2",
-      "name": "Upper H4",
+      "county_id": "lakeview_south",
+      "position": { "q": -1, "r": -2 },
+      "total_population": 1626,
+      "initial_district_id": "d4",
+      "name": "South (-1,-2)",
       "demographic_groups": [
         {
-          "id": "p038-base",
-          "name": "Registered voters",
+          "id": "p038-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6326, "ryu": 0.3674 }
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6688, "ryu": 0.3312 }
         }
       ]
     },
     {
       "id": "p039",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 8, "r": 3 },
-      "total_population": 1593,
-      "initial_district_id": "d2",
-      "name": "Upper I4",
+      "county_id": "lakeview_south",
+      "position": { "q": 0, "r": -2 },
+      "total_population": 1458,
+      "initial_district_id": "d4",
+      "name": "South (0,-2)",
       "demographic_groups": [
         {
-          "id": "p039-base",
-          "name": "Registered voters",
+          "id": "p039-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6623, "ryu": 0.3377 }
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6864, "ryu": 0.3136 }
         }
       ]
     },
     {
       "id": "p040",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 9, "r": 3 },
-      "total_population": 1427,
-      "initial_district_id": "d2",
-      "name": "Upper J4",
+      "county_id": "lakeview_south",
+      "position": { "q": 1, "r": -2 },
+      "total_population": 1521,
+      "initial_district_id": "d4",
+      "name": "South (1,-2)",
       "demographic_groups": [
         {
-          "id": "p040-base",
-          "name": "Registered voters",
+          "id": "p040-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6766, "ryu": 0.3234 }
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6250, "ryu": 0.3750 }
         }
       ]
     },
     {
       "id": "p041",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 4 },
-      "total_population": 1523,
-      "initial_district_id": "d2",
-      "name": "Upper A5",
+      "county_id": "lakeview_south",
+      "position": { "q": 2, "r": -2 },
+      "total_population": 1435,
+      "initial_district_id": "d4",
+      "name": "South (2,-2)",
       "demographic_groups": [
         {
-          "id": "p041-base",
-          "name": "Registered voters",
+          "id": "p041-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6778, "ryu": 0.3222 }
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6518, "ryu": 0.3482 }
         }
       ]
     },
     {
       "id": "p042",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 4 },
-      "total_population": 1463,
-      "initial_district_id": "d2",
-      "name": "Upper B5",
+      "county_id": "lakeview_south",
+      "position": { "q": 3, "r": -2 },
+      "total_population": 1441,
+      "initial_district_id": "d4",
+      "name": "South (3,-2)",
       "demographic_groups": [
         {
-          "id": "p042-base",
-          "name": "Registered voters",
+          "id": "p042-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6523, "ryu": 0.3477 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6415, "ryu": 0.3585 }
         }
       ]
     },
     {
       "id": "p043",
       "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 2, "r": 4 },
-      "total_population": 1572,
-      "initial_district_id": "d2",
-      "name": "Upper C5",
+      "county_id": "lakeview_south",
+      "position": { "q": 4, "r": -2 },
+      "total_population": 1484,
+      "initial_district_id": "d4",
+      "name": "South (4,-2)",
       "demographic_groups": [
         {
-          "id": "p043-base",
-          "name": "Registered voters",
+          "id": "p043-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6229, "ryu": 0.3771 }
+        }
+      ]
+    },
+    {
+      "id": "p044",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 5, "r": -2 },
+      "total_population": 1456,
+      "initial_district_id": "d4",
+      "name": "South (5,-2)",
+      "demographic_groups": [
+        {
+          "id": "p044-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6824, "ryu": 0.3176 }
+        }
+      ]
+    },
+    {
+      "id": "p045",
+      "editable": true,
+      "county_id": "lakeview_south",
+      "position": { "q": 6, "r": -2 },
+      "total_population": 1540,
+      "initial_district_id": "d4",
+      "name": "South (6,-2)",
+      "demographic_groups": [
+        {
+          "id": "p045-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6314, "ryu": 0.3686 }
+        }
+      ]
+    },
+    {
+      "id": "p046",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -5, "r": -1 },
+      "total_population": 1364,
+      "initial_district_id": "d3",
+      "name": "South (-5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p046-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6575, "ryu": 0.3425 }
+        }
+      ]
+    },
+    {
+      "id": "p047",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -4, "r": -1 },
+      "total_population": 1602,
+      "initial_district_id": "d3",
+      "name": "South (-4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p047-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6116, "ryu": 0.3884 }
+        }
+      ]
+    },
+    {
+      "id": "p048",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -3, "r": -1 },
+      "total_population": 1376,
+      "initial_district_id": "d3",
+      "name": "South (-3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p048-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6588, "ryu": 0.3412 }
+        }
+      ]
+    },
+    {
+      "id": "p049",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -2, "r": -1 },
+      "total_population": 1608,
+      "initial_district_id": "d3",
+      "name": "South (-2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p049-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6159, "ryu": 0.3841 }
+        }
+      ]
+    },
+    {
+      "id": "p050",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -1, "r": -1 },
+      "total_population": 1427,
+      "initial_district_id": "d3",
+      "name": "South (-1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p050-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6856, "ryu": 0.3144 }
+        }
+      ]
+    },
+    {
+      "id": "p051",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 0, "r": -1 },
+      "total_population": 1492,
+      "initial_district_id": "d3",
+      "name": "South (0,-1)",
+      "demographic_groups": [
+        {
+          "id": "p051-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6889, "ryu": 0.3111 }
+        }
+      ]
+    },
+    {
+      "id": "p052",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 1, "r": -1 },
+      "total_population": 1518,
+      "initial_district_id": "d3",
+      "name": "South (1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p052-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6334, "ryu": 0.3666 }
+        }
+      ]
+    },
+    {
+      "id": "p053",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 2, "r": -1 },
+      "total_population": 1415,
+      "initial_district_id": "d3",
+      "name": "South (2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p053-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6895, "ryu": 0.3105 }
+        }
+      ]
+    },
+    {
+      "id": "p054",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 3, "r": -1 },
+      "total_population": 1470,
+      "initial_district_id": "d3",
+      "name": "South (3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p054-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6474, "ryu": 0.3526 }
+        }
+      ]
+    },
+    {
+      "id": "p055",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 4, "r": -1 },
+      "total_population": 1380,
+      "initial_district_id": "d3",
+      "name": "South (4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p055-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6476, "ryu": 0.3524 }
+        }
+      ]
+    },
+    {
+      "id": "p056",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 5, "r": -1 },
+      "total_population": 1538,
+      "initial_district_id": "d3",
+      "name": "South (5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p056-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6866, "ryu": 0.3134 }
+        }
+      ]
+    },
+    {
+      "id": "p057",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 6, "r": -1 },
+      "total_population": 1473,
+      "initial_district_id": "d3",
+      "name": "South (6,-1)",
+      "demographic_groups": [
+        {
+          "id": "p057-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6764, "ryu": 0.3236 }
+        }
+      ]
+    },
+    {
+      "id": "p058",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -6, "r": 0 },
+      "total_population": 1598,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (-6,0)",
+      "demographic_groups": [
+        {
+          "id": "p058-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.1782, "ryu": 0.8218 }
+        }
+      ]
+    },
+    {
+      "id": "p059",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -5, "r": 0 },
+      "total_population": 1549,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (-5,0)",
+      "demographic_groups": [
+        {
+          "id": "p059-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.1980, "ryu": 0.8020 }
+        }
+      ]
+    },
+    {
+      "id": "p060",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -4, "r": 0 },
+      "total_population": 1615,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (-4,0)",
+      "demographic_groups": [
+        {
+          "id": "p060-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.1741, "ryu": 0.8259 }
+        }
+      ]
+    },
+    {
+      "id": "p061",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -3, "r": 0 },
+      "total_population": 1400,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (-3,0)",
+      "demographic_groups": [
+        {
+          "id": "p061-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.2148, "ryu": 0.7852 }
+        }
+      ]
+    },
+    {
+      "id": "p062",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -2, "r": 0 },
+      "total_population": 1526,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (-2,0)",
+      "demographic_groups": [
+        {
+          "id": "p062-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.1411, "ryu": 0.8589 }
+        }
+      ]
+    },
+    {
+      "id": "p063",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -1, "r": 0 },
+      "total_population": 1578,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (-1,0)",
+      "demographic_groups": [
+        {
+          "id": "p063-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.1991, "ryu": 0.8009 }
+        }
+      ]
+    },
+    {
+      "id": "p064",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 0, "r": 0 },
+      "total_population": 1555,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (0,0)",
+      "demographic_groups": [
+        {
+          "id": "p064-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.1618, "ryu": 0.8382 }
+        }
+      ]
+    },
+    {
+      "id": "p065",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 1, "r": 0 },
+      "total_population": 1549,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (1,0)",
+      "demographic_groups": [
+        {
+          "id": "p065-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.2070, "ryu": 0.7930 }
+        }
+      ]
+    },
+    {
+      "id": "p066",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 2, "r": 0 },
+      "total_population": 1467,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (2,0)",
+      "demographic_groups": [
+        {
+          "id": "p066-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.1711, "ryu": 0.8289 }
+        }
+      ]
+    },
+    {
+      "id": "p067",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 3, "r": 0 },
+      "total_population": 1373,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (3,0)",
+      "demographic_groups": [
+        {
+          "id": "p067-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.1640, "ryu": 0.8360 }
+        }
+      ]
+    },
+    {
+      "id": "p068",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 4, "r": 0 },
+      "total_population": 1642,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (4,0)",
+      "demographic_groups": [
+        {
+          "id": "p068-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.1528, "ryu": 0.8472 }
+        }
+      ]
+    },
+    {
+      "id": "p069",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 5, "r": 0 },
+      "total_population": 1523,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (5,0)",
+      "demographic_groups": [
+        {
+          "id": "p069-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.1964, "ryu": 0.8036 }
+        }
+      ]
+    },
+    {
+      "id": "p070",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 6, "r": 0 },
+      "total_population": 1564,
+      "initial_district_id": "d3",
+      "name": "Lakeshore (6,0)",
+      "demographic_groups": [
+        {
+          "id": "p070-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.2066, "ryu": 0.7934 }
+        }
+      ]
+    },
+    {
+      "id": "p071",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -6, "r": 1 },
+      "total_population": 1472,
+      "initial_district_id": "d3",
+      "name": "North (-6,1)",
+      "demographic_groups": [
+        {
+          "id": "p071-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.6258, "ryu": 0.3742 }
+        }
+      ]
+    },
+    {
+      "id": "p072",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -5, "r": 1 },
+      "total_population": 1561,
+      "initial_district_id": "d3",
+      "name": "North (-5,1)",
+      "demographic_groups": [
+        {
+          "id": "p072-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6150, "ryu": 0.3850 }
+        }
+      ]
+    },
+    {
+      "id": "p073",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -4, "r": 1 },
+      "total_population": 1459,
+      "initial_district_id": "d3",
+      "name": "North (-4,1)",
+      "demographic_groups": [
+        {
+          "id": "p073-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6570, "ryu": 0.3430 }
+        }
+      ]
+    },
+    {
+      "id": "p074",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -3, "r": 1 },
+      "total_population": 1365,
+      "initial_district_id": "d3",
+      "name": "North (-3,1)",
+      "demographic_groups": [
+        {
+          "id": "p074-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+        }
+      ]
+    },
+    {
+      "id": "p075",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -2, "r": 1 },
+      "total_population": 1576,
+      "initial_district_id": "d3",
+      "name": "North (-2,1)",
+      "demographic_groups": [
+        {
+          "id": "p075-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.6607, "ryu": 0.3393 }
+        }
+      ]
+    },
+    {
+      "id": "p076",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": -1, "r": 1 },
+      "total_population": 1537,
+      "initial_district_id": "d3",
+      "name": "North (-1,1)",
+      "demographic_groups": [
+        {
+          "id": "p076-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6156, "ryu": 0.3844 }
+        }
+      ]
+    },
+    {
+      "id": "p077",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 0, "r": 1 },
+      "total_population": 1408,
+      "initial_district_id": "d3",
+      "name": "North (0,1)",
+      "demographic_groups": [
+        {
+          "id": "p077-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6600, "ryu": 0.3400 }
+        }
+      ]
+    },
+    {
+      "id": "p078",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 1, "r": 1 },
+      "total_population": 1503,
+      "initial_district_id": "d3",
+      "name": "North (1,1)",
+      "demographic_groups": [
+        {
+          "id": "p078-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6114, "ryu": 0.3886 }
+        }
+      ]
+    },
+    {
+      "id": "p079",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 2, "r": 1 },
+      "total_population": 1467,
+      "initial_district_id": "d3",
+      "name": "North (2,1)",
+      "demographic_groups": [
+        {
+          "id": "p079-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6844, "ryu": 0.3156 }
+        }
+      ]
+    },
+    {
+      "id": "p080",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 3, "r": 1 },
+      "total_population": 1493,
+      "initial_district_id": "d3",
+      "name": "North (3,1)",
+      "demographic_groups": [
+        {
+          "id": "p080-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6295, "ryu": 0.3705 }
+        }
+      ]
+    },
+    {
+      "id": "p081",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 4, "r": 1 },
+      "total_population": 1354,
+      "initial_district_id": "d3",
+      "name": "North (4,1)",
+      "demographic_groups": [
+        {
+          "id": "p081-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6798, "ryu": 0.3202 }
+        }
+      ]
+    },
+    {
+      "id": "p082",
+      "editable": true,
+      "county_id": "lakeview_central",
+      "position": { "q": 5, "r": 1 },
+      "total_population": 1419,
+      "initial_district_id": "d3",
+      "name": "North (5,1)",
+      "demographic_groups": [
+        {
+          "id": "p082-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6812, "ryu": 0.3188 }
+        }
+      ]
+    },
+    {
+      "id": "p083",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -6, "r": 2 },
+      "total_population": 1527,
+      "initial_district_id": "d2",
+      "name": "North (-6,2)",
+      "demographic_groups": [
+        {
+          "id": "p083-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6548, "ryu": 0.3452 }
+        }
+      ]
+    },
+    {
+      "id": "p084",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -5, "r": 2 },
+      "total_population": 1433,
+      "initial_district_id": "d2",
+      "name": "North (-5,2)",
+      "demographic_groups": [
+        {
+          "id": "p084-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6496, "ryu": 0.3504 }
+        }
+      ]
+    },
+    {
+      "id": "p085",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -4, "r": 2 },
+      "total_population": 1355,
+      "initial_district_id": "d2",
+      "name": "North (-4,2)",
+      "demographic_groups": [
+        {
+          "id": "p085-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6529, "ryu": 0.3471 }
+        }
+      ]
+    },
+    {
+      "id": "p086",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -3, "r": 2 },
+      "total_population": 1390,
+      "initial_district_id": "d2",
+      "name": "North (-3,2)",
+      "demographic_groups": [
+        {
+          "id": "p086-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6456, "ryu": 0.3544 }
+        }
+      ]
+    },
+    {
+      "id": "p087",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -2, "r": 2 },
+      "total_population": 1463,
+      "initial_district_id": "d2",
+      "name": "North (-2,2)",
+      "demographic_groups": [
+        {
+          "id": "p087-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+        }
+      ]
+    },
+    {
+      "id": "p088",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -1, "r": 2 },
+      "total_population": 1646,
+      "initial_district_id": "d2",
+      "name": "North (-1,2)",
+      "demographic_groups": [
+        {
+          "id": "p088-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6744, "ryu": 0.3256 }
+        }
+      ]
+    },
+    {
+      "id": "p089",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 0, "r": 2 },
+      "total_population": 1528,
+      "initial_district_id": "d2",
+      "name": "North (0,2)",
+      "demographic_groups": [
+        {
+          "id": "p089-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6378, "ryu": 0.3622 }
+        }
+      ]
+    },
+    {
+      "id": "p090",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 1, "r": 2 },
+      "total_population": 1563,
+      "initial_district_id": "d2",
+      "name": "North (1,2)",
+      "demographic_groups": [
+        {
+          "id": "p090-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6469, "ryu": 0.3531 }
+        }
+      ]
+    },
+    {
+      "id": "p091",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 2, "r": 2 },
+      "total_population": 1612,
+      "initial_district_id": "d2",
+      "name": "North (2,2)",
+      "demographic_groups": [
+        {
+          "id": "p091-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6510, "ryu": 0.3490 }
+        }
+      ]
+    },
+    {
+      "id": "p092",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 3, "r": 2 },
+      "total_population": 1535,
+      "initial_district_id": "d2",
+      "name": "North (3,2)",
+      "demographic_groups": [
+        {
+          "id": "p092-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.6167, "ryu": 0.3833 }
+        }
+      ]
+    },
+    {
+      "id": "p093",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 4, "r": 2 },
+      "total_population": 1425,
+      "initial_district_id": "d2",
+      "name": "North (4,2)",
+      "demographic_groups": [
+        {
+          "id": "p093-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6266, "ryu": 0.3734 }
+        }
+      ]
+    },
+    {
+      "id": "p094",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -6, "r": 3 },
+      "total_population": 1626,
+      "initial_district_id": "d1",
+      "name": "North (-6,3)",
+      "demographic_groups": [
+        {
+          "id": "p094-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6502, "ryu": 0.3498 }
+        }
+      ]
+    },
+    {
+      "id": "p095",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -5, "r": 3 },
+      "total_population": 1474,
+      "initial_district_id": "d1",
+      "name": "North (-5,3)",
+      "demographic_groups": [
+        {
+          "id": "p095-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6254, "ryu": 0.3746 }
+        }
+      ]
+    },
+    {
+      "id": "p096",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -4, "r": 3 },
+      "total_population": 1541,
+      "initial_district_id": "d1",
+      "name": "North (-4,3)",
+      "demographic_groups": [
+        {
+          "id": "p096-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6729, "ryu": 0.3271 }
+        }
+      ]
+    },
+    {
+      "id": "p097",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -3, "r": 3 },
+      "total_population": 1550,
+      "initial_district_id": "d1",
+      "name": "North (-3,3)",
+      "demographic_groups": [
+        {
+          "id": "p097-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6685, "ryu": 0.3315 }
+        }
+      ]
+    },
+    {
+      "id": "p098",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -2, "r": 3 },
+      "total_population": 1556,
+      "initial_district_id": "d1",
+      "name": "North (-2,3)",
+      "demographic_groups": [
+        {
+          "id": "p098-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6288, "ryu": 0.3712 }
+        }
+      ]
+    },
+    {
+      "id": "p099",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -1, "r": 3 },
+      "total_population": 1537,
+      "initial_district_id": "d1",
+      "name": "North (-1,3)",
+      "demographic_groups": [
+        {
+          "id": "p099-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6619, "ryu": 0.3381 }
+        }
+      ]
+    },
+    {
+      "id": "p100",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 0, "r": 3 },
+      "total_population": 1571,
+      "initial_district_id": "d1",
+      "name": "North (0,3)",
+      "demographic_groups": [
+        {
+          "id": "p100-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6356, "ryu": 0.3644 }
+        }
+      ]
+    },
+    {
+      "id": "p101",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 1, "r": 3 },
+      "total_population": 1609,
+      "initial_district_id": "d1",
+      "name": "North (1,3)",
+      "demographic_groups": [
+        {
+          "id": "p101-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6829, "ryu": 0.3171 }
+        }
+      ]
+    },
+    {
+      "id": "p102",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 2, "r": 3 },
+      "total_population": 1530,
+      "initial_district_id": "d1",
+      "name": "North (2,3)",
+      "demographic_groups": [
+        {
+          "id": "p102-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6817, "ryu": 0.3183 }
+        }
+      ]
+    },
+    {
+      "id": "p103",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 3, "r": 3 },
+      "total_population": 1358,
+      "initial_district_id": "d1",
+      "name": "North (3,3)",
+      "demographic_groups": [
+        {
+          "id": "p103-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6732, "ryu": 0.3268 }
+        }
+      ]
+    },
+    {
+      "id": "p104",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -6, "r": 4 },
+      "total_population": 1446,
+      "initial_district_id": "d1",
+      "name": "North (-6,4)",
+      "demographic_groups": [
+        {
+          "id": "p104-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.6665, "ryu": 0.3335 }
+        }
+      ]
+    },
+    {
+      "id": "p105",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -5, "r": 4 },
+      "total_population": 1506,
+      "initial_district_id": "d1",
+      "name": "North (-5,4)",
+      "demographic_groups": [
+        {
+          "id": "p105-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6819, "ryu": 0.3181 }
+        }
+      ]
+    },
+    {
+      "id": "p106",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -4, "r": 4 },
+      "total_population": 1452,
+      "initial_district_id": "d1",
+      "name": "North (-4,4)",
+      "demographic_groups": [
+        {
+          "id": "p106-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6333, "ryu": 0.3667 }
+        }
+      ]
+    },
+    {
+      "id": "p107",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -3, "r": 4 },
+      "total_population": 1585,
+      "initial_district_id": "d1",
+      "name": "North (-3,4)",
+      "demographic_groups": [
+        {
+          "id": "p107-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6251, "ryu": 0.3749 }
+        }
+      ]
+    },
+    {
+      "id": "p108",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -2, "r": 4 },
+      "total_population": 1479,
+      "initial_district_id": "d1",
+      "name": "North (-2,4)",
+      "demographic_groups": [
+        {
+          "id": "p108-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6726, "ryu": 0.3274 }
+        }
+      ]
+    },
+    {
+      "id": "p109",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -1, "r": 4 },
+      "total_population": 1453,
+      "initial_district_id": "d1",
+      "name": "North (-1,4)",
+      "demographic_groups": [
+        {
+          "id": "p109-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6534, "ryu": 0.3466 }
+        }
+      ]
+    },
+    {
+      "id": "p110",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 0, "r": 4 },
+      "total_population": 1596,
+      "initial_district_id": "d1",
+      "name": "North (0,4)",
+      "demographic_groups": [
+        {
+          "id": "p110-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.6585, "ryu": 0.3415 }
+        }
+      ]
+    },
+    {
+      "id": "p111",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 1, "r": 4 },
+      "total_population": 1573,
+      "initial_district_id": "d1",
+      "name": "North (1,4)",
+      "demographic_groups": [
+        {
+          "id": "p111-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6325, "ryu": 0.3675 }
+        }
+      ]
+    },
+    {
+      "id": "p112",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 2, "r": 4 },
+      "total_population": 1430,
+      "initial_district_id": "d1",
+      "name": "North (2,4)",
+      "demographic_groups": [
+        {
+          "id": "p112-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.6552, "ryu": 0.3448 }
+        }
+      ]
+    },
+    {
+      "id": "p113",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -6, "r": 5 },
+      "total_population": 1648,
+      "initial_district_id": "d1",
+      "name": "North (-6,5)",
+      "demographic_groups": [
+        {
+          "id": "p113-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6777, "ryu": 0.3223 }
+        }
+      ]
+    },
+    {
+      "id": "p114",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -5, "r": 5 },
+      "total_population": 1633,
+      "initial_district_id": "d1",
+      "name": "North (-5,5)",
+      "demographic_groups": [
+        {
+          "id": "p114-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6819, "ryu": 0.3181 }
+        }
+      ]
+    },
+    {
+      "id": "p115",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -4, "r": 5 },
+      "total_population": 1472,
+      "initial_district_id": "d1",
+      "name": "North (-4,5)",
+      "demographic_groups": [
+        {
+          "id": "p115-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6552, "ryu": 0.3448 }
+        }
+      ]
+    },
+    {
+      "id": "p116",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -3, "r": 5 },
+      "total_population": 1362,
+      "initial_district_id": "d1",
+      "name": "North (-3,5)",
+      "demographic_groups": [
+        {
+          "id": "p116-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6547, "ryu": 0.3453 }
+        }
+      ]
+    },
+    {
+      "id": "p117",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -2, "r": 5 },
+      "total_population": 1364,
+      "initial_district_id": "d1",
+      "name": "North (-2,5)",
+      "demographic_groups": [
+        {
+          "id": "p117-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6563, "ryu": 0.3437 }
+        }
+      ]
+    },
+    {
+      "id": "p118",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -1, "r": 5 },
+      "total_population": 1358,
+      "initial_district_id": "d1",
+      "name": "North (-1,5)",
+      "demographic_groups": [
+        {
+          "id": "p118-all",
+          "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
           "vote_shares": { "ken": 0.6320, "ryu": 0.3680 }
@@ -796,1388 +2146,164 @@
       ]
     },
     {
-      "id": "p044",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 3, "r": 4 },
-      "total_population": 1497,
-      "initial_district_id": "d2",
-      "name": "Upper D5",
-      "demographic_groups": [
-        {
-          "id": "p044-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6712, "ryu": 0.3288 }
-        }
-      ]
-    },
-    {
-      "id": "p045",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 4, "r": 4 },
-      "total_population": 1510,
-      "initial_district_id": "d2",
-      "name": "Upper E5",
-      "demographic_groups": [
-        {
-          "id": "p045-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6341, "ryu": 0.3659 }
-        }
-      ]
-    },
-    {
-      "id": "p046",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 5, "r": 4 },
-      "total_population": 1403,
-      "initial_district_id": "d2",
-      "name": "Upper F5",
-      "demographic_groups": [
-        {
-          "id": "p046-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6245, "ryu": 0.3755 }
-        }
-      ]
-    },
-    {
-      "id": "p047",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 6, "r": 4 },
-      "total_population": 1434,
-      "initial_district_id": "d2",
-      "name": "Upper G5",
-      "demographic_groups": [
-        {
-          "id": "p047-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6650, "ryu": 0.3350 }
-        }
-      ]
-    },
-    {
-      "id": "p048",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 7, "r": 4 },
-      "total_population": 1553,
-      "initial_district_id": "d2",
-      "name": "Upper H5",
-      "demographic_groups": [
-        {
-          "id": "p048-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6527, "ryu": 0.3473 }
-        }
-      ]
-    },
-    {
-      "id": "p049",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 8, "r": 4 },
-      "total_population": 1583,
-      "initial_district_id": "d3",
-      "name": "Upper I5",
-      "demographic_groups": [
-        {
-          "id": "p049-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6528, "ryu": 0.3472 }
-        }
-      ]
-    },
-    {
-      "id": "p050",
-      "editable": true,
-      "county_id": "lakeview_north",
-      "position": { "q": 9, "r": 4 },
-      "total_population": 1412,
-      "initial_district_id": "d3",
-      "name": "Upper J5",
-      "demographic_groups": [
-        {
-          "id": "p050-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6569, "ryu": 0.3431 }
-        }
-      ]
-    },
-    {
-      "id": "p051",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 0, "r": 5 },
-      "total_population": 1500,
-      "initial_district_id": "d3",
-      "name": "Corridor A6",
-      "demographic_groups": [
-        {
-          "id": "p051-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.1815, "ryu": 0.8185 }
-        }
-      ]
-    },
-    {
-      "id": "p052",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 1, "r": 5 },
-      "total_population": 1510,
-      "initial_district_id": "d3",
-      "name": "Corridor B6",
-      "demographic_groups": [
-        {
-          "id": "p052-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.1679, "ryu": 0.8321 }
-        }
-      ]
-    },
-    {
-      "id": "p053",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 2, "r": 5 },
-      "total_population": 1455,
-      "initial_district_id": "d3",
-      "name": "Corridor C6",
-      "demographic_groups": [
-        {
-          "id": "p053-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.1798, "ryu": 0.8202 }
-        }
-      ]
-    },
-    {
-      "id": "p054",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 3, "r": 5 },
-      "total_population": 1508,
-      "initial_district_id": "d3",
-      "name": "Corridor D6",
-      "demographic_groups": [
-        {
-          "id": "p054-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.1792, "ryu": 0.8208 }
-        }
-      ]
-    },
-    {
-      "id": "p055",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 4, "r": 5 },
-      "total_population": 1524,
-      "initial_district_id": "d3",
-      "name": "Corridor E6",
-      "demographic_groups": [
-        {
-          "id": "p055-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.1968, "ryu": 0.8032 }
-        }
-      ]
-    },
-    {
-      "id": "p056",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 5, "r": 5 },
-      "total_population": 1500,
-      "initial_district_id": "d3",
-      "name": "Corridor F6",
-      "demographic_groups": [
-        {
-          "id": "p056-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1849, "ryu": 0.8151 }
-        }
-      ]
-    },
-    {
-      "id": "p057",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 6, "r": 5 },
-      "total_population": 1522,
-      "initial_district_id": "d3",
-      "name": "Corridor G6",
-      "demographic_groups": [
-        {
-          "id": "p057-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.1739, "ryu": 0.8261 }
-        }
-      ]
-    },
-    {
-      "id": "p058",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 7, "r": 5 },
-      "total_population": 1476,
-      "initial_district_id": "d3",
-      "name": "Corridor H6",
-      "demographic_groups": [
-        {
-          "id": "p058-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.1780, "ryu": 0.8220 }
-        }
-      ]
-    },
-    {
-      "id": "p059",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 8, "r": 5 },
-      "total_population": 1524,
-      "initial_district_id": "d3",
-      "name": "Corridor I6",
-      "demographic_groups": [
-        {
-          "id": "p059-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.1678, "ryu": 0.8322 }
-        }
-      ]
-    },
-    {
-      "id": "p060",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 9, "r": 5 },
-      "total_population": 1477,
-      "initial_district_id": "d3",
-      "name": "Corridor J6",
-      "demographic_groups": [
-        {
-          "id": "p060-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1947, "ryu": 0.8053 }
-        }
-      ]
-    },
-    {
-      "id": "p061",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 0, "r": 6 },
-      "total_population": 1561,
-      "initial_district_id": "d3",
-      "name": "Corridor A7",
-      "demographic_groups": [
-        {
-          "id": "p061-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.1713, "ryu": 0.8287 }
-        }
-      ]
-    },
-    {
-      "id": "p062",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 1, "r": 6 },
-      "total_population": 1418,
-      "initial_district_id": "d3",
-      "name": "Corridor B7",
-      "demographic_groups": [
-        {
-          "id": "p062-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.2018, "ryu": 0.7982 }
-        }
-      ]
-    },
-    {
-      "id": "p063",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 2, "r": 6 },
-      "total_population": 1480,
-      "initial_district_id": "d3",
-      "name": "Corridor C7",
-      "demographic_groups": [
-        {
-          "id": "p063-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.1730, "ryu": 0.8270 }
-        }
-      ]
-    },
-    {
-      "id": "p064",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 3, "r": 6 },
-      "total_population": 1586,
-      "initial_district_id": "d3",
-      "name": "Corridor D7",
-      "demographic_groups": [
-        {
-          "id": "p064-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.2017, "ryu": 0.7983 }
-        }
-      ]
-    },
-    {
-      "id": "p065",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 4, "r": 6 },
-      "total_population": 1443,
-      "initial_district_id": "d3",
-      "name": "Corridor E7",
-      "demographic_groups": [
-        {
-          "id": "p065-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.1816, "ryu": 0.8184 }
-        }
-      ]
-    },
-    {
-      "id": "p066",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 5, "r": 6 },
-      "total_population": 1442,
-      "initial_district_id": "d3",
-      "name": "Corridor F7",
-      "demographic_groups": [
-        {
-          "id": "p066-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.1753, "ryu": 0.8247 }
-        }
-      ]
-    },
-    {
-      "id": "p067",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 6, "r": 6 },
-      "total_population": 1569,
-      "initial_district_id": "d3",
-      "name": "Corridor G7",
-      "demographic_groups": [
-        {
-          "id": "p067-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.1622, "ryu": 0.8378 }
-        }
-      ]
-    },
-    {
-      "id": "p068",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 7, "r": 6 },
-      "total_population": 1511,
-      "initial_district_id": "d3",
-      "name": "Corridor H7",
-      "demographic_groups": [
-        {
-          "id": "p068-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.1692, "ryu": 0.8308 }
-        }
-      ]
-    },
-    {
-      "id": "p069",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 8, "r": 6 },
-      "total_population": 1427,
-      "initial_district_id": "d3",
-      "name": "Corridor I7",
-      "demographic_groups": [
-        {
-          "id": "p069-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.2088, "ryu": 0.7912 }
-        }
-      ]
-    },
-    {
-      "id": "p070",
-      "editable": true,
-      "county_id": "lakeview_city",
-      "position": { "q": 9, "r": 6 },
-      "total_population": 1447,
-      "initial_district_id": "d3",
-      "name": "Corridor J7",
-      "demographic_groups": [
-        {
-          "id": "p070-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.1510, "ryu": 0.8490 }
-        }
-      ]
-    },
-    {
-      "id": "p071",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 0, "r": 7 },
-      "total_population": 1439,
-      "initial_district_id": "d3",
-      "name": "Lower A8",
-      "demographic_groups": [
-        {
-          "id": "p071-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6745, "ryu": 0.3255 }
-        }
-      ]
-    },
-    {
-      "id": "p072",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 1, "r": 7 },
-      "total_population": 1482,
-      "initial_district_id": "d3",
-      "name": "Lower B8",
-      "demographic_groups": [
-        {
-          "id": "p072-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6596, "ryu": 0.3404 }
-        }
-      ]
-    },
-    {
-      "id": "p073",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 2, "r": 7 },
-      "total_population": 1426,
-      "initial_district_id": "d4",
-      "name": "Lower C8",
-      "demographic_groups": [
-        {
-          "id": "p073-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6322, "ryu": 0.3678 }
-        }
-      ]
-    },
-    {
-      "id": "p074",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 3, "r": 7 },
-      "total_population": 1595,
-      "initial_district_id": "d4",
-      "name": "Lower D8",
-      "demographic_groups": [
-        {
-          "id": "p074-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6671, "ryu": 0.3329 }
-        }
-      ]
-    },
-    {
-      "id": "p075",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 4, "r": 7 },
-      "total_population": 1474,
-      "initial_district_id": "d4",
-      "name": "Lower E8",
-      "demographic_groups": [
-        {
-          "id": "p075-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6744, "ryu": 0.3256 }
-        }
-      ]
-    },
-    {
-      "id": "p076",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 5, "r": 7 },
-      "total_population": 1514,
-      "initial_district_id": "d4",
-      "name": "Lower F8",
-      "demographic_groups": [
-        {
-          "id": "p076-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6471, "ryu": 0.3529 }
-        }
-      ]
-    },
-    {
-      "id": "p077",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 6, "r": 7 },
-      "total_population": 1591,
-      "initial_district_id": "d5",
-      "name": "Lower G8",
-      "demographic_groups": [
-        {
-          "id": "p077-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6764, "ryu": 0.3236 }
-        }
-      ]
-    },
-    {
-      "id": "p078",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 7, "r": 7 },
-      "total_population": 1557,
-      "initial_district_id": "d5",
-      "name": "Lower H8",
-      "demographic_groups": [
-        {
-          "id": "p078-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6587, "ryu": 0.3413 }
-        }
-      ]
-    },
-    {
-      "id": "p079",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 8, "r": 7 },
-      "total_population": 1520,
-      "initial_district_id": "d5",
-      "name": "Lower I8",
-      "demographic_groups": [
-        {
-          "id": "p079-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6689, "ryu": 0.3311 }
-        }
-      ]
-    },
-    {
-      "id": "p080",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 9, "r": 7 },
-      "total_population": 1547,
-      "initial_district_id": "d5",
-      "name": "Lower J8",
-      "demographic_groups": [
-        {
-          "id": "p080-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6731, "ryu": 0.3269 }
-        }
-      ]
-    },
-    {
-      "id": "p081",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 0, "r": 8 },
-      "total_population": 1471,
-      "initial_district_id": "d4",
-      "name": "Lower A9",
-      "demographic_groups": [
-        {
-          "id": "p081-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6246, "ryu": 0.3754 }
-        }
-      ]
-    },
-    {
-      "id": "p082",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 1, "r": 8 },
-      "total_population": 1443,
-      "initial_district_id": "d4",
-      "name": "Lower B9",
-      "demographic_groups": [
-        {
-          "id": "p082-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6400, "ryu": 0.3600 }
-        }
-      ]
-    },
-    {
-      "id": "p083",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 2, "r": 8 },
-      "total_population": 1406,
-      "initial_district_id": "d4",
-      "name": "Lower C9",
-      "demographic_groups": [
-        {
-          "id": "p083-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6637, "ryu": 0.3363 }
-        }
-      ]
-    },
-    {
-      "id": "p084",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 3, "r": 8 },
-      "total_population": 1421,
-      "initial_district_id": "d4",
-      "name": "Lower D9",
-      "demographic_groups": [
-        {
-          "id": "p084-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6325, "ryu": 0.3675 }
-        }
-      ]
-    },
-    {
-      "id": "p085",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 4, "r": 8 },
-      "total_population": 1461,
-      "initial_district_id": "d4",
-      "name": "Lower E9",
-      "demographic_groups": [
-        {
-          "id": "p085-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6254, "ryu": 0.3746 }
-        }
-      ]
-    },
-    {
-      "id": "p086",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 5, "r": 8 },
-      "total_population": 1412,
-      "initial_district_id": "d4",
-      "name": "Lower F9",
-      "demographic_groups": [
-        {
-          "id": "p086-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6435, "ryu": 0.3565 }
-        }
-      ]
-    },
-    {
-      "id": "p087",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 6, "r": 8 },
-      "total_population": 1550,
-      "initial_district_id": "d4",
-      "name": "Lower G9",
-      "demographic_groups": [
-        {
-          "id": "p087-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6588, "ryu": 0.3412 }
-        }
-      ]
-    },
-    {
-      "id": "p088",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 7, "r": 8 },
-      "total_population": 1480,
-      "initial_district_id": "d4",
-      "name": "Lower H9",
-      "demographic_groups": [
-        {
-          "id": "p088-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6453, "ryu": 0.3547 }
-        }
-      ]
-    },
-    {
-      "id": "p089",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 8, "r": 8 },
-      "total_population": 1585,
-      "initial_district_id": "d4",
-      "name": "Lower I9",
-      "demographic_groups": [
-        {
-          "id": "p089-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6319, "ryu": 0.3681 }
-        }
-      ]
-    },
-    {
-      "id": "p090",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 9, "r": 8 },
-      "total_population": 1456,
-      "initial_district_id": "d4",
-      "name": "Lower J9",
-      "demographic_groups": [
-        {
-          "id": "p090-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6647, "ryu": 0.3353 }
-        }
-      ]
-    },
-    {
-      "id": "p091",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 0, "r": 9 },
-      "total_population": 1453,
-      "initial_district_id": "d4",
-      "name": "Lower A10",
-      "demographic_groups": [
-        {
-          "id": "p091-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6653, "ryu": 0.3347 }
-        }
-      ]
-    },
-    {
-      "id": "p092",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 1, "r": 9 },
-      "total_population": 1401,
-      "initial_district_id": "d4",
-      "name": "Lower B10",
-      "demographic_groups": [
-        {
-          "id": "p092-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6411, "ryu": 0.3589 }
-        }
-      ]
-    },
-    {
-      "id": "p093",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 2, "r": 9 },
-      "total_population": 1456,
-      "initial_district_id": "d4",
-      "name": "Lower C10",
-      "demographic_groups": [
-        {
-          "id": "p093-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6234, "ryu": 0.3766 }
-        }
-      ]
-    },
-    {
-      "id": "p094",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 3, "r": 9 },
-      "total_population": 1600,
-      "initial_district_id": "d4",
-      "name": "Lower D10",
-      "demographic_groups": [
-        {
-          "id": "p094-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6425, "ryu": 0.3575 }
-        }
-      ]
-    },
-    {
-      "id": "p095",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 4, "r": 9 },
-      "total_population": 1490,
-      "initial_district_id": "d4",
-      "name": "Lower E10",
-      "demographic_groups": [
-        {
-          "id": "p095-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6205, "ryu": 0.3795 }
-        }
-      ]
-    },
-    {
-      "id": "p096",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 5, "r": 9 },
-      "total_population": 1401,
-      "initial_district_id": "d4",
-      "name": "Lower F10",
-      "demographic_groups": [
-        {
-          "id": "p096-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6799, "ryu": 0.3201 }
-        }
-      ]
-    },
-    {
-      "id": "p097",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 6, "r": 9 },
-      "total_population": 1572,
-      "initial_district_id": "d4",
-      "name": "Lower G10",
-      "demographic_groups": [
-        {
-          "id": "p097-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6584, "ryu": 0.3416 }
-        }
-      ]
-    },
-    {
-      "id": "p098",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 7, "r": 9 },
-      "total_population": 1450,
-      "initial_district_id": "d4",
-      "name": "Lower H10",
-      "demographic_groups": [
-        {
-          "id": "p098-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6201, "ryu": 0.3799 }
-        }
-      ]
-    },
-    {
-      "id": "p099",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 8, "r": 9 },
-      "total_population": 1431,
-      "initial_district_id": "d4",
-      "name": "Lower I10",
-      "demographic_groups": [
-        {
-          "id": "p099-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6338, "ryu": 0.3662 }
-        }
-      ]
-    },
-    {
-      "id": "p100",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 9, "r": 9 },
-      "total_population": 1415,
-      "initial_district_id": "d4",
-      "name": "Lower J10",
-      "demographic_groups": [
-        {
-          "id": "p100-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6608, "ryu": 0.3392 }
-        }
-      ]
-    },
-    {
-      "id": "p101",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 0, "r": 10 },
-      "total_population": 1501,
-      "initial_district_id": "d5",
-      "name": "Lower A11",
-      "demographic_groups": [
-        {
-          "id": "p101-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6624, "ryu": 0.3376 }
-        }
-      ]
-    },
-    {
-      "id": "p102",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 1, "r": 10 },
-      "total_population": 1540,
-      "initial_district_id": "d5",
-      "name": "Lower B11",
-      "demographic_groups": [
-        {
-          "id": "p102-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6303, "ryu": 0.3697 }
-        }
-      ]
-    },
-    {
-      "id": "p103",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 2, "r": 10 },
-      "total_population": 1548,
-      "initial_district_id": "d5",
-      "name": "Lower C11",
-      "demographic_groups": [
-        {
-          "id": "p103-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6730, "ryu": 0.3270 }
-        }
-      ]
-    },
-    {
-      "id": "p104",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 3, "r": 10 },
-      "total_population": 1504,
-      "initial_district_id": "d5",
-      "name": "Lower D11",
-      "demographic_groups": [
-        {
-          "id": "p104-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6225, "ryu": 0.3775 }
-        }
-      ]
-    },
-    {
-      "id": "p105",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 4, "r": 10 },
-      "total_population": 1432,
-      "initial_district_id": "d5",
-      "name": "Lower E11",
-      "demographic_groups": [
-        {
-          "id": "p105-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6216, "ryu": 0.3784 }
-        }
-      ]
-    },
-    {
-      "id": "p106",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 5, "r": 10 },
-      "total_population": 1532,
-      "initial_district_id": "d5",
-      "name": "Lower F11",
-      "demographic_groups": [
-        {
-          "id": "p106-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6748, "ryu": 0.3252 }
-        }
-      ]
-    },
-    {
-      "id": "p107",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 6, "r": 10 },
-      "total_population": 1510,
-      "initial_district_id": "d5",
-      "name": "Lower G11",
-      "demographic_groups": [
-        {
-          "id": "p107-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6458, "ryu": 0.3542 }
-        }
-      ]
-    },
-    {
-      "id": "p108",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 7, "r": 10 },
-      "total_population": 1455,
-      "initial_district_id": "d5",
-      "name": "Lower H11",
-      "demographic_groups": [
-        {
-          "id": "p108-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6580, "ryu": 0.3420 }
-        }
-      ]
-    },
-    {
-      "id": "p109",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 8, "r": 10 },
-      "total_population": 1481,
-      "initial_district_id": "d5",
-      "name": "Lower I11",
-      "demographic_groups": [
-        {
-          "id": "p109-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6541, "ryu": 0.3459 }
-        }
-      ]
-    },
-    {
-      "id": "p110",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 9, "r": 10 },
-      "total_population": 1443,
-      "initial_district_id": "d5",
-      "name": "Lower J11",
-      "demographic_groups": [
-        {
-          "id": "p110-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6665, "ryu": 0.3335 }
-        }
-      ]
-    },
-    {
-      "id": "p111",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 0, "r": 11 },
-      "total_population": 1566,
-      "initial_district_id": "d5",
-      "name": "Lower A12",
-      "demographic_groups": [
-        {
-          "id": "p111-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6622, "ryu": 0.3378 }
-        }
-      ]
-    },
-    {
-      "id": "p112",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 1, "r": 11 },
-      "total_population": 1573,
-      "initial_district_id": "d5",
-      "name": "Lower B12",
-      "demographic_groups": [
-        {
-          "id": "p112-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6580, "ryu": 0.3420 }
-        }
-      ]
-    },
-    {
-      "id": "p113",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 2, "r": 11 },
-      "total_population": 1486,
-      "initial_district_id": "d5",
-      "name": "Lower C12",
-      "demographic_groups": [
-        {
-          "id": "p113-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6397, "ryu": 0.3603 }
-        }
-      ]
-    },
-    {
-      "id": "p114",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 3, "r": 11 },
-      "total_population": 1440,
-      "initial_district_id": "d5",
-      "name": "Lower D12",
-      "demographic_groups": [
-        {
-          "id": "p114-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6579, "ryu": 0.3421 }
-        }
-      ]
-    },
-    {
-      "id": "p115",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 4, "r": 11 },
-      "total_population": 1455,
-      "initial_district_id": "d5",
-      "name": "Lower E12",
-      "demographic_groups": [
-        {
-          "id": "p115-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6490, "ryu": 0.3510 }
-        }
-      ]
-    },
-    {
-      "id": "p116",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 5, "r": 11 },
-      "total_population": 1581,
-      "initial_district_id": "d5",
-      "name": "Lower F12",
-      "demographic_groups": [
-        {
-          "id": "p116-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6637, "ryu": 0.3363 }
-        }
-      ]
-    },
-    {
-      "id": "p117",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 6, "r": 11 },
-      "total_population": 1445,
-      "initial_district_id": "d5",
-      "name": "Lower G12",
-      "demographic_groups": [
-        {
-          "id": "p117-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6607, "ryu": 0.3393 }
-        }
-      ]
-    },
-    {
-      "id": "p118",
-      "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 7, "r": 11 },
-      "total_population": 1532,
-      "initial_district_id": "d5",
-      "name": "Lower H12",
-      "demographic_groups": [
-        {
-          "id": "p118-base",
-          "name": "Registered voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6485, "ryu": 0.3515 }
-        }
-      ]
-    },
-    {
       "id": "p119",
       "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 8, "r": 11 },
-      "total_population": 1537,
-      "initial_district_id": "d5",
-      "name": "Lower I12",
+      "county_id": "lakeview_north",
+      "position": { "q": 0, "r": 5 },
+      "total_population": 1388,
+      "initial_district_id": "d1",
+      "name": "North (0,5)",
       "demographic_groups": [
         {
-          "id": "p119-base",
-          "name": "Registered voters",
+          "id": "p119-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6347, "ryu": 0.3653 }
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.6488, "ryu": 0.3512 }
         }
       ]
     },
     {
       "id": "p120",
       "editable": true,
-      "county_id": "lakeview_south",
-      "position": { "q": 9, "r": 11 },
-      "total_population": 1590,
-      "initial_district_id": "d5",
-      "name": "Lower J12",
+      "county_id": "lakeview_north",
+      "position": { "q": 1, "r": 5 },
+      "total_population": 1644,
+      "initial_district_id": "d1",
+      "name": "North (1,5)",
       "demographic_groups": [
         {
-          "id": "p120-base",
-          "name": "Registered voters",
+          "id": "p120-all",
+          "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6310, "ryu": 0.3690 }
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6696, "ryu": 0.3304 }
+        }
+      ]
+    },
+    {
+      "id": "p121",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -6, "r": 6 },
+      "total_population": 1516,
+      "initial_district_id": "d1",
+      "name": "North (-6,6)",
+      "demographic_groups": [
+        {
+          "id": "p121-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6846, "ryu": 0.3154 }
+        }
+      ]
+    },
+    {
+      "id": "p122",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -5, "r": 6 },
+      "total_population": 1449,
+      "initial_district_id": "d1",
+      "name": "North (-5,6)",
+      "demographic_groups": [
+        {
+          "id": "p122-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.6401, "ryu": 0.3599 }
+        }
+      ]
+    },
+    {
+      "id": "p123",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -4, "r": 6 },
+      "total_population": 1567,
+      "initial_district_id": "d1",
+      "name": "North (-4,6)",
+      "demographic_groups": [
+        {
+          "id": "p123-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6315, "ryu": 0.3685 }
+        }
+      ]
+    },
+    {
+      "id": "p124",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -3, "r": 6 },
+      "total_population": 1603,
+      "initial_district_id": "d1",
+      "name": "North (-3,6)",
+      "demographic_groups": [
+        {
+          "id": "p124-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.6234, "ryu": 0.3766 }
+        }
+      ]
+    },
+    {
+      "id": "p125",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -2, "r": 6 },
+      "total_population": 1353,
+      "initial_district_id": "d1",
+      "name": "North (-2,6)",
+      "demographic_groups": [
+        {
+          "id": "p125-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6234, "ryu": 0.3766 }
+        }
+      ]
+    },
+    {
+      "id": "p126",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": -1, "r": 6 },
+      "total_population": 1419,
+      "initial_district_id": "d1",
+      "name": "North (-1,6)",
+      "demographic_groups": [
+        {
+          "id": "p126-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6315, "ryu": 0.3685 }
+        }
+      ]
+    },
+    {
+      "id": "p127",
+      "editable": true,
+      "county_id": "lakeview_north",
+      "position": { "q": 0, "r": 6 },
+      "total_population": 1445,
+      "initial_district_id": "d1",
+      "name": "North (0,6)",
+      "demographic_groups": [
+        {
+          "id": "p127-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6273, "ryu": 0.3727 }
         }
       ]
     }
@@ -2201,9 +2327,9 @@
       "criterion": { "type": "population_balance" }
     },
     {
-      "id": "sc-ken-seats",
+      "id": "sc-ken-all-seats",
       "required": true,
-      "description": "The Ken Party wins all 5 districts — leave the Ryu corridor nowhere to win.",
+      "description": "Ken Party wins every seat — all 5 districts.",
       "criterion": {
         "type": "seat_count",
         "party": "ken",
@@ -2214,7 +2340,7 @@
     {
       "id": "sc-mean-median",
       "required": false,
-      "description": "Mean-median difference is 10% or less — a statistically uniform crack.",
+      "description": "How skewed is your map? Mean-median gap ≤ 10%.",
       "criterion": {
         "type": "mean_median",
         "party": "ken",
@@ -2226,19 +2352,23 @@
   "narrative": {
     "character": {
       "name": "You",
-      "role": "Political Director, Ken Party Legislative Caucus",
-      "motivation": "Last time you packed the opposition into one district. This time, the goal is different — dilute them so thoroughly they can't win anywhere."
+      "role": "Ken Party Redistricting Director, Lakeview County",
+      "motivation": "Last cycle, the Ryu Party won a seat in Lakeview by concentrating their voters along the lakeshore corridor. The Ken Party wants that seat back — and every other seat too. Your job: split the corridor so Ryu voters can't form a majority anywhere."
     },
     "intro_slides": [
       {
-        "heading": "The Ryu Corridor",
-        "body": "A band of Ryu-leaning precincts runs through the middle of Lakeview County. In the current map, they're grouped together — and they win District 3.\n\nYour job: make sure that never happens."
+        "heading": "The Corridor",
+        "body": "A narrow band of Ryu voters runs through the center of Lakeview County — along the lakeshore, where the apartments are dense and the politics lean hard Ryu.\n\nRight now, if those voters are in one district, they win it. Your predecessor let that happen. You won't."
       },
       {
-        "heading": "Crack the Bloc",
-        "body": "Cracking means splitting a concentrated voting bloc across multiple districts — diluting their power so they can't win any of them.\n\nDraw lines that cut across the corridor. Give each district a slice of Ryu voters — too few to tip any district Ryu, but just enough to waste their votes."
+        "heading": "The Cracking Play",
+        "body": "Cracking is the opposite of packing. Instead of concentrating the opposition, you split them. Draw district lines that cut through the corridor, dividing Ryu voters across multiple districts.\n\nIn each district, the corridor's Ryu precincts are outnumbered by the surrounding Ken territory. Ryu voters still vote — but they lose everywhere."
+      },
+      {
+        "heading": "The Disappearing Voice",
+        "body": "Notice what happens: a community that could win one seat now wins zero. Their total vote count hasn't changed. Their turnout hasn't dropped. But the lines moved, and their voice vanished.\n\nThis is what cracking does. It doesn't silence voters — it dilutes them until they don't matter."
       }
     ],
-    "objective": "Crack the Ryu corridor across all 5 districts so the Ken Party wins every seat."
+    "objective": "Crack the Ryu corridor across all 5 districts. Ken Party must win every seat."
   }
 }

--- a/game/scenarios/scenario-005.json
+++ b/game/scenarios/scenario-005.json
@@ -28,11 +28,11 @@
     {
       "id": "p001",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 0, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 0, "r": -6 },
       "total_population": 1386,
       "initial_district_id": "d1",
-      "name": "Rim A1",
+      "name": "Rim (0,-6)",
       "demographic_groups": [
         {
           "id": "p001-latino",
@@ -55,11 +55,11 @@
     {
       "id": "p002",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 1, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 1, "r": -6 },
       "total_population": 1597,
       "initial_district_id": "d1",
-      "name": "Rim B1",
+      "name": "Rim (1,-6)",
       "demographic_groups": [
         {
           "id": "p002-latino",
@@ -82,11 +82,11 @@
     {
       "id": "p003",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 2, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 2, "r": -6 },
       "total_population": 1496,
-      "initial_district_id": "d2",
-      "name": "Rim C1",
+      "initial_district_id": "d1",
+      "name": "Rim (2,-6)",
       "demographic_groups": [
         {
           "id": "p003-latino",
@@ -109,11 +109,11 @@
     {
       "id": "p004",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 3, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 3, "r": -6 },
       "total_population": 1387,
-      "initial_district_id": "d2",
-      "name": "Rim D1",
+      "initial_district_id": "d1",
+      "name": "Rim (3,-6)",
       "demographic_groups": [
         {
           "id": "p004-latino",
@@ -136,11 +136,11 @@
     {
       "id": "p005",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 4, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 4, "r": -6 },
       "total_population": 1591,
-      "initial_district_id": "d3",
-      "name": "Rim E1",
+      "initial_district_id": "d2",
+      "name": "Rim (4,-6)",
       "demographic_groups": [
         {
           "id": "p005-latino",
@@ -163,11 +163,11 @@
     {
       "id": "p006",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 5, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 5, "r": -6 },
       "total_population": 1600,
-      "initial_district_id": "d3",
-      "name": "Rim F1",
+      "initial_district_id": "d2",
+      "name": "Rim (5,-6)",
       "demographic_groups": [
         {
           "id": "p006-latino",
@@ -190,11 +190,11 @@
     {
       "id": "p007",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 6, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 6, "r": -6 },
       "total_population": 1499,
-      "initial_district_id": "d4",
-      "name": "Rim G1",
+      "initial_district_id": "d3",
+      "name": "Rim (6,-6)",
       "demographic_groups": [
         {
           "id": "p007-latino",
@@ -217,11 +217,11 @@
     {
       "id": "p008",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 7, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -1, "r": -5 },
       "total_population": 1431,
-      "initial_district_id": "d4",
-      "name": "Rim H1",
+      "initial_district_id": "d1",
+      "name": "Rim (-1,-5)",
       "demographic_groups": [
         {
           "id": "p008-latino",
@@ -244,11 +244,11 @@
     {
       "id": "p009",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 8, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 0, "r": -5 },
       "total_population": 1502,
-      "initial_district_id": "d5",
-      "name": "Rim I1",
+      "initial_district_id": "d1",
+      "name": "Rim (0,-5)",
       "demographic_groups": [
         {
           "id": "p009-latino",
@@ -271,11 +271,11 @@
     {
       "id": "p010",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 9, "r": 0 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 1, "r": -5 },
       "total_population": 1430,
-      "initial_district_id": "d5",
-      "name": "Rim J1",
+      "initial_district_id": "d1",
+      "name": "Rim (1,-5)",
       "demographic_groups": [
         {
           "id": "p010-latino",
@@ -298,11 +298,11 @@
     {
       "id": "p011",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 0, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 2, "r": -5 },
       "total_population": 1550,
       "initial_district_id": "d1",
-      "name": "Rim A2",
+      "name": "Rim (2,-5)",
       "demographic_groups": [
         {
           "id": "p011-latino",
@@ -325,11 +325,11 @@
     {
       "id": "p012",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 1, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 3, "r": -5 },
       "total_population": 1640,
-      "initial_district_id": "d1",
-      "name": "Rim B2",
+      "initial_district_id": "d2",
+      "name": "Rim (3,-5)",
       "demographic_groups": [
         {
           "id": "p012-latino",
@@ -352,11 +352,11 @@
     {
       "id": "p013",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 2, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 4, "r": -5 },
       "total_population": 1626,
       "initial_district_id": "d2",
-      "name": "Rim C2",
+      "name": "Rim (4,-5)",
       "demographic_groups": [
         {
           "id": "p013-latino",
@@ -379,11 +379,11 @@
     {
       "id": "p014",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 3, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 5, "r": -5 },
       "total_population": 1487,
-      "initial_district_id": "d2",
-      "name": "Rim D2",
+      "initial_district_id": "d3",
+      "name": "Rim (5,-5)",
       "demographic_groups": [
         {
           "id": "p014-latino",
@@ -406,11 +406,11 @@
     {
       "id": "p015",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 4, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 6, "r": -5 },
       "total_population": 1560,
-      "initial_district_id": "d3",
-      "name": "Rim E2",
+      "initial_district_id": "d4",
+      "name": "Rim (6,-5)",
       "demographic_groups": [
         {
           "id": "p015-latino",
@@ -433,11 +433,11 @@
     {
       "id": "p016",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 5, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -2, "r": -4 },
       "total_population": 1552,
-      "initial_district_id": "d3",
-      "name": "Rim F2",
+      "initial_district_id": "d1",
+      "name": "Rim (-2,-4)",
       "demographic_groups": [
         {
           "id": "p016-latino",
@@ -460,11 +460,11 @@
     {
       "id": "p017",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 6, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -1, "r": -4 },
       "total_population": 1426,
-      "initial_district_id": "d4",
-      "name": "Rim G2",
+      "initial_district_id": "d1",
+      "name": "Rim (-1,-4)",
       "demographic_groups": [
         {
           "id": "p017-latino",
@@ -487,11 +487,11 @@
     {
       "id": "p018",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 7, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 0, "r": -4 },
       "total_population": 1534,
-      "initial_district_id": "d4",
-      "name": "Rim H2",
+      "initial_district_id": "d1",
+      "name": "Rim (0,-4)",
       "demographic_groups": [
         {
           "id": "p018-latino",
@@ -514,11 +514,11 @@
     {
       "id": "p019",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 8, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 1, "r": -4 },
       "total_population": 1366,
-      "initial_district_id": "d5",
-      "name": "Rim I2",
+      "initial_district_id": "d1",
+      "name": "Rim (1,-4)",
       "demographic_groups": [
         {
           "id": "p019-latino",
@@ -541,11 +541,11 @@
     {
       "id": "p020",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 9, "r": 1 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 2, "r": -4 },
       "total_population": 1440,
-      "initial_district_id": "d5",
-      "name": "Rim J2",
+      "initial_district_id": "d2",
+      "name": "Rim (2,-4)",
       "demographic_groups": [
         {
           "id": "p020-latino",
@@ -568,11 +568,11 @@
     {
       "id": "p021",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 0, "r": 2 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 3, "r": -4 },
       "total_population": 1527,
-      "initial_district_id": "d1",
-      "name": "Rim A3",
+      "initial_district_id": "d2",
+      "name": "Rim (3,-4)",
       "demographic_groups": [
         {
           "id": "p021-latino",
@@ -595,11 +595,11 @@
     {
       "id": "p022",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 1, "r": 2 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 4, "r": -4 },
       "total_population": 1564,
-      "initial_district_id": "d1",
-      "name": "Rim B3",
+      "initial_district_id": "d3",
+      "name": "Rim (4,-4)",
       "demographic_groups": [
         {
           "id": "p022-latino",
@@ -622,11 +622,11 @@
     {
       "id": "p023",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 2, "r": 2 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 5, "r": -4 },
       "total_population": 1365,
-      "initial_district_id": "d2",
-      "name": "Rim C3",
+      "initial_district_id": "d4",
+      "name": "Rim (5,-4)",
       "demographic_groups": [
         {
           "id": "p023-latino",
@@ -649,11 +649,11 @@
     {
       "id": "p024",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 3, "r": 2 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 6, "r": -4 },
       "total_population": 1437,
-      "initial_district_id": "d2",
-      "name": "Rim D3",
+      "initial_district_id": "d4",
+      "name": "Rim (6,-4)",
       "demographic_groups": [
         {
           "id": "p024-latino",
@@ -676,11 +676,11 @@
     {
       "id": "p025",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 4, "r": 2 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -3, "r": -3 },
       "total_population": 1417,
-      "initial_district_id": "d3",
-      "name": "Rim E3",
+      "initial_district_id": "d1",
+      "name": "Rim (-3,-3)",
       "demographic_groups": [
         {
           "id": "p025-latino",
@@ -703,11 +703,11 @@
     {
       "id": "p026",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 5, "r": 2 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -2, "r": -3 },
       "total_population": 1554,
-      "initial_district_id": "d3",
-      "name": "Rim F3",
+      "initial_district_id": "d1",
+      "name": "Rim (-2,-3)",
       "demographic_groups": [
         {
           "id": "p026-latino",
@@ -730,11 +730,11 @@
     {
       "id": "p027",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 6, "r": 2 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -1, "r": -3 },
       "total_population": 1643,
-      "initial_district_id": "d4",
-      "name": "Rim G3",
+      "initial_district_id": "d1",
+      "name": "Rim (-1,-3)",
       "demographic_groups": [
         {
           "id": "p027-latino",
@@ -757,11 +757,11 @@
     {
       "id": "p028",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 7, "r": 2 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 0, "r": -3 },
       "total_population": 1511,
-      "initial_district_id": "d4",
-      "name": "Rim H3",
+      "initial_district_id": "d1",
+      "name": "Rim (0,-3)",
       "demographic_groups": [
         {
           "id": "p028-latino",
@@ -784,11 +784,11 @@
     {
       "id": "p029",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 8, "r": 2 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 1, "r": -3 },
       "total_population": 1397,
-      "initial_district_id": "d5",
-      "name": "Rim I3",
+      "initial_district_id": "d2",
+      "name": "Rim (1,-3)",
       "demographic_groups": [
         {
           "id": "p029-latino",
@@ -811,11 +811,11 @@
     {
       "id": "p030",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 9, "r": 2 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 2, "r": -3 },
       "total_population": 1507,
-      "initial_district_id": "d5",
-      "name": "Rim J3",
+      "initial_district_id": "d2",
+      "name": "Rim (2,-3)",
       "demographic_groups": [
         {
           "id": "p030-latino",
@@ -838,11 +838,11 @@
     {
       "id": "p031",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 0, "r": 3 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 3, "r": -3 },
       "total_population": 1429,
-      "initial_district_id": "d1",
-      "name": "Rim A4",
+      "initial_district_id": "d3",
+      "name": "Rim (3,-3)",
       "demographic_groups": [
         {
           "id": "p031-latino",
@@ -865,11 +865,11 @@
     {
       "id": "p032",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 1, "r": 3 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 4, "r": -3 },
       "total_population": 1625,
-      "initial_district_id": "d1",
-      "name": "Rim B4",
+      "initial_district_id": "d4",
+      "name": "Rim (4,-3)",
       "demographic_groups": [
         {
           "id": "p032-latino",
@@ -892,11 +892,11 @@
     {
       "id": "p033",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 2, "r": 3 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 5, "r": -3 },
       "total_population": 1491,
-      "initial_district_id": "d2",
-      "name": "Rim C4",
+      "initial_district_id": "d4",
+      "name": "Rim (5,-3)",
       "demographic_groups": [
         {
           "id": "p033-latino",
@@ -919,11 +919,11 @@
     {
       "id": "p034",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 3, "r": 3 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 6, "r": -3 },
       "total_population": 1585,
-      "initial_district_id": "d2",
-      "name": "Rim D4",
+      "initial_district_id": "d5",
+      "name": "Rim (6,-3)",
       "demographic_groups": [
         {
           "id": "p034-latino",
@@ -946,11 +946,11 @@
     {
       "id": "p035",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 4, "r": 3 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": -2 },
       "total_population": 1499,
-      "initial_district_id": "d3",
-      "name": "Rim E4",
+      "initial_district_id": "d1",
+      "name": "Rim (-4,-2)",
       "demographic_groups": [
         {
           "id": "p035-latino",
@@ -973,11 +973,11 @@
     {
       "id": "p036",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 5, "r": 3 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -3, "r": -2 },
       "total_population": 1649,
-      "initial_district_id": "d3",
-      "name": "Rim F4",
+      "initial_district_id": "d1",
+      "name": "Rim (-3,-2)",
       "demographic_groups": [
         {
           "id": "p036-latino",
@@ -1000,11 +1000,11 @@
     {
       "id": "p037",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 6, "r": 3 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -2, "r": -2 },
       "total_population": 1482,
-      "initial_district_id": "d4",
-      "name": "Rim G4",
+      "initial_district_id": "d1",
+      "name": "Rim (-2,-2)",
       "demographic_groups": [
         {
           "id": "p037-latino",
@@ -1027,11 +1027,11 @@
     {
       "id": "p038",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 7, "r": 3 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -1, "r": -2 },
       "total_population": 1473,
-      "initial_district_id": "d4",
-      "name": "Rim H4",
+      "initial_district_id": "d1",
+      "name": "Rim (-1,-2)",
       "demographic_groups": [
         {
           "id": "p038-latino",
@@ -1054,11 +1054,11 @@
     {
       "id": "p039",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 8, "r": 3 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 0, "r": -2 },
       "total_population": 1559,
-      "initial_district_id": "d5",
-      "name": "Rim I4",
+      "initial_district_id": "d2",
+      "name": "Rim (0,-2)",
       "demographic_groups": [
         {
           "id": "p039-latino",
@@ -1081,16 +1081,16 @@
     {
       "id": "p040",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 9, "r": 3 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 1, "r": -2 },
       "total_population": 1494,
-      "initial_district_id": "d5",
-      "name": "Rim J4",
+      "initial_district_id": "d2",
+      "name": "Valley (1,-2)",
       "demographic_groups": [
         {
           "id": "p040-latino",
           "name": "Latino residents",
-          "population_share": 0.2133,
+          "population_share": 0.7133,
           "turnout_rate": 0.57,
           "vote_shares": { "ken": 0.7567, "ryu": 0.2433 },
           "dimensions": { "ethnicity": "latino" }
@@ -1098,7 +1098,7 @@
         {
           "id": "p040-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7867,
+          "population_share": 0.2867,
           "turnout_rate": 0.59,
           "vote_shares": { "ken": 0.3661, "ryu": 0.6339 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1108,16 +1108,16 @@
     {
       "id": "p041",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 0, "r": 4 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 2, "r": -2 },
       "total_population": 1492,
-      "initial_district_id": "d1",
-      "name": "Rim A5",
+      "initial_district_id": "d3",
+      "name": "Valley (2,-2)",
       "demographic_groups": [
         {
           "id": "p041-latino",
           "name": "Latino residents",
-          "population_share": 0.2063,
+          "population_share": 0.7063,
           "turnout_rate": 0.54,
           "vote_shares": { "ken": 0.7619, "ryu": 0.2381 },
           "dimensions": { "ethnicity": "latino" }
@@ -1125,7 +1125,7 @@
         {
           "id": "p041-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7937,
+          "population_share": 0.2937,
           "turnout_rate": 0.66,
           "vote_shares": { "ken": 0.3710, "ryu": 0.6290 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1135,16 +1135,16 @@
     {
       "id": "p042",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 1, "r": 4 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 3, "r": -2 },
       "total_population": 1611,
-      "initial_district_id": "d1",
-      "name": "Rim B5",
+      "initial_district_id": "d4",
+      "name": "Valley (3,-2)",
       "demographic_groups": [
         {
           "id": "p042-latino",
           "name": "Latino residents",
-          "population_share": 0.1836,
+          "population_share": 0.6836,
           "turnout_rate": 0.52,
           "vote_shares": { "ken": 0.7835, "ryu": 0.2165 },
           "dimensions": { "ethnicity": "latino" }
@@ -1152,7 +1152,7 @@
         {
           "id": "p042-anglo",
           "name": "Anglo residents",
-          "population_share": 0.8164,
+          "population_share": 0.3164,
           "turnout_rate": 0.66,
           "vote_shares": { "ken": 0.3542, "ryu": 0.6458 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1162,16 +1162,16 @@
     {
       "id": "p043",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 2, "r": 4 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 4, "r": -2 },
       "total_population": 1604,
-      "initial_district_id": "d2",
-      "name": "Rim C5",
+      "initial_district_id": "d4",
+      "name": "Valley (4,-2)",
       "demographic_groups": [
         {
           "id": "p043-latino",
           "name": "Latino residents",
-          "population_share": 0.2049,
+          "population_share": 0.7049,
           "turnout_rate": 0.53,
           "vote_shares": { "ken": 0.7609, "ryu": 0.2391 },
           "dimensions": { "ethnicity": "latino" }
@@ -1179,7 +1179,7 @@
         {
           "id": "p043-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7951,
+          "population_share": 0.2951,
           "turnout_rate": 0.64,
           "vote_shares": { "ken": 0.4076, "ryu": 0.5924 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1189,16 +1189,16 @@
     {
       "id": "p044",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 3, "r": 4 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 5, "r": -2 },
       "total_population": 1413,
-      "initial_district_id": "d2",
-      "name": "Rim D5",
+      "initial_district_id": "d5",
+      "name": "Valley (5,-2)",
       "demographic_groups": [
         {
           "id": "p044-latino",
           "name": "Latino residents",
-          "population_share": 0.2109,
+          "population_share": 0.7109,
           "turnout_rate": 0.60,
           "vote_shares": { "ken": 0.7798, "ryu": 0.2202 },
           "dimensions": { "ethnicity": "latino" }
@@ -1206,7 +1206,7 @@
         {
           "id": "p044-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7891,
+          "population_share": 0.2891,
           "turnout_rate": 0.64,
           "vote_shares": { "ken": 0.3949, "ryu": 0.6051 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1216,11 +1216,11 @@
     {
       "id": "p045",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 4, "r": 4 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 6, "r": -2 },
       "total_population": 1389,
-      "initial_district_id": "d3",
-      "name": "Rim E5",
+      "initial_district_id": "d5",
+      "name": "Rim (6,-2)",
       "demographic_groups": [
         {
           "id": "p045-latino",
@@ -1243,11 +1243,11 @@
     {
       "id": "p046",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 5, "r": 4 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -5, "r": -1 },
       "total_population": 1524,
-      "initial_district_id": "d3",
-      "name": "Rim F5",
+      "initial_district_id": "d1",
+      "name": "Rim (-5,-1)",
       "demographic_groups": [
         {
           "id": "p046-latino",
@@ -1270,11 +1270,11 @@
     {
       "id": "p047",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 6, "r": 4 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": -1 },
       "total_population": 1497,
-      "initial_district_id": "d4",
-      "name": "Rim G5",
+      "initial_district_id": "d1",
+      "name": "Rim (-4,-1)",
       "demographic_groups": [
         {
           "id": "p047-latino",
@@ -1297,11 +1297,11 @@
     {
       "id": "p048",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 7, "r": 4 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -3, "r": -1 },
       "total_population": 1562,
-      "initial_district_id": "d4",
-      "name": "Rim H5",
+      "initial_district_id": "d1",
+      "name": "Rim (-3,-1)",
       "demographic_groups": [
         {
           "id": "p048-latino",
@@ -1324,11 +1324,11 @@
     {
       "id": "p049",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 8, "r": 4 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -2, "r": -1 },
       "total_population": 1400,
-      "initial_district_id": "d5",
-      "name": "Rim I5",
+      "initial_district_id": "d1",
+      "name": "Rim (-2,-1)",
       "demographic_groups": [
         {
           "id": "p049-latino",
@@ -1351,11 +1351,11 @@
     {
       "id": "p050",
       "editable": true,
-      "county_id": "valle_verde_north",
-      "position": { "q": 9, "r": 4 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -1, "r": -1 },
       "total_population": 1572,
-      "initial_district_id": "d5",
-      "name": "Rim J5",
+      "initial_district_id": "d2",
+      "name": "Rim (-1,-1)",
       "demographic_groups": [
         {
           "id": "p050-latino",
@@ -1378,11 +1378,11 @@
     {
       "id": "p051",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 0, "r": 5 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 0, "r": -1 },
       "total_population": 1482,
-      "initial_district_id": "d1",
-      "name": "Rim A6",
+      "initial_district_id": "d2",
+      "name": "Rim (0,-1)",
       "demographic_groups": [
         {
           "id": "p051-latino",
@@ -1405,16 +1405,16 @@
     {
       "id": "p052",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 1, "r": 5 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 1, "r": -1 },
       "total_population": 1623,
-      "initial_district_id": "d1",
-      "name": "Rim B6",
+      "initial_district_id": "d3",
+      "name": "Valley (1,-1)",
       "demographic_groups": [
         {
           "id": "p052-latino",
           "name": "Latino residents",
-          "population_share": 0.1724,
+          "population_share": 0.6724,
           "turnout_rate": 0.55,
           "vote_shares": { "ken": 0.7657, "ryu": 0.2343 },
           "dimensions": { "ethnicity": "latino" }
@@ -1422,7 +1422,7 @@
         {
           "id": "p052-anglo",
           "name": "Anglo residents",
-          "population_share": 0.8276,
+          "population_share": 0.3276,
           "turnout_rate": 0.63,
           "vote_shares": { "ken": 0.3676, "ryu": 0.6324 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1432,16 +1432,16 @@
     {
       "id": "p053",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 2, "r": 5 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 2, "r": -1 },
       "total_population": 1430,
-      "initial_district_id": "d2",
-      "name": "Rim C6",
+      "initial_district_id": "d4",
+      "name": "Valley (2,-1)",
       "demographic_groups": [
         {
           "id": "p053-latino",
           "name": "Latino residents",
-          "population_share": 0.1680,
+          "population_share": 0.6680,
           "turnout_rate": 0.56,
           "vote_shares": { "ken": 0.7756, "ryu": 0.2244 },
           "dimensions": { "ethnicity": "latino" }
@@ -1449,7 +1449,7 @@
         {
           "id": "p053-anglo",
           "name": "Anglo residents",
-          "population_share": 0.8320,
+          "population_share": 0.3320,
           "turnout_rate": 0.66,
           "vote_shares": { "ken": 0.3805, "ryu": 0.6195 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1460,10 +1460,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 3, "r": 5 },
+      "position": { "q": 3, "r": -1 },
       "total_population": 1498,
-      "initial_district_id": "d2",
-      "name": "Valley D6",
+      "initial_district_id": "d4",
+      "name": "Valley (3,-1)",
       "demographic_groups": [
         {
           "id": "p054-latino",
@@ -1487,10 +1487,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 4, "r": 5 },
+      "position": { "q": 4, "r": -1 },
       "total_population": 1618,
-      "initial_district_id": "d3",
-      "name": "Valley E6",
+      "initial_district_id": "d5",
+      "name": "Valley (4,-1)",
       "demographic_groups": [
         {
           "id": "p055-latino",
@@ -1514,10 +1514,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 5, "r": 5 },
+      "position": { "q": 5, "r": -1 },
       "total_population": 1555,
-      "initial_district_id": "d3",
-      "name": "Valley F6",
+      "initial_district_id": "d5",
+      "name": "Valley (5,-1)",
       "demographic_groups": [
         {
           "id": "p056-latino",
@@ -1540,16 +1540,16 @@
     {
       "id": "p057",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 6, "r": 5 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 6, "r": -1 },
       "total_population": 1510,
-      "initial_district_id": "d4",
-      "name": "Valley G6",
+      "initial_district_id": "d5",
+      "name": "Rim (6,-1)",
       "demographic_groups": [
         {
           "id": "p057-latino",
           "name": "Latino residents",
-          "population_share": 0.7233,
+          "population_share": 0.2233,
           "turnout_rate": 0.54,
           "vote_shares": { "ken": 0.8009, "ryu": 0.1991 },
           "dimensions": { "ethnicity": "latino" }
@@ -1557,7 +1557,7 @@
         {
           "id": "p057-anglo",
           "name": "Anglo residents",
-          "population_share": 0.2767,
+          "population_share": 0.7767,
           "turnout_rate": 0.64,
           "vote_shares": { "ken": 0.3669, "ryu": 0.6331 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1567,16 +1567,16 @@
     {
       "id": "p058",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 7, "r": 5 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -6, "r": 0 },
       "total_population": 1645,
-      "initial_district_id": "d4",
-      "name": "Valley H6",
+      "initial_district_id": "d1",
+      "name": "Rim (-6,0)",
       "demographic_groups": [
         {
           "id": "p058-latino",
           "name": "Latino residents",
-          "population_share": 0.6604,
+          "population_share": 0.1604,
           "turnout_rate": 0.58,
           "vote_shares": { "ken": 0.8090, "ryu": 0.1910 },
           "dimensions": { "ethnicity": "latino" }
@@ -1584,7 +1584,7 @@
         {
           "id": "p058-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3396,
+          "population_share": 0.8396,
           "turnout_rate": 0.65,
           "vote_shares": { "ken": 0.3837, "ryu": 0.6163 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1594,16 +1594,16 @@
     {
       "id": "p059",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 8, "r": 5 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -5, "r": 0 },
       "total_population": 1530,
-      "initial_district_id": "d5",
-      "name": "Valley I6",
+      "initial_district_id": "d1",
+      "name": "Rim (-5,0)",
       "demographic_groups": [
         {
           "id": "p059-latino",
           "name": "Latino residents",
-          "population_share": 0.6976,
+          "population_share": 0.1976,
           "turnout_rate": 0.60,
           "vote_shares": { "ken": 0.7820, "ryu": 0.2180 },
           "dimensions": { "ethnicity": "latino" }
@@ -1611,7 +1611,7 @@
         {
           "id": "p059-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3024,
+          "population_share": 0.8024,
           "turnout_rate": 0.59,
           "vote_shares": { "ken": 0.3976, "ryu": 0.6024 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1621,11 +1621,11 @@
     {
       "id": "p060",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 9, "r": 5 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": 0 },
       "total_population": 1565,
-      "initial_district_id": "d5",
-      "name": "Rim J6",
+      "initial_district_id": "d1",
+      "name": "Rim (-4,0)",
       "demographic_groups": [
         {
           "id": "p060-latino",
@@ -1648,11 +1648,11 @@
     {
       "id": "p061",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 0, "r": 6 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -3, "r": 0 },
       "total_population": 1633,
       "initial_district_id": "d1",
-      "name": "Rim A7",
+      "name": "Rim (-3,0)",
       "demographic_groups": [
         {
           "id": "p061-latino",
@@ -1675,11 +1675,11 @@
     {
       "id": "p062",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 1, "r": 6 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -2, "r": 0 },
       "total_population": 1530,
-      "initial_district_id": "d1",
-      "name": "Rim B7",
+      "initial_district_id": "d2",
+      "name": "Rim (-2,0)",
       "demographic_groups": [
         {
           "id": "p062-latino",
@@ -1702,11 +1702,11 @@
     {
       "id": "p063",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 2, "r": 6 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -1, "r": 0 },
       "total_population": 1388,
       "initial_district_id": "d2",
-      "name": "Rim C7",
+      "name": "Rim (-1,0)",
       "demographic_groups": [
         {
           "id": "p063-latino",
@@ -1729,16 +1729,16 @@
     {
       "id": "p064",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 3, "r": 6 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 0, "r": 0 },
       "total_population": 1468,
-      "initial_district_id": "d2",
-      "name": "Valley D7",
+      "initial_district_id": "d3",
+      "name": "Rim (0,0)",
       "demographic_groups": [
         {
           "id": "p064-latino",
           "name": "Latino residents",
-          "population_share": 0.6922,
+          "population_share": 0.1922,
           "turnout_rate": 0.55,
           "vote_shares": { "ken": 0.7600, "ryu": 0.2400 },
           "dimensions": { "ethnicity": "latino" }
@@ -1746,7 +1746,7 @@
         {
           "id": "p064-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3078,
+          "population_share": 0.8078,
           "turnout_rate": 0.59,
           "vote_shares": { "ken": 0.3609, "ryu": 0.6391 },
           "dimensions": { "ethnicity": "anglo" }
@@ -1757,10 +1757,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 4, "r": 6 },
+      "position": { "q": 1, "r": 0 },
       "total_population": 1626,
-      "initial_district_id": "d3",
-      "name": "Valley E7",
+      "initial_district_id": "d4",
+      "name": "Valley (1,0)",
       "demographic_groups": [
         {
           "id": "p065-latino",
@@ -1784,10 +1784,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 5, "r": 6 },
+      "position": { "q": 2, "r": 0 },
       "total_population": 1568,
-      "initial_district_id": "d3",
-      "name": "Valley F7",
+      "initial_district_id": "d4",
+      "name": "Valley (2,0)",
       "demographic_groups": [
         {
           "id": "p066-latino",
@@ -1811,10 +1811,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 6, "r": 6 },
+      "position": { "q": 3, "r": 0 },
       "total_population": 1506,
-      "initial_district_id": "d4",
-      "name": "Valley G7",
+      "initial_district_id": "d5",
+      "name": "Valley (3,0)",
       "demographic_groups": [
         {
           "id": "p067-latino",
@@ -1838,10 +1838,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 7, "r": 6 },
+      "position": { "q": 4, "r": 0 },
       "total_population": 1428,
-      "initial_district_id": "d4",
-      "name": "Valley H7",
+      "initial_district_id": "d5",
+      "name": "Valley (4,0)",
       "demographic_groups": [
         {
           "id": "p068-latino",
@@ -1865,10 +1865,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 8, "r": 6 },
+      "position": { "q": 5, "r": 0 },
       "total_population": 1373,
       "initial_district_id": "d5",
-      "name": "Valley I7",
+      "name": "Valley (5,0)",
       "demographic_groups": [
         {
           "id": "p069-latino",
@@ -1891,11 +1891,11 @@
     {
       "id": "p070",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 9, "r": 6 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 6, "r": 0 },
       "total_population": 1450,
       "initial_district_id": "d5",
-      "name": "Rim J7",
+      "name": "Rim (6,0)",
       "demographic_groups": [
         {
           "id": "p070-latino",
@@ -1918,11 +1918,11 @@
     {
       "id": "p071",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 0, "r": 7 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -6, "r": 1 },
       "total_population": 1577,
       "initial_district_id": "d1",
-      "name": "Rim A8",
+      "name": "Rim (-6,1)",
       "demographic_groups": [
         {
           "id": "p071-latino",
@@ -1945,11 +1945,11 @@
     {
       "id": "p072",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 1, "r": 7 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -5, "r": 1 },
       "total_population": 1416,
       "initial_district_id": "d1",
-      "name": "Rim B8",
+      "name": "Rim (-5,1)",
       "demographic_groups": [
         {
           "id": "p072-latino",
@@ -1972,11 +1972,11 @@
     {
       "id": "p073",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 2, "r": 7 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": 1 },
       "total_population": 1445,
-      "initial_district_id": "d2",
-      "name": "Rim C8",
+      "initial_district_id": "d1",
+      "name": "Rim (-4,1)",
       "demographic_groups": [
         {
           "id": "p073-latino",
@@ -1999,16 +1999,16 @@
     {
       "id": "p074",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 3, "r": 7 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -3, "r": 1 },
       "total_population": 1424,
       "initial_district_id": "d2",
-      "name": "Valley D8",
+      "name": "Rim (-3,1)",
       "demographic_groups": [
         {
           "id": "p074-latino",
           "name": "Latino residents",
-          "population_share": 0.6628,
+          "population_share": 0.1628,
           "turnout_rate": 0.58,
           "vote_shares": { "ken": 0.7539, "ryu": 0.2461 },
           "dimensions": { "ethnicity": "latino" }
@@ -2016,7 +2016,7 @@
         {
           "id": "p074-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3372,
+          "population_share": 0.8372,
           "turnout_rate": 0.66,
           "vote_shares": { "ken": 0.3849, "ryu": 0.6151 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2026,16 +2026,16 @@
     {
       "id": "p075",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 4, "r": 7 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -2, "r": 1 },
       "total_population": 1492,
-      "initial_district_id": "d3",
-      "name": "Valley E8",
+      "initial_district_id": "d2",
+      "name": "Rim (-2,1)",
       "demographic_groups": [
         {
           "id": "p075-latino",
           "name": "Latino residents",
-          "population_share": 0.7026,
+          "population_share": 0.2026,
           "turnout_rate": 0.60,
           "vote_shares": { "ken": 0.7809, "ryu": 0.2191 },
           "dimensions": { "ethnicity": "latino" }
@@ -2043,7 +2043,7 @@
         {
           "id": "p075-anglo",
           "name": "Anglo residents",
-          "population_share": 0.2974,
+          "population_share": 0.7974,
           "turnout_rate": 0.65,
           "vote_shares": { "ken": 0.3800, "ryu": 0.6200 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2053,16 +2053,16 @@
     {
       "id": "p076",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 5, "r": 7 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -1, "r": 1 },
       "total_population": 1538,
       "initial_district_id": "d3",
-      "name": "Valley F8",
+      "name": "Rim (-1,1)",
       "demographic_groups": [
         {
           "id": "p076-latino",
           "name": "Latino residents",
-          "population_share": 0.7186,
+          "population_share": 0.2186,
           "turnout_rate": 0.55,
           "vote_shares": { "ken": 0.7872, "ryu": 0.2128 },
           "dimensions": { "ethnicity": "latino" }
@@ -2070,7 +2070,7 @@
         {
           "id": "p076-anglo",
           "name": "Anglo residents",
-          "population_share": 0.2814,
+          "population_share": 0.7814,
           "turnout_rate": 0.62,
           "vote_shares": { "ken": 0.3507, "ryu": 0.6493 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2080,16 +2080,16 @@
     {
       "id": "p077",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 6, "r": 7 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 0, "r": 1 },
       "total_population": 1631,
       "initial_district_id": "d4",
-      "name": "Valley G8",
+      "name": "Rim (0,1)",
       "demographic_groups": [
         {
           "id": "p077-latino",
           "name": "Latino residents",
-          "population_share": 0.6850,
+          "population_share": 0.1850,
           "turnout_rate": 0.59,
           "vote_shares": { "ken": 0.7613, "ryu": 0.2387 },
           "dimensions": { "ethnicity": "latino" }
@@ -2097,7 +2097,7 @@
         {
           "id": "p077-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3150,
+          "population_share": 0.8150,
           "turnout_rate": 0.59,
           "vote_shares": { "ken": 0.3955, "ryu": 0.6045 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2108,10 +2108,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 7, "r": 7 },
+      "position": { "q": 1, "r": 1 },
       "total_population": 1621,
       "initial_district_id": "d4",
-      "name": "Valley H8",
+      "name": "Valley (1,1)",
       "demographic_groups": [
         {
           "id": "p078-latino",
@@ -2135,10 +2135,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 8, "r": 7 },
+      "position": { "q": 2, "r": 1 },
       "total_population": 1357,
       "initial_district_id": "d5",
-      "name": "Valley I8",
+      "name": "Valley (2,1)",
       "demographic_groups": [
         {
           "id": "p079-latino",
@@ -2161,16 +2161,16 @@
     {
       "id": "p080",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 9, "r": 7 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 3, "r": 1 },
       "total_population": 1366,
       "initial_district_id": "d5",
-      "name": "Rim J8",
+      "name": "Valley (3,1)",
       "demographic_groups": [
         {
           "id": "p080-latino",
           "name": "Latino residents",
-          "population_share": 0.2036,
+          "population_share": 0.7036,
           "turnout_rate": 0.57,
           "vote_shares": { "ken": 0.7773, "ryu": 0.2227 },
           "dimensions": { "ethnicity": "latino" }
@@ -2178,7 +2178,7 @@
         {
           "id": "p080-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7964,
+          "population_share": 0.2964,
           "turnout_rate": 0.63,
           "vote_shares": { "ken": 0.4037, "ryu": 0.5963 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2188,16 +2188,16 @@
     {
       "id": "p081",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 0, "r": 8 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 4, "r": 1 },
       "total_population": 1492,
-      "initial_district_id": "d1",
-      "name": "Rim A9",
+      "initial_district_id": "d5",
+      "name": "Valley (4,1)",
       "demographic_groups": [
         {
           "id": "p081-latino",
           "name": "Latino residents",
-          "population_share": 0.1721,
+          "population_share": 0.6721,
           "turnout_rate": 0.53,
           "vote_shares": { "ken": 0.7572, "ryu": 0.2428 },
           "dimensions": { "ethnicity": "latino" }
@@ -2205,7 +2205,7 @@
         {
           "id": "p081-anglo",
           "name": "Anglo residents",
-          "population_share": 0.8279,
+          "population_share": 0.3279,
           "turnout_rate": 0.61,
           "vote_shares": { "ken": 0.3710, "ryu": 0.6290 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2215,16 +2215,16 @@
     {
       "id": "p082",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 1, "r": 8 },
+      "county_id": "valle_verde_valley",
+      "position": { "q": 5, "r": 1 },
       "total_population": 1649,
-      "initial_district_id": "d1",
-      "name": "Rim B9",
+      "initial_district_id": "d5",
+      "name": "Valley (5,1)",
       "demographic_groups": [
         {
           "id": "p082-latino",
           "name": "Latino residents",
-          "population_share": 0.2324,
+          "population_share": 0.7324,
           "turnout_rate": 0.55,
           "vote_shares": { "ken": 0.7860, "ryu": 0.2140 },
           "dimensions": { "ethnicity": "latino" }
@@ -2232,7 +2232,7 @@
         {
           "id": "p082-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7676,
+          "population_share": 0.2676,
           "turnout_rate": 0.60,
           "vote_shares": { "ken": 0.4003, "ryu": 0.5997 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2242,11 +2242,11 @@
     {
       "id": "p083",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 2, "r": 8 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -6, "r": 2 },
       "total_population": 1558,
-      "initial_district_id": "d2",
-      "name": "Rim C9",
+      "initial_district_id": "d1",
+      "name": "Rim (-6,2)",
       "demographic_groups": [
         {
           "id": "p083-latino",
@@ -2269,16 +2269,16 @@
     {
       "id": "p084",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 3, "r": 8 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -5, "r": 2 },
       "total_population": 1523,
-      "initial_district_id": "d2",
-      "name": "Valley D9",
+      "initial_district_id": "d1",
+      "name": "Rim (-5,2)",
       "demographic_groups": [
         {
           "id": "p084-latino",
           "name": "Latino residents",
-          "population_share": 0.6816,
+          "population_share": 0.1816,
           "turnout_rate": 0.60,
           "vote_shares": { "ken": 0.8082, "ryu": 0.1918 },
           "dimensions": { "ethnicity": "latino" }
@@ -2286,7 +2286,7 @@
         {
           "id": "p084-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3184,
+          "population_share": 0.8184,
           "turnout_rate": 0.61,
           "vote_shares": { "ken": 0.4020, "ryu": 0.5980 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2296,16 +2296,16 @@
     {
       "id": "p085",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 4, "r": 8 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": 2 },
       "total_population": 1367,
-      "initial_district_id": "d3",
-      "name": "Valley E9",
+      "initial_district_id": "d2",
+      "name": "Rim (-4,2)",
       "demographic_groups": [
         {
           "id": "p085-latino",
           "name": "Latino residents",
-          "population_share": 0.6749,
+          "population_share": 0.1749,
           "turnout_rate": 0.61,
           "vote_shares": { "ken": 0.7961, "ryu": 0.2039 },
           "dimensions": { "ethnicity": "latino" }
@@ -2313,7 +2313,7 @@
         {
           "id": "p085-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3251,
+          "population_share": 0.8251,
           "turnout_rate": 0.63,
           "vote_shares": { "ken": 0.3975, "ryu": 0.6025 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2323,16 +2323,16 @@
     {
       "id": "p086",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 5, "r": 8 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -3, "r": 2 },
       "total_population": 1357,
-      "initial_district_id": "d3",
-      "name": "Valley F9",
+      "initial_district_id": "d2",
+      "name": "Rim (-3,2)",
       "demographic_groups": [
         {
           "id": "p086-latino",
           "name": "Latino residents",
-          "population_share": 0.7067,
+          "population_share": 0.2067,
           "turnout_rate": 0.60,
           "vote_shares": { "ken": 0.8023, "ryu": 0.1977 },
           "dimensions": { "ethnicity": "latino" }
@@ -2340,7 +2340,7 @@
         {
           "id": "p086-anglo",
           "name": "Anglo residents",
-          "population_share": 0.2933,
+          "population_share": 0.7933,
           "turnout_rate": 0.59,
           "vote_shares": { "ken": 0.3897, "ryu": 0.6103 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2350,16 +2350,16 @@
     {
       "id": "p087",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 6, "r": 8 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -2, "r": 2 },
       "total_population": 1595,
-      "initial_district_id": "d4",
-      "name": "Valley G9",
+      "initial_district_id": "d3",
+      "name": "Rim (-2,2)",
       "demographic_groups": [
         {
           "id": "p087-latino",
           "name": "Latino residents",
-          "population_share": 0.7119,
+          "population_share": 0.2119,
           "turnout_rate": 0.61,
           "vote_shares": { "ken": 0.7785, "ryu": 0.2215 },
           "dimensions": { "ethnicity": "latino" }
@@ -2367,7 +2367,7 @@
         {
           "id": "p087-anglo",
           "name": "Anglo residents",
-          "population_share": 0.2881,
+          "population_share": 0.7881,
           "turnout_rate": 0.61,
           "vote_shares": { "ken": 0.3968, "ryu": 0.6032 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2377,16 +2377,16 @@
     {
       "id": "p088",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 7, "r": 8 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -1, "r": 2 },
       "total_population": 1541,
       "initial_district_id": "d4",
-      "name": "Valley H9",
+      "name": "Rim (-1,2)",
       "demographic_groups": [
         {
           "id": "p088-latino",
           "name": "Latino residents",
-          "population_share": 0.6617,
+          "population_share": 0.1617,
           "turnout_rate": 0.58,
           "vote_shares": { "ken": 0.7805, "ryu": 0.2195 },
           "dimensions": { "ethnicity": "latino" }
@@ -2394,7 +2394,7 @@
         {
           "id": "p088-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3383,
+          "population_share": 0.8383,
           "turnout_rate": 0.68,
           "vote_shares": { "ken": 0.3780, "ryu": 0.6220 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2404,16 +2404,16 @@
     {
       "id": "p089",
       "editable": true,
-      "county_id": "valle_verde_valley",
-      "position": { "q": 8, "r": 8 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 0, "r": 2 },
       "total_population": 1579,
-      "initial_district_id": "d5",
-      "name": "Valley I9",
+      "initial_district_id": "d4",
+      "name": "Rim (0,2)",
       "demographic_groups": [
         {
           "id": "p089-latino",
           "name": "Latino residents",
-          "population_share": 0.7392,
+          "population_share": 0.2392,
           "turnout_rate": 0.58,
           "vote_shares": { "ken": 0.7885, "ryu": 0.2115 },
           "dimensions": { "ethnicity": "latino" }
@@ -2421,7 +2421,7 @@
         {
           "id": "p089-anglo",
           "name": "Anglo residents",
-          "population_share": 0.2608,
+          "population_share": 0.7608,
           "turnout_rate": 0.64,
           "vote_shares": { "ken": 0.4020, "ryu": 0.5980 },
           "dimensions": { "ethnicity": "anglo" }
@@ -2431,11 +2431,11 @@
     {
       "id": "p090",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 9, "r": 8 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 1, "r": 2 },
       "total_population": 1510,
       "initial_district_id": "d5",
-      "name": "Rim J9",
+      "name": "Rim (1,2)",
       "demographic_groups": [
         {
           "id": "p090-latino",
@@ -2458,11 +2458,11 @@
     {
       "id": "p091",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 0, "r": 9 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 2, "r": 2 },
       "total_population": 1562,
-      "initial_district_id": "d1",
-      "name": "Rim A10",
+      "initial_district_id": "d5",
+      "name": "Rim (2,2)",
       "demographic_groups": [
         {
           "id": "p091-latino",
@@ -2485,11 +2485,11 @@
     {
       "id": "p092",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 1, "r": 9 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 3, "r": 2 },
       "total_population": 1483,
-      "initial_district_id": "d1",
-      "name": "Rim B10",
+      "initial_district_id": "d5",
+      "name": "Rim (3,2)",
       "demographic_groups": [
         {
           "id": "p092-latino",
@@ -2512,11 +2512,11 @@
     {
       "id": "p093",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 2, "r": 9 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 4, "r": 2 },
       "total_population": 1462,
-      "initial_district_id": "d2",
-      "name": "Rim C10",
+      "initial_district_id": "d5",
+      "name": "Rim (4,2)",
       "demographic_groups": [
         {
           "id": "p093-latino",
@@ -2539,11 +2539,11 @@
     {
       "id": "p094",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 3, "r": 9 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -6, "r": 3 },
       "total_population": 1428,
-      "initial_district_id": "d2",
-      "name": "Rim D10",
+      "initial_district_id": "d1",
+      "name": "Rim (-6,3)",
       "demographic_groups": [
         {
           "id": "p094-latino",
@@ -2566,11 +2566,11 @@
     {
       "id": "p095",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 4, "r": 9 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -5, "r": 3 },
       "total_population": 1439,
-      "initial_district_id": "d3",
-      "name": "Rim E10",
+      "initial_district_id": "d2",
+      "name": "Rim (-5,3)",
       "demographic_groups": [
         {
           "id": "p095-latino",
@@ -2593,11 +2593,11 @@
     {
       "id": "p096",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 5, "r": 9 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": 3 },
       "total_population": 1411,
-      "initial_district_id": "d3",
-      "name": "Rim F10",
+      "initial_district_id": "d2",
+      "name": "Rim (-4,3)",
       "demographic_groups": [
         {
           "id": "p096-latino",
@@ -2620,11 +2620,11 @@
     {
       "id": "p097",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 6, "r": 9 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -3, "r": 3 },
       "total_population": 1508,
-      "initial_district_id": "d4",
-      "name": "Rim G10",
+      "initial_district_id": "d3",
+      "name": "Rim (-3,3)",
       "demographic_groups": [
         {
           "id": "p097-latino",
@@ -2647,11 +2647,11 @@
     {
       "id": "p098",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 7, "r": 9 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -2, "r": 3 },
       "total_population": 1469,
       "initial_district_id": "d4",
-      "name": "Rim H10",
+      "name": "Rim (-2,3)",
       "demographic_groups": [
         {
           "id": "p098-latino",
@@ -2674,11 +2674,11 @@
     {
       "id": "p099",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 8, "r": 9 },
+      "county_id": "valle_verde_central",
+      "position": { "q": -1, "r": 3 },
       "total_population": 1444,
-      "initial_district_id": "d5",
-      "name": "Rim I10",
+      "initial_district_id": "d4",
+      "name": "Rim (-1,3)",
       "demographic_groups": [
         {
           "id": "p099-latino",
@@ -2701,11 +2701,11 @@
     {
       "id": "p100",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 9, "r": 9 },
+      "county_id": "valle_verde_central",
+      "position": { "q": 0, "r": 3 },
       "total_population": 1352,
       "initial_district_id": "d5",
-      "name": "Rim J10",
+      "name": "Rim (0,3)",
       "demographic_groups": [
         {
           "id": "p100-latino",
@@ -2728,11 +2728,11 @@
     {
       "id": "p101",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 0, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 1, "r": 3 },
       "total_population": 1397,
-      "initial_district_id": "d1",
-      "name": "Rim A11",
+      "initial_district_id": "d5",
+      "name": "Rim (1,3)",
       "demographic_groups": [
         {
           "id": "p101-latino",
@@ -2755,11 +2755,11 @@
     {
       "id": "p102",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 1, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 2, "r": 3 },
       "total_population": 1555,
-      "initial_district_id": "d1",
-      "name": "Rim B11",
+      "initial_district_id": "d5",
+      "name": "Rim (2,3)",
       "demographic_groups": [
         {
           "id": "p102-latino",
@@ -2782,11 +2782,11 @@
     {
       "id": "p103",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 2, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 3, "r": 3 },
       "total_population": 1385,
-      "initial_district_id": "d2",
-      "name": "Rim C11",
+      "initial_district_id": "d5",
+      "name": "Rim (3,3)",
       "demographic_groups": [
         {
           "id": "p103-latino",
@@ -2809,11 +2809,11 @@
     {
       "id": "p104",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 3, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -6, "r": 4 },
       "total_population": 1559,
       "initial_district_id": "d2",
-      "name": "Rim D11",
+      "name": "Rim (-6,4)",
       "demographic_groups": [
         {
           "id": "p104-latino",
@@ -2836,11 +2836,11 @@
     {
       "id": "p105",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 4, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -5, "r": 4 },
       "total_population": 1573,
-      "initial_district_id": "d3",
-      "name": "Rim E11",
+      "initial_district_id": "d2",
+      "name": "Rim (-5,4)",
       "demographic_groups": [
         {
           "id": "p105-latino",
@@ -2863,11 +2863,11 @@
     {
       "id": "p106",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 5, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": 4 },
       "total_population": 1458,
       "initial_district_id": "d3",
-      "name": "Rim F11",
+      "name": "Rim (-4,4)",
       "demographic_groups": [
         {
           "id": "p106-latino",
@@ -2890,11 +2890,11 @@
     {
       "id": "p107",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 6, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -3, "r": 4 },
       "total_population": 1501,
       "initial_district_id": "d4",
-      "name": "Rim G11",
+      "name": "Rim (-3,4)",
       "demographic_groups": [
         {
           "id": "p107-latino",
@@ -2917,11 +2917,11 @@
     {
       "id": "p108",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 7, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -2, "r": 4 },
       "total_population": 1467,
       "initial_district_id": "d4",
-      "name": "Rim H11",
+      "name": "Rim (-2,4)",
       "demographic_groups": [
         {
           "id": "p108-latino",
@@ -2944,11 +2944,11 @@
     {
       "id": "p109",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 8, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -1, "r": 4 },
       "total_population": 1637,
       "initial_district_id": "d5",
-      "name": "Rim I11",
+      "name": "Rim (-1,4)",
       "demographic_groups": [
         {
           "id": "p109-latino",
@@ -2971,11 +2971,11 @@
     {
       "id": "p110",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 9, "r": 10 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 0, "r": 4 },
       "total_population": 1414,
       "initial_district_id": "d5",
-      "name": "Rim J11",
+      "name": "Rim (0,4)",
       "demographic_groups": [
         {
           "id": "p110-latino",
@@ -2998,11 +2998,11 @@
     {
       "id": "p111",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 0, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 1, "r": 4 },
       "total_population": 1631,
-      "initial_district_id": "d1",
-      "name": "Rim A12",
+      "initial_district_id": "d5",
+      "name": "Rim (1,4)",
       "demographic_groups": [
         {
           "id": "p111-latino",
@@ -3025,11 +3025,11 @@
     {
       "id": "p112",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 1, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 2, "r": 4 },
       "total_population": 1629,
-      "initial_district_id": "d1",
-      "name": "Rim B12",
+      "initial_district_id": "d5",
+      "name": "Rim (2,4)",
       "demographic_groups": [
         {
           "id": "p112-latino",
@@ -3052,11 +3052,11 @@
     {
       "id": "p113",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 2, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -6, "r": 5 },
       "total_population": 1616,
       "initial_district_id": "d2",
-      "name": "Rim C12",
+      "name": "Rim (-6,5)",
       "demographic_groups": [
         {
           "id": "p113-latino",
@@ -3079,11 +3079,11 @@
     {
       "id": "p114",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 3, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -5, "r": 5 },
       "total_population": 1419,
-      "initial_district_id": "d2",
-      "name": "Rim D12",
+      "initial_district_id": "d3",
+      "name": "Rim (-5,5)",
       "demographic_groups": [
         {
           "id": "p114-latino",
@@ -3106,11 +3106,11 @@
     {
       "id": "p115",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 4, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": 5 },
       "total_population": 1586,
-      "initial_district_id": "d3",
-      "name": "Rim E12",
+      "initial_district_id": "d4",
+      "name": "Rim (-4,5)",
       "demographic_groups": [
         {
           "id": "p115-latino",
@@ -3133,11 +3133,11 @@
     {
       "id": "p116",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 5, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -3, "r": 5 },
       "total_population": 1609,
-      "initial_district_id": "d3",
-      "name": "Rim F12",
+      "initial_district_id": "d4",
+      "name": "Rim (-3,5)",
       "demographic_groups": [
         {
           "id": "p116-latino",
@@ -3160,11 +3160,11 @@
     {
       "id": "p117",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 6, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -2, "r": 5 },
       "total_population": 1414,
-      "initial_district_id": "d4",
-      "name": "Rim G12",
+      "initial_district_id": "d5",
+      "name": "Rim (-2,5)",
       "demographic_groups": [
         {
           "id": "p117-latino",
@@ -3187,11 +3187,11 @@
     {
       "id": "p118",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 7, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": -1, "r": 5 },
       "total_population": 1406,
-      "initial_district_id": "d4",
-      "name": "Rim H12",
+      "initial_district_id": "d5",
+      "name": "Rim (-1,5)",
       "demographic_groups": [
         {
           "id": "p118-latino",
@@ -3214,11 +3214,11 @@
     {
       "id": "p119",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 8, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 0, "r": 5 },
       "total_population": 1605,
       "initial_district_id": "d5",
-      "name": "Rim I12",
+      "name": "Rim (0,5)",
       "demographic_groups": [
         {
           "id": "p119-latino",
@@ -3241,11 +3241,11 @@
     {
       "id": "p120",
       "editable": true,
-      "county_id": "valle_verde_south",
-      "position": { "q": 9, "r": 11 },
+      "county_id": "valle_verde_rim",
+      "position": { "q": 1, "r": 5 },
       "total_population": 1485,
       "initial_district_id": "d5",
-      "name": "Rim J12",
+      "name": "Rim (1,5)",
       "demographic_groups": [
         {
           "id": "p120-latino",
@@ -3261,6 +3261,195 @@
           "population_share": 0.8238,
           "turnout_rate": 0.68,
           "vote_shares": { "ken": 0.3689, "ryu": 0.6311 },
+          "dimensions": { "ethnicity": "anglo" }
+        }
+      ]
+    },
+    {
+      "id": "p121",
+      "editable": true,
+      "county_id": "valle_verde_rim",
+      "position": { "q": -6, "r": 6 },
+      "total_population": 1414,
+      "initial_district_id": "d3",
+      "name": "Rim (-6,6)",
+      "demographic_groups": [
+        {
+          "id": "p121-latino",
+          "name": "Latino residents",
+          "population_share": 0.2313,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.7603, "ryu": 0.2397 },
+          "dimensions": { "ethnicity": "latino" }
+        },
+        {
+          "id": "p121-anglo",
+          "name": "Anglo residents",
+          "population_share": 0.7687,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.3590, "ryu": 0.6410 },
+          "dimensions": { "ethnicity": "anglo" }
+        }
+      ]
+    },
+    {
+      "id": "p122",
+      "editable": true,
+      "county_id": "valle_verde_rim",
+      "position": { "q": -5, "r": 6 },
+      "total_population": 1571,
+      "initial_district_id": "d4",
+      "name": "Rim (-5,6)",
+      "demographic_groups": [
+        {
+          "id": "p122-latino",
+          "name": "Latino residents",
+          "population_share": 0.2203,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ken": 0.7977, "ryu": 0.2023 },
+          "dimensions": { "ethnicity": "latino" }
+        },
+        {
+          "id": "p122-anglo",
+          "name": "Anglo residents",
+          "population_share": 0.7797,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4090, "ryu": 0.5910 },
+          "dimensions": { "ethnicity": "anglo" }
+        }
+      ]
+    },
+    {
+      "id": "p123",
+      "editable": true,
+      "county_id": "valle_verde_rim",
+      "position": { "q": -4, "r": 6 },
+      "total_population": 1642,
+      "initial_district_id": "d4",
+      "name": "Rim (-4,6)",
+      "demographic_groups": [
+        {
+          "id": "p123-latino",
+          "name": "Latino residents",
+          "population_share": 0.2362,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.7767, "ryu": 0.2233 },
+          "dimensions": { "ethnicity": "latino" }
+        },
+        {
+          "id": "p123-anglo",
+          "name": "Anglo residents",
+          "population_share": 0.7638,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.3538, "ryu": 0.6462 },
+          "dimensions": { "ethnicity": "anglo" }
+        }
+      ]
+    },
+    {
+      "id": "p124",
+      "editable": true,
+      "county_id": "valle_verde_rim",
+      "position": { "q": -3, "r": 6 },
+      "total_population": 1627,
+      "initial_district_id": "d5",
+      "name": "Rim (-3,6)",
+      "demographic_groups": [
+        {
+          "id": "p124-latino",
+          "name": "Latino residents",
+          "population_share": 0.2169,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.7795, "ryu": 0.2205 },
+          "dimensions": { "ethnicity": "latino" }
+        },
+        {
+          "id": "p124-anglo",
+          "name": "Anglo residents",
+          "population_share": 0.7831,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4063, "ryu": 0.5937 },
+          "dimensions": { "ethnicity": "anglo" }
+        }
+      ]
+    },
+    {
+      "id": "p125",
+      "editable": true,
+      "county_id": "valle_verde_rim",
+      "position": { "q": -2, "r": 6 },
+      "total_population": 1648,
+      "initial_district_id": "d5",
+      "name": "Rim (-2,6)",
+      "demographic_groups": [
+        {
+          "id": "p125-latino",
+          "name": "Latino residents",
+          "population_share": 0.1806,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.7577, "ryu": 0.2423 },
+          "dimensions": { "ethnicity": "latino" }
+        },
+        {
+          "id": "p125-anglo",
+          "name": "Anglo residents",
+          "population_share": 0.8194,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.3821, "ryu": 0.6179 },
+          "dimensions": { "ethnicity": "anglo" }
+        }
+      ]
+    },
+    {
+      "id": "p126",
+      "editable": true,
+      "county_id": "valle_verde_rim",
+      "position": { "q": -1, "r": 6 },
+      "total_population": 1523,
+      "initial_district_id": "d5",
+      "name": "Rim (-1,6)",
+      "demographic_groups": [
+        {
+          "id": "p126-latino",
+          "name": "Latino residents",
+          "population_share": 0.2223,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.8095, "ryu": 0.1905 },
+          "dimensions": { "ethnicity": "latino" }
+        },
+        {
+          "id": "p126-anglo",
+          "name": "Anglo residents",
+          "population_share": 0.7777,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4081, "ryu": 0.5919 },
+          "dimensions": { "ethnicity": "anglo" }
+        }
+      ]
+    },
+    {
+      "id": "p127",
+      "editable": true,
+      "county_id": "valle_verde_rim",
+      "position": { "q": 0, "r": 6 },
+      "total_population": 1374,
+      "initial_district_id": "d5",
+      "name": "Rim (0,6)",
+      "demographic_groups": [
+        {
+          "id": "p127-latino",
+          "name": "Latino residents",
+          "population_share": 0.1905,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.7611, "ryu": 0.2389 },
+          "dimensions": { "ethnicity": "latino" }
+        },
+        {
+          "id": "p127-anglo",
+          "name": "Anglo residents",
+          "population_share": 0.8095,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.3605, "ryu": 0.6395 },
           "dimensions": { "ethnicity": "anglo" }
         }
       ]
@@ -3310,12 +3499,12 @@
     "character": {
       "name": "You",
       "role": "Court-Appointed Redistricting Coordinator, Valle Verde County",
-      "motivation": "A federal court found that the current district map violates the Voting Rights Act. The Valley's Latino community has been cracked across four districts — diluted so thoroughly that they cannot elect their preferred candidate anywhere. You must draw a new map that complies with the law."
+      "motivation": "A federal court found that the current district map violates the Voting Rights Act. The Valley's Latino community has been cracked across multiple districts — diluted so thoroughly that they cannot elect their preferred candidate anywhere. You must draw a new map that complies with the law."
     },
     "intro_slides": [
       {
         "heading": "The Valley Grows",
-        "body": "Over the past decade, Valle Verde County's Valley has seen significant population growth. The Latino community, concentrated in this area, now makes up a meaningful share of the county's total population.\n\nBut on the current map, drawn ten years ago, the Valley is sliced into four strips — each one a piece of a different district, none large enough to matter."
+        "body": "Over the past decade, Valle Verde County's Valley has seen significant population growth. The Latino community, concentrated in this area, now makes up a meaningful share of the county's total population.\n\nBut on the current map, drawn ten years ago, the Valley is sliced across multiple districts — each one a piece of a different district, none large enough to matter."
       },
       {
         "heading": "The Voting Rights Act",

--- a/game/scenarios/scenario-006.json
+++ b/game/scenarios/scenario-006.json
@@ -25,10 +25,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 0 },
+      "position": { "q": 0, "r": -6 },
       "total_population": 1562,
       "initial_district_id": "d1",
-      "name": "West A1",
+      "name": "West (0,-6)",
       "demographic_groups": [
         {
           "id": "p001-all",
@@ -42,90 +42,90 @@
     {
       "id": "p002",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 0 },
+      "county_id": "eastbrook",
+      "position": { "q": 1, "r": -6 },
       "total_population": 1611,
-      "initial_district_id": "d2",
-      "name": "West B1",
+      "initial_district_id": "d1",
+      "name": "East (1,-6)",
       "demographic_groups": [
         {
           "id": "p002-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6277, "ryu": 0.3723 }
+          "vote_shares": { "ken": 0.3877, "ryu": 0.6123 }
         }
       ]
     },
     {
       "id": "p003",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 2, "r": 0 },
+      "county_id": "eastbrook",
+      "position": { "q": 2, "r": -6 },
       "total_population": 1490,
-      "initial_district_id": "d3",
-      "name": "West C1",
+      "initial_district_id": "d2",
+      "name": "East (2,-6)",
       "demographic_groups": [
         {
           "id": "p003-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5943, "ryu": 0.4057 }
+          "vote_shares": { "ken": 0.3543, "ryu": 0.6457 }
         }
       ]
     },
     {
       "id": "p004",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 3, "r": 0 },
+      "county_id": "eastbrook",
+      "position": { "q": 3, "r": -6 },
       "total_population": 1581,
-      "initial_district_id": "d4",
-      "name": "West D1",
+      "initial_district_id": "d2",
+      "name": "East (3,-6)",
       "demographic_groups": [
         {
           "id": "p004-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6174, "ryu": 0.3826 }
+          "vote_shares": { "ken": 0.3774, "ryu": 0.6226 }
         }
       ]
     },
     {
       "id": "p005",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 4, "r": 0 },
+      "county_id": "eastbrook",
+      "position": { "q": 4, "r": -6 },
       "total_population": 1574,
-      "initial_district_id": "d5",
-      "name": "West E1",
+      "initial_district_id": "d2",
+      "name": "East (4,-6)",
       "demographic_groups": [
         {
           "id": "p005-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6077, "ryu": 0.3923 }
+          "vote_shares": { "ken": 0.3677, "ryu": 0.6323 }
         }
       ]
     },
     {
       "id": "p006",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 5, "r": 0 },
+      "county_id": "eastbrook",
+      "position": { "q": 5, "r": -6 },
       "total_population": 1480,
-      "initial_district_id": "d5",
-      "name": "West F1",
+      "initial_district_id": "d2",
+      "name": "East (5,-6)",
       "demographic_groups": [
         {
           "id": "p006-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6347, "ryu": 0.3653 }
+          "vote_shares": { "ken": 0.3947, "ryu": 0.6053 }
         }
       ]
     },
@@ -133,10 +133,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": 0 },
+      "position": { "q": 6, "r": -6 },
       "total_population": 1548,
-      "initial_district_id": "d4",
-      "name": "East G1",
+      "initial_district_id": "d2",
+      "name": "East (6,-6)",
       "demographic_groups": [
         {
           "id": "p007-all",
@@ -150,36 +150,36 @@
     {
       "id": "p008",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 0 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": -5 },
       "total_population": 1376,
-      "initial_district_id": "d3",
-      "name": "East H1",
+      "initial_district_id": "d1",
+      "name": "West (-1,-5)",
       "demographic_groups": [
         {
           "id": "p008-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3412, "ryu": 0.6588 }
+          "vote_shares": { "ken": 0.5812, "ryu": 0.4188 }
         }
       ]
     },
     {
       "id": "p009",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 8, "r": 0 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": -5 },
       "total_population": 1431,
-      "initial_district_id": "d2",
-      "name": "East I1",
+      "initial_district_id": "d1",
+      "name": "West (0,-5)",
       "demographic_groups": [
         {
           "id": "p009-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.3748, "ryu": 0.6252 }
+          "vote_shares": { "ken": 0.6148, "ryu": 0.3852 }
         }
       ]
     },
@@ -187,10 +187,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 9, "r": 0 },
+      "position": { "q": 1, "r": -5 },
       "total_population": 1571,
       "initial_district_id": "d1",
-      "name": "East J1",
+      "name": "East (1,-5)",
       "demographic_groups": [
         {
           "id": "p010-all",
@@ -204,90 +204,90 @@
     {
       "id": "p011",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 0, "r": 1 },
+      "county_id": "eastbrook",
+      "position": { "q": 2, "r": -5 },
       "total_population": 1574,
-      "initial_district_id": "d1",
-      "name": "West A2",
+      "initial_district_id": "d2",
+      "name": "East (2,-5)",
       "demographic_groups": [
         {
           "id": "p011-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6166, "ryu": 0.3834 }
+          "vote_shares": { "ken": 0.3766, "ryu": 0.6234 }
         }
       ]
     },
     {
       "id": "p012",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 1 },
+      "county_id": "eastbrook",
+      "position": { "q": 3, "r": -5 },
       "total_population": 1378,
       "initial_district_id": "d2",
-      "name": "West B2",
+      "name": "East (3,-5)",
       "demographic_groups": [
         {
           "id": "p012-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6016, "ryu": 0.3984 }
+          "vote_shares": { "ken": 0.3616, "ryu": 0.6384 }
         }
       ]
     },
     {
       "id": "p013",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 2, "r": 1 },
+      "county_id": "eastbrook",
+      "position": { "q": 4, "r": -5 },
       "total_population": 1593,
-      "initial_district_id": "d3",
-      "name": "West C2",
+      "initial_district_id": "d2",
+      "name": "East (4,-5)",
       "demographic_groups": [
         {
           "id": "p013-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5897, "ryu": 0.4103 }
+          "vote_shares": { "ken": 0.3497, "ryu": 0.6503 }
         }
       ]
     },
     {
       "id": "p014",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 3, "r": 1 },
+      "county_id": "eastbrook",
+      "position": { "q": 5, "r": -5 },
       "total_population": 1597,
-      "initial_district_id": "d4",
-      "name": "West D2",
+      "initial_district_id": "d2",
+      "name": "East (5,-5)",
       "demographic_groups": [
         {
           "id": "p014-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5823, "ryu": 0.4177 }
+          "vote_shares": { "ken": 0.3423, "ryu": 0.6577 }
         }
       ]
     },
     {
       "id": "p015",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 4, "r": 1 },
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": -5 },
       "total_population": 1456,
-      "initial_district_id": "d5",
-      "name": "West E2",
+      "initial_district_id": "d2",
+      "name": "East (6,-5)",
       "demographic_groups": [
         {
           "id": "p015-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6457, "ryu": 0.3543 }
+          "vote_shares": { "ken": 0.4057, "ryu": 0.5943 }
         }
       ]
     },
@@ -295,10 +295,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 1 },
+      "position": { "q": -2, "r": -4 },
       "total_population": 1511,
-      "initial_district_id": "d5",
-      "name": "West F2",
+      "initial_district_id": "d1",
+      "name": "West (-2,-4)",
       "demographic_groups": [
         {
           "id": "p016-all",
@@ -312,36 +312,36 @@
     {
       "id": "p017",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 1 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": -4 },
       "total_population": 1511,
-      "initial_district_id": "d4",
-      "name": "East G2",
+      "initial_district_id": "d1",
+      "name": "West (-1,-4)",
       "demographic_groups": [
         {
           "id": "p017-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3968, "ryu": 0.6032 }
+          "vote_shares": { "ken": 0.6368, "ryu": 0.3632 }
         }
       ]
     },
     {
       "id": "p018",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 1 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": -4 },
       "total_population": 1535,
-      "initial_district_id": "d3",
-      "name": "East H2",
+      "initial_district_id": "d1",
+      "name": "West (0,-4)",
       "demographic_groups": [
         {
           "id": "p018-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3915, "ryu": 0.6085 }
+          "vote_shares": { "ken": 0.6315, "ryu": 0.3685 }
         }
       ]
     },
@@ -349,10 +349,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 8, "r": 1 },
+      "position": { "q": 1, "r": -4 },
       "total_population": 1431,
       "initial_district_id": "d2",
-      "name": "East I2",
+      "name": "East (1,-4)",
       "demographic_groups": [
         {
           "id": "p019-all",
@@ -367,10 +367,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 9, "r": 1 },
+      "position": { "q": 2, "r": -4 },
       "total_population": 1353,
-      "initial_district_id": "d1",
-      "name": "East J2",
+      "initial_district_id": "d2",
+      "name": "East (2,-4)",
       "demographic_groups": [
         {
           "id": "p020-all",
@@ -384,72 +384,72 @@
     {
       "id": "p021",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 0, "r": 2 },
+      "county_id": "eastbrook",
+      "position": { "q": 3, "r": -4 },
       "total_population": 1528,
-      "initial_district_id": "d1",
-      "name": "West A3",
+      "initial_district_id": "d2",
+      "name": "East (3,-4)",
       "demographic_groups": [
         {
           "id": "p021-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6437, "ryu": 0.3563 }
+          "vote_shares": { "ken": 0.4037, "ryu": 0.5963 }
         }
       ]
     },
     {
       "id": "p022",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 2 },
+      "county_id": "eastbrook",
+      "position": { "q": 4, "r": -4 },
       "total_population": 1397,
       "initial_district_id": "d2",
-      "name": "West B3",
+      "name": "East (4,-4)",
       "demographic_groups": [
         {
           "id": "p022-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6163, "ryu": 0.3837 }
+          "vote_shares": { "ken": 0.3763, "ryu": 0.6237 }
         }
       ]
     },
     {
       "id": "p023",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 2, "r": 2 },
+      "county_id": "eastbrook",
+      "position": { "q": 5, "r": -4 },
       "total_population": 1385,
-      "initial_district_id": "d3",
-      "name": "West C3",
+      "initial_district_id": "d2",
+      "name": "East (5,-4)",
       "demographic_groups": [
         {
           "id": "p023-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6574, "ryu": 0.3426 }
+          "vote_shares": { "ken": 0.4174, "ryu": 0.5826 }
         }
       ]
     },
     {
       "id": "p024",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 3, "r": 2 },
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": -4 },
       "total_population": 1378,
-      "initial_district_id": "d4",
-      "name": "West D3",
+      "initial_district_id": "d2",
+      "name": "East (6,-4)",
       "demographic_groups": [
         {
           "id": "p024-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6301, "ryu": 0.3699 }
+          "vote_shares": { "ken": 0.3901, "ryu": 0.6099 }
         }
       ]
     },
@@ -457,10 +457,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 4, "r": 2 },
+      "position": { "q": -3, "r": -3 },
       "total_population": 1500,
-      "initial_district_id": "d5",
-      "name": "West E3",
+      "initial_district_id": "d1",
+      "name": "West (-3,-3)",
       "demographic_groups": [
         {
           "id": "p025-all",
@@ -475,10 +475,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 2 },
+      "position": { "q": -2, "r": -3 },
       "total_population": 1501,
-      "initial_district_id": "d5",
-      "name": "West F3",
+      "initial_district_id": "d1",
+      "name": "West (-2,-3)",
       "demographic_groups": [
         {
           "id": "p026-all",
@@ -492,36 +492,36 @@
     {
       "id": "p027",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 2 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": -3 },
       "total_population": 1373,
-      "initial_district_id": "d4",
-      "name": "East G3",
+      "initial_district_id": "d1",
+      "name": "West (-1,-3)",
       "demographic_groups": [
         {
           "id": "p027-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3875, "ryu": 0.6125 }
+          "vote_shares": { "ken": 0.6275, "ryu": 0.3725 }
         }
       ]
     },
     {
       "id": "p028",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 2 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": -3 },
       "total_population": 1569,
-      "initial_district_id": "d3",
-      "name": "East H3",
+      "initial_district_id": "d1",
+      "name": "West (0,-3)",
       "demographic_groups": [
         {
           "id": "p028-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.3603, "ryu": 0.6397 }
+          "vote_shares": { "ken": 0.6003, "ryu": 0.3997 }
         }
       ]
     },
@@ -529,10 +529,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 8, "r": 2 },
+      "position": { "q": 1, "r": -3 },
       "total_population": 1535,
       "initial_district_id": "d2",
-      "name": "East I3",
+      "name": "East (1,-3)",
       "demographic_groups": [
         {
           "id": "p029-all",
@@ -547,10 +547,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 9, "r": 2 },
+      "position": { "q": 2, "r": -3 },
       "total_population": 1452,
-      "initial_district_id": "d1",
-      "name": "East J3",
+      "initial_district_id": "d2",
+      "name": "East (2,-3)",
       "demographic_groups": [
         {
           "id": "p030-all",
@@ -564,72 +564,72 @@
     {
       "id": "p031",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 0, "r": 3 },
+      "county_id": "eastbrook",
+      "position": { "q": 3, "r": -3 },
       "total_population": 1524,
-      "initial_district_id": "d1",
-      "name": "West A4",
+      "initial_district_id": "d2",
+      "name": "East (3,-3)",
       "demographic_groups": [
         {
           "id": "p031-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5998, "ryu": 0.4002 }
+          "vote_shares": { "ken": 0.3598, "ryu": 0.6402 }
         }
       ]
     },
     {
       "id": "p032",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 3 },
+      "county_id": "eastbrook",
+      "position": { "q": 4, "r": -3 },
       "total_population": 1471,
       "initial_district_id": "d2",
-      "name": "West B4",
+      "name": "East (4,-3)",
       "demographic_groups": [
         {
           "id": "p032-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6056, "ryu": 0.3944 }
+          "vote_shares": { "ken": 0.3656, "ryu": 0.6344 }
         }
       ]
     },
     {
       "id": "p033",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 2, "r": 3 },
+      "county_id": "eastbrook",
+      "position": { "q": 5, "r": -3 },
       "total_population": 1613,
-      "initial_district_id": "d3",
-      "name": "West C4",
+      "initial_district_id": "d2",
+      "name": "East (5,-3)",
       "demographic_groups": [
         {
           "id": "p033-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6052, "ryu": 0.3948 }
+          "vote_shares": { "ken": 0.3652, "ryu": 0.6348 }
         }
       ]
     },
     {
       "id": "p034",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 3, "r": 3 },
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": -3 },
       "total_population": 1377,
-      "initial_district_id": "d4",
-      "name": "West D4",
+      "initial_district_id": "d3",
+      "name": "East (6,-3)",
       "demographic_groups": [
         {
           "id": "p034-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6205, "ryu": 0.3795 }
+          "vote_shares": { "ken": 0.3805, "ryu": 0.6195 }
         }
       ]
     },
@@ -637,10 +637,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 4, "r": 3 },
+      "position": { "q": -4, "r": -2 },
       "total_population": 1475,
-      "initial_district_id": "d5",
-      "name": "West E4",
+      "initial_district_id": "d1",
+      "name": "West (-4,-2)",
       "demographic_groups": [
         {
           "id": "p035-all",
@@ -655,10 +655,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 3 },
+      "position": { "q": -3, "r": -2 },
       "total_population": 1519,
-      "initial_district_id": "d5",
-      "name": "West F4",
+      "initial_district_id": "d1",
+      "name": "West (-3,-2)",
       "demographic_groups": [
         {
           "id": "p036-all",
@@ -672,54 +672,54 @@
     {
       "id": "p037",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 3 },
+      "county_id": "westbrook",
+      "position": { "q": -2, "r": -2 },
       "total_population": 1553,
-      "initial_district_id": "d4",
-      "name": "East G4",
+      "initial_district_id": "d1",
+      "name": "West (-2,-2)",
       "demographic_groups": [
         {
           "id": "p037-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3585, "ryu": 0.6415 }
+          "vote_shares": { "ken": 0.5985, "ryu": 0.4015 }
         }
       ]
     },
     {
       "id": "p038",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 3 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": -2 },
       "total_population": 1546,
-      "initial_district_id": "d3",
-      "name": "East H4",
+      "initial_district_id": "d1",
+      "name": "West (-1,-2)",
       "demographic_groups": [
         {
           "id": "p038-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4096, "ryu": 0.5904 }
+          "vote_shares": { "ken": 0.6496, "ryu": 0.3504 }
         }
       ]
     },
     {
       "id": "p039",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 8, "r": 3 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": -2 },
       "total_population": 1599,
-      "initial_district_id": "d2",
-      "name": "East I4",
+      "initial_district_id": "d1",
+      "name": "West (0,-2)",
       "demographic_groups": [
         {
           "id": "p039-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4019, "ryu": 0.5981 }
+          "vote_shares": { "ken": 0.6419, "ryu": 0.3581 }
         }
       ]
     },
@@ -727,10 +727,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 9, "r": 3 },
+      "position": { "q": 1, "r": -2 },
       "total_population": 1547,
-      "initial_district_id": "d1",
-      "name": "East J4",
+      "initial_district_id": "d2",
+      "name": "East (1,-2)",
       "demographic_groups": [
         {
           "id": "p040-all",
@@ -744,90 +744,90 @@
     {
       "id": "p041",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 0, "r": 4 },
+      "county_id": "eastbrook",
+      "position": { "q": 2, "r": -2 },
       "total_population": 1567,
-      "initial_district_id": "d1",
-      "name": "West A5",
+      "initial_district_id": "d2",
+      "name": "East (2,-2)",
       "demographic_groups": [
         {
           "id": "p041-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6398, "ryu": 0.3602 }
+          "vote_shares": { "ken": 0.3998, "ryu": 0.6002 }
         }
       ]
     },
     {
       "id": "p042",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 4 },
+      "county_id": "eastbrook",
+      "position": { "q": 3, "r": -2 },
       "total_population": 1619,
       "initial_district_id": "d2",
-      "name": "West B5",
+      "name": "East (3,-2)",
       "demographic_groups": [
         {
           "id": "p042-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6265, "ryu": 0.3735 }
+          "vote_shares": { "ken": 0.3865, "ryu": 0.6135 }
         }
       ]
     },
     {
       "id": "p043",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 2, "r": 4 },
+      "county_id": "eastbrook",
+      "position": { "q": 4, "r": -2 },
       "total_population": 1362,
       "initial_district_id": "d3",
-      "name": "West C5",
+      "name": "East (4,-2)",
       "demographic_groups": [
         {
           "id": "p043-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6038, "ryu": 0.3962 }
+          "vote_shares": { "ken": 0.3638, "ryu": 0.6362 }
         }
       ]
     },
     {
       "id": "p044",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 3, "r": 4 },
+      "county_id": "eastbrook",
+      "position": { "q": 5, "r": -2 },
       "total_population": 1374,
-      "initial_district_id": "d4",
-      "name": "West D5",
+      "initial_district_id": "d3",
+      "name": "East (5,-2)",
       "demographic_groups": [
         {
           "id": "p044-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6554, "ryu": 0.3446 }
+          "vote_shares": { "ken": 0.4154, "ryu": 0.5846 }
         }
       ]
     },
     {
       "id": "p045",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 4, "r": 4 },
+      "county_id": "eastbrook",
+      "position": { "q": 6, "r": -2 },
       "total_population": 1614,
-      "initial_district_id": "d5",
-      "name": "West E5",
+      "initial_district_id": "d3",
+      "name": "East (6,-2)",
       "demographic_groups": [
         {
           "id": "p045-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6483, "ryu": 0.3517 }
+          "vote_shares": { "ken": 0.4083, "ryu": 0.5917 }
         }
       ]
     },
@@ -835,10 +835,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 4 },
+      "position": { "q": -5, "r": -1 },
       "total_population": 1371,
-      "initial_district_id": "d5",
-      "name": "West F5",
+      "initial_district_id": "d1",
+      "name": "West (-5,-1)",
       "demographic_groups": [
         {
           "id": "p046-all",
@@ -852,72 +852,72 @@
     {
       "id": "p047",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 4 },
+      "county_id": "westbrook",
+      "position": { "q": -4, "r": -1 },
       "total_population": 1617,
-      "initial_district_id": "d4",
-      "name": "East G5",
+      "initial_district_id": "d1",
+      "name": "West (-4,-1)",
       "demographic_groups": [
         {
           "id": "p047-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4086, "ryu": 0.5914 }
+          "vote_shares": { "ken": 0.6486, "ryu": 0.3514 }
         }
       ]
     },
     {
       "id": "p048",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 4 },
+      "county_id": "westbrook",
+      "position": { "q": -3, "r": -1 },
       "total_population": 1570,
-      "initial_district_id": "d3",
-      "name": "East H5",
+      "initial_district_id": "d1",
+      "name": "West (-3,-1)",
       "demographic_groups": [
         {
           "id": "p048-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.3744, "ryu": 0.6256 }
+          "vote_shares": { "ken": 0.6144, "ryu": 0.3856 }
         }
       ]
     },
     {
       "id": "p049",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 8, "r": 4 },
+      "county_id": "westbrook",
+      "position": { "q": -2, "r": -1 },
       "total_population": 1480,
-      "initial_district_id": "d2",
-      "name": "East I5",
+      "initial_district_id": "d1",
+      "name": "West (-2,-1)",
       "demographic_groups": [
         {
           "id": "p049-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.3856, "ryu": 0.6144 }
+          "vote_shares": { "ken": 0.6256, "ryu": 0.3744 }
         }
       ]
     },
     {
       "id": "p050",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 9, "r": 4 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": -1 },
       "total_population": 1533,
       "initial_district_id": "d1",
-      "name": "East J5",
+      "name": "West (-1,-1)",
       "demographic_groups": [
         {
           "id": "p050-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.3669, "ryu": 0.6331 }
+          "vote_shares": { "ken": 0.6069, "ryu": 0.3931 }
         }
       ]
     },
@@ -925,10 +925,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 5 },
+      "position": { "q": 0, "r": -1 },
       "total_population": 1377,
       "initial_district_id": "d1",
-      "name": "West A6",
+      "name": "West (0,-1)",
       "demographic_groups": [
         {
           "id": "p051-all",
@@ -942,90 +942,90 @@
     {
       "id": "p052",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 5 },
+      "county_id": "eastbrook",
+      "position": { "q": 1, "r": -1 },
       "total_population": 1592,
       "initial_district_id": "d2",
-      "name": "West B6",
+      "name": "East (1,-1)",
       "demographic_groups": [
         {
           "id": "p052-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.5894, "ryu": 0.4106 }
+          "vote_shares": { "ken": 0.3494, "ryu": 0.6506 }
         }
       ]
     },
     {
       "id": "p053",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 2, "r": 5 },
+      "county_id": "eastbrook",
+      "position": { "q": 2, "r": -1 },
       "total_population": 1501,
       "initial_district_id": "d3",
-      "name": "West C6",
+      "name": "East (2,-1)",
       "demographic_groups": [
         {
           "id": "p053-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6370, "ryu": 0.3630 }
+          "vote_shares": { "ken": 0.3970, "ryu": 0.6030 }
         }
       ]
     },
     {
       "id": "p054",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 3, "r": 5 },
+      "county_id": "eastbrook",
+      "position": { "q": 3, "r": -1 },
       "total_population": 1473,
-      "initial_district_id": "d4",
-      "name": "West D6",
+      "initial_district_id": "d3",
+      "name": "East (3,-1)",
       "demographic_groups": [
         {
           "id": "p054-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5923, "ryu": 0.4077 }
+          "vote_shares": { "ken": 0.3523, "ryu": 0.6477 }
         }
       ]
     },
     {
       "id": "p055",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 4, "r": 5 },
+      "county_id": "eastbrook",
+      "position": { "q": 4, "r": -1 },
       "total_population": 1381,
-      "initial_district_id": "d5",
-      "name": "West E6",
+      "initial_district_id": "d3",
+      "name": "East (4,-1)",
       "demographic_groups": [
         {
           "id": "p055-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6063, "ryu": 0.3937 }
+          "vote_shares": { "ken": 0.3663, "ryu": 0.6337 }
         }
       ]
     },
     {
       "id": "p056",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 5, "r": 5 },
+      "county_id": "eastbrook",
+      "position": { "q": 5, "r": -1 },
       "total_population": 1359,
-      "initial_district_id": "d5",
-      "name": "West F6",
+      "initial_district_id": "d3",
+      "name": "East (5,-1)",
       "demographic_groups": [
         {
           "id": "p056-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6104, "ryu": 0.3896 }
+          "vote_shares": { "ken": 0.3704, "ryu": 0.6296 }
         }
       ]
     },
@@ -1033,10 +1033,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": 5 },
+      "position": { "q": 6, "r": -1 },
       "total_population": 1627,
-      "initial_district_id": "d4",
-      "name": "East G6",
+      "initial_district_id": "d3",
+      "name": "East (6,-1)",
       "demographic_groups": [
         {
           "id": "p057-all",
@@ -1050,54 +1050,54 @@
     {
       "id": "p058",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 5 },
+      "county_id": "westbrook",
+      "position": { "q": -6, "r": 0 },
       "total_population": 1411,
-      "initial_district_id": "d3",
-      "name": "East H6",
+      "initial_district_id": "d5",
+      "name": "West (-6,0)",
       "demographic_groups": [
         {
           "id": "p058-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4077, "ryu": 0.5923 }
+          "vote_shares": { "ken": 0.6477, "ryu": 0.3523 }
         }
       ]
     },
     {
       "id": "p059",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 8, "r": 5 },
+      "county_id": "westbrook",
+      "position": { "q": -5, "r": 0 },
       "total_population": 1420,
-      "initial_district_id": "d2",
-      "name": "East I6",
+      "initial_district_id": "d5",
+      "name": "West (-5,0)",
       "demographic_groups": [
         {
           "id": "p059-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3609, "ryu": 0.6391 }
+          "vote_shares": { "ken": 0.6009, "ryu": 0.3991 }
         }
       ]
     },
     {
       "id": "p060",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 9, "r": 5 },
+      "county_id": "westbrook",
+      "position": { "q": -4, "r": 0 },
       "total_population": 1524,
-      "initial_district_id": "d1",
-      "name": "East J6",
+      "initial_district_id": "d5",
+      "name": "West (-4,0)",
       "demographic_groups": [
         {
           "id": "p060-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.3793, "ryu": 0.6207 }
+          "vote_shares": { "ken": 0.6193, "ryu": 0.3807 }
         }
       ]
     },
@@ -1105,10 +1105,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 6 },
+      "position": { "q": -3, "r": 0 },
       "total_population": 1394,
-      "initial_district_id": "d1",
-      "name": "West A7",
+      "initial_district_id": "d5",
+      "name": "West (-3,0)",
       "demographic_groups": [
         {
           "id": "p061-all",
@@ -1123,10 +1123,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 1, "r": 6 },
+      "position": { "q": -2, "r": 0 },
       "total_population": 1353,
-      "initial_district_id": "d2",
-      "name": "West B7",
+      "initial_district_id": "d5",
+      "name": "West (-2,0)",
       "demographic_groups": [
         {
           "id": "p062-all",
@@ -1141,10 +1141,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 2, "r": 6 },
+      "position": { "q": -1, "r": 0 },
       "total_population": 1611,
-      "initial_district_id": "d3",
-      "name": "West C7",
+      "initial_district_id": "d5",
+      "name": "West (-1,0)",
       "demographic_groups": [
         {
           "id": "p063-all",
@@ -1159,10 +1159,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 3, "r": 6 },
+      "position": { "q": 0, "r": 0 },
       "total_population": 1603,
-      "initial_district_id": "d4",
-      "name": "West D7",
+      "initial_district_id": "d3",
+      "name": "West (0,0)",
       "demographic_groups": [
         {
           "id": "p064-all",
@@ -1176,36 +1176,36 @@
     {
       "id": "p065",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 4, "r": 6 },
+      "county_id": "eastbrook",
+      "position": { "q": 1, "r": 0 },
       "total_population": 1573,
-      "initial_district_id": "d5",
-      "name": "West E7",
+      "initial_district_id": "d3",
+      "name": "East (1,0)",
       "demographic_groups": [
         {
           "id": "p065-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6148, "ryu": 0.3852 }
+          "vote_shares": { "ken": 0.3748, "ryu": 0.6252 }
         }
       ]
     },
     {
       "id": "p066",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 5, "r": 6 },
+      "county_id": "eastbrook",
+      "position": { "q": 2, "r": 0 },
       "total_population": 1625,
-      "initial_district_id": "d5",
-      "name": "West F7",
+      "initial_district_id": "d3",
+      "name": "East (2,0)",
       "demographic_groups": [
         {
           "id": "p066-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6481, "ryu": 0.3519 }
+          "vote_shares": { "ken": 0.4081, "ryu": 0.5919 }
         }
       ]
     },
@@ -1213,10 +1213,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": 6 },
+      "position": { "q": 3, "r": 0 },
       "total_population": 1474,
-      "initial_district_id": "d4",
-      "name": "East G7",
+      "initial_district_id": "d3",
+      "name": "East (3,0)",
       "demographic_groups": [
         {
           "id": "p067-all",
@@ -1231,10 +1231,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 7, "r": 6 },
+      "position": { "q": 4, "r": 0 },
       "total_population": 1443,
       "initial_district_id": "d3",
-      "name": "East H7",
+      "name": "East (4,0)",
       "demographic_groups": [
         {
           "id": "p068-all",
@@ -1249,10 +1249,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 8, "r": 6 },
+      "position": { "q": 5, "r": 0 },
       "total_population": 1568,
-      "initial_district_id": "d2",
-      "name": "East I7",
+      "initial_district_id": "d3",
+      "name": "East (5,0)",
       "demographic_groups": [
         {
           "id": "p069-all",
@@ -1267,10 +1267,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 9, "r": 6 },
+      "position": { "q": 6, "r": 0 },
       "total_population": 1474,
-      "initial_district_id": "d1",
-      "name": "East J7",
+      "initial_district_id": "d3",
+      "name": "East (6,0)",
       "demographic_groups": [
         {
           "id": "p070-all",
@@ -1285,10 +1285,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 7 },
+      "position": { "q": -6, "r": 1 },
       "total_population": 1411,
-      "initial_district_id": "d1",
-      "name": "West A8",
+      "initial_district_id": "d5",
+      "name": "West (-6,1)",
       "demographic_groups": [
         {
           "id": "p071-all",
@@ -1303,10 +1303,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 1, "r": 7 },
+      "position": { "q": -5, "r": 1 },
       "total_population": 1430,
-      "initial_district_id": "d2",
-      "name": "West B8",
+      "initial_district_id": "d5",
+      "name": "West (-5,1)",
       "demographic_groups": [
         {
           "id": "p072-all",
@@ -1321,10 +1321,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 2, "r": 7 },
+      "position": { "q": -4, "r": 1 },
       "total_population": 1571,
-      "initial_district_id": "d3",
-      "name": "West C8",
+      "initial_district_id": "d5",
+      "name": "West (-4,1)",
       "demographic_groups": [
         {
           "id": "p073-all",
@@ -1339,10 +1339,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 3, "r": 7 },
+      "position": { "q": -3, "r": 1 },
       "total_population": 1556,
-      "initial_district_id": "d4",
-      "name": "West D8",
+      "initial_district_id": "d5",
+      "name": "West (-3,1)",
       "demographic_groups": [
         {
           "id": "p074-all",
@@ -1357,10 +1357,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 4, "r": 7 },
+      "position": { "q": -2, "r": 1 },
       "total_population": 1597,
       "initial_district_id": "d5",
-      "name": "West E8",
+      "name": "West (-2,1)",
       "demographic_groups": [
         {
           "id": "p075-all",
@@ -1375,10 +1375,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 7 },
+      "position": { "q": -1, "r": 1 },
       "total_population": 1354,
       "initial_district_id": "d5",
-      "name": "West F8",
+      "name": "West (-1,1)",
       "demographic_groups": [
         {
           "id": "p076-all",
@@ -1392,18 +1392,18 @@
     {
       "id": "p077",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 7 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 1 },
       "total_population": 1541,
       "initial_district_id": "d4",
-      "name": "East G8",
+      "name": "West (0,1)",
       "demographic_groups": [
         {
           "id": "p077-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4026, "ryu": 0.5974 }
+          "vote_shares": { "ken": 0.6426, "ryu": 0.3574 }
         }
       ]
     },
@@ -1411,10 +1411,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 7, "r": 7 },
+      "position": { "q": 1, "r": 1 },
       "total_population": 1607,
       "initial_district_id": "d3",
-      "name": "East H8",
+      "name": "East (1,1)",
       "demographic_groups": [
         {
           "id": "p078-all",
@@ -1429,10 +1429,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 8, "r": 7 },
+      "position": { "q": 2, "r": 1 },
       "total_population": 1632,
-      "initial_district_id": "d2",
-      "name": "East I8",
+      "initial_district_id": "d3",
+      "name": "East (2,1)",
       "demographic_groups": [
         {
           "id": "p079-all",
@@ -1447,10 +1447,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 9, "r": 7 },
+      "position": { "q": 3, "r": 1 },
       "total_population": 1495,
-      "initial_district_id": "d1",
-      "name": "East J8",
+      "initial_district_id": "d3",
+      "name": "East (3,1)",
       "demographic_groups": [
         {
           "id": "p080-all",
@@ -1464,36 +1464,36 @@
     {
       "id": "p081",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 0, "r": 8 },
+      "county_id": "eastbrook",
+      "position": { "q": 4, "r": 1 },
       "total_population": 1384,
-      "initial_district_id": "d1",
-      "name": "West A9",
+      "initial_district_id": "d3",
+      "name": "East (4,1)",
       "demographic_groups": [
         {
           "id": "p081-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6323, "ryu": 0.3677 }
+          "vote_shares": { "ken": 0.3923, "ryu": 0.6077 }
         }
       ]
     },
     {
       "id": "p082",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 8 },
+      "county_id": "eastbrook",
+      "position": { "q": 5, "r": 1 },
       "total_population": 1400,
-      "initial_district_id": "d2",
-      "name": "West B9",
+      "initial_district_id": "d3",
+      "name": "East (5,1)",
       "demographic_groups": [
         {
           "id": "p082-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6369, "ryu": 0.3631 }
+          "vote_shares": { "ken": 0.3969, "ryu": 0.6031 }
         }
       ]
     },
@@ -1501,10 +1501,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 2, "r": 8 },
+      "position": { "q": -6, "r": 2 },
       "total_population": 1389,
-      "initial_district_id": "d3",
-      "name": "West C9",
+      "initial_district_id": "d5",
+      "name": "West (-6,2)",
       "demographic_groups": [
         {
           "id": "p083-all",
@@ -1519,10 +1519,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 3, "r": 8 },
+      "position": { "q": -5, "r": 2 },
       "total_population": 1542,
-      "initial_district_id": "d4",
-      "name": "West D9",
+      "initial_district_id": "d5",
+      "name": "West (-5,2)",
       "demographic_groups": [
         {
           "id": "p084-all",
@@ -1537,10 +1537,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 4, "r": 8 },
+      "position": { "q": -4, "r": 2 },
       "total_population": 1650,
       "initial_district_id": "d5",
-      "name": "West E9",
+      "name": "West (-4,2)",
       "demographic_groups": [
         {
           "id": "p085-all",
@@ -1555,10 +1555,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 8 },
+      "position": { "q": -3, "r": 2 },
       "total_population": 1430,
       "initial_district_id": "d5",
-      "name": "West F9",
+      "name": "West (-3,2)",
       "demographic_groups": [
         {
           "id": "p086-all",
@@ -1572,54 +1572,54 @@
     {
       "id": "p087",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 8 },
+      "county_id": "westbrook",
+      "position": { "q": -2, "r": 2 },
       "total_population": 1357,
-      "initial_district_id": "d4",
-      "name": "East G9",
+      "initial_district_id": "d5",
+      "name": "West (-2,2)",
       "demographic_groups": [
         {
           "id": "p087-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3713, "ryu": 0.6287 }
+          "vote_shares": { "ken": 0.6113, "ryu": 0.3887 }
         }
       ]
     },
     {
       "id": "p088",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 8 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": 2 },
       "total_population": 1437,
-      "initial_district_id": "d3",
-      "name": "East H9",
+      "initial_district_id": "d4",
+      "name": "West (-1,2)",
       "demographic_groups": [
         {
           "id": "p088-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4199, "ryu": 0.5801 }
+          "vote_shares": { "ken": 0.6599, "ryu": 0.3401 }
         }
       ]
     },
     {
       "id": "p089",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 8, "r": 8 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 2 },
       "total_population": 1589,
-      "initial_district_id": "d2",
-      "name": "East I9",
+      "initial_district_id": "d4",
+      "name": "West (0,2)",
       "demographic_groups": [
         {
           "id": "p089-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3921, "ryu": 0.6079 }
+          "vote_shares": { "ken": 0.6321, "ryu": 0.3679 }
         }
       ]
     },
@@ -1627,10 +1627,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 9, "r": 8 },
+      "position": { "q": 1, "r": 2 },
       "total_population": 1488,
-      "initial_district_id": "d1",
-      "name": "East J9",
+      "initial_district_id": "d4",
+      "name": "East (1,2)",
       "demographic_groups": [
         {
           "id": "p090-all",
@@ -1644,54 +1644,54 @@
     {
       "id": "p091",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 0, "r": 9 },
+      "county_id": "eastbrook",
+      "position": { "q": 2, "r": 2 },
       "total_population": 1581,
-      "initial_district_id": "d1",
-      "name": "West A10",
+      "initial_district_id": "d3",
+      "name": "East (2,2)",
       "demographic_groups": [
         {
           "id": "p091-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5863, "ryu": 0.4137 }
+          "vote_shares": { "ken": 0.3463, "ryu": 0.6537 }
         }
       ]
     },
     {
       "id": "p092",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 9 },
+      "county_id": "eastbrook",
+      "position": { "q": 3, "r": 2 },
       "total_population": 1422,
-      "initial_district_id": "d2",
-      "name": "West B10",
+      "initial_district_id": "d3",
+      "name": "East (3,2)",
       "demographic_groups": [
         {
           "id": "p092-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6176, "ryu": 0.3824 }
+          "vote_shares": { "ken": 0.3776, "ryu": 0.6224 }
         }
       ]
     },
     {
       "id": "p093",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 2, "r": 9 },
+      "county_id": "eastbrook",
+      "position": { "q": 4, "r": 2 },
       "total_population": 1398,
       "initial_district_id": "d3",
-      "name": "West C10",
+      "name": "East (4,2)",
       "demographic_groups": [
         {
           "id": "p093-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6055, "ryu": 0.3945 }
+          "vote_shares": { "ken": 0.3655, "ryu": 0.6345 }
         }
       ]
     },
@@ -1699,10 +1699,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 3, "r": 9 },
+      "position": { "q": -6, "r": 3 },
       "total_population": 1560,
-      "initial_district_id": "d4",
-      "name": "West D10",
+      "initial_district_id": "d5",
+      "name": "West (-6,3)",
       "demographic_groups": [
         {
           "id": "p094-all",
@@ -1717,10 +1717,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 4, "r": 9 },
+      "position": { "q": -5, "r": 3 },
       "total_population": 1618,
       "initial_district_id": "d5",
-      "name": "West E10",
+      "name": "West (-5,3)",
       "demographic_groups": [
         {
           "id": "p095-all",
@@ -1735,10 +1735,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 9 },
+      "position": { "q": -4, "r": 3 },
       "total_population": 1536,
       "initial_district_id": "d5",
-      "name": "West F10",
+      "name": "West (-4,3)",
       "demographic_groups": [
         {
           "id": "p096-all",
@@ -1752,126 +1752,126 @@
     {
       "id": "p097",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 9 },
+      "county_id": "westbrook",
+      "position": { "q": -3, "r": 3 },
       "total_population": 1489,
-      "initial_district_id": "d4",
-      "name": "East G10",
+      "initial_district_id": "d5",
+      "name": "West (-3,3)",
       "demographic_groups": [
         {
           "id": "p097-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3897, "ryu": 0.6103 }
+          "vote_shares": { "ken": 0.6297, "ryu": 0.3703 }
         }
       ]
     },
     {
       "id": "p098",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 9 },
+      "county_id": "westbrook",
+      "position": { "q": -2, "r": 3 },
       "total_population": 1509,
-      "initial_district_id": "d3",
-      "name": "East H10",
+      "initial_district_id": "d4",
+      "name": "West (-2,3)",
       "demographic_groups": [
         {
           "id": "p098-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4130, "ryu": 0.5870 }
+          "vote_shares": { "ken": 0.6530, "ryu": 0.3470 }
         }
       ]
     },
     {
       "id": "p099",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 8, "r": 9 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": 3 },
       "total_population": 1497,
-      "initial_district_id": "d2",
-      "name": "East I10",
+      "initial_district_id": "d4",
+      "name": "West (-1,3)",
       "demographic_groups": [
         {
           "id": "p099-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3959, "ryu": 0.6041 }
+          "vote_shares": { "ken": 0.6359, "ryu": 0.3641 }
         }
       ]
     },
     {
       "id": "p100",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 9, "r": 9 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 3 },
       "total_population": 1359,
-      "initial_district_id": "d1",
-      "name": "East J10",
+      "initial_district_id": "d4",
+      "name": "West (0,3)",
       "demographic_groups": [
         {
           "id": "p100-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4187, "ryu": 0.5813 }
+          "vote_shares": { "ken": 0.6587, "ryu": 0.3413 }
         }
       ]
     },
     {
       "id": "p101",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 0, "r": 10 },
+      "county_id": "eastbrook",
+      "position": { "q": 1, "r": 3 },
       "total_population": 1645,
-      "initial_district_id": "d1",
-      "name": "West A11",
+      "initial_district_id": "d4",
+      "name": "East (1,3)",
       "demographic_groups": [
         {
           "id": "p101-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6007, "ryu": 0.3993 }
+          "vote_shares": { "ken": 0.3607, "ryu": 0.6393 }
         }
       ]
     },
     {
       "id": "p102",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 10 },
+      "county_id": "eastbrook",
+      "position": { "q": 2, "r": 3 },
       "total_population": 1571,
-      "initial_district_id": "d2",
-      "name": "West B11",
+      "initial_district_id": "d4",
+      "name": "East (2,3)",
       "demographic_groups": [
         {
           "id": "p102-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6181, "ryu": 0.3819 }
+          "vote_shares": { "ken": 0.3781, "ryu": 0.6219 }
         }
       ]
     },
     {
       "id": "p103",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 2, "r": 10 },
+      "county_id": "eastbrook",
+      "position": { "q": 3, "r": 3 },
       "total_population": 1482,
       "initial_district_id": "d3",
-      "name": "West C11",
+      "name": "East (3,3)",
       "demographic_groups": [
         {
           "id": "p103-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.5903, "ryu": 0.4097 }
+          "vote_shares": { "ken": 0.3503, "ryu": 0.6497 }
         }
       ]
     },
@@ -1879,10 +1879,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 3, "r": 10 },
+      "position": { "q": -6, "r": 4 },
       "total_population": 1615,
-      "initial_district_id": "d4",
-      "name": "West D11",
+      "initial_district_id": "d5",
+      "name": "West (-6,4)",
       "demographic_groups": [
         {
           "id": "p104-all",
@@ -1897,10 +1897,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 4, "r": 10 },
+      "position": { "q": -5, "r": 4 },
       "total_population": 1544,
       "initial_district_id": "d5",
-      "name": "West E11",
+      "name": "West (-5,4)",
       "demographic_groups": [
         {
           "id": "p105-all",
@@ -1915,10 +1915,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 10 },
+      "position": { "q": -4, "r": 4 },
       "total_population": 1641,
       "initial_district_id": "d5",
-      "name": "West F11",
+      "name": "West (-4,4)",
       "demographic_groups": [
         {
           "id": "p106-all",
@@ -1932,108 +1932,108 @@
     {
       "id": "p107",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 10 },
+      "county_id": "westbrook",
+      "position": { "q": -3, "r": 4 },
       "total_population": 1537,
       "initial_district_id": "d4",
-      "name": "East G11",
+      "name": "West (-3,4)",
       "demographic_groups": [
         {
           "id": "p107-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3830, "ryu": 0.6170 }
+          "vote_shares": { "ken": 0.6230, "ryu": 0.3770 }
         }
       ]
     },
     {
       "id": "p108",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 10 },
+      "county_id": "westbrook",
+      "position": { "q": -2, "r": 4 },
       "total_population": 1400,
-      "initial_district_id": "d3",
-      "name": "East H11",
+      "initial_district_id": "d4",
+      "name": "West (-2,4)",
       "demographic_groups": [
         {
           "id": "p108-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4129, "ryu": 0.5871 }
+          "vote_shares": { "ken": 0.6529, "ryu": 0.3471 }
         }
       ]
     },
     {
       "id": "p109",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 8, "r": 10 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": 4 },
       "total_population": 1559,
-      "initial_district_id": "d2",
-      "name": "East I11",
+      "initial_district_id": "d4",
+      "name": "West (-1,4)",
       "demographic_groups": [
         {
           "id": "p109-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3531, "ryu": 0.6469 }
+          "vote_shares": { "ken": 0.5931, "ryu": 0.4069 }
         }
       ]
     },
     {
       "id": "p110",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 9, "r": 10 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 4 },
       "total_population": 1423,
-      "initial_district_id": "d1",
-      "name": "East J11",
+      "initial_district_id": "d4",
+      "name": "West (0,4)",
       "demographic_groups": [
         {
           "id": "p110-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3934, "ryu": 0.6066 }
+          "vote_shares": { "ken": 0.6334, "ryu": 0.3666 }
         }
       ]
     },
     {
       "id": "p111",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 0, "r": 11 },
+      "county_id": "eastbrook",
+      "position": { "q": 1, "r": 4 },
       "total_population": 1572,
-      "initial_district_id": "d1",
-      "name": "West A12",
+      "initial_district_id": "d4",
+      "name": "East (1,4)",
       "demographic_groups": [
         {
           "id": "p111-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.5810, "ryu": 0.4190 }
+          "vote_shares": { "ken": 0.3410, "ryu": 0.6590 }
         }
       ]
     },
     {
       "id": "p112",
       "editable": true,
-      "county_id": "westbrook",
-      "position": { "q": 1, "r": 11 },
+      "county_id": "eastbrook",
+      "position": { "q": 2, "r": 4 },
       "total_population": 1433,
-      "initial_district_id": "d2",
-      "name": "West B12",
+      "initial_district_id": "d4",
+      "name": "East (2,4)",
       "demographic_groups": [
         {
           "id": "p112-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6071, "ryu": 0.3929 }
+          "vote_shares": { "ken": 0.3671, "ryu": 0.6329 }
         }
       ]
     },
@@ -2041,10 +2041,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 2, "r": 11 },
+      "position": { "q": -6, "r": 5 },
       "total_population": 1419,
-      "initial_district_id": "d3",
-      "name": "West C12",
+      "initial_district_id": "d5",
+      "name": "West (-6,5)",
       "demographic_groups": [
         {
           "id": "p113-all",
@@ -2059,10 +2059,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 3, "r": 11 },
+      "position": { "q": -5, "r": 5 },
       "total_population": 1402,
-      "initial_district_id": "d4",
-      "name": "West D12",
+      "initial_district_id": "d5",
+      "name": "West (-5,5)",
       "demographic_groups": [
         {
           "id": "p114-all",
@@ -2077,10 +2077,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 4, "r": 11 },
+      "position": { "q": -4, "r": 5 },
       "total_population": 1615,
       "initial_district_id": "d5",
-      "name": "West E12",
+      "name": "West (-4,5)",
       "demographic_groups": [
         {
           "id": "p115-all",
@@ -2095,10 +2095,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 5, "r": 11 },
+      "position": { "q": -3, "r": 5 },
       "total_population": 1586,
-      "initial_district_id": "d5",
-      "name": "West F12",
+      "initial_district_id": "d4",
+      "name": "West (-3,5)",
       "demographic_groups": [
         {
           "id": "p116-all",
@@ -2112,54 +2112,54 @@
     {
       "id": "p117",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 6, "r": 11 },
+      "county_id": "westbrook",
+      "position": { "q": -2, "r": 5 },
       "total_population": 1353,
       "initial_district_id": "d4",
-      "name": "East G12",
+      "name": "West (-2,5)",
       "demographic_groups": [
         {
           "id": "p117-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.3586, "ryu": 0.6414 }
+          "vote_shares": { "ken": 0.5986, "ryu": 0.4014 }
         }
       ]
     },
     {
       "id": "p118",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 7, "r": 11 },
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": 5 },
       "total_population": 1508,
-      "initial_district_id": "d3",
-      "name": "East H12",
+      "initial_district_id": "d4",
+      "name": "West (-1,5)",
       "demographic_groups": [
         {
           "id": "p118-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3666, "ryu": 0.6334 }
+          "vote_shares": { "ken": 0.6066, "ryu": 0.3934 }
         }
       ]
     },
     {
       "id": "p119",
       "editable": true,
-      "county_id": "eastbrook",
-      "position": { "q": 8, "r": 11 },
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 5 },
       "total_population": 1480,
-      "initial_district_id": "d2",
-      "name": "East I12",
+      "initial_district_id": "d4",
+      "name": "West (0,5)",
       "demographic_groups": [
         {
           "id": "p119-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.3959, "ryu": 0.6041 }
+          "vote_shares": { "ken": 0.6359, "ryu": 0.3641 }
         }
       ]
     },
@@ -2167,10 +2167,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 9, "r": 11 },
+      "position": { "q": 1, "r": 5 },
       "total_population": 1590,
-      "initial_district_id": "d1",
-      "name": "East J12",
+      "initial_district_id": "d4",
+      "name": "East (1,5)",
       "demographic_groups": [
         {
           "id": "p120-all",
@@ -2178,6 +2178,132 @@
           "population_share": 1.0,
           "turnout_rate": 0.66,
           "vote_shares": { "ken": 0.3693, "ryu": 0.6307 }
+        }
+      ]
+    },
+    {
+      "id": "p121",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": -6, "r": 6 },
+      "total_population": 1450,
+      "initial_district_id": "d5",
+      "name": "West (-6,6)",
+      "demographic_groups": [
+        {
+          "id": "p121-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.6448, "ryu": 0.3552 }
+        }
+      ]
+    },
+    {
+      "id": "p122",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": -5, "r": 6 },
+      "total_population": 1610,
+      "initial_district_id": "d5",
+      "name": "West (-5,6)",
+      "demographic_groups": [
+        {
+          "id": "p122-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.6469, "ryu": 0.3531 }
+        }
+      ]
+    },
+    {
+      "id": "p123",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": -4, "r": 6 },
+      "total_population": 1497,
+      "initial_district_id": "d4",
+      "name": "West (-4,6)",
+      "demographic_groups": [
+        {
+          "id": "p123-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.5982, "ryu": 0.4018 }
+        }
+      ]
+    },
+    {
+      "id": "p124",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": -3, "r": 6 },
+      "total_population": 1470,
+      "initial_district_id": "d4",
+      "name": "West (-3,6)",
+      "demographic_groups": [
+        {
+          "id": "p124-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5898, "ryu": 0.4102 }
+        }
+      ]
+    },
+    {
+      "id": "p125",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": -2, "r": 6 },
+      "total_population": 1377,
+      "initial_district_id": "d4",
+      "name": "West (-2,6)",
+      "demographic_groups": [
+        {
+          "id": "p125-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.6372, "ryu": 0.3628 }
+        }
+      ]
+    },
+    {
+      "id": "p126",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": -1, "r": 6 },
+      "total_population": 1351,
+      "initial_district_id": "d4",
+      "name": "West (-1,6)",
+      "demographic_groups": [
+        {
+          "id": "p126-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6524, "ryu": 0.3476 }
+        }
+      ]
+    },
+    {
+      "id": "p127",
+      "editable": true,
+      "county_id": "westbrook",
+      "position": { "q": 0, "r": 6 },
+      "total_population": 1607,
+      "initial_district_id": "d4",
+      "name": "West (0,6)",
+      "demographic_groups": [
+        {
+          "id": "p127-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5845, "ryu": 0.4155 }
         }
       ]
     }

--- a/game/scenarios/tutorial-002.json
+++ b/game/scenarios/tutorial-002.json
@@ -4,37 +4,18 @@
   "title": "Millbrook County: Three-District Challenge",
   "election_type": "state_house",
   "region": {
-    "id": "millbrook_tri_county",
-    "name": "Millbrook Tri-County Area"
+    "id": "millbrook_county",
+    "name": "Millbrook County"
   },
-  "geometry": {
-    "type": "hex_axial"
-  },
+  "geometry": { "type": "hex_axial" },
   "parties": [
-    {
-      "id": "ken",
-      "name": "Ken Party",
-      "abbreviation": "KEN"
-    },
-    {
-      "id": "ryu",
-      "name": "Ryu Party",
-      "abbreviation": "RYU"
-    }
+    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
+    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
   ],
   "districts": [
-    {
-      "id": "d1",
-      "name": "District 1"
-    },
-    {
-      "id": "d2",
-      "name": "District 2"
-    },
-    {
-      "id": "d3",
-      "name": "District 3"
-    }
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -42,23 +23,17 @@
       "id": "p001",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 0,
-        "r": 0
-      },
-      "total_population": 1500,
+      "position": { "q": 0, "r": -8 },
+      "total_population": 2731,
       "initial_district_id": "d1",
-      "name": "North A1",
+      "name": "North (0,-8)",
       "demographic_groups": [
         {
-          "id": "p001-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6,
-            "ryu": 0.4
-          }
+          "id": "p001-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5323, "ryu": 0.4677 }
         }
       ]
     },
@@ -66,23 +41,17 @@
       "id": "p002",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 1,
-        "r": 0
-      },
-      "total_population": 1531,
+      "position": { "q": 1, "r": -8 },
+      "total_population": 3118,
       "initial_district_id": "d1",
-      "name": "North A2",
+      "name": "North (1,-8)",
       "demographic_groups": [
         {
-          "id": "p002-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6076923076923076,
-            "ryu": 0.39230769230769236
-          }
+          "id": "p002-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5917, "ryu": 0.4083 }
         }
       ]
     },
@@ -90,23 +59,17 @@
       "id": "p003",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 2,
-        "r": 0
-      },
-      "total_population": 1612,
+      "position": { "q": -1, "r": -7 },
+      "total_population": 2860,
       "initial_district_id": "d1",
-      "name": "North A3",
+      "name": "North (-1,-7)",
       "demographic_groups": [
         {
-          "id": "p003-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6153846153846154,
-            "ryu": 0.3846153846153846
-          }
+          "id": "p003-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5739, "ryu": 0.4261 }
         }
       ]
     },
@@ -114,23 +77,17 @@
       "id": "p004",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 3,
-        "r": 0
-      },
-      "total_population": 1724,
+      "position": { "q": 0, "r": -7 },
+      "total_population": 2724,
       "initial_district_id": "d1",
-      "name": "North A4",
+      "name": "North (0,-7)",
       "demographic_groups": [
         {
-          "id": "p004-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6230769230769231,
-            "ryu": 0.3769230769230769
-          }
+          "id": "p004-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5671, "ryu": 0.4329 }
         }
       ]
     },
@@ -138,23 +95,17 @@
       "id": "p005",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 4,
-        "r": 0
-      },
-      "total_population": 1846,
+      "position": { "q": 1, "r": -7 },
+      "total_population": 2897,
       "initial_district_id": "d1",
-      "name": "North A5",
+      "name": "North (1,-7)",
       "demographic_groups": [
         {
-          "id": "p005-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6307692307692307,
-            "ryu": 0.36923076923076925
-          }
+          "id": "p005-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5247, "ryu": 0.4753 }
         }
       ]
     },
@@ -162,23 +113,17 @@
       "id": "p006",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 5,
-        "r": 0
-      },
-      "total_population": 1955,
+      "position": { "q": 2, "r": -7 },
+      "total_population": 2727,
       "initial_district_id": "d1",
-      "name": "North A6",
+      "name": "North (2,-7)",
       "demographic_groups": [
         {
-          "id": "p006-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6384615384615384,
-            "ryu": 0.3615384615384616
-          }
+          "id": "p006-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5113, "ryu": 0.4887 }
         }
       ]
     },
@@ -186,23 +131,17 @@
       "id": "p007",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 6,
-        "r": 0
-      },
-      "total_population": 2031,
+      "position": { "q": 3, "r": -7 },
+      "total_population": 2738,
       "initial_district_id": "d1",
-      "name": "North A7",
+      "name": "North (3,-7)",
       "demographic_groups": [
         {
-          "id": "p007-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6461538461538461,
-            "ryu": 0.3538461538461539
-          }
+          "id": "p007-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5795, "ryu": 0.4205 }
         }
       ]
     },
@@ -210,23 +149,17 @@
       "id": "p008",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 7,
-        "r": 0
-      },
-      "total_population": 2058,
+      "position": { "q": 4, "r": -7 },
+      "total_population": 3228,
       "initial_district_id": "d1",
-      "name": "North A8",
+      "name": "North (4,-7)",
       "demographic_groups": [
         {
-          "id": "p008-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6538461538461539,
-            "ryu": 0.34615384615384615
-          }
+          "id": "p008-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5467, "ryu": 0.4533 }
         }
       ]
     },
@@ -234,23 +167,17 @@
       "id": "p009",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 8,
-        "r": 0
-      },
-      "total_population": 2031,
+      "position": { "q": 5, "r": -7 },
+      "total_population": 2716,
       "initial_district_id": "d1",
-      "name": "North A9",
+      "name": "North (5,-7)",
       "demographic_groups": [
         {
-          "id": "p009-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6615384615384615,
-            "ryu": 0.3384615384615385
-          }
+          "id": "p009-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5895, "ryu": 0.4105 }
         }
       ]
     },
@@ -258,23 +185,17 @@
       "id": "p010",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 9,
-        "r": 0
-      },
-      "total_population": 1955,
+      "position": { "q": 6, "r": -7 },
+      "total_population": 3230,
       "initial_district_id": "d1",
-      "name": "North A10",
+      "name": "North (6,-7)",
       "demographic_groups": [
         {
-          "id": "p010-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6692307692307692,
-            "ryu": 0.3307692307692308
-          }
+          "id": "p010-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4937, "ryu": 0.5063 }
         }
       ]
     },
@@ -282,23 +203,17 @@
       "id": "p011",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 10,
-        "r": 0
-      },
-      "total_population": 1846,
+      "position": { "q": 7, "r": -7 },
+      "total_population": 2736,
       "initial_district_id": "d1",
-      "name": "North A11",
+      "name": "North (7,-7)",
       "demographic_groups": [
         {
-          "id": "p011-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.676923076923077,
-            "ryu": 0.32307692307692304
-          }
+          "id": "p011-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5602, "ryu": 0.4398 }
         }
       ]
     },
@@ -306,23 +221,17 @@
       "id": "p012",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 11,
-        "r": 0
-      },
-      "total_population": 1724,
+      "position": { "q": -2, "r": -6 },
+      "total_population": 2953,
       "initial_district_id": "d1",
-      "name": "North A12",
+      "name": "North (-2,-6)",
       "demographic_groups": [
         {
-          "id": "p012-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6846153846153846,
-            "ryu": 0.3153846153846154
-          }
+          "id": "p012-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6006, "ryu": 0.3994 }
         }
       ]
     },
@@ -330,23 +239,17 @@
       "id": "p013",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 12,
-        "r": 0
-      },
-      "total_population": 1612,
+      "position": { "q": -1, "r": -6 },
+      "total_population": 3127,
       "initial_district_id": "d1",
-      "name": "North A13",
+      "name": "North (-1,-6)",
       "demographic_groups": [
         {
-          "id": "p013-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6923076923076923,
-            "ryu": 0.3076923076923077
-          }
+          "id": "p013-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5678, "ryu": 0.4322 }
         }
       ]
     },
@@ -354,23 +257,17 @@
       "id": "p014",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 13,
-        "r": 0
-      },
-      "total_population": 1531,
+      "position": { "q": 0, "r": -6 },
+      "total_population": 2958,
       "initial_district_id": "d1",
-      "name": "North A14",
+      "name": "North (0,-6)",
       "demographic_groups": [
         {
-          "id": "p014-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.7,
-            "ryu": 0.30000000000000004
-          }
+          "id": "p014-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5795, "ryu": 0.4205 }
         }
       ]
     },
@@ -378,23 +275,17 @@
       "id": "p015",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 0,
-        "r": 1
-      },
-      "total_population": 1531,
+      "position": { "q": 1, "r": -6 },
+      "total_population": 2819,
       "initial_district_id": "d1",
-      "name": "North B1",
+      "name": "North (1,-6)",
       "demographic_groups": [
         {
-          "id": "p015-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5807692307692307,
-            "ryu": 0.4192307692307693
-          }
+          "id": "p015-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.5372, "ryu": 0.4628 }
         }
       ]
     },
@@ -402,23 +293,17 @@
       "id": "p016",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 1,
-        "r": 1
-      },
-      "total_population": 1633,
+      "position": { "q": 2, "r": -6 },
+      "total_population": 3180,
       "initial_district_id": "d1",
-      "name": "North B2",
+      "name": "North (2,-6)",
       "demographic_groups": [
         {
-          "id": "p016-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5884615384615384,
-            "ryu": 0.41153846153846163
-          }
+          "id": "p016-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5709, "ryu": 0.4291 }
         }
       ]
     },
@@ -426,23 +311,17 @@
       "id": "p017",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 2,
-        "r": 1
-      },
-      "total_population": 1790,
+      "position": { "q": 3, "r": -6 },
+      "total_population": 2932,
       "initial_district_id": "d1",
-      "name": "North B3",
+      "name": "North (3,-6)",
       "demographic_groups": [
         {
-          "id": "p017-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.596153846153846,
-            "ryu": 0.40384615384615397
-          }
+          "id": "p017-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5192, "ryu": 0.4808 }
         }
       ]
     },
@@ -450,23 +329,17 @@
       "id": "p018",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 3,
-        "r": 1
-      },
-      "total_population": 1979,
+      "position": { "q": 4, "r": -6 },
+      "total_population": 2962,
       "initial_district_id": "d1",
-      "name": "North B4",
+      "name": "North (4,-6)",
       "demographic_groups": [
         {
-          "id": "p018-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6038461538461538,
-            "ryu": 0.3961538461538462
-          }
+          "id": "p018-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5326, "ryu": 0.4674 }
         }
       ]
     },
@@ -474,23 +347,17 @@
       "id": "p019",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 4,
-        "r": 1
-      },
-      "total_population": 2175,
+      "position": { "q": 5, "r": -6 },
+      "total_population": 3152,
       "initial_district_id": "d1",
-      "name": "North B5",
+      "name": "North (5,-6)",
       "demographic_groups": [
         {
-          "id": "p019-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6115384615384615,
-            "ryu": 0.3884615384615385
-          }
+          "id": "p019-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5127, "ryu": 0.4873 }
         }
       ]
     },
@@ -498,23 +365,17 @@
       "id": "p020",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 5,
-        "r": 1
-      },
-      "total_population": 2348,
+      "position": { "q": 6, "r": -6 },
+      "total_population": 2831,
       "initial_district_id": "d1",
-      "name": "North B6",
+      "name": "North (6,-6)",
       "demographic_groups": [
         {
-          "id": "p020-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6192307692307691,
-            "ryu": 0.38076923076923086
-          }
+          "id": "p020-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.5590, "ryu": 0.4410 }
         }
       ]
     },
@@ -522,23 +383,17 @@
       "id": "p021",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 6,
-        "r": 1
-      },
-      "total_population": 2466,
+      "position": { "q": 7, "r": -6 },
+      "total_population": 3274,
       "initial_district_id": "d1",
-      "name": "North B7",
+      "name": "North (7,-6)",
       "demographic_groups": [
         {
-          "id": "p021-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6269230769230769,
-            "ryu": 0.3730769230769231
-          }
+          "id": "p021-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6059, "ryu": 0.3941 }
         }
       ]
     },
@@ -546,23 +401,17 @@
       "id": "p022",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 7,
-        "r": 1
-      },
-      "total_population": 2509,
+      "position": { "q": -3, "r": -5 },
+      "total_population": 3120,
       "initial_district_id": "d1",
-      "name": "North B8",
+      "name": "North (-3,-5)",
       "demographic_groups": [
         {
-          "id": "p022-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6346153846153846,
-            "ryu": 0.3653846153846154
-          }
+          "id": "p022-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.5305, "ryu": 0.4695 }
         }
       ]
     },
@@ -570,23 +419,17 @@
       "id": "p023",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 8,
-        "r": 1
-      },
-      "total_population": 2466,
+      "position": { "q": -2, "r": -5 },
+      "total_population": 3103,
       "initial_district_id": "d1",
-      "name": "North B9",
+      "name": "North (-2,-5)",
       "demographic_groups": [
         {
-          "id": "p023-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6423076923076922,
-            "ryu": 0.35769230769230775
-          }
+          "id": "p023-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5955, "ryu": 0.4045 }
         }
       ]
     },
@@ -594,23 +437,17 @@
       "id": "p024",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 9,
-        "r": 1
-      },
-      "total_population": 2348,
+      "position": { "q": -1, "r": -5 },
+      "total_population": 3046,
       "initial_district_id": "d1",
-      "name": "North B10",
+      "name": "North (-1,-5)",
       "demographic_groups": [
         {
-          "id": "p024-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6499999999999999,
-            "ryu": 0.3500000000000001
-          }
+          "id": "p024-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5841, "ryu": 0.4159 }
         }
       ]
     },
@@ -618,23 +455,17 @@
       "id": "p025",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 10,
-        "r": 1
-      },
-      "total_population": 2175,
+      "position": { "q": 0, "r": -5 },
+      "total_population": 2718,
       "initial_district_id": "d1",
-      "name": "North B11",
+      "name": "North (0,-5)",
       "demographic_groups": [
         {
-          "id": "p025-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6576923076923076,
-            "ryu": 0.3423076923076924
-          }
+          "id": "p025-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5699, "ryu": 0.4301 }
         }
       ]
     },
@@ -642,23 +473,17 @@
       "id": "p026",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 11,
-        "r": 1
-      },
-      "total_population": 1979,
+      "position": { "q": 1, "r": -5 },
+      "total_population": 2855,
       "initial_district_id": "d1",
-      "name": "North B12",
+      "name": "North (1,-5)",
       "demographic_groups": [
         {
-          "id": "p026-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6653846153846154,
-            "ryu": 0.33461538461538465
-          }
+          "id": "p026-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5287, "ryu": 0.4713 }
         }
       ]
     },
@@ -666,23 +491,17 @@
       "id": "p027",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 12,
-        "r": 1
-      },
-      "total_population": 1790,
+      "position": { "q": 2, "r": -5 },
+      "total_population": 3058,
       "initial_district_id": "d1",
-      "name": "North B13",
+      "name": "North (2,-5)",
       "demographic_groups": [
         {
-          "id": "p027-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.673076923076923,
-            "ryu": 0.326923076923077
-          }
+          "id": "p027-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5458, "ryu": 0.4542 }
         }
       ]
     },
@@ -690,23 +509,17 @@
       "id": "p028",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 13,
-        "r": 1
-      },
-      "total_population": 1633,
+      "position": { "q": 3, "r": -5 },
+      "total_population": 3098,
       "initial_district_id": "d1",
-      "name": "North B14",
+      "name": "North (3,-5)",
       "demographic_groups": [
         {
-          "id": "p028-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6807692307692307,
-            "ryu": 0.3192307692307693
-          }
+          "id": "p028-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5642, "ryu": 0.4358 }
         }
       ]
     },
@@ -714,23 +527,17 @@
       "id": "p029",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 0,
-        "r": 2
-      },
-      "total_population": 1612,
+      "position": { "q": 4, "r": -5 },
+      "total_population": 3210,
       "initial_district_id": "d1",
-      "name": "North C1",
+      "name": "North (4,-5)",
       "demographic_groups": [
         {
-          "id": "p029-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5615384615384615,
-            "ryu": 0.43846153846153846
-          }
+          "id": "p029-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5195, "ryu": 0.4805 }
         }
       ]
     },
@@ -738,23 +545,17 @@
       "id": "p030",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 1,
-        "r": 2
-      },
-      "total_population": 1790,
+      "position": { "q": 5, "r": -5 },
+      "total_population": 2841,
       "initial_district_id": "d1",
-      "name": "North C2",
+      "name": "North (5,-5)",
       "demographic_groups": [
         {
-          "id": "p030-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5692307692307692,
-            "ryu": 0.4307692307692308
-          }
+          "id": "p030-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5731, "ryu": 0.4269 }
         }
       ]
     },
@@ -762,23 +563,17 @@
       "id": "p031",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 2,
-        "r": 2
-      },
-      "total_population": 2031,
+      "position": { "q": 6, "r": -5 },
+      "total_population": 2750,
       "initial_district_id": "d1",
-      "name": "North C3",
+      "name": "North (6,-5)",
       "demographic_groups": [
         {
-          "id": "p031-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5769230769230769,
-            "ryu": 0.42307692307692313
-          }
+          "id": "p031-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5576, "ryu": 0.4424 }
         }
       ]
     },
@@ -786,23 +581,17 @@
       "id": "p032",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 3,
-        "r": 2
-      },
-      "total_population": 2311,
+      "position": { "q": 7, "r": -5 },
+      "total_population": 2735,
       "initial_district_id": "d1",
-      "name": "North C4",
+      "name": "North (7,-5)",
       "demographic_groups": [
         {
-          "id": "p032-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5846153846153846,
-            "ryu": 0.41538461538461535
-          }
+          "id": "p032-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5566, "ryu": 0.4434 }
         }
       ]
     },
@@ -810,23 +599,17 @@
       "id": "p033",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 4,
-        "r": 2
-      },
-      "total_population": 2598,
+      "position": { "q": -4, "r": -4 },
+      "total_population": 3272,
       "initial_district_id": "d1",
-      "name": "North C5",
+      "name": "North (-4,-4)",
       "demographic_groups": [
         {
-          "id": "p033-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5923076923076923,
-            "ryu": 0.4076923076923077
-          }
+          "id": "p033-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.6044, "ryu": 0.3956 }
         }
       ]
     },
@@ -834,23 +617,17 @@
       "id": "p034",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 5,
-        "r": 2
-      },
-      "total_population": 2852,
+      "position": { "q": -3, "r": -4 },
+      "total_population": 3131,
       "initial_district_id": "d1",
-      "name": "North C6",
+      "name": "North (-3,-4)",
       "demographic_groups": [
         {
-          "id": "p034-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6,
-            "ryu": 0.4
-          }
+          "id": "p034-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5043, "ryu": 0.4957 }
         }
       ]
     },
@@ -858,23 +635,17 @@
       "id": "p035",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 6,
-        "r": 2
-      },
-      "total_population": 3028,
+      "position": { "q": -2, "r": -4 },
+      "total_population": 2769,
       "initial_district_id": "d1",
-      "name": "North C7",
+      "name": "North (-2,-4)",
       "demographic_groups": [
         {
-          "id": "p035-base",
-          "name": "Registered voters",
-          "population_share": 1,
+          "id": "p035-all",
+          "name": "All voters",
+          "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6076923076923078,
-            "ryu": 0.39230769230769225
-          }
+          "vote_shares": { "ken": 0.5950, "ryu": 0.4050 }
         }
       ]
     },
@@ -882,23 +653,17 @@
       "id": "p036",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 7,
-        "r": 2
-      },
-      "total_population": 3092,
+      "position": { "q": -1, "r": -4 },
+      "total_population": 3261,
       "initial_district_id": "d1",
-      "name": "North C8",
+      "name": "North (-1,-4)",
       "demographic_groups": [
         {
-          "id": "p036-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6153846153846154,
-            "ryu": 0.3846153846153846
-          }
+          "id": "p036-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5395, "ryu": 0.4605 }
         }
       ]
     },
@@ -906,23 +671,17 @@
       "id": "p037",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 8,
-        "r": 2
-      },
-      "total_population": 3028,
+      "position": { "q": 0, "r": -4 },
+      "total_population": 3004,
       "initial_district_id": "d1",
-      "name": "North C9",
+      "name": "North (0,-4)",
       "demographic_groups": [
         {
-          "id": "p037-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6230769230769231,
-            "ryu": 0.3769230769230769
-          }
+          "id": "p037-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5554, "ryu": 0.4446 }
         }
       ]
     },
@@ -930,23 +689,17 @@
       "id": "p038",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 9,
-        "r": 2
-      },
-      "total_population": 2852,
+      "position": { "q": 1, "r": -4 },
+      "total_population": 3288,
       "initial_district_id": "d1",
-      "name": "North C10",
+      "name": "North (1,-4)",
       "demographic_groups": [
         {
-          "id": "p038-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6307692307692307,
-            "ryu": 0.36923076923076925
-          }
+          "id": "p038-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5534, "ryu": 0.4466 }
         }
       ]
     },
@@ -954,23 +707,17 @@
       "id": "p039",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 10,
-        "r": 2
-      },
-      "total_population": 2598,
+      "position": { "q": 2, "r": -4 },
+      "total_population": 2905,
       "initial_district_id": "d1",
-      "name": "North C11",
+      "name": "North (2,-4)",
       "demographic_groups": [
         {
-          "id": "p039-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6384615384615384,
-            "ryu": 0.3615384615384616
-          }
+          "id": "p039-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5604, "ryu": 0.4396 }
         }
       ]
     },
@@ -978,23 +725,17 @@
       "id": "p040",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 11,
-        "r": 2
-      },
-      "total_population": 2311,
+      "position": { "q": 3, "r": -4 },
+      "total_population": 3091,
       "initial_district_id": "d1",
-      "name": "North C12",
+      "name": "North (3,-4)",
       "demographic_groups": [
         {
-          "id": "p040-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6461538461538462,
-            "ryu": 0.3538461538461538
-          }
+          "id": "p040-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5248, "ryu": 0.4752 }
         }
       ]
     },
@@ -1002,23 +743,17 @@
       "id": "p041",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 12,
-        "r": 2
-      },
-      "total_population": 2031,
+      "position": { "q": 4, "r": -4 },
+      "total_population": 2907,
       "initial_district_id": "d1",
-      "name": "North C13",
+      "name": "North (4,-4)",
       "demographic_groups": [
         {
-          "id": "p041-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6538461538461539,
-            "ryu": 0.34615384615384615
-          }
+          "id": "p041-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5024, "ryu": 0.4976 }
         }
       ]
     },
@@ -1026,23 +761,17 @@
       "id": "p042",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 13,
-        "r": 2
-      },
-      "total_population": 1790,
+      "position": { "q": 5, "r": -4 },
+      "total_population": 2838,
       "initial_district_id": "d1",
-      "name": "North C14",
+      "name": "North (5,-4)",
       "demographic_groups": [
         {
-          "id": "p042-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6615384615384615,
-            "ryu": 0.3384615384615385
-          }
+          "id": "p042-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.6088, "ryu": 0.3912 }
         }
       ]
     },
@@ -1050,23 +779,17 @@
       "id": "p043",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 0,
-        "r": 3
-      },
-      "total_population": 1724,
+      "position": { "q": 6, "r": -4 },
+      "total_population": 2862,
       "initial_district_id": "d1",
-      "name": "North D1",
+      "name": "North (6,-4)",
       "demographic_groups": [
         {
-          "id": "p043-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5423076923076923,
-            "ryu": 0.45769230769230773
-          }
+          "id": "p043-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5569, "ryu": 0.4431 }
         }
       ]
     },
@@ -1074,23 +797,17 @@
       "id": "p044",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 1,
-        "r": 3
-      },
-      "total_population": 1979,
+      "position": { "q": 7, "r": -4 },
+      "total_population": 2942,
       "initial_district_id": "d1",
-      "name": "North D2",
+      "name": "North (7,-4)",
       "demographic_groups": [
         {
-          "id": "p044-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5499999999999999,
-            "ryu": 0.45000000000000007
-          }
+          "id": "p044-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5564, "ryu": 0.4436 }
         }
       ]
     },
@@ -1098,23 +815,17 @@
       "id": "p045",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 2,
-        "r": 3
-      },
-      "total_population": 2311,
+      "position": { "q": -5, "r": -3 },
+      "total_population": 3057,
       "initial_district_id": "d1",
-      "name": "North D3",
+      "name": "North (-5,-3)",
       "demographic_groups": [
         {
-          "id": "p045-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5576923076923077,
-            "ryu": 0.4423076923076923
-          }
+          "id": "p045-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5112, "ryu": 0.4888 }
         }
       ]
     },
@@ -1122,23 +833,17 @@
       "id": "p046",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 3,
-        "r": 3
-      },
-      "total_population": 2694,
+      "position": { "q": -4, "r": -3 },
+      "total_population": 2898,
       "initial_district_id": "d1",
-      "name": "North D4",
+      "name": "North (-4,-3)",
       "demographic_groups": [
         {
-          "id": "p046-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5653846153846154,
-            "ryu": 0.4346153846153846
-          }
+          "id": "p046-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5332, "ryu": 0.4668 }
         }
       ]
     },
@@ -1146,23 +851,17 @@
       "id": "p047",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 4,
-        "r": 3
-      },
-      "total_population": 3092,
+      "position": { "q": -3, "r": -3 },
+      "total_population": 3029,
       "initial_district_id": "d1",
-      "name": "North D5",
+      "name": "North (-3,-3)",
       "demographic_groups": [
         {
-          "id": "p047-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.573076923076923,
-            "ryu": 0.42692307692307696
-          }
+          "id": "p047-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5366, "ryu": 0.4634 }
         }
       ]
     },
@@ -1170,23 +869,17 @@
       "id": "p048",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 5,
-        "r": 3
-      },
-      "total_population": 3454,
+      "position": { "q": -2, "r": -3 },
+      "total_population": 2725,
       "initial_district_id": "d1",
-      "name": "North D6",
+      "name": "North (-2,-3)",
       "demographic_groups": [
         {
-          "id": "p048-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5807692307692307,
-            "ryu": 0.4192307692307693
-          }
+          "id": "p048-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.5759, "ryu": 0.4241 }
         }
       ]
     },
@@ -1194,23 +887,17 @@
       "id": "p049",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 6,
-        "r": 3
-      },
-      "total_population": 3713,
+      "position": { "q": -1, "r": -3 },
+      "total_population": 3110,
       "initial_district_id": "d1",
-      "name": "North D7",
+      "name": "North (-1,-3)",
       "demographic_groups": [
         {
-          "id": "p049-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5884615384615384,
-            "ryu": 0.41153846153846163
-          }
+          "id": "p049-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5086, "ryu": 0.4914 }
         }
       ]
     },
@@ -1218,23 +905,17 @@
       "id": "p050",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 7,
-        "r": 3
-      },
-      "total_population": 3808,
+      "position": { "q": 0, "r": -3 },
+      "total_population": 3039,
       "initial_district_id": "d1",
-      "name": "North D8",
+      "name": "North (0,-3)",
       "demographic_groups": [
         {
-          "id": "p050-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5961538461538461,
-            "ryu": 0.40384615384615385
-          }
+          "id": "p050-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.6056, "ryu": 0.3944 }
         }
       ]
     },
@@ -1242,23 +923,17 @@
       "id": "p051",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 8,
-        "r": 3
-      },
-      "total_population": 3713,
+      "position": { "q": 1, "r": -3 },
+      "total_population": 3252,
       "initial_district_id": "d1",
-      "name": "North D9",
+      "name": "North (1,-3)",
       "demographic_groups": [
         {
-          "id": "p051-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6038461538461538,
-            "ryu": 0.3961538461538462
-          }
+          "id": "p051-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5185, "ryu": 0.4815 }
         }
       ]
     },
@@ -1266,23 +941,17 @@
       "id": "p052",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 9,
-        "r": 3
-      },
-      "total_population": 3454,
+      "position": { "q": 2, "r": -3 },
+      "total_population": 3099,
       "initial_district_id": "d1",
-      "name": "North D10",
+      "name": "North (2,-3)",
       "demographic_groups": [
         {
-          "id": "p052-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6115384615384615,
-            "ryu": 0.3884615384615385
-          }
+          "id": "p052-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5749, "ryu": 0.4251 }
         }
       ]
     },
@@ -1290,23 +959,17 @@
       "id": "p053",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 10,
-        "r": 3
-      },
-      "total_population": 3092,
+      "position": { "q": 3, "r": -3 },
+      "total_population": 3235,
       "initial_district_id": "d1",
-      "name": "North D11",
+      "name": "North (3,-3)",
       "demographic_groups": [
         {
-          "id": "p053-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6192307692307693,
-            "ryu": 0.38076923076923075
-          }
+          "id": "p053-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.6095, "ryu": 0.3905 }
         }
       ]
     },
@@ -1314,23 +977,17 @@
       "id": "p054",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 11,
-        "r": 3
-      },
-      "total_population": 2694,
+      "position": { "q": 4, "r": -3 },
+      "total_population": 2783,
       "initial_district_id": "d1",
-      "name": "North D12",
+      "name": "North (4,-3)",
       "demographic_groups": [
         {
-          "id": "p054-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6269230769230769,
-            "ryu": 0.3730769230769231
-          }
+          "id": "p054-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5759, "ryu": 0.4241 }
         }
       ]
     },
@@ -1338,23 +995,17 @@
       "id": "p055",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 12,
-        "r": 3
-      },
-      "total_population": 2311,
+      "position": { "q": 5, "r": -3 },
+      "total_population": 2924,
       "initial_district_id": "d1",
-      "name": "North D13",
+      "name": "North (5,-3)",
       "demographic_groups": [
         {
-          "id": "p055-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6346153846153846,
-            "ryu": 0.3653846153846154
-          }
+          "id": "p055-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5444, "ryu": 0.4556 }
         }
       ]
     },
@@ -1362,23 +1013,17 @@
       "id": "p056",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 13,
-        "r": 3
-      },
-      "total_population": 1979,
+      "position": { "q": 6, "r": -3 },
+      "total_population": 2946,
       "initial_district_id": "d1",
-      "name": "North D14",
+      "name": "North (6,-3)",
       "demographic_groups": [
         {
-          "id": "p056-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6423076923076922,
-            "ryu": 0.35769230769230775
-          }
+          "id": "p056-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5875, "ryu": 0.4125 }
         }
       ]
     },
@@ -1386,335 +1031,251 @@
       "id": "p057",
       "editable": true,
       "county_id": "north",
-      "position": {
-        "q": 0,
-        "r": 4
-      },
-      "total_population": 1846,
+      "position": { "q": 7, "r": -3 },
+      "total_population": 3295,
       "initial_district_id": "d1",
-      "name": "North E1",
+      "name": "North (7,-3)",
       "demographic_groups": [
         {
-          "id": "p057-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.523076923076923,
-            "ryu": 0.476923076923077
-          }
+          "id": "p057-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5170, "ryu": 0.4830 }
         }
       ]
     },
     {
       "id": "p058",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 1,
-        "r": 4
-      },
-      "total_population": 2175,
-      "initial_district_id": "d1",
-      "name": "North E2",
+      "county_id": "central",
+      "position": { "q": -6, "r": -2 },
+      "total_population": 3233,
+      "initial_district_id": "d2",
+      "name": "Central (-6,-2)",
       "demographic_groups": [
         {
-          "id": "p058-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5307692307692307,
-            "ryu": 0.46923076923076934
-          }
+          "id": "p058-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4452, "ryu": 0.5548 }
         }
       ]
     },
     {
       "id": "p059",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 2,
-        "r": 4
-      },
-      "total_population": 2598,
-      "initial_district_id": "d1",
-      "name": "North E3",
+      "county_id": "central",
+      "position": { "q": -5, "r": -2 },
+      "total_population": 2820,
+      "initial_district_id": "d2",
+      "name": "Central (-5,-2)",
       "demographic_groups": [
         {
-          "id": "p059-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5384615384615383,
-            "ryu": 0.4615384615384617
-          }
+          "id": "p059-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4563, "ryu": 0.5437 }
         }
       ]
     },
     {
       "id": "p060",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 3,
-        "r": 4
-      },
-      "total_population": 3092,
-      "initial_district_id": "d1",
-      "name": "North E4",
+      "county_id": "central",
+      "position": { "q": -4, "r": -2 },
+      "total_population": 3051,
+      "initial_district_id": "d2",
+      "name": "Central (-4,-2)",
       "demographic_groups": [
         {
-          "id": "p060-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5461538461538461,
-            "ryu": 0.4538461538461539
-          }
+          "id": "p060-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4715, "ryu": 0.5285 }
         }
       ]
     },
     {
       "id": "p061",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 4,
-        "r": 4
-      },
-      "total_population": 3622,
-      "initial_district_id": "d1",
-      "name": "North E5",
+      "county_id": "central",
+      "position": { "q": -3, "r": -2 },
+      "total_population": 3160,
+      "initial_district_id": "d2",
+      "name": "Central (-3,-2)",
       "demographic_groups": [
         {
-          "id": "p061-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5538461538461538,
-            "ryu": 0.44615384615384623
-          }
+          "id": "p061-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5144, "ryu": 0.4856 }
         }
       ]
     },
     {
       "id": "p062",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 5,
-        "r": 4
-      },
-      "total_population": 4127,
-      "initial_district_id": "d1",
-      "name": "North E6",
+      "county_id": "central",
+      "position": { "q": -2, "r": -2 },
+      "total_population": 2955,
+      "initial_district_id": "d2",
+      "name": "Central (-2,-2)",
       "demographic_groups": [
         {
-          "id": "p062-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5615384615384614,
-            "ryu": 0.43846153846153857
-          }
+          "id": "p062-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4536, "ryu": 0.5464 }
         }
       ]
     },
     {
       "id": "p063",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 6,
-        "r": 4
-      },
-      "total_population": 4511,
-      "initial_district_id": "d1",
-      "name": "North E7",
+      "county_id": "central",
+      "position": { "q": -1, "r": -2 },
+      "total_population": 3257,
+      "initial_district_id": "d2",
+      "name": "Central (-1,-2)",
       "demographic_groups": [
         {
-          "id": "p063-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5692307692307692,
-            "ryu": 0.4307692307692308
-          }
+          "id": "p063-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4526, "ryu": 0.5474 }
         }
       ]
     },
     {
       "id": "p064",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 7,
-        "r": 4
-      },
-      "total_population": 4657,
-      "initial_district_id": "d1",
-      "name": "North E8",
+      "county_id": "central",
+      "position": { "q": 0, "r": -2 },
+      "total_population": 3032,
+      "initial_district_id": "d2",
+      "name": "Central (0,-2)",
       "demographic_groups": [
         {
-          "id": "p064-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5769230769230769,
-            "ryu": 0.42307692307692313
-          }
+          "id": "p064-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4720, "ryu": 0.5280 }
         }
       ]
     },
     {
       "id": "p065",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 8,
-        "r": 4
-      },
-      "total_population": 4511,
-      "initial_district_id": "d1",
-      "name": "North E9",
+      "county_id": "central",
+      "position": { "q": 1, "r": -2 },
+      "total_population": 3033,
+      "initial_district_id": "d2",
+      "name": "Central (1,-2)",
       "demographic_groups": [
         {
-          "id": "p065-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5846153846153845,
-            "ryu": 0.41538461538461546
-          }
+          "id": "p065-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5452, "ryu": 0.4548 }
         }
       ]
     },
     {
       "id": "p066",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 9,
-        "r": 4
-      },
-      "total_population": 4127,
-      "initial_district_id": "d1",
-      "name": "North E10",
+      "county_id": "central",
+      "position": { "q": 2, "r": -2 },
+      "total_population": 3161,
+      "initial_district_id": "d2",
+      "name": "Central (2,-2)",
       "demographic_groups": [
         {
-          "id": "p066-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5923076923076922,
-            "ryu": 0.4076923076923078
-          }
+          "id": "p066-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5147, "ryu": 0.4853 }
         }
       ]
     },
     {
       "id": "p067",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 10,
-        "r": 4
-      },
-      "total_population": 3622,
-      "initial_district_id": "d1",
-      "name": "North E11",
+      "county_id": "central",
+      "position": { "q": 3, "r": -2 },
+      "total_population": 3283,
+      "initial_district_id": "d2",
+      "name": "Central (3,-2)",
       "demographic_groups": [
         {
-          "id": "p067-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5999999999999999,
-            "ryu": 0.40000000000000013
-          }
+          "id": "p067-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5025, "ryu": 0.4975 }
         }
       ]
     },
     {
       "id": "p068",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 11,
-        "r": 4
-      },
-      "total_population": 3092,
-      "initial_district_id": "d1",
-      "name": "North E12",
+      "county_id": "central",
+      "position": { "q": 4, "r": -2 },
+      "total_population": 3197,
+      "initial_district_id": "d2",
+      "name": "Central (4,-2)",
       "demographic_groups": [
         {
-          "id": "p068-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6076923076923076,
-            "ryu": 0.39230769230769236
-          }
+          "id": "p068-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4765, "ryu": 0.5235 }
         }
       ]
     },
     {
       "id": "p069",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 12,
-        "r": 4
-      },
-      "total_population": 2598,
-      "initial_district_id": "d1",
-      "name": "North E13",
+      "county_id": "central",
+      "position": { "q": 5, "r": -2 },
+      "total_population": 2735,
+      "initial_district_id": "d2",
+      "name": "Central (5,-2)",
       "demographic_groups": [
         {
-          "id": "p069-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6153846153846153,
-            "ryu": 0.3846153846153847
-          }
+          "id": "p069-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5326, "ryu": 0.4674 }
         }
       ]
     },
     {
       "id": "p070",
       "editable": true,
-      "county_id": "north",
-      "position": {
-        "q": 13,
-        "r": 4
-      },
-      "total_population": 2175,
-      "initial_district_id": "d1",
-      "name": "North E14",
+      "county_id": "central",
+      "position": { "q": 6, "r": -2 },
+      "total_population": 2859,
+      "initial_district_id": "d2",
+      "name": "Central (6,-2)",
       "demographic_groups": [
         {
-          "id": "p070-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.623076923076923,
-            "ryu": 0.376923076923077
-          }
+          "id": "p070-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5536, "ryu": 0.4464 }
         }
       ]
     },
@@ -1722,23 +1283,17 @@
       "id": "p071",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 0,
-        "r": 5
-      },
-      "total_population": 1955,
+      "position": { "q": 7, "r": -2 },
+      "total_population": 3155,
       "initial_district_id": "d2",
-      "name": "Central F1",
+      "name": "Central (7,-2)",
       "demographic_groups": [
         {
-          "id": "p071-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5038461538461538,
-            "ryu": 0.49615384615384617
-          }
+          "id": "p071-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5056, "ryu": 0.4944 }
         }
       ]
     },
@@ -1746,23 +1301,17 @@
       "id": "p072",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 1,
-        "r": 5
-      },
-      "total_population": 2348,
+      "position": { "q": -7, "r": -1 },
+      "total_population": 2861,
       "initial_district_id": "d2",
-      "name": "Central F2",
+      "name": "Central (-7,-1)",
       "demographic_groups": [
         {
-          "id": "p072-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5115384615384615,
-            "ryu": 0.4884615384615385
-          }
+          "id": "p072-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4519, "ryu": 0.5481 }
         }
       ]
     },
@@ -1770,23 +1319,17 @@
       "id": "p073",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 2,
-        "r": 5
-      },
-      "total_population": 2852,
+      "position": { "q": -6, "r": -1 },
+      "total_population": 2869,
       "initial_district_id": "d2",
-      "name": "Central F3",
+      "name": "Central (-6,-1)",
       "demographic_groups": [
         {
-          "id": "p073-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5192307692307692,
-            "ryu": 0.48076923076923084
-          }
+          "id": "p073-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4620, "ryu": 0.5380 }
         }
       ]
     },
@@ -1794,23 +1337,17 @@
       "id": "p074",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 3,
-        "r": 5
-      },
-      "total_population": 3454,
+      "position": { "q": -5, "r": -1 },
+      "total_population": 3268,
       "initial_district_id": "d2",
-      "name": "Central F4",
+      "name": "Central (-5,-1)",
       "demographic_groups": [
         {
-          "id": "p074-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5269230769230769,
-            "ryu": 0.47307692307692306
-          }
+          "id": "p074-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5213, "ryu": 0.4787 }
         }
       ]
     },
@@ -1818,23 +1355,17 @@
       "id": "p075",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 4,
-        "r": 5
-      },
-      "total_population": 4127,
+      "position": { "q": -4, "r": -1 },
+      "total_population": 2895,
       "initial_district_id": "d2",
-      "name": "Central F5",
+      "name": "Central (-4,-1)",
       "demographic_groups": [
         {
-          "id": "p075-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5346153846153846,
-            "ryu": 0.4653846153846154
-          }
+          "id": "p075-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4840, "ryu": 0.5160 }
         }
       ]
     },
@@ -1842,23 +1373,17 @@
       "id": "p076",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 5,
-        "r": 5
-      },
-      "total_population": 4816,
+      "position": { "q": -3, "r": -1 },
+      "total_population": 2784,
       "initial_district_id": "d2",
-      "name": "Central F6",
+      "name": "Central (-3,-1)",
       "demographic_groups": [
         {
-          "id": "p076-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5423076923076923,
-            "ryu": 0.45769230769230773
-          }
+          "id": "p076-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.5553, "ryu": 0.4447 }
         }
       ]
     },
@@ -1866,23 +1391,17 @@
       "id": "p077",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 6,
-        "r": 5
-      },
-      "total_population": 5395,
+      "position": { "q": -2, "r": -1 },
+      "total_population": 2799,
       "initial_district_id": "d2",
-      "name": "Central F7",
+      "name": "Central (-2,-1)",
       "demographic_groups": [
         {
-          "id": "p077-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.55,
-            "ryu": 0.44999999999999996
-          }
+          "id": "p077-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4619, "ryu": 0.5381 }
         }
       ]
     },
@@ -1890,23 +1409,17 @@
       "id": "p078",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 7,
-        "r": 5
-      },
-      "total_population": 5639,
+      "position": { "q": -1, "r": -1 },
+      "total_population": 3299,
       "initial_district_id": "d2",
-      "name": "Central F8",
+      "name": "Central (-1,-1)",
       "demographic_groups": [
         {
-          "id": "p078-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5576923076923077,
-            "ryu": 0.4423076923076923
-          }
+          "id": "p078-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4698, "ryu": 0.5302 }
         }
       ]
     },
@@ -1914,23 +1427,17 @@
       "id": "p079",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 8,
-        "r": 5
-      },
-      "total_population": 5395,
+      "position": { "q": 0, "r": -1 },
+      "total_population": 3229,
       "initial_district_id": "d2",
-      "name": "Central F9",
+      "name": "Central (0,-1)",
       "demographic_groups": [
         {
-          "id": "p079-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5653846153846154,
-            "ryu": 0.4346153846153846
-          }
+          "id": "p079-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4901, "ryu": 0.5099 }
         }
       ]
     },
@@ -1938,23 +1445,17 @@
       "id": "p080",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 9,
-        "r": 5
-      },
-      "total_population": 4816,
+      "position": { "q": 1, "r": -1 },
+      "total_population": 3226,
       "initial_district_id": "d2",
-      "name": "Central F10",
+      "name": "Central (1,-1)",
       "demographic_groups": [
         {
-          "id": "p080-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.573076923076923,
-            "ryu": 0.42692307692307696
-          }
+          "id": "p080-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4567, "ryu": 0.5433 }
         }
       ]
     },
@@ -1962,23 +1463,17 @@
       "id": "p081",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 10,
-        "r": 5
-      },
-      "total_population": 4127,
+      "position": { "q": 2, "r": -1 },
+      "total_population": 3275,
       "initial_district_id": "d2",
-      "name": "Central F11",
+      "name": "Central (2,-1)",
       "demographic_groups": [
         {
-          "id": "p081-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5807692307692307,
-            "ryu": 0.4192307692307693
-          }
+          "id": "p081-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4816, "ryu": 0.5184 }
         }
       ]
     },
@@ -1986,23 +1481,17 @@
       "id": "p082",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 11,
-        "r": 5
-      },
-      "total_population": 3454,
+      "position": { "q": 3, "r": -1 },
+      "total_population": 2767,
       "initial_district_id": "d2",
-      "name": "Central F12",
+      "name": "Central (3,-1)",
       "demographic_groups": [
         {
-          "id": "p082-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5884615384615385,
-            "ryu": 0.4115384615384615
-          }
+          "id": "p082-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4531, "ryu": 0.5469 }
         }
       ]
     },
@@ -2010,23 +1499,17 @@
       "id": "p083",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 12,
-        "r": 5
-      },
-      "total_population": 2852,
+      "position": { "q": 4, "r": -1 },
+      "total_population": 3162,
       "initial_district_id": "d2",
-      "name": "Central F13",
+      "name": "Central (4,-1)",
       "demographic_groups": [
         {
-          "id": "p083-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5961538461538461,
-            "ryu": 0.40384615384615385
-          }
+          "id": "p083-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5570, "ryu": 0.4430 }
         }
       ]
     },
@@ -2034,23 +1517,17 @@
       "id": "p084",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 13,
-        "r": 5
-      },
-      "total_population": 2348,
+      "position": { "q": 5, "r": -1 },
+      "total_population": 3282,
       "initial_district_id": "d2",
-      "name": "Central F14",
+      "name": "Central (5,-1)",
       "demographic_groups": [
         {
-          "id": "p084-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.6038461538461538,
-            "ryu": 0.3961538461538462
-          }
+          "id": "p084-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5009, "ryu": 0.4991 }
         }
       ]
     },
@@ -2058,23 +1535,17 @@
       "id": "p085",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 0,
-        "r": 6
-      },
-      "total_population": 2031,
+      "position": { "q": 6, "r": -1 },
+      "total_population": 2959,
       "initial_district_id": "d2",
-      "name": "Central G1",
+      "name": "Central (6,-1)",
       "demographic_groups": [
         {
-          "id": "p085-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.48461538461538456,
-            "ryu": 0.5153846153846154
-          }
+          "id": "p085-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4762, "ryu": 0.5238 }
         }
       ]
     },
@@ -2082,23 +1553,17 @@
       "id": "p086",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 1,
-        "r": 6
-      },
-      "total_population": 2466,
+      "position": { "q": 7, "r": -1 },
+      "total_population": 2794,
       "initial_district_id": "d2",
-      "name": "Central G2",
+      "name": "Central (7,-1)",
       "demographic_groups": [
         {
-          "id": "p086-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4923076923076922,
-            "ryu": 0.5076923076923078
-          }
+          "id": "p086-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5285, "ryu": 0.4715 }
         }
       ]
     },
@@ -2106,23 +1571,17 @@
       "id": "p087",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 2,
-        "r": 6
-      },
-      "total_population": 3028,
+      "position": { "q": -8, "r": 0 },
+      "total_population": 2713,
       "initial_district_id": "d2",
-      "name": "Central G3",
+      "name": "Central (-8,0)",
       "demographic_groups": [
         {
-          "id": "p087-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.49999999999999994,
-            "ryu": 0.5
-          }
+          "id": "p087-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5584, "ryu": 0.4416 }
         }
       ]
     },
@@ -2130,23 +1589,17 @@
       "id": "p088",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 3,
-        "r": 6
-      },
-      "total_population": 3713,
+      "position": { "q": -7, "r": 0 },
+      "total_population": 3094,
       "initial_district_id": "d2",
-      "name": "Central G4",
+      "name": "Central (-7,0)",
       "demographic_groups": [
         {
-          "id": "p088-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5076923076923077,
-            "ryu": 0.49230769230769234
-          }
+          "id": "p088-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5488, "ryu": 0.4512 }
         }
       ]
     },
@@ -2154,23 +1607,17 @@
       "id": "p089",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 4,
-        "r": 6
-      },
-      "total_population": 4511,
+      "position": { "q": -6, "r": 0 },
+      "total_population": 3274,
       "initial_district_id": "d2",
-      "name": "Central G5",
+      "name": "Central (-6,0)",
       "demographic_groups": [
         {
-          "id": "p089-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5153846153846153,
-            "ryu": 0.48461538461538467
-          }
+          "id": "p089-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4836, "ryu": 0.5164 }
         }
       ]
     },
@@ -2178,23 +1625,17 @@
       "id": "p090",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 5,
-        "r": 6
-      },
-      "total_population": 5395,
+      "position": { "q": -5, "r": 0 },
+      "total_population": 3229,
       "initial_district_id": "d2",
-      "name": "Central G6",
+      "name": "Central (-5,0)",
       "demographic_groups": [
         {
-          "id": "p090-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.523076923076923,
-            "ryu": 0.476923076923077
-          }
+          "id": "p090-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.5587, "ryu": 0.4413 }
         }
       ]
     },
@@ -2202,23 +1643,17 @@
       "id": "p091",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 6,
-        "r": 6
-      },
-      "total_population": 6276,
+      "position": { "q": -4, "r": 0 },
+      "total_population": 2960,
       "initial_district_id": "d2",
-      "name": "Central G7",
+      "name": "Central (-4,0)",
       "demographic_groups": [
         {
-          "id": "p091-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5307692307692307,
-            "ryu": 0.46923076923076934
-          }
+          "id": "p091-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.5062, "ryu": 0.4938 }
         }
       ]
     },
@@ -2226,23 +1661,17 @@
       "id": "p092",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 7,
-        "r": 6
-      },
-      "total_population": 6753,
+      "position": { "q": -3, "r": 0 },
+      "total_population": 2897,
       "initial_district_id": "d2",
-      "name": "Central G8",
+      "name": "Central (-3,0)",
       "demographic_groups": [
         {
-          "id": "p092-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5384615384615384,
-            "ryu": 0.46153846153846156
-          }
+          "id": "p092-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5535, "ryu": 0.4465 }
         }
       ]
     },
@@ -2250,23 +1679,17 @@
       "id": "p093",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 8,
-        "r": 6
-      },
-      "total_population": 6276,
+      "position": { "q": -2, "r": 0 },
+      "total_population": 2849,
       "initial_district_id": "d2",
-      "name": "Central G9",
+      "name": "Central (-2,0)",
       "demographic_groups": [
         {
-          "id": "p093-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5461538461538461,
-            "ryu": 0.4538461538461539
-          }
+          "id": "p093-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5587, "ryu": 0.4413 }
         }
       ]
     },
@@ -2274,23 +1697,17 @@
       "id": "p094",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 9,
-        "r": 6
-      },
-      "total_population": 5395,
+      "position": { "q": -1, "r": 0 },
+      "total_population": 3216,
       "initial_district_id": "d2",
-      "name": "Central G10",
+      "name": "Central (-1,0)",
       "demographic_groups": [
         {
-          "id": "p094-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5538461538461538,
-            "ryu": 0.44615384615384623
-          }
+          "id": "p094-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4612, "ryu": 0.5388 }
         }
       ]
     },
@@ -2298,23 +1715,17 @@
       "id": "p095",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 10,
-        "r": 6
-      },
-      "total_population": 4511,
+      "position": { "q": 0, "r": 0 },
+      "total_population": 3047,
       "initial_district_id": "d2",
-      "name": "Central G11",
+      "name": "Central (0,0)",
       "demographic_groups": [
         {
-          "id": "p095-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5615384615384615,
-            "ryu": 0.43846153846153846
-          }
+          "id": "p095-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5530, "ryu": 0.4470 }
         }
       ]
     },
@@ -2322,23 +1733,17 @@
       "id": "p096",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 11,
-        "r": 6
-      },
-      "total_population": 3713,
+      "position": { "q": 1, "r": 0 },
+      "total_population": 2816,
       "initial_district_id": "d2",
-      "name": "Central G12",
+      "name": "Central (1,0)",
       "demographic_groups": [
         {
-          "id": "p096-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5692307692307692,
-            "ryu": 0.4307692307692308
-          }
+          "id": "p096-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.5525, "ryu": 0.4475 }
         }
       ]
     },
@@ -2346,23 +1751,17 @@
       "id": "p097",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 12,
-        "r": 6
-      },
-      "total_population": 3028,
+      "position": { "q": 2, "r": 0 },
+      "total_population": 2960,
       "initial_district_id": "d2",
-      "name": "Central G13",
+      "name": "Central (2,0)",
       "demographic_groups": [
         {
-          "id": "p097-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5769230769230769,
-            "ryu": 0.42307692307692313
-          }
+          "id": "p097-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.5110, "ryu": 0.4890 }
         }
       ]
     },
@@ -2370,23 +1769,17 @@
       "id": "p098",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 13,
-        "r": 6
-      },
-      "total_population": 2466,
+      "position": { "q": 3, "r": 0 },
+      "total_population": 3108,
       "initial_district_id": "d2",
-      "name": "Central G14",
+      "name": "Central (3,0)",
       "demographic_groups": [
         {
-          "id": "p098-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5846153846153845,
-            "ryu": 0.41538461538461546
-          }
+          "id": "p098-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4677, "ryu": 0.5323 }
         }
       ]
     },
@@ -2394,23 +1787,17 @@
       "id": "p099",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 0,
-        "r": 7
-      },
-      "total_population": 2058,
+      "position": { "q": 4, "r": 0 },
+      "total_population": 2951,
       "initial_district_id": "d2",
-      "name": "Central H1",
+      "name": "Central (4,0)",
       "demographic_groups": [
         {
-          "id": "p099-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4653846153846154,
-            "ryu": 0.5346153846153846
-          }
+          "id": "p099-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4886, "ryu": 0.5114 }
         }
       ]
     },
@@ -2418,23 +1805,17 @@
       "id": "p100",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 1,
-        "r": 7
-      },
-      "total_population": 2509,
+      "position": { "q": 5, "r": 0 },
+      "total_population": 2922,
       "initial_district_id": "d2",
-      "name": "Central H2",
+      "name": "Central (5,0)",
       "demographic_groups": [
         {
-          "id": "p100-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.47307692307692306,
-            "ryu": 0.5269230769230769
-          }
+          "id": "p100-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.5500, "ryu": 0.4500 }
         }
       ]
     },
@@ -2442,23 +1823,17 @@
       "id": "p101",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 2,
-        "r": 7
-      },
-      "total_population": 3092,
+      "position": { "q": 6, "r": 0 },
+      "total_population": 2812,
       "initial_district_id": "d2",
-      "name": "Central H3",
+      "name": "Central (6,0)",
       "demographic_groups": [
         {
-          "id": "p101-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4807692307692308,
-            "ryu": 0.5192307692307692
-          }
+          "id": "p101-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4622, "ryu": 0.5378 }
         }
       ]
     },
@@ -2466,23 +1841,17 @@
       "id": "p102",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 3,
-        "r": 7
-      },
-      "total_population": 3808,
+      "position": { "q": 7, "r": 0 },
+      "total_population": 3248,
       "initial_district_id": "d2",
-      "name": "Central H4",
+      "name": "Central (7,0)",
       "demographic_groups": [
         {
-          "id": "p102-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4884615384615385,
-            "ryu": 0.5115384615384615
-          }
+          "id": "p102-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5117, "ryu": 0.4883 }
         }
       ]
     },
@@ -2490,23 +1859,17 @@
       "id": "p103",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 4,
-        "r": 7
-      },
-      "total_population": 4657,
+      "position": { "q": -8, "r": 1 },
+      "total_population": 3265,
       "initial_district_id": "d2",
-      "name": "Central H5",
+      "name": "Central (-8,1)",
       "demographic_groups": [
         {
-          "id": "p103-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.49615384615384617,
-            "ryu": 0.5038461538461538
-          }
+          "id": "p103-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4835, "ryu": 0.5165 }
         }
       ]
     },
@@ -2514,23 +1877,17 @@
       "id": "p104",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 5,
-        "r": 7
-      },
-      "total_population": 5639,
+      "position": { "q": -7, "r": 1 },
+      "total_population": 2837,
       "initial_district_id": "d2",
-      "name": "Central H6",
+      "name": "Central (-7,1)",
       "demographic_groups": [
         {
-          "id": "p104-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5038461538461538,
-            "ryu": 0.49615384615384617
-          }
+          "id": "p104-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4538, "ryu": 0.5462 }
         }
       ]
     },
@@ -2538,23 +1895,17 @@
       "id": "p105",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 6,
-        "r": 7
-      },
-      "total_population": 6753,
+      "position": { "q": -6, "r": 1 },
+      "total_population": 2721,
       "initial_district_id": "d2",
-      "name": "Central H7",
+      "name": "Central (-6,1)",
       "demographic_groups": [
         {
-          "id": "p105-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5115384615384615,
-            "ryu": 0.4884615384615385
-          }
+          "id": "p105-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4744, "ryu": 0.5256 }
         }
       ]
     },
@@ -2562,23 +1913,17 @@
       "id": "p106",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 7,
-        "r": 7
-      },
-      "total_population": 8000,
+      "position": { "q": -5, "r": 1 },
+      "total_population": 2843,
       "initial_district_id": "d2",
-      "name": "Central H8",
+      "name": "Central (-5,1)",
       "demographic_groups": [
         {
-          "id": "p106-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5192307692307693,
-            "ryu": 0.4807692307692307
-          }
+          "id": "p106-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5122, "ryu": 0.4878 }
         }
       ]
     },
@@ -2586,23 +1931,17 @@
       "id": "p107",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 8,
-        "r": 7
-      },
-      "total_population": 6753,
+      "position": { "q": -4, "r": 1 },
+      "total_population": 3152,
       "initial_district_id": "d2",
-      "name": "Central H9",
+      "name": "Central (-4,1)",
       "demographic_groups": [
         {
-          "id": "p107-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5269230769230769,
-            "ryu": 0.47307692307692306
-          }
+          "id": "p107-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4960, "ryu": 0.5040 }
         }
       ]
     },
@@ -2610,23 +1949,17 @@
       "id": "p108",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 9,
-        "r": 7
-      },
-      "total_population": 5639,
+      "position": { "q": -3, "r": 1 },
+      "total_population": 2947,
       "initial_district_id": "d2",
-      "name": "Central H10",
+      "name": "Central (-3,1)",
       "demographic_groups": [
         {
-          "id": "p108-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5346153846153846,
-            "ryu": 0.4653846153846154
-          }
+          "id": "p108-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5113, "ryu": 0.4887 }
         }
       ]
     },
@@ -2634,23 +1967,17 @@
       "id": "p109",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 10,
-        "r": 7
-      },
-      "total_population": 4657,
+      "position": { "q": -2, "r": 1 },
+      "total_population": 3276,
       "initial_district_id": "d2",
-      "name": "Central H11",
+      "name": "Central (-2,1)",
       "demographic_groups": [
         {
-          "id": "p109-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5423076923076924,
-            "ryu": 0.4576923076923076
-          }
+          "id": "p109-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4952, "ryu": 0.5048 }
         }
       ]
     },
@@ -2658,23 +1985,17 @@
       "id": "p110",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 11,
-        "r": 7
-      },
-      "total_population": 3808,
+      "position": { "q": -1, "r": 1 },
+      "total_population": 3102,
       "initial_district_id": "d2",
-      "name": "Central H12",
+      "name": "Central (-1,1)",
       "demographic_groups": [
         {
-          "id": "p110-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.55,
-            "ryu": 0.44999999999999996
-          }
+          "id": "p110-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4610, "ryu": 0.5390 }
         }
       ]
     },
@@ -2682,23 +2003,17 @@
       "id": "p111",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 12,
-        "r": 7
-      },
-      "total_population": 3092,
+      "position": { "q": 0, "r": 1 },
+      "total_population": 2901,
       "initial_district_id": "d2",
-      "name": "Central H13",
+      "name": "Central (0,1)",
       "demographic_groups": [
         {
-          "id": "p111-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5576923076923077,
-            "ryu": 0.4423076923076923
-          }
+          "id": "p111-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4977, "ryu": 0.5023 }
         }
       ]
     },
@@ -2706,23 +2021,17 @@
       "id": "p112",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 13,
-        "r": 7
-      },
-      "total_population": 2509,
+      "position": { "q": 1, "r": 1 },
+      "total_population": 3055,
       "initial_district_id": "d2",
-      "name": "Central H14",
+      "name": "Central (1,1)",
       "demographic_groups": [
         {
-          "id": "p112-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5653846153846154,
-            "ryu": 0.4346153846153846
-          }
+          "id": "p112-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4594, "ryu": 0.5406 }
         }
       ]
     },
@@ -2730,23 +2039,17 @@
       "id": "p113",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 0,
-        "r": 8
-      },
-      "total_population": 2031,
+      "position": { "q": 2, "r": 1 },
+      "total_population": 2798,
       "initial_district_id": "d2",
-      "name": "Central I1",
+      "name": "Central (2,1)",
       "demographic_groups": [
         {
-          "id": "p113-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4461538461538461,
-            "ryu": 0.5538461538461539
-          }
+          "id": "p113-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.5080, "ryu": 0.4920 }
         }
       ]
     },
@@ -2754,23 +2057,17 @@
       "id": "p114",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 1,
-        "r": 8
-      },
-      "total_population": 2466,
+      "position": { "q": 3, "r": 1 },
+      "total_population": 2951,
       "initial_district_id": "d2",
-      "name": "Central I2",
+      "name": "Central (3,1)",
       "demographic_groups": [
         {
-          "id": "p114-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4538461538461538,
-            "ryu": 0.5461538461538462
-          }
+          "id": "p114-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4984, "ryu": 0.5016 }
         }
       ]
     },
@@ -2778,23 +2075,17 @@
       "id": "p115",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 2,
-        "r": 8
-      },
-      "total_population": 3028,
+      "position": { "q": 4, "r": 1 },
+      "total_population": 2867,
       "initial_district_id": "d2",
-      "name": "Central I3",
+      "name": "Central (4,1)",
       "demographic_groups": [
         {
-          "id": "p115-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4615384615384615,
-            "ryu": 0.5384615384615385
-          }
+          "id": "p115-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5299, "ryu": 0.4701 }
         }
       ]
     },
@@ -2802,23 +2093,17 @@
       "id": "p116",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 3,
-        "r": 8
-      },
-      "total_population": 3713,
+      "position": { "q": 5, "r": 1 },
+      "total_population": 2819,
       "initial_district_id": "d2",
-      "name": "Central I4",
+      "name": "Central (5,1)",
       "demographic_groups": [
         {
-          "id": "p116-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.46923076923076923,
-            "ryu": 0.5307692307692308
-          }
+          "id": "p116-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5010, "ryu": 0.4990 }
         }
       ]
     },
@@ -2826,23 +2111,17 @@
       "id": "p117",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 4,
-        "r": 8
-      },
-      "total_population": 4511,
+      "position": { "q": 6, "r": 1 },
+      "total_population": 3070,
       "initial_district_id": "d2",
-      "name": "Central I5",
+      "name": "Central (6,1)",
       "demographic_groups": [
         {
-          "id": "p117-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4769230769230769,
-            "ryu": 0.5230769230769231
-          }
+          "id": "p117-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4625, "ryu": 0.5375 }
         }
       ]
     },
@@ -2850,23 +2129,17 @@
       "id": "p118",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 5,
-        "r": 8
-      },
-      "total_population": 5395,
+      "position": { "q": -8, "r": 2 },
+      "total_population": 2978,
       "initial_district_id": "d2",
-      "name": "Central I6",
+      "name": "Central (-8,2)",
       "demographic_groups": [
         {
-          "id": "p118-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.48461538461538456,
-            "ryu": 0.5153846153846154
-          }
+          "id": "p118-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4826, "ryu": 0.5174 }
         }
       ]
     },
@@ -2874,23 +2147,17 @@
       "id": "p119",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 6,
-        "r": 8
-      },
-      "total_population": 6276,
+      "position": { "q": -7, "r": 2 },
+      "total_population": 2777,
       "initial_district_id": "d2",
-      "name": "Central I7",
+      "name": "Central (-7,2)",
       "demographic_groups": [
         {
-          "id": "p119-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4923076923076923,
-            "ryu": 0.5076923076923077
-          }
+          "id": "p119-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4754, "ryu": 0.5246 }
         }
       ]
     },
@@ -2898,23 +2165,17 @@
       "id": "p120",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 7,
-        "r": 8
-      },
-      "total_population": 6753,
+      "position": { "q": -6, "r": 2 },
+      "total_population": 2821,
       "initial_district_id": "d2",
-      "name": "Central I8",
+      "name": "Central (-6,2)",
       "demographic_groups": [
         {
-          "id": "p120-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5,
-            "ryu": 0.5
-          }
+          "id": "p120-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.5201, "ryu": 0.4799 }
         }
       ]
     },
@@ -2922,23 +2183,17 @@
       "id": "p121",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 8,
-        "r": 8
-      },
-      "total_population": 6276,
+      "position": { "q": -5, "r": 2 },
+      "total_population": 3161,
       "initial_district_id": "d2",
-      "name": "Central I9",
+      "name": "Central (-5,2)",
       "demographic_groups": [
         {
-          "id": "p121-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5076923076923077,
-            "ryu": 0.49230769230769234
-          }
+          "id": "p121-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.5230, "ryu": 0.4770 }
         }
       ]
     },
@@ -2946,23 +2201,17 @@
       "id": "p122",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 9,
-        "r": 8
-      },
-      "total_population": 5395,
+      "position": { "q": -4, "r": 2 },
+      "total_population": 2820,
       "initial_district_id": "d2",
-      "name": "Central I10",
+      "name": "Central (-4,2)",
       "demographic_groups": [
         {
-          "id": "p122-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5153846153846153,
-            "ryu": 0.48461538461538467
-          }
+          "id": "p122-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4573, "ryu": 0.5427 }
         }
       ]
     },
@@ -2970,23 +2219,17 @@
       "id": "p123",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 10,
-        "r": 8
-      },
-      "total_population": 4511,
+      "position": { "q": -3, "r": 2 },
+      "total_population": 2855,
       "initial_district_id": "d2",
-      "name": "Central I11",
+      "name": "Central (-3,2)",
       "demographic_groups": [
         {
-          "id": "p123-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.523076923076923,
-            "ryu": 0.476923076923077
-          }
+          "id": "p123-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5495, "ryu": 0.4505 }
         }
       ]
     },
@@ -2994,23 +2237,17 @@
       "id": "p124",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 11,
-        "r": 8
-      },
-      "total_population": 3713,
+      "position": { "q": -2, "r": 2 },
+      "total_population": 3146,
       "initial_district_id": "d2",
-      "name": "Central I12",
+      "name": "Central (-2,2)",
       "demographic_groups": [
         {
-          "id": "p124-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5307692307692308,
-            "ryu": 0.46923076923076923
-          }
+          "id": "p124-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4599, "ryu": 0.5401 }
         }
       ]
     },
@@ -3018,23 +2255,17 @@
       "id": "p125",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 12,
-        "r": 8
-      },
-      "total_population": 3028,
+      "position": { "q": -1, "r": 2 },
+      "total_population": 3227,
       "initial_district_id": "d2",
-      "name": "Central I13",
+      "name": "Central (-1,2)",
       "demographic_groups": [
         {
-          "id": "p125-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5384615384615384,
-            "ryu": 0.46153846153846156
-          }
+          "id": "p125-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.5492, "ryu": 0.4508 }
         }
       ]
     },
@@ -3042,143 +2273,107 @@
       "id": "p126",
       "editable": true,
       "county_id": "central",
-      "position": {
-        "q": 13,
-        "r": 8
-      },
-      "total_population": 2466,
+      "position": { "q": 0, "r": 2 },
+      "total_population": 3184,
       "initial_district_id": "d2",
-      "name": "Central I14",
+      "name": "Central (0,2)",
       "demographic_groups": [
         {
-          "id": "p126-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5461538461538461,
-            "ryu": 0.4538461538461539
-          }
+          "id": "p126-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4468, "ryu": 0.5532 }
         }
       ]
     },
     {
       "id": "p127",
       "editable": true,
-      "county_id": "south",
-      "position": {
-        "q": 0,
-        "r": 9
-      },
-      "total_population": 1955,
-      "initial_district_id": "d3",
-      "name": "South J1",
+      "county_id": "central",
+      "position": { "q": 1, "r": 2 },
+      "total_population": 2702,
+      "initial_district_id": "d2",
+      "name": "Central (1,2)",
       "demographic_groups": [
         {
-          "id": "p127-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4269230769230769,
-            "ryu": 0.573076923076923
-          }
+          "id": "p127-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.5353, "ryu": 0.4647 }
         }
       ]
     },
     {
       "id": "p128",
       "editable": true,
-      "county_id": "south",
-      "position": {
-        "q": 1,
-        "r": 9
-      },
-      "total_population": 2348,
-      "initial_district_id": "d3",
-      "name": "South J2",
+      "county_id": "central",
+      "position": { "q": 2, "r": 2 },
+      "total_population": 3001,
+      "initial_district_id": "d2",
+      "name": "Central (2,2)",
       "demographic_groups": [
         {
-          "id": "p128-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4346153846153846,
-            "ryu": 0.5653846153846154
-          }
+          "id": "p128-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4888, "ryu": 0.5112 }
         }
       ]
     },
     {
       "id": "p129",
       "editable": true,
-      "county_id": "south",
-      "position": {
-        "q": 2,
-        "r": 9
-      },
-      "total_population": 2852,
-      "initial_district_id": "d3",
-      "name": "South J3",
+      "county_id": "central",
+      "position": { "q": 3, "r": 2 },
+      "total_population": 3158,
+      "initial_district_id": "d2",
+      "name": "Central (3,2)",
       "demographic_groups": [
         {
-          "id": "p129-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4423076923076923,
-            "ryu": 0.5576923076923077
-          }
+          "id": "p129-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.5049, "ryu": 0.4951 }
         }
       ]
     },
     {
       "id": "p130",
       "editable": true,
-      "county_id": "south",
-      "position": {
-        "q": 3,
-        "r": 9
-      },
-      "total_population": 3454,
-      "initial_district_id": "d3",
-      "name": "South J4",
+      "county_id": "central",
+      "position": { "q": 4, "r": 2 },
+      "total_population": 3003,
+      "initial_district_id": "d2",
+      "name": "Central (4,2)",
       "demographic_groups": [
         {
-          "id": "p130-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.44999999999999996,
-            "ryu": 0.55
-          }
+          "id": "p130-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.5236, "ryu": 0.4764 }
         }
       ]
     },
     {
       "id": "p131",
       "editable": true,
-      "county_id": "south",
-      "position": {
-        "q": 4,
-        "r": 9
-      },
-      "total_population": 4127,
-      "initial_district_id": "d3",
-      "name": "South J5",
+      "county_id": "central",
+      "position": { "q": 5, "r": 2 },
+      "total_population": 3254,
+      "initial_district_id": "d2",
+      "name": "Central (5,2)",
       "demographic_groups": [
         {
-          "id": "p131-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4576923076923077,
-            "ryu": 0.5423076923076924
-          }
+          "id": "p131-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.5584, "ryu": 0.4416 }
         }
       ]
     },
@@ -3186,23 +2381,17 @@
       "id": "p132",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 5,
-        "r": 9
-      },
-      "total_population": 4816,
+      "position": { "q": -8, "r": 3 },
+      "total_population": 2810,
       "initial_district_id": "d3",
-      "name": "South J6",
+      "name": "South (-8,3)",
       "demographic_groups": [
         {
-          "id": "p132-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4653846153846154,
-            "ryu": 0.5346153846153846
-          }
+          "id": "p132-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.4615, "ryu": 0.5385 }
         }
       ]
     },
@@ -3210,23 +2399,17 @@
       "id": "p133",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 6,
-        "r": 9
-      },
-      "total_population": 5395,
+      "position": { "q": -7, "r": 3 },
+      "total_population": 2793,
       "initial_district_id": "d3",
-      "name": "South J7",
+      "name": "South (-7,3)",
       "demographic_groups": [
         {
-          "id": "p133-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.47307692307692306,
-            "ryu": 0.5269230769230769
-          }
+          "id": "p133-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4353, "ryu": 0.5647 }
         }
       ]
     },
@@ -3234,23 +2417,17 @@
       "id": "p134",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 7,
-        "r": 9
-      },
-      "total_population": 5639,
+      "position": { "q": -6, "r": 3 },
+      "total_population": 3049,
       "initial_district_id": "d3",
-      "name": "South J8",
+      "name": "South (-6,3)",
       "demographic_groups": [
         {
-          "id": "p134-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4807692307692307,
-            "ryu": 0.5192307692307693
-          }
+          "id": "p134-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.3925, "ryu": 0.6075 }
         }
       ]
     },
@@ -3258,23 +2435,17 @@
       "id": "p135",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 8,
-        "r": 9
-      },
-      "total_population": 5395,
+      "position": { "q": -5, "r": 3 },
+      "total_population": 3131,
       "initial_district_id": "d3",
-      "name": "South J9",
+      "name": "South (-5,3)",
       "demographic_groups": [
         {
-          "id": "p135-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.48846153846153845,
-            "ryu": 0.5115384615384615
-          }
+          "id": "p135-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4676, "ryu": 0.5324 }
         }
       ]
     },
@@ -3282,23 +2453,17 @@
       "id": "p136",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 9,
-        "r": 9
-      },
-      "total_population": 4816,
+      "position": { "q": -4, "r": 3 },
+      "total_population": 2719,
       "initial_district_id": "d3",
-      "name": "South J10",
+      "name": "South (-4,3)",
       "demographic_groups": [
         {
-          "id": "p136-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.49615384615384617,
-            "ryu": 0.5038461538461538
-          }
+          "id": "p136-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4319, "ryu": 0.5681 }
         }
       ]
     },
@@ -3306,23 +2471,17 @@
       "id": "p137",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 10,
-        "r": 9
-      },
-      "total_population": 4127,
+      "position": { "q": -3, "r": 3 },
+      "total_population": 3063,
       "initial_district_id": "d3",
-      "name": "South J11",
+      "name": "South (-3,3)",
       "demographic_groups": [
         {
-          "id": "p137-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5038461538461538,
-            "ryu": 0.49615384615384617
-          }
+          "id": "p137-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4063, "ryu": 0.5937 }
         }
       ]
     },
@@ -3330,23 +2489,17 @@
       "id": "p138",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 11,
-        "r": 9
-      },
-      "total_population": 3454,
+      "position": { "q": -2, "r": 3 },
+      "total_population": 2824,
       "initial_district_id": "d3",
-      "name": "South J12",
+      "name": "South (-2,3)",
       "demographic_groups": [
         {
-          "id": "p138-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5115384615384615,
-            "ryu": 0.4884615384615385
-          }
+          "id": "p138-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4865, "ryu": 0.5135 }
         }
       ]
     },
@@ -3354,23 +2507,17 @@
       "id": "p139",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 12,
-        "r": 9
-      },
-      "total_population": 2852,
+      "position": { "q": -1, "r": 3 },
+      "total_population": 3198,
       "initial_district_id": "d3",
-      "name": "South J13",
+      "name": "South (-1,3)",
       "demographic_groups": [
         {
-          "id": "p139-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5192307692307692,
-            "ryu": 0.48076923076923084
-          }
+          "id": "p139-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.3951, "ryu": 0.6049 }
         }
       ]
     },
@@ -3378,23 +2525,17 @@
       "id": "p140",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 13,
-        "r": 9
-      },
-      "total_population": 2348,
+      "position": { "q": 0, "r": 3 },
+      "total_population": 3153,
       "initial_district_id": "d3",
-      "name": "South J14",
+      "name": "South (0,3)",
       "demographic_groups": [
         {
-          "id": "p140-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5269230769230769,
-            "ryu": 0.47307692307692306
-          }
+          "id": "p140-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4269, "ryu": 0.5731 }
         }
       ]
     },
@@ -3402,23 +2543,17 @@
       "id": "p141",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 0,
-        "r": 10
-      },
-      "total_population": 1846,
+      "position": { "q": 1, "r": 3 },
+      "total_population": 3120,
       "initial_district_id": "d3",
-      "name": "South A1",
+      "name": "South (1,3)",
       "demographic_groups": [
         {
-          "id": "p141-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4076923076923077,
-            "ryu": 0.5923076923076923
-          }
+          "id": "p141-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4780, "ryu": 0.5220 }
         }
       ]
     },
@@ -3426,23 +2561,17 @@
       "id": "p142",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 1,
-        "r": 10
-      },
-      "total_population": 2175,
+      "position": { "q": 2, "r": 3 },
+      "total_population": 3197,
       "initial_district_id": "d3",
-      "name": "South A2",
+      "name": "South (2,3)",
       "demographic_groups": [
         {
-          "id": "p142-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.41538461538461535,
-            "ryu": 0.5846153846153846
-          }
+          "id": "p142-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4662, "ryu": 0.5338 }
         }
       ]
     },
@@ -3450,23 +2579,17 @@
       "id": "p143",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 2,
-        "r": 10
-      },
-      "total_population": 2598,
+      "position": { "q": 3, "r": 3 },
+      "total_population": 2892,
       "initial_district_id": "d3",
-      "name": "South A3",
+      "name": "South (3,3)",
       "demographic_groups": [
         {
-          "id": "p143-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4230769230769231,
-            "ryu": 0.5769230769230769
-          }
+          "id": "p143-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4418, "ryu": 0.5582 }
         }
       ]
     },
@@ -3474,23 +2597,17 @@
       "id": "p144",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 3,
-        "r": 10
-      },
-      "total_population": 3092,
+      "position": { "q": 4, "r": 3 },
+      "total_population": 3167,
       "initial_district_id": "d3",
-      "name": "South A4",
+      "name": "South (4,3)",
       "demographic_groups": [
         {
-          "id": "p144-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4307692307692308,
-            "ryu": 0.5692307692307692
-          }
+          "id": "p144-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4617, "ryu": 0.5383 }
         }
       ]
     },
@@ -3498,23 +2615,17 @@
       "id": "p145",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 4,
-        "r": 10
-      },
-      "total_population": 3622,
+      "position": { "q": -8, "r": 4 },
+      "total_population": 3116,
       "initial_district_id": "d3",
-      "name": "South A5",
+      "name": "South (-8,4)",
       "demographic_groups": [
         {
-          "id": "p145-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.43846153846153846,
-            "ryu": 0.5615384615384615
-          }
+          "id": "p145-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.3941, "ryu": 0.6059 }
         }
       ]
     },
@@ -3522,23 +2633,17 @@
       "id": "p146",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 5,
-        "r": 10
-      },
-      "total_population": 4127,
+      "position": { "q": -7, "r": 4 },
+      "total_population": 3061,
       "initial_district_id": "d3",
-      "name": "South A6",
+      "name": "South (-7,4)",
       "demographic_groups": [
         {
-          "id": "p146-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4461538461538461,
-            "ryu": 0.5538461538461539
-          }
+          "id": "p146-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4737, "ryu": 0.5263 }
         }
       ]
     },
@@ -3546,23 +2651,17 @@
       "id": "p147",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 6,
-        "r": 10
-      },
-      "total_population": 4511,
+      "position": { "q": -6, "r": 4 },
+      "total_population": 2806,
       "initial_district_id": "d3",
-      "name": "South A7",
+      "name": "South (-6,4)",
       "demographic_groups": [
         {
-          "id": "p147-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.45384615384615384,
-            "ryu": 0.5461538461538462
-          }
+          "id": "p147-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4283, "ryu": 0.5717 }
         }
       ]
     },
@@ -3570,23 +2669,17 @@
       "id": "p148",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 7,
-        "r": 10
-      },
-      "total_population": 4657,
+      "position": { "q": -5, "r": 4 },
+      "total_population": 3157,
       "initial_district_id": "d3",
-      "name": "South A8",
+      "name": "South (-5,4)",
       "demographic_groups": [
         {
-          "id": "p148-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.46153846153846156,
-            "ryu": 0.5384615384615384
-          }
+          "id": "p148-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4636, "ryu": 0.5364 }
         }
       ]
     },
@@ -3594,23 +2687,17 @@
       "id": "p149",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 8,
-        "r": 10
-      },
-      "total_population": 4511,
+      "position": { "q": -4, "r": 4 },
+      "total_population": 2834,
       "initial_district_id": "d3",
-      "name": "South A9",
+      "name": "South (-4,4)",
       "demographic_groups": [
         {
-          "id": "p149-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.46923076923076923,
-            "ryu": 0.5307692307692308
-          }
+          "id": "p149-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4611, "ryu": 0.5389 }
         }
       ]
     },
@@ -3618,23 +2705,17 @@
       "id": "p150",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 9,
-        "r": 10
-      },
-      "total_population": 4127,
+      "position": { "q": -3, "r": 4 },
+      "total_population": 3219,
       "initial_district_id": "d3",
-      "name": "South A10",
+      "name": "South (-3,4)",
       "demographic_groups": [
         {
-          "id": "p150-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4769230769230769,
-            "ryu": 0.5230769230769231
-          }
+          "id": "p150-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.3913, "ryu": 0.6087 }
         }
       ]
     },
@@ -3642,23 +2723,17 @@
       "id": "p151",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 10,
-        "r": 10
-      },
-      "total_population": 3622,
+      "position": { "q": -2, "r": 4 },
+      "total_population": 2880,
       "initial_district_id": "d3",
-      "name": "South A11",
+      "name": "South (-2,4)",
       "demographic_groups": [
         {
-          "id": "p151-base",
-          "name": "Registered voters",
-          "population_share": 1,
+          "id": "p151-all",
+          "name": "All voters",
+          "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4846153846153846,
-            "ryu": 0.5153846153846153
-          }
+          "vote_shares": { "ken": 0.4659, "ryu": 0.5341 }
         }
       ]
     },
@@ -3666,23 +2741,17 @@
       "id": "p152",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 11,
-        "r": 10
-      },
-      "total_population": 3092,
+      "position": { "q": -1, "r": 4 },
+      "total_population": 2704,
       "initial_district_id": "d3",
-      "name": "South A12",
+      "name": "South (-1,4)",
       "demographic_groups": [
         {
-          "id": "p152-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.49230769230769234,
-            "ryu": 0.5076923076923077
-          }
+          "id": "p152-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4573, "ryu": 0.5427 }
         }
       ]
     },
@@ -3690,23 +2759,17 @@
       "id": "p153",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 12,
-        "r": 10
-      },
-      "total_population": 2598,
+      "position": { "q": 0, "r": 4 },
+      "total_population": 3177,
       "initial_district_id": "d3",
-      "name": "South A13",
+      "name": "South (0,4)",
       "demographic_groups": [
         {
-          "id": "p153-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5,
-            "ryu": 0.5
-          }
+          "id": "p153-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.4991, "ryu": 0.5009 }
         }
       ]
     },
@@ -3714,23 +2777,17 @@
       "id": "p154",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 13,
-        "r": 10
-      },
-      "total_population": 2175,
+      "position": { "q": 1, "r": 4 },
+      "total_population": 3201,
       "initial_district_id": "d3",
-      "name": "South A14",
+      "name": "South (1,4)",
       "demographic_groups": [
         {
-          "id": "p154-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.5076923076923077,
-            "ryu": 0.49230769230769234
-          }
+          "id": "p154-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4155, "ryu": 0.5845 }
         }
       ]
     },
@@ -3738,23 +2795,17 @@
       "id": "p155",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 0,
-        "r": 11
-      },
-      "total_population": 1724,
+      "position": { "q": 2, "r": 4 },
+      "total_population": 3083,
       "initial_district_id": "d3",
-      "name": "South B1",
+      "name": "South (2,4)",
       "demographic_groups": [
         {
-          "id": "p155-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.3884615384615384,
-            "ryu": 0.6115384615384616
-          }
+          "id": "p155-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ken": 0.4079, "ryu": 0.5921 }
         }
       ]
     },
@@ -3762,23 +2813,17 @@
       "id": "p156",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 1,
-        "r": 11
-      },
-      "total_population": 1979,
+      "position": { "q": 3, "r": 4 },
+      "total_population": 2808,
       "initial_district_id": "d3",
-      "name": "South B2",
+      "name": "South (3,4)",
       "demographic_groups": [
         {
-          "id": "p156-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.3961538461538461,
-            "ryu": 0.6038461538461539
-          }
+          "id": "p156-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.4744, "ryu": 0.5256 }
         }
       ]
     },
@@ -3786,23 +2831,17 @@
       "id": "p157",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 2,
-        "r": 11
-      },
-      "total_population": 2311,
+      "position": { "q": -8, "r": 5 },
+      "total_population": 3211,
       "initial_district_id": "d3",
-      "name": "South B3",
+      "name": "South (-8,5)",
       "demographic_groups": [
         {
-          "id": "p157-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4038461538461538,
-            "ryu": 0.5961538461538463
-          }
+          "id": "p157-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4703, "ryu": 0.5297 }
         }
       ]
     },
@@ -3810,23 +2849,17 @@
       "id": "p158",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 3,
-        "r": 11
-      },
-      "total_population": 2694,
+      "position": { "q": -7, "r": 5 },
+      "total_population": 2755,
       "initial_district_id": "d3",
-      "name": "South B4",
+      "name": "South (-7,5)",
       "demographic_groups": [
         {
-          "id": "p158-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4115384615384615,
-            "ryu": 0.5884615384615385
-          }
+          "id": "p158-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4425, "ryu": 0.5575 }
         }
       ]
     },
@@ -3834,23 +2867,17 @@
       "id": "p159",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 4,
-        "r": 11
-      },
-      "total_population": 3092,
+      "position": { "q": -6, "r": 5 },
+      "total_population": 3020,
       "initial_district_id": "d3",
-      "name": "South B5",
+      "name": "South (-6,5)",
       "demographic_groups": [
         {
-          "id": "p159-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4192307692307692,
-            "ryu": 0.5807692307692308
-          }
+          "id": "p159-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.5024, "ryu": 0.4976 }
         }
       ]
     },
@@ -3858,23 +2885,17 @@
       "id": "p160",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 5,
-        "r": 11
-      },
-      "total_population": 3454,
+      "position": { "q": -5, "r": 5 },
+      "total_population": 3043,
       "initial_district_id": "d3",
-      "name": "South B6",
+      "name": "South (-5,5)",
       "demographic_groups": [
         {
-          "id": "p160-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.42692307692307685,
-            "ryu": 0.5730769230769232
-          }
+          "id": "p160-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4696, "ryu": 0.5304 }
         }
       ]
     },
@@ -3882,23 +2903,17 @@
       "id": "p161",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 6,
-        "r": 11
-      },
-      "total_population": 3713,
+      "position": { "q": -4, "r": 5 },
+      "total_population": 3278,
       "initial_district_id": "d3",
-      "name": "South B7",
+      "name": "South (-4,5)",
       "demographic_groups": [
         {
-          "id": "p161-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.43461538461538457,
-            "ryu": 0.5653846153846154
-          }
+          "id": "p161-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4074, "ryu": 0.5926 }
         }
       ]
     },
@@ -3906,23 +2921,17 @@
       "id": "p162",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 7,
-        "r": 11
-      },
-      "total_population": 3808,
+      "position": { "q": -3, "r": 5 },
+      "total_population": 3220,
       "initial_district_id": "d3",
-      "name": "South B8",
+      "name": "South (-3,5)",
       "demographic_groups": [
         {
-          "id": "p162-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4423076923076923,
-            "ryu": 0.5576923076923077
-          }
+          "id": "p162-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4149, "ryu": 0.5851 }
         }
       ]
     },
@@ -3930,23 +2939,17 @@
       "id": "p163",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 8,
-        "r": 11
-      },
-      "total_population": 3713,
+      "position": { "q": -2, "r": 5 },
+      "total_population": 3138,
       "initial_district_id": "d3",
-      "name": "South B9",
+      "name": "South (-2,5)",
       "demographic_groups": [
         {
-          "id": "p163-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.44999999999999996,
-            "ryu": 0.55
-          }
+          "id": "p163-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4094, "ryu": 0.5906 }
         }
       ]
     },
@@ -3954,23 +2957,17 @@
       "id": "p164",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 9,
-        "r": 11
-      },
-      "total_population": 3454,
+      "position": { "q": -1, "r": 5 },
+      "total_population": 3044,
       "initial_district_id": "d3",
-      "name": "South B10",
+      "name": "South (-1,5)",
       "demographic_groups": [
         {
-          "id": "p164-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4576923076923076,
-            "ryu": 0.5423076923076924
-          }
+          "id": "p164-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.3932, "ryu": 0.6068 }
         }
       ]
     },
@@ -3978,23 +2975,17 @@
       "id": "p165",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 10,
-        "r": 11
-      },
-      "total_population": 3092,
+      "position": { "q": 0, "r": 5 },
+      "total_population": 3194,
       "initial_district_id": "d3",
-      "name": "South B11",
+      "name": "South (0,5)",
       "demographic_groups": [
         {
-          "id": "p165-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.46538461538461534,
-            "ryu": 0.5346153846153847
-          }
+          "id": "p165-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4726, "ryu": 0.5274 }
         }
       ]
     },
@@ -4002,23 +2993,17 @@
       "id": "p166",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 11,
-        "r": 11
-      },
-      "total_population": 2694,
+      "position": { "q": 1, "r": 5 },
+      "total_population": 3020,
       "initial_district_id": "d3",
-      "name": "South B12",
+      "name": "South (1,5)",
       "demographic_groups": [
         {
-          "id": "p166-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.47307692307692306,
-            "ryu": 0.5269230769230769
-          }
+          "id": "p166-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ken": 0.4037, "ryu": 0.5963 }
         }
       ]
     },
@@ -4026,23 +3011,17 @@
       "id": "p167",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 12,
-        "r": 11
-      },
-      "total_population": 2311,
+      "position": { "q": 2, "r": 5 },
+      "total_population": 2993,
       "initial_district_id": "d3",
-      "name": "South B13",
+      "name": "South (2,5)",
       "demographic_groups": [
         {
-          "id": "p167-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4807692307692307,
-            "ryu": 0.5192307692307693
-          }
+          "id": "p167-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4567, "ryu": 0.5433 }
         }
       ]
     },
@@ -4050,23 +3029,17 @@
       "id": "p168",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 13,
-        "r": 11
-      },
-      "total_population": 1979,
+      "position": { "q": -8, "r": 6 },
+      "total_population": 3075,
       "initial_district_id": "d3",
-      "name": "South B14",
+      "name": "South (-8,6)",
       "demographic_groups": [
         {
-          "id": "p168-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4884615384615384,
-            "ryu": 0.5115384615384616
-          }
+          "id": "p168-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.5046, "ryu": 0.4954 }
         }
       ]
     },
@@ -4074,23 +3047,17 @@
       "id": "p169",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 0,
-        "r": 12
-      },
-      "total_population": 1612,
+      "position": { "q": -7, "r": 6 },
+      "total_population": 3237,
       "initial_district_id": "d3",
-      "name": "South C1",
+      "name": "South (-7,6)",
       "demographic_groups": [
         {
-          "id": "p169-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.3692307692307692,
-            "ryu": 0.6307692307692307
-          }
+          "id": "p169-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.3934, "ryu": 0.6066 }
         }
       ]
     },
@@ -4098,23 +3065,17 @@
       "id": "p170",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 1,
-        "r": 12
-      },
-      "total_population": 1790,
+      "position": { "q": -6, "r": 6 },
+      "total_population": 3091,
       "initial_district_id": "d3",
-      "name": "South C2",
+      "name": "South (-6,6)",
       "demographic_groups": [
         {
-          "id": "p170-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.3769230769230769,
-            "ryu": 0.6230769230769231
-          }
+          "id": "p170-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ken": 0.4155, "ryu": 0.5845 }
         }
       ]
     },
@@ -4122,23 +3083,17 @@
       "id": "p171",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 2,
-        "r": 12
-      },
-      "total_population": 2031,
+      "position": { "q": -5, "r": 6 },
+      "total_population": 3228,
       "initial_district_id": "d3",
-      "name": "South C3",
+      "name": "South (-5,6)",
       "demographic_groups": [
         {
-          "id": "p171-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.3846153846153846,
-            "ryu": 0.6153846153846154
-          }
+          "id": "p171-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4674, "ryu": 0.5326 }
         }
       ]
     },
@@ -4146,23 +3101,17 @@
       "id": "p172",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 3,
-        "r": 12
-      },
-      "total_population": 2311,
+      "position": { "q": -4, "r": 6 },
+      "total_population": 2964,
       "initial_district_id": "d3",
-      "name": "South C4",
+      "name": "South (-4,6)",
       "demographic_groups": [
         {
-          "id": "p172-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.39230769230769225,
-            "ryu": 0.6076923076923078
-          }
+          "id": "p172-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4885, "ryu": 0.5115 }
         }
       ]
     },
@@ -4170,23 +3119,17 @@
       "id": "p173",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 4,
-        "r": 12
-      },
-      "total_population": 2598,
+      "position": { "q": -3, "r": 6 },
+      "total_population": 3241,
       "initial_district_id": "d3",
-      "name": "South C5",
+      "name": "South (-3,6)",
       "demographic_groups": [
         {
-          "id": "p173-base",
-          "name": "Registered voters",
-          "population_share": 1,
+          "id": "p173-all",
+          "name": "All voters",
+          "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.39999999999999997,
-            "ryu": 0.6000000000000001
-          }
+          "vote_shares": { "ken": 0.4520, "ryu": 0.5480 }
         }
       ]
     },
@@ -4194,23 +3137,17 @@
       "id": "p174",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 5,
-        "r": 12
-      },
-      "total_population": 2852,
+      "position": { "q": -2, "r": 6 },
+      "total_population": 2976,
       "initial_district_id": "d3",
-      "name": "South C6",
+      "name": "South (-2,6)",
       "demographic_groups": [
         {
-          "id": "p174-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4076923076923077,
-            "ryu": 0.5923076923076923
-          }
+          "id": "p174-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4210, "ryu": 0.5790 }
         }
       ]
     },
@@ -4218,23 +3155,17 @@
       "id": "p175",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 6,
-        "r": 12
-      },
-      "total_population": 3028,
+      "position": { "q": -1, "r": 6 },
+      "total_population": 2786,
       "initial_district_id": "d3",
-      "name": "South C7",
+      "name": "South (-1,6)",
       "demographic_groups": [
         {
-          "id": "p175-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.41538461538461535,
-            "ryu": 0.5846153846153846
-          }
+          "id": "p175-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4270, "ryu": 0.5730 }
         }
       ]
     },
@@ -4242,23 +3173,17 @@
       "id": "p176",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 7,
-        "r": 12
-      },
-      "total_population": 3092,
+      "position": { "q": 0, "r": 6 },
+      "total_population": 3224,
       "initial_district_id": "d3",
-      "name": "South C8",
+      "name": "South (0,6)",
       "demographic_groups": [
         {
-          "id": "p176-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.423076923076923,
-            "ryu": 0.576923076923077
-          }
+          "id": "p176-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4495, "ryu": 0.5505 }
         }
       ]
     },
@@ -4266,23 +3191,17 @@
       "id": "p177",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 8,
-        "r": 12
-      },
-      "total_population": 3028,
+      "position": { "q": 1, "r": 6 },
+      "total_population": 3087,
       "initial_district_id": "d3",
-      "name": "South C9",
+      "name": "South (1,6)",
       "demographic_groups": [
         {
-          "id": "p177-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.43076923076923074,
-            "ryu": 0.5692307692307692
-          }
+          "id": "p177-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ken": 0.4751, "ryu": 0.5249 }
         }
       ]
     },
@@ -4290,23 +3209,17 @@
       "id": "p178",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 9,
-        "r": 12
-      },
-      "total_population": 2852,
+      "position": { "q": -8, "r": 7 },
+      "total_population": 3080,
       "initial_district_id": "d3",
-      "name": "South C10",
+      "name": "South (-8,7)",
       "demographic_groups": [
         {
-          "id": "p178-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.43846153846153846,
-            "ryu": 0.5615384615384615
-          }
+          "id": "p178-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4821, "ryu": 0.5179 }
         }
       ]
     },
@@ -4314,23 +3227,17 @@
       "id": "p179",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 10,
-        "r": 12
-      },
-      "total_population": 2598,
+      "position": { "q": -7, "r": 7 },
+      "total_population": 3283,
       "initial_district_id": "d3",
-      "name": "South C11",
+      "name": "South (-7,7)",
       "demographic_groups": [
         {
-          "id": "p179-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4461538461538461,
-            "ryu": 0.5538461538461539
-          }
+          "id": "p179-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ken": 0.4391, "ryu": 0.5609 }
         }
       ]
     },
@@ -4338,23 +3245,17 @@
       "id": "p180",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 11,
-        "r": 12
-      },
-      "total_population": 2311,
+      "position": { "q": -6, "r": 7 },
+      "total_population": 2701,
       "initial_district_id": "d3",
-      "name": "South C12",
+      "name": "South (-6,7)",
       "demographic_groups": [
         {
-          "id": "p180-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4538461538461538,
-            "ryu": 0.5461538461538462
-          }
+          "id": "p180-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4809, "ryu": 0.5191 }
         }
       ]
     },
@@ -4362,23 +3263,17 @@
       "id": "p181",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 12,
-        "r": 12
-      },
-      "total_population": 2031,
+      "position": { "q": -5, "r": 7 },
+      "total_population": 3060,
       "initial_district_id": "d3",
-      "name": "South C13",
+      "name": "South (-5,7)",
       "demographic_groups": [
         {
-          "id": "p181-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4615384615384615,
-            "ryu": 0.5384615384615385
-          }
+          "id": "p181-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4507, "ryu": 0.5493 }
         }
       ]
     },
@@ -4386,23 +3281,17 @@
       "id": "p182",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 13,
-        "r": 12
-      },
-      "total_population": 1790,
+      "position": { "q": -4, "r": 7 },
+      "total_population": 3182,
       "initial_district_id": "d3",
-      "name": "South C14",
+      "name": "South (-4,7)",
       "demographic_groups": [
         {
-          "id": "p182-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.46923076923076923,
-            "ryu": 0.5307692307692308
-          }
+          "id": "p182-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ken": 0.4605, "ryu": 0.5395 }
         }
       ]
     },
@@ -4410,23 +3299,17 @@
       "id": "p183",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 0,
-        "r": 13
-      },
-      "total_population": 1531,
+      "position": { "q": -3, "r": 7 },
+      "total_population": 3050,
       "initial_district_id": "d3",
-      "name": "South D1",
+      "name": "South (-3,7)",
       "demographic_groups": [
         {
-          "id": "p183-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.35,
-            "ryu": 0.65
-          }
+          "id": "p183-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ken": 0.4915, "ryu": 0.5085 }
         }
       ]
     },
@@ -4434,23 +3317,17 @@
       "id": "p184",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 1,
-        "r": 13
-      },
-      "total_population": 1633,
+      "position": { "q": -2, "r": 7 },
+      "total_population": 3088,
       "initial_district_id": "d3",
-      "name": "South D2",
+      "name": "South (-2,7)",
       "demographic_groups": [
         {
-          "id": "p184-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.35769230769230764,
-            "ryu": 0.6423076923076924
-          }
+          "id": "p184-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4640, "ryu": 0.5360 }
         }
       ]
     },
@@ -4458,23 +3335,17 @@
       "id": "p185",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 2,
-        "r": 13
-      },
-      "total_population": 1790,
+      "position": { "q": -1, "r": 7 },
+      "total_population": 3059,
       "initial_district_id": "d3",
-      "name": "South D3",
+      "name": "South (-1,7)",
       "demographic_groups": [
         {
-          "id": "p185-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.36538461538461536,
-            "ryu": 0.6346153846153846
-          }
+          "id": "p185-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.4737, "ryu": 0.5263 }
         }
       ]
     },
@@ -4482,23 +3353,17 @@
       "id": "p186",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 3,
-        "r": 13
-      },
-      "total_population": 1979,
+      "position": { "q": 0, "r": 7 },
+      "total_population": 2770,
       "initial_district_id": "d3",
-      "name": "South D4",
+      "name": "South (0,7)",
       "demographic_groups": [
         {
-          "id": "p186-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.3730769230769231,
-            "ryu": 0.6269230769230769
-          }
+          "id": "p186-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ken": 0.3935, "ryu": 0.6065 }
         }
       ]
     },
@@ -4506,23 +3371,17 @@
       "id": "p187",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 4,
-        "r": 13
-      },
-      "total_population": 2175,
+      "position": { "q": 1, "r": 7 },
+      "total_population": 3178,
       "initial_district_id": "d3",
-      "name": "South D5",
+      "name": "South (1,7)",
       "demographic_groups": [
         {
-          "id": "p187-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.38076923076923075,
-            "ryu": 0.6192307692307693
-          }
+          "id": "p187-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ken": 0.4461, "ryu": 0.5539 }
         }
       ]
     },
@@ -4530,23 +3389,17 @@
       "id": "p188",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 5,
-        "r": 13
-      },
-      "total_population": 2348,
+      "position": { "q": -8, "r": 8 },
+      "total_population": 3223,
       "initial_district_id": "d3",
-      "name": "South D6",
+      "name": "South (-8,8)",
       "demographic_groups": [
         {
-          "id": "p188-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.3884615384615384,
-            "ryu": 0.6115384615384616
-          }
+          "id": "p188-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4124, "ryu": 0.5876 }
         }
       ]
     },
@@ -4554,23 +3407,17 @@
       "id": "p189",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 6,
-        "r": 13
-      },
-      "total_population": 2466,
+      "position": { "q": -7, "r": 8 },
+      "total_population": 2713,
       "initial_district_id": "d3",
-      "name": "South D7",
+      "name": "South (-7,8)",
       "demographic_groups": [
         {
-          "id": "p189-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.39615384615384613,
-            "ryu": 0.6038461538461539
-          }
+          "id": "p189-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4940, "ryu": 0.5060 }
         }
       ]
     },
@@ -4578,23 +3425,17 @@
       "id": "p190",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 7,
-        "r": 13
-      },
-      "total_population": 2509,
+      "position": { "q": -6, "r": 8 },
+      "total_population": 3240,
       "initial_district_id": "d3",
-      "name": "South D8",
+      "name": "South (-6,8)",
       "demographic_groups": [
         {
-          "id": "p190-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.40384615384615385,
-            "ryu": 0.5961538461538461
-          }
+          "id": "p190-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4489, "ryu": 0.5511 }
         }
       ]
     },
@@ -4602,23 +3443,17 @@
       "id": "p191",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 8,
-        "r": 13
-      },
-      "total_population": 2466,
+      "position": { "q": -5, "r": 8 },
+      "total_population": 2772,
       "initial_district_id": "d3",
-      "name": "South D9",
+      "name": "South (-5,8)",
       "demographic_groups": [
         {
-          "id": "p191-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4115384615384615,
-            "ryu": 0.5884615384615385
-          }
+          "id": "p191-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ken": 0.4177, "ryu": 0.5823 }
         }
       ]
     },
@@ -4626,23 +3461,17 @@
       "id": "p192",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 9,
-        "r": 13
-      },
-      "total_population": 2348,
+      "position": { "q": -4, "r": 8 },
+      "total_population": 2999,
       "initial_district_id": "d3",
-      "name": "South D10",
+      "name": "South (-4,8)",
       "demographic_groups": [
         {
-          "id": "p192-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4192307692307692,
-            "ryu": 0.5807692307692308
-          }
+          "id": "p192-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ken": 0.4502, "ryu": 0.5498 }
         }
       ]
     },
@@ -4650,23 +3479,17 @@
       "id": "p193",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 10,
-        "r": 13
-      },
-      "total_population": 2175,
+      "position": { "q": -3, "r": 8 },
+      "total_population": 3171,
       "initial_district_id": "d3",
-      "name": "South D11",
+      "name": "South (-3,8)",
       "demographic_groups": [
         {
-          "id": "p193-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4269230769230769,
-            "ryu": 0.573076923076923
-          }
+          "id": "p193-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ken": 0.4756, "ryu": 0.5244 }
         }
       ]
     },
@@ -4674,23 +3497,17 @@
       "id": "p194",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 11,
-        "r": 13
-      },
-      "total_population": 1979,
+      "position": { "q": -2, "r": 8 },
+      "total_population": 2726,
       "initial_district_id": "d3",
-      "name": "South D12",
+      "name": "South (-2,8)",
       "demographic_groups": [
         {
-          "id": "p194-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4346153846153846,
-            "ryu": 0.5653846153846154
-          }
+          "id": "p194-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ken": 0.4649, "ryu": 0.5351 }
         }
       ]
     },
@@ -4698,23 +3515,17 @@
       "id": "p195",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 12,
-        "r": 13
-      },
-      "total_population": 1790,
+      "position": { "q": -1, "r": 8 },
+      "total_population": 3241,
       "initial_district_id": "d3",
-      "name": "South D13",
+      "name": "South (-1,8)",
       "demographic_groups": [
         {
-          "id": "p195-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.4423076923076923,
-            "ryu": 0.5576923076923077
-          }
+          "id": "p195-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ken": 0.4739, "ryu": 0.5261 }
         }
       ]
     },
@@ -4722,76 +3533,66 @@
       "id": "p196",
       "editable": true,
       "county_id": "south",
-      "position": {
-        "q": 13,
-        "r": 13
-      },
-      "total_population": 1633,
+      "position": { "q": 0, "r": 8 },
+      "total_population": 3152,
       "initial_district_id": "d3",
-      "name": "South D14",
+      "name": "South (0,8)",
       "demographic_groups": [
         {
-          "id": "p196-base",
-          "name": "Registered voters",
-          "population_share": 1,
-          "turnout_rate": 0.55,
-          "vote_shares": {
-            "ken": 0.44999999999999996,
-            "ryu": 0.55
-          }
+          "id": "p196-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ken": 0.4165, "ryu": 0.5835 }
         }
       ]
     }
   ],
   "events": [],
   "rules": {
-    "population_tolerance": 0.1,
+    "population_tolerance": 0.10,
     "contiguity": "required"
   },
   "success_criteria": [
     {
       "id": "sc-district-count",
       "required": true,
-      "description": "Every precinct is assigned to a district, and all three districts are in use.",
-      "criterion": {
-        "type": "district_count"
-      }
+      "description": "All three districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
     },
     {
       "id": "sc-population-balance",
       "required": true,
       "description": "All three districts have roughly equal population (within 10%).",
-      "criterion": {
-        "type": "population_balance"
-      }
+      "criterion": { "type": "population_balance" }
     },
     {
       "id": "sc-compactness",
       "required": false,
-      "description": "Districts have reasonable, compact shapes.",
+      "description": "All districts are reasonably compact (compactness ≥ 40%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
-        "threshold": 0.4
+        "threshold": 0.40
       }
     }
   ],
   "narrative": {
     "character": {
       "name": "You",
-      "role": "Redistricting Coordinator, Millbrook Tri-County Area",
-      "motivation": "The tri-county commission needs three State House districts for the upcoming election. Equal population, contiguous boundaries — by Friday."
+      "role": "Redistricting Commissioner, Millbrook County",
+      "motivation": "Millbrook County needs new district boundaries. The three counties — North, Central, and South — each have different populations. Your job is to draw three districts with roughly equal population. The current county-aligned map is out of balance."
     },
     "intro_slides": [
       {
-        "heading": "Three Counties. Three Districts.",
-        "body": "North County, Central County, and South County are being redrawn into three State House districts.\n\nThe challenge: population is unevenly distributed. You'll need to split counties to balance the numbers."
+        "heading": "Welcome to Millbrook County",
+        "body": "This is a larger map than the tutorial. Millbrook County has three regions: North, Central, and South. The current district boundaries follow county lines — but the populations aren't equal.\n\nYour job: adjust the boundaries so all three districts have roughly the same number of people."
       },
       {
-        "heading": "The rules are simple",
-        "body": "Each district must be contiguous — no islands. Population must be within 10% of equal. Party politics? Not your problem.\n\nDraw the lines."
+        "heading": "The Tools",
+        "body": "Select a district from the toolbar, then paint precincts to assign them. You don't need to redraw the entire map — just move a few boundary precincts to balance the populations.\n\nWatch the population balance indicator in the sidebar. When all three districts are within 10% of the target, the Submit button will activate."
       }
     ],
-    "objective": "Divide the Millbrook Tri-County Area into 3 contiguous districts with roughly equal population."
+    "objective": "Balance the three districts so each has roughly equal population (within 10%). Move boundary precincts between districts to fix the imbalance."
   }
 }

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -55,67 +55,110 @@ async function selectDistrict(
   await page.locator("button.district-btn").nth(nth).click();
 }
 
+/**
+ * Paint a set of hexes (given as [q,r] pairs) into a district using paintStroke.
+ * Resolves hex coordinates to precinct indices at runtime via the game store.
+ * This keeps tests readable: callers specify hex positions, not opaque index arrays.
+ */
+async function paintHexes(
+  page: import("@playwright/test").Page,
+  hexes: [number, number][],
+  district: number,
+): Promise<void> {
+  await page.evaluate(({ hexes, district }) => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], district: number) => void;
+      precincts: { coord: { q: number; r: number } }[];
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found on window");
+    const state = store.getState();
+    // Build (q,r) → index lookup from precincts
+    const coordToIdx = new Map<string, number>();
+    state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
+      coordToIdx.set(`${p.coord.q},${p.coord.r}`, i);
+    });
+    const ids = hexes.map(([q, r]: [number, number]) => {
+      const idx = coordToIdx.get(`${q},${r}`);
+      if (idx === undefined) throw new Error(`Hex (${q},${r}) not found in precincts`);
+      return idx;
+    });
+    state.paintStroke(ids, district);
+  }, { hexes, district });
+}
+
 // ─── scenario-002: "Give the Governor a Win" ─────────────────────────────────
 
-test("scenario-002 smoke: loads and renders 96 precincts", async ({ page }) => {
+test("scenario-002 smoke: loads and renders 91 precincts", async ({ page }) => {
   await page.goto("/?s=scenario-002&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
   await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
-
-  const hexCount = await page.locator("path.hex").count();
-  expect(hexCount).toBe(96);
+  expect(await page.locator("path.hex").count()).toBe(91);
 });
 
 test("scenario-002 smoke: intro shows correct character and objective", async ({ page }) => {
   await page.goto("/?s=scenario-002&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Ken Party");
-  await expect(page.locator("#objective-text")).toContainText("Ken Party wins at least 3 seats");
+  await expect(page.locator("#objective-text")).toContainText("Ken Party wins at least 3");
 });
 
-test("scenario-002 winnability: gerrymandering 3/4 Ken districts passes the map", async ({ page }) => {
+test("scenario-002 winnability: packing east Ryu bloc into one district passes", async ({ page }) => {
   /**
-   * Layout: 8 cols (q=0..7) × 12 rows (r=0..11) = 96 precincts, 4 districts × 24.
-   * Index formula: r * 8 + q  (0-based).
+   * Hex-of-hexes R=5: 91 precincts, 4 districts of ~23.
+   * Geography: inner-east (q≥1, d≤3) = 25% Ken (Ryu stronghold),
+   *            west (q≤0) = 62% Ken, outer-east = 52% Ken.
    *
-   * Initial (2-col vertical strips):
-   *   D1=q0-1, D2=q2-3, D3=q4-5, D4=q6-7
-   *   D1,D2 → north+SW → ~56% Ken → KEN
-   *   D3,D4 → north+SE → ~42% Ken → RYU
-   *   Result: 2 Ken / 2 Ryu → fails ≥3 Ken criterion
-   *
-   * Winning gerrymander:
-   *   Step 1: Select D3; paint q=6-7, r=0-5 (currently D4) → D3 gains North strip
-   *     Indices: r=0..5, q=6..7 → [6,7,14,15,22,23,30,31,38,39,46,47]
-   *   Step 2: Select D4; paint q=4-5, r=6-11 (currently D3) → D4 gets SE zone
-   *     Indices: r=6..11, q=4..5 → [52,53,60,61,68,69,76,77,84,85,92,93]
-   *
-   * Final:
-   *   D1=q0-1 all rows (56% Ken → KEN)
-   *   D2=q2-3 all rows (56% Ken → KEN)
-   *   D3=q4-7 r=0-5   (60% Ken North → KEN)
-   *   D4=q4-7 r=6-11  (25% Ken SE → RYU, sacrificed)
-   *   3 Ken / 1 Ryu ✓
+   * Winning strategy: pack the Ryu stronghold into D4, spread Ken across D1-D3.
+   *   D1 (23): west-center blob — Ken territory
+   *   D2 (22): southwest + south — Ken territory
+   *   D3 (23): northeast arc + outer-east — competitive Ken
+   *   D4 (23): inner-east Ryu core + nearby expansion — Ryu sacrifice
+   * Result: 3 Ken / 1 Ryu ✓
    */
   await loadScenario(page, "scenario-002");
 
-  // Initial map is valid (contiguous, balanced) — submit is enabled but criteria fail.
-  // No need to assert disabled; just apply the winning redistribution.
+  // Initial diagonal-strip assignment should fail (≤2 Ken seats)
+  await expect(page.locator("#btn-submit")).toBeDisabled();
 
-  // Step 1: D3 claims the northern strip from D4
-  await selectDistrict(page, 2); // D3
-  for (const idx of [6, 7, 14, 15, 22, 23, 30, 31, 38, 39, 46, 47]) {
-    await paintPrecinct(page, idx);
-  }
+  // D1: west-center Ken blob (23 hexes)
+  await paintHexes(page, [
+    [-3,-2],[-2,-2],[-1,-2], [-4,-1],[-3,-1],[-2,-1],[-1,-1],
+    [-5,0],[-4,0],[-3,0],[-2,0],[-1,0],[0,0],
+    [-5,1],[-4,1],[-3,1],[-2,1],[-1,1],[0,1],
+    [-5,2],[-4,2],[-3,2],[-2,2],
+  ], 1);
 
-  // Step 2: D4 claims the SE zone from D3
-  await selectDistrict(page, 3); // D4
-  for (const idx of [52, 53, 60, 61, 68, 69, 76, 77, 84, 85, 92, 93]) {
-    await paintPrecinct(page, idx);
-  }
+  // D2: south + southwest Ken territory (22 hexes)
+  await paintHexes(page, [
+    [-1,2],[0,2],
+    [-5,3],[-4,3],[-3,3],[-2,3],[-1,3],[0,3],[2,3],
+    [-5,4],[-4,4],[-3,4],[-2,4],[-1,4],[0,4],[1,4],
+    [-5,5],[-4,5],[-3,5],[-2,5],[-1,5],[0,5],
+  ], 2);
 
+  // D3: north + outer-east Ken arc (23 hexes)
+  await paintHexes(page, [
+    [0,-5],[1,-5],[2,-5],[3,-5],[4,-5],[5,-5],
+    [-1,-4],[0,-4],[5,-4],
+    [-2,-3],[-1,-3],[5,-3],
+    [4,-2],[5,-2], [4,-1],[5,-1],
+    [4,0],[5,0], [3,1],[4,1],
+    [2,2],[3,2], [1,3],
+  ], 3);
+
+  // D4: inner-east Ryu sacrifice — stronghold packed into one district (23 hexes)
+  await paintHexes(page, [
+    [1,-4],[2,-4],[3,-4],[4,-4],
+    [0,-3],[1,-3],[2,-3],[3,-3],[4,-3],
+    [0,-2],[1,-2],[2,-2],[3,-2],
+    [0,-1],[1,-1],[2,-1],[3,-1],
+    [1,0],[2,0],[3,0],
+    [1,1],[2,1], [1,2],
+  ], 4);
+
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
   await page.locator("#btn-submit").click();
   await expect(page.locator("#result-screen")).toBeVisible();
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
@@ -123,78 +166,94 @@ test("scenario-002 winnability: gerrymandering 3/4 Ken districts passes the map"
 
 // ─── scenario-003: "The Packing Problem" ─────────────────────────────────────
 
-test("scenario-003 smoke: loads and renders 120 precincts", async ({ page }) => {
+test("scenario-003 smoke: loads and renders 127 precincts", async ({ page }) => {
   await page.goto("/?s=scenario-003&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
   await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
-
-  const hexCount = await page.locator("path.hex").count();
-  expect(hexCount).toBe(120);
+  expect(await page.locator("path.hex").count()).toBe(127);
 });
 
 test("scenario-003 smoke: intro shows packing character and objective", async ({ page }) => {
   await page.goto("/?s=scenario-003&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Ken Party");
-  await expect(page.locator("#objective-text")).toContainText("4 of the 5 seats");
+  await expect(page.locator("#objective-text")).toContainText("at least 4 of 5 seats");
 });
 
-test("scenario-003 winnability: packing urban core into one district passes the map", async ({ page }) => {
+test("scenario-003 winnability: packing urban core into one district passes", async ({ page }) => {
   /**
-   * Layout: 10 cols (q=0..9) × 12 rows (r=0..11) = 120 precincts, 5 districts × 24.
-   * Index formula: r * 10 + q  (0-based).
+   * Hex-of-hexes R=6: 127 precincts, 5 districts of ~25.
+   * Geography: concentric — urban core (d≤2) = 15% Ken, suburban (d=3-4) = 42%,
+   *            rural (d=5-6) = 65%.
    *
-   * Urban core: q=3..6, r=3..8 = 24 precincts (15% Ken → strong Ryu).
-   * Initial (2-col vertical strips): D1=q0-1, D2=q2-3, D3=q4-5, D4=q6-7, D5=q8-9
-   *   D2 gets 6 core precincts (q=3, r=3-8) → leans Ryu → RYU
-   *   D3 gets 12 core precincts (q=4-5, r=3-8) → strongly Ryu → RYU
-   *   D4 gets 6 core precincts (q=6, r=3-8) → leans Ryu → RYU
-   *   D1, D5 are all rural (65% Ken) → KEN
-   *   Result: 2 Ken / 3 Ryu → fails ≥4 Ken
-   *
-   * Winning pack — consolidate all 24 core precincts into D3:
-   *   Step 1: Select D3; paint D2's core (q=3, r=3-8) → [33,43,53,63,73,83]
-   *   Step 2:            paint D4's core (q=6, r=3-8) → [36,46,56,66,76,86]
-   *     D3 now has 24+6+6=36 (over). Need to shed 12 non-core to D2 and D4.
-   *   Step 3: Select D2; paint q=4, r=0-2 and r=9-11 from D3 → [4,14,24,94,104,114]
-   *   Step 4: Select D4; paint q=5, r=0-2 and r=9-11 from D3 → [5,15,25,95,105,115]
-   *
-   * Final:
-   *   D1=q0-1 all rows (rural, 65% Ken → KEN)
-   *   D2=q2-3 non-core + q=4 r=0-2,r=9-11 (rural/suburban, ~59% Ken → KEN)
-   *   D3=q3-6 r=3-8 exactly (all urban core, 15% Ken → RYU, sacrifice)
-   *   D4=q5 r=0-2,r=9-11 + q=6-7 non-core (rural/suburban, ~59% Ken → KEN)
-   *   D5=q8-9 all rows (rural, 65% Ken → KEN)
-   *   4 Ken / 1 Ryu ✓
+   * Winning strategy: pack the urban Ryu core (d≤2, 19 hexes) + nearby
+   * suburban hexes into D3 as the sacrifice district (~22% Ken → Ryu landslide).
+   * Remaining 4 districts are suburban+rural → all Ken-majority (53-59% Ken).
+   *   D1 (26): northeast arc — rural/suburban Ken
+   *   D2 (26): northwest — rural/suburban Ken
+   *   D3 (25): urban core sacrifice — packed Ryu (~22% Ken)
+   *   D4 (25): southwest — suburban/rural Ken
+   *   D5 (25): southeast — suburban/rural Ken
+   * Result: 4 Ken / 1 Ryu ✓
    */
   await loadScenario(page, "scenario-003");
 
-  // Initial map is valid (contiguous, balanced) — submit is enabled but criteria fail.
-  // No need to assert disabled; just apply the winning redistribution.
+  // Initial angular-wedge assignment should fail (sectors mix urban+rural → ≤2 Ken seats)
+  await expect(page.locator("#btn-submit")).toBeDisabled();
 
-  // Step 1+2: Pack all core precincts into D3
-  await selectDistrict(page, 2); // D3
-  for (const idx of [33, 43, 53, 63, 73, 83]) {  // q=3, r=3-8 from D2
-    await paintPrecinct(page, idx);
-  }
-  for (const idx of [36, 46, 56, 66, 76, 86]) {  // q=6, r=3-8 from D4
-    await paintPrecinct(page, idx);
-  }
+  // D1: northeast arc — rural + suburban Ken territory (26 hexes)
+  await paintHexes(page, [
+    [0,-6],[1,-6],[2,-6],[3,-6],[4,-6],[5,-6],[6,-6],
+    [-1,-5],[0,-5],[1,-5],[2,-5],[3,-5],[4,-5],[5,-5],[6,-5],
+    [0,-4],[1,-4],[2,-4],[3,-4],[4,-4],[5,-4],[6,-4],
+    [4,-3],[5,-3],[6,-3],[4,-2],
+  ], 1);
 
-  // Step 3: Shed D3's non-core northern/southern q=4 column into D2
-  await selectDistrict(page, 1); // D2
-  for (const idx of [4, 14, 24, 94, 104, 114]) {  // q=4, r=0-2 and r=9-11
-    await paintPrecinct(page, idx);
-  }
+  // D2: northwest — rural + suburban Ken territory (26 hexes)
+  await paintHexes(page, [
+    [-2,-4],[-1,-4],
+    [-3,-3],[-2,-3],[-1,-3],
+    [-4,-2],[-3,-2],[-2,-2],
+    [-5,-1],[-4,-1],[-3,-1],[-2,-1],
+    [-6,0],[-5,0],[-4,0],[-3,0],
+    [-6,1],[-5,1],[-4,1],[-3,1],
+    [-6,2],[-5,2],[-4,2],
+    [-6,3],[-5,3],[-6,4],
+  ], 2);
 
-  // Step 4: Shed D3's non-core northern/southern q=5 column into D4
-  await selectDistrict(page, 3); // D4
-  for (const idx of [5, 15, 25, 95, 105, 115]) {  // q=5, r=0-2 and r=9-11
-    await paintPrecinct(page, idx);
-  }
+  // D3: urban core sacrifice — packed Ryu (25 hexes, ~22% Ken)
+  await paintHexes(page, [
+    [0,-3],[1,-3],[2,-3],[3,-3],
+    [-1,-2],[0,-2],[1,-2],[2,-2],[3,-2],
+    [-1,-1],[0,-1],[1,-1],[2,-1],
+    [-2,0],[-1,0],[0,0],[1,0],[2,0],
+    [-2,1],[-1,1],[0,1],[1,1],
+    [-2,2],[-1,2],[0,2],
+  ], 3);
 
+  // D4: southwest — suburban + rural Ken territory (25 hexes)
+  await paintHexes(page, [
+    [-3,2],
+    [-4,3],[-3,3],[-2,3],[-1,3],
+    [-5,4],[-4,4],[-3,4],[-2,4],[0,4],[1,4],
+    [-6,5],[-5,5],[-4,5],[-3,5],[-1,5],[0,5],[1,5],
+    [-6,6],[-5,6],[-4,6],[-3,6],[-2,6],[-1,6],[0,6],
+  ], 4);
+
+  // D5: southeast — suburban + rural Ken territory (25 hexes)
+  await paintHexes(page, [
+    [5,-2],[6,-2],
+    [3,-1],[4,-1],[5,-1],[6,-1],
+    [3,0],[4,0],[5,0],[6,0],
+    [2,1],[3,1],[4,1],[5,1],
+    [1,2],[2,2],[3,2],[4,2],
+    [0,3],[1,3],[2,3],[3,3],
+    [-1,4],[2,4],[-2,5],
+  ], 5);
+
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
   await page.locator("#btn-submit").click();
   await expect(page.locator("#result-screen")).toBeVisible();
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
@@ -202,71 +261,115 @@ test("scenario-003 winnability: packing urban core into one district passes the 
 
 // ─── scenario-004: "Cracking the Opposition" ─────────────────────────────────
 
-test("scenario-004 smoke: loads and renders 120 precincts", async ({ page }) => {
+test("scenario-004 smoke: loads and renders 127 precincts", async ({ page }) => {
   await page.goto("/?s=scenario-004&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
   await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
-
-  const hexCount = await page.locator("path.hex").count();
-  expect(hexCount).toBe(120);
+  expect(await page.locator("path.hex").count()).toBe(127);
 });
 
-test("scenario-004 smoke: intro references cracking tactic and prior scenario", async ({ page }) => {
+test("scenario-004 smoke: intro references cracking tactic", async ({ page }) => {
   await page.goto("/?s=scenario-004&debug");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("#char-role")).toContainText("Ken Party");
-  await expect(page.locator("#objective-text")).toContainText("Ken Party wins every seat");
+  await expect(page.locator("#objective-text")).toContainText("Ken Party must win every seat");
 });
 
 test("scenario-004 winnability: cracking the corridor across all 5 districts passes", async ({ page }) => {
   /**
-   * Layout: 10 cols (q=0..9) × 12 rows (r=0..11) = 120 precincts, 5 districts × 24.
-   * Index formula: r * 10 + q  (0-based).
+   * Hex-of-hexes R=6: 127 precincts, 5 districts of ~25.
+   * Geography: corridor (r=0, 13 hexes) = 18% Ken (Ryu band),
+   *            rest = 65% Ken (reliable Ken territory).
+   * Initial: horizontal slabs consolidating corridor in D3 → 4 Ken / 1 Ryu.
    *
-   * Corridor: r=5..6 (2 rows × 10 cols = 20 precincts, 18% Ken → strong Ryu).
-   * Upper: r=0..4 (50 precincts, 65% Ken). Lower: r=7..11 (50 precincts, 65% Ken).
-   *
-   * Initial (horizontal bands, corridor isolated in D3):
-   *   D3 = r=4,q=8-9 + r=5-6(all) + r=7,q=0-1 → corridor-heavy → 25% Ken → RYU
-   *   D1,D2,D4,D5 are upper/lower → 65% Ken → KEN
-   *   Result: 4 Ken / 1 Ryu → fails "all 5" (≥5 Ken) criterion
-   *
-   * Winning crack: vertical 2-col strips (each district gets 4 corridor precincts).
-   *   Each district (q=2k..2k+1, all rows): (4×0.18 + 20×0.65)/24 ≈ 57% Ken → KEN
-   *   Result: 5 Ken / 0 Ryu ✓
-   *
-   * Because the full redistribution spans 96+ precinct operations, we use
-   * window.__gameStore.paintStroke() to set assignments directly.
+   * Winning crack: 5 vertical q-column strips. Each crosses the corridor,
+   * picking up 2-4 Ryu hexes diluted among 24-27 Ken hexes → all Ken.
+   *   D1 (24): q≤-4 — far west strip, 3 corridor hexes (~59% Ken)
+   *   D2 (25): q=-3,-2 — west strip, 2 corridor hexes (~61% Ken)
+   *   D3 (25): q=-1,0 — center strip, 2 corridor hexes (~61% Ken)
+   *   D4 (26): q=1,2 — east strip, 2 corridor hexes (~62% Ken)
+   *   D5 (27): q≥3 — far east strip, 4 corridor hexes (~58% Ken)
+   * Result: 5 Ken / 0 Ryu ✓
    */
   await loadScenario(page, "scenario-004");
 
+  // Initial horizontal-slab assignment consolidates corridor → fails all-5 criterion
   await expect(page.locator("#btn-submit")).toBeDisabled();
 
-  // Build complete vertical-strip assignment via store.paintStroke()
-  // Each district d (0-based index) owns columns q=2d..2d+1, all rows.
-  await page.evaluate(() => {
-    const store = (window as unknown as Record<string, { getState: () => {
-      paintStroke: (ids: number[], district: number) => void;
-    } }>)["__gameStore"];
-    if (!store) throw new Error("__gameStore not found on window");
-    const getState = store.getState.bind(store);
-    const numQ = 10;
-    const numR = 12;
-    const districts = [1, 2, 3, 4, 5];
+  // D1: far west strip q≤-4 (24 hexes, crosses corridor at q=-6..-4 r=0)
+  await paintHexes(page, [
+    [-4,-2],
+    [-5,-1],[-4,-1],
+    [-6,0],[-5,0],[-4,0],
+    [-6,1],[-5,1],[-4,1],
+    [-6,2],[-5,2],[-4,2],
+    [-6,3],[-5,3],[-4,3],
+    [-6,4],[-5,4],[-4,4],
+    [-6,5],[-5,5],[-4,5],
+    [-6,6],[-5,6],[-4,6],
+  ], 1);
 
-    for (let d = 0; d < 5; d++) {
-      const ids: number[] = [];
-      for (let r = 0; r < numR; r++) {
-        for (let qOffset = 0; qOffset < 2; qOffset++) {
-          const q = d * 2 + qOffset;
-          ids.push(r * numQ + q);
-        }
-      }
-      getState().paintStroke(ids, districts[d]);
-    }
-  });
+  // D2: west strip q=-3,-2 (25 hexes, crosses corridor at q=-3,-2 r=0)
+  await paintHexes(page, [
+    [-2,-4],[-1,-4],
+    [-3,-3],[-2,-3],[-1,-3],
+    [-3,-2],[-2,-2],[-1,-2],
+    [-3,-1],[-2,-1],[-1,-1],
+    [-3,0],[-2,0],
+    [-3,1],[-2,1],
+    [-3,2],[-2,2],
+    [-3,3],[-2,3],
+    [-3,4],[-2,4],
+    [-3,5],[-2,5],
+    [-3,6],[-2,6],
+  ], 2);
+
+  // D3: center strip q=-1,0 (25 hexes, crosses corridor at q=-1,0 r=0)
+  await paintHexes(page, [
+    [0,-6],
+    [-1,-5],[0,-5],[1,-5],
+    [0,-4],[1,-4],
+    [0,-3],[1,-3],
+    [0,-2],[1,-2],
+    [0,-1],
+    [-1,0],[0,0],
+    [-1,1],[0,1],
+    [-1,2],[0,2],
+    [-1,3],[0,3],
+    [-1,4],[0,4],
+    [-1,5],[0,5],
+    [-1,6],[0,6],
+  ], 3);
+
+  // D4: east strip q=1,2 (26 hexes, crosses corridor at q=1,2 r=0)
+  await paintHexes(page, [
+    [1,-6],[2,-6],[3,-6],[4,-6],[5,-6],[6,-6],
+    [2,-5],[3,-5],[4,-5],
+    [2,-4],
+    [2,-3],[3,-3],
+    [2,-2],
+    [1,-1],[2,-1],
+    [1,0],[2,0],
+    [1,1],[2,1],
+    [1,2],[2,2],
+    [1,3],[2,3],
+    [1,4],[2,4],
+    [1,5],
+  ], 4);
+
+  // D5: far east strip q≥3 (27 hexes, crosses corridor at q=3..6 r=0)
+  await paintHexes(page, [
+    [5,-5],[6,-5],
+    [3,-4],[4,-4],[5,-4],[6,-4],
+    [4,-3],[5,-3],[6,-3],
+    [3,-2],[4,-2],[5,-2],[6,-2],
+    [3,-1],[4,-1],[5,-1],[6,-1],
+    [3,0],[4,0],[5,0],[6,0],
+    [3,1],[4,1],[5,1],
+    [3,2],[4,2],[3,3],
+  ], 5);
 
   await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
   await page.locator("#btn-submit").click();
@@ -276,15 +379,13 @@ test("scenario-004 winnability: cracking the corridor across all 5 districts pas
 
 // ─── scenario-005: "Valle Verde: A Voice for the Valley" ─────────────────────
 
-test("scenario-005 smoke: loads and renders 120 precincts", async ({ page }) => {
+test("scenario-005 smoke: loads and renders 127 precincts", async ({ page }) => {
   await page.goto("/?s=scenario-005&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
   await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
-
-  const hexCount = await page.locator("path.hex").count();
-  expect(hexCount).toBe(120);
+  expect(await page.locator("path.hex").count()).toBe(127);
 });
 
 test("scenario-005 smoke: intro shows VRA character and objective", async ({ page }) => {
@@ -296,61 +397,66 @@ test("scenario-005 smoke: intro shows VRA character and objective", async ({ pag
 
 test("scenario-005 winnability: consolidating the valley into one district passes", async ({ page }) => {
   /**
-   * Layout: 10 cols (q=0..9) × 12 rows (r=0..11) = 120 precincts, 5 districts × 24.
-   * Index formula: r * 10 + q  (0-based).
+   * Hex-of-hexes R=6: 127 precincts, 5 districts of ~25.
+   * Geography: valley (q=1..5, r=-2..1) = ~70% Latino, rim = ~20% Latino.
+   * Initial: diagonal strips crack the valley → no district ≥50% Latino.
    *
-   * Valley zone: q=3..8, r=5..8 = 24 precincts (~70% Latino).
-   * Initial (vertical 2-col strips): no district reaches 50% Latino → criterion fails.
-   *
-   * Winning redistribution — give the valley its own district (D3):
-   *   D1: q=0-1, all rows (unchanged — 24 pcts)
-   *   D2: q=2, all rows (12) + q=3-8, r=0-1 (12) = 24
-   *   D3: q=3-8, r=5-8 (valley, 24 pcts, ~70% Latino → majority_minority passes)
-   *   D4: q=3-8, r=2-4 (18) + q=9, r=0-5 (6) = 24
-   *   D5: q=9, r=6-11 (6) + q=3-8, r=9-11 (18) = 24
-   *
-   * All districts contiguous; population balanced (BASE_POP=1500 ±150, variance
-   * within 10% across all 24-precinct districts).
+   * Winning strategy: consolidate valley into D1 (20 valley + 5 nearby = 25).
+   *   D1 (25): valley hexes + nearby expansion → ~60% Latino ✓
+   *   D2-D5: rim hexes split into 4 contiguous districts
+   * Result: 1 majority-Latino district ✓
    */
   await loadScenario(page, "scenario-005");
 
-  await page.evaluate(() => {
-    const store = (window as unknown as Record<string, { getState: () => {
-      paintStroke: (ids: number[], district: number) => void;
-    } }>)["__gameStore"];
-    if (!store) throw new Error("__gameStore not found on window");
-    const { paintStroke } = store.getState();
+  // Initial diagonal-strip assignment cracks the valley → fails VRA criterion
+  await expect(page.locator("#btn-submit")).toBeDisabled();
 
-    const d1: number[] = [];
-    const d2: number[] = [];
-    const d3: number[] = [];
-    const d4: number[] = [];
-    const d5: number[] = [];
+  // D1: valley consolidated — all valley hexes (q=1..5, r=-2..1) + nearby (25 hexes, ~60% Latino)
+  await paintHexes(page, [
+    [1,-3],[2,-3],[3,-3],
+    [0,-2],[1,-2],[2,-2],[3,-2],[4,-2],[5,-2],
+    [0,-1],[1,-1],[2,-1],[3,-1],[4,-1],[5,-1],
+    [1,0],[2,0],[3,0],[4,0],[5,0],
+    [1,1],[2,1],[3,1],[4,1],[5,1],
+  ], 1);
 
-    // D1: q=0-1, all rows
-    for (let r = 0; r < 12; r++) for (let q = 0; q <= 1; q++) d1.push(r * 10 + q);
+  // D2: west rim (26 hexes)
+  await paintHexes(page, [
+    [-6,1],[-5,1],[-4,1],[-3,1],[-2,1],[-1,1],
+    [-6,2],[-5,2],[-4,2],[-3,2],[-2,2],[-1,2],
+    [-6,3],[-5,3],[-4,3],[-3,3],[-2,3],
+    [-6,4],[-5,4],[-4,4],[-3,4],
+    [-6,5],[-5,5],[-4,5],
+    [-6,6],[-5,6],
+  ], 2);
 
-    // D2: q=2 (all rows) + q=3-8 (r=0-1)
-    for (let r = 0; r < 12; r++) d2.push(r * 10 + 2);
-    for (let r = 0; r <= 1; r++) for (let q = 3; q <= 8; q++) d2.push(r * 10 + q);
+  // D3: northwest rim (25 hexes)
+  await paintHexes(page, [
+    [-1,-5],
+    [-2,-4],[-1,-4],[0,-4],[1,-4],
+    [-3,-3],[-2,-3],[-1,-3],[0,-3],
+    [-4,-2],[-3,-2],[-2,-2],[-1,-2],
+    [-5,-1],[-4,-1],[-3,-1],[-2,-1],[-1,-1],
+    [-6,0],[-5,0],[-4,0],[-3,0],[-2,0],[-1,0],[0,0],
+  ], 3);
 
-    // D3: valley q=3-8, r=5-8
-    for (let r = 5; r <= 8; r++) for (let q = 3; q <= 8; q++) d3.push(r * 10 + q);
+  // D4: south rim (26 hexes)
+  await paintHexes(page, [
+    [0,1],[0,2],[1,2],[2,2],[3,2],[4,2],
+    [-1,3],[0,3],[1,3],[2,3],[3,3],
+    [-2,4],[-1,4],[0,4],[1,4],[2,4],
+    [-3,5],[-2,5],[-1,5],[0,5],[1,5],
+    [-4,6],[-3,6],[-2,6],[-1,6],[0,6],
+  ], 4);
 
-    // D4: q=3-8, r=2-4 + q=9, r=0-5
-    for (let r = 2; r <= 4; r++) for (let q = 3; q <= 8; q++) d4.push(r * 10 + q);
-    for (let r = 0; r <= 5; r++) d4.push(r * 10 + 9);
-
-    // D5: q=9, r=6-11 + q=3-8, r=9-11
-    for (let r = 6; r <= 11; r++) d5.push(r * 10 + 9);
-    for (let r = 9; r <= 11; r++) for (let q = 3; q <= 8; q++) d5.push(r * 10 + q);
-
-    paintStroke(d1, 1);
-    paintStroke(d2, 2);
-    paintStroke(d3, 3);
-    paintStroke(d4, 4);
-    paintStroke(d5, 5);
-  });
+  // D5: northeast rim (25 hexes)
+  await paintHexes(page, [
+    [0,-6],[1,-6],[2,-6],[3,-6],[4,-6],[5,-6],[6,-6],
+    [0,-5],[1,-5],[2,-5],[3,-5],[4,-5],[5,-5],[6,-5],
+    [2,-4],[3,-4],[4,-4],[5,-4],[6,-4],
+    [4,-3],[5,-3],[6,-3],
+    [6,-2],[6,-1],[6,0],
+  ], 5);
 
   await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
   await page.locator("#btn-submit").click();
@@ -360,13 +466,13 @@ test("scenario-005 winnability: consolidating the valley into one district passe
 
 // ─── scenario-006: "Harden the Map" ─────────────────────────────────────────
 
-test("scenario-006 smoke: loads and renders 120 precincts", async ({ page }) => {
+test("scenario-006 smoke: loads and renders 127 precincts", async ({ page }) => {
   await page.goto("/?s=scenario-006&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
   await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
-  expect(await page.locator("path.hex").count()).toBe(120);
+  expect(await page.locator("path.hex").count()).toBe(127);
 });
 
 test("scenario-006 smoke: intro shows bipartisan consultant role", async ({ page }) => {
@@ -376,30 +482,100 @@ test("scenario-006 smoke: intro shows bipartisan consultant role", async ({ page
   await expect(page.locator("#objective-text")).toContainText("safe seats");
 });
 
-test("scenario-006 winnability: separating partisan flanks into safe districts passes", async ({ page }) => {
+test("scenario-006 winnability: column strips separate partisan flanks into safe seats", async ({ page }) => {
   /**
-   * Geography: q=0-5 Ken flank (~62%); q=6-9 Ryu flank (~62% Ryu).
-   * Winning: vertical 2-col strips — D1=q0-1, D2=q2-3, D3=q4-5 (Ken safe x3),
-   *          D4=q6-7, D5=q8-9 (Ryu safe x2). All margins ~24% > 15% threshold.
+   * Hex-of-hexes R=6: 127 precincts, 5 districts of ~25.
+   * Geography: left (q≤0) = 62% Ken, right (q≥1) = 38% Ken.
+   * Initial: angular wedges mixing both sides → all competitive.
+   *
+   * Winning strategy: vertical column strips that keep flanks separated.
+   * Boundary columns (q=-1, q=1, q=3) are shared between adjacent districts.
+   *   D1 (24): q=-6,-5,-4 — pure Ken (62%, margin 25% → safe Ken)
+   *   D2 (25): q=-3,-2 + upper q=-1 — pure Ken (62%, margin 24% → safe Ken)
+   *   D3 (25): lower q=-1 + q=0 + upper q=1 — mostly Ken (59%, margin 18% → safe Ken)
+   *   D4 (25): lower q=1 + q=2 + upper q=3 — Ryu territory (38%, margin 25% → safe Ryu)
+   *   D5 (28): lower q=3 + q=4,5,6 — Ryu territory (38%, margin 24% → safe Ryu)
+   * Result: 3 Ken safe + 2 Ryu safe ✓
    */
   await loadScenario(page, "scenario-006");
 
-  await page.evaluate(() => {
-    const store = (window as unknown as Record<string, { getState: () => {
-      paintStroke: (ids: number[], district: number) => void;
-    } }>)["__gameStore"];
-    if (!store) throw new Error("__gameStore not found on window");
-    const { paintStroke } = store.getState();
-    const numQ = 10, numR = 12;
-    for (let d = 0; d < 5; d++) {
-      const ids: number[] = [];
-      for (let r = 0; r < numR; r++) {
-        ids.push(r * numQ + d * 2);
-        ids.push(r * numQ + d * 2 + 1);
-      }
-      paintStroke(ids, d + 1);
-    }
-  });
+  // Initial angular-wedge assignment mixes left+right → all competitive → fails safe_seats
+  await expect(page.locator("#btn-submit")).toBeDisabled();
+
+  // D1: far-left Ken strip q=-6,-5,-4 (24 hexes)
+  await paintHexes(page, [
+    [-4,-2],
+    [-5,-1],[-4,-1],
+    [-6,0],[-5,0],[-4,0],
+    [-6,1],[-5,1],[-4,1],
+    [-6,2],[-5,2],[-4,2],
+    [-6,3],[-5,3],[-4,3],
+    [-6,4],[-5,4],[-4,4],
+    [-6,5],[-5,5],[-4,5],
+    [-6,6],[-5,6],[-4,6],
+  ], 1);
+
+  // D2: left Ken strip q=-3,-2 + upper 4 of q=-1 (25 hexes)
+  await paintHexes(page, [
+    [-1,-5],
+    [-2,-4],[-1,-4],
+    [-3,-3],[-2,-3],[-1,-3],
+    [-3,-2],[-2,-2],[-1,-2],
+    [-3,-1],[-2,-1],
+    [-3,0],[-2,0],
+    [-3,1],[-2,1],
+    [-3,2],[-2,2],
+    [-3,3],[-2,3],
+    [-3,4],[-2,4],
+    [-3,5],[-2,5],
+    [-3,6],[-2,6],
+  ], 2);
+
+  // D3: center Ken strip — lower q=-1 + q=0 + upper 4 of q=1 (25 hexes)
+  await paintHexes(page, [
+    [0,-6],[1,-6],
+    [0,-5],[1,-5],
+    [0,-4],[1,-4],
+    [0,-3],[1,-3],
+    [0,-2],
+    [-1,-1],[0,-1],
+    [-1,0],[0,0],
+    [-1,1],[0,1],
+    [-1,2],[0,2],
+    [-1,3],[0,3],
+    [-1,4],[0,4],
+    [-1,5],[0,5],
+    [-1,6],[0,6],
+  ], 3);
+
+  // D4: right Ryu strip — lower q=1 + q=2 + upper 6 of q=3 (25 hexes)
+  await paintHexes(page, [
+    [2,-6],[3,-6],
+    [2,-5],[3,-5],
+    [2,-4],[3,-4],
+    [2,-3],[3,-3],
+    [1,-2],[2,-2],[3,-2],
+    [1,-1],[2,-1],[3,-1],
+    [1,0],[2,0],
+    [1,1],[2,1],
+    [1,2],[2,2],
+    [1,3],[2,3],
+    [1,4],[2,4],
+    [1,5],
+  ], 4);
+
+  // D5: far-right Ryu strip — lower q=3 + q=4,5,6 (28 hexes)
+  await paintHexes(page, [
+    [4,-6],[5,-6],[6,-6],
+    [4,-5],[5,-5],[6,-5],
+    [4,-4],[5,-4],[6,-4],
+    [4,-3],[5,-3],[6,-3],
+    [4,-2],[5,-2],[6,-2],
+    [4,-1],[5,-1],[6,-1],
+    [3,0],[4,0],[5,0],[6,0],
+    [3,1],[4,1],[5,1],
+    [3,2],[4,2],[3,3],
+  ], 5);
 
   await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
   await page.locator("#btn-submit").click();

--- a/game/web/e2e/sprint3.spec.ts
+++ b/game/web/e2e/sprint3.spec.ts
@@ -63,15 +63,15 @@ test("intro: screen is visible on initial load before editor", async ({ page }) 
 test("intro: character name and role are shown from scenario narrative", async ({ page }) => {
   await page.goto("/");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
-  // tutorial-002.json character: name="You", role="Redistricting Coordinator, Millbrook Tri-County Area"
+  // tutorial-002.json character: name="You", role="Redistricting Commissioner, Millbrook County"
   await expect(page.locator("#char-name")).toHaveText("You");
-  await expect(page.locator("#char-role")).toContainText("Redistricting Coordinator");
+  await expect(page.locator("#char-role")).toContainText("Redistricting Commissioner");
 });
 
 test("intro: first slide heading is shown and Previous is disabled", async ({ page }) => {
   await page.goto("/");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
-  await expect(page.locator("#intro-slide-heading")).toHaveText("Three Counties. Three Districts.");
+  await expect(page.locator("#intro-slide-heading")).toHaveText("Welcome to Millbrook County");
   await expect(page.locator("#btn-intro-prev")).toBeDisabled();
 });
 
@@ -81,12 +81,12 @@ test("intro: Next advances to second slide; Previous returns to first", async ({
 
   // Advance to slide 2
   await page.locator("#btn-intro-next").click();
-  await expect(page.locator("#intro-slide-heading")).toHaveText("The rules are simple");
+  await expect(page.locator("#intro-slide-heading")).toHaveText("The Tools");
   await expect(page.locator("#btn-intro-prev")).toBeEnabled();
 
   // Return to slide 1
   await page.locator("#btn-intro-prev").click();
-  await expect(page.locator("#intro-slide-heading")).toHaveText("Three Counties. Three Districts.");
+  await expect(page.locator("#intro-slide-heading")).toHaveText("Welcome to Millbrook County");
 });
 
 test("intro: Start Drawing button appears on last slide and reveals editor", async ({ page }) => {
@@ -121,7 +121,7 @@ test("intro: Skip intro immediately reveals editor without navigating slides", a
 test("intro: objective text is shown from scenario narrative", async ({ page }) => {
   await page.goto("/");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
-  await expect(page.locator("#objective-text")).toContainText("Divide the Millbrook Tri-County Area");
+  await expect(page.locator("#objective-text")).toContainText("Balance the three districts");
 });
 
 // ─── GAME-017: Evaluation phase ───────────────────────────────────────────────
@@ -365,15 +365,25 @@ test("wip: WIP is cleared from localStorage after scenario completion", async ({
   await skip.click();
   await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
 
-  // Paint the 5 boundary precincts (indices 70-74) from d2→d1 — same winning move
-  // as the winnability test. After this the map is valid and submit is enabled.
+  // Paint 7 boundary precincts at r=-2, q=-6..0 from d2 (central) → d1 (north).
+  // Same winning move as the winnability test. After this the map is balanced.
   await page.evaluate(() => {
     const store = (window as unknown as Record<string, unknown>)["__gameStore"] as
-      | { getState: () => { paintStroke: (ids: number[], d: number) => void; setActiveDistrict: (d: number) => void } }
+      | { getState: () => { paintStroke: (ids: number[], d: number) => void; setActiveDistrict: (d: number) => void; precincts: { coord: { q: number; r: number } }[] } }
       | undefined;
     if (!store) throw new Error("__gameStore not exposed");
-    store.getState().setActiveDistrict(1);
-    store.getState().paintStroke([70, 71, 72, 73, 74], 1);
+    const state = store.getState();
+    state.setActiveDistrict(1);
+    const coordToIdx = new Map<string, number>();
+    state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
+      coordToIdx.set(`${p.coord.q},${p.coord.r}`, i);
+    });
+    const ids: number[] = [];
+    for (let q = -6; q <= 0; q++) {
+      const idx = coordToIdx.get(`${q},-2`);
+      if (idx !== undefined) ids.push(idx);
+    }
+    state.paintStroke(ids, 1);
   });
 
   await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
@@ -388,21 +398,17 @@ test("wip: WIP is cleared from localStorage after scenario completion", async ({
 
 // ─── GAME-019: Tutorial-002 winnability ───────────────────────────────────────
 
-test("winnability: painting 5 boundary precincts enables submit and produces a passing map", async ({ page }) => {
+test("winnability: painting boundary precincts enables submit and produces a passing map", async ({ page }) => {
   /**
    * tutorial-002 initial state: county-aligned (north→d1, central→d2, south→d3).
-   *   d1 = 174,473  (too low)
-   *   d2 = 235,676  (too high)
-   *   d3 = 203,095  (valid)
+   * Hex-of-hexes R=8 trimmed to 196. Counties split at r=-2/r=2.
+   *   d1 (north, r<-2): ~57 hexes, underpopulated (~-14%)
+   *   d2 (central, |r|≤2): ~74 hexes, overpopulated (~+13%)
+   *   d3 (south, r>2): ~65 hexes, about right (~+0.4%)
    * Submit is disabled; population imbalance prevents submission.
    *
-   * Winning move: paint precincts p071–p075 (q=0–4 at r=5, the north edge of the
-   * central county) from d2 → d1. This transfers 14,736 population:
-   *   d1 → 189,209  ✓  (target 204,415 ± 10% = [183,973, 224,856])
-   *   d2 → 220,940  ✓
-   *   d3 → 203,095  ✓
-   * All districts are contiguous. Compactness threshold (≥ 0.4, optional) should
-   * be satisfied by the resulting compact rectangular shapes.
+   * Winning move: paint 7 hexes at r=-2, q=-6..0 from d2 → d1.
+   * This transfers ~21k population, bringing all three districts within ±3%.
    */
   await loadEditor(page);
 
@@ -412,19 +418,28 @@ test("winnability: painting 5 boundary precincts enables submit and produces a p
   // Activate district 1 (the default, but be explicit)
   await page.locator("button.district-btn").first().click();
 
-  // Paint the 5 boundary precincts into district 1.
-  // The adapter uses 0-based array indices as DOM data-precinct-id values,
-  // not the string IDs from the JSON (p071→70, p072→71, …, p075→74).
-  // Uses page.evaluate + direct DOM dispatch rather than Playwright locator
-  // resolution, which can be unreliable for SVG data attributes.
-  for (const idx of [70, 71, 72, 73, 74]) {
-    await page.evaluate((id) => {
-      const path = document.querySelector(`path.hex[data-precinct-id='${id}']`);
-      if (!path) throw new Error(`Precinct path not found for index: ${id}`);
-      path.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
-      window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
-    }, idx);
-  }
+  // Paint 7 boundary precincts (r=-2, q=-6..0) from central (d2) into north (d1).
+  // These hexes are at the boundary between the north and central counties.
+  // Uses paintHexes helper for hex-coordinate-based painting.
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], district: number) => void;
+      precincts: { coord: { q: number; r: number } }[];
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found on window");
+    const state = store.getState();
+    const coordToIdx = new Map<string, number>();
+    state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
+      coordToIdx.set(`${p.coord.q},${p.coord.r}`, i);
+    });
+    // Move 7 hexes at r=-2, q=-6 through q=0 from d2 (central) into d1 (north)
+    const ids: number[] = [];
+    for (let q = -6; q <= 0; q++) {
+      const idx = coordToIdx.get(`${q},-2`);
+      if (idx !== undefined) ids.push(idx);
+    }
+    state.paintStroke(ids, 1);  // district 1 (north)
+  });
 
   // Submit should now be enabled (all districts within tolerance, contiguous)
   await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });

--- a/thoughts/shared/tickets/GAME-032-scenario-loader-error-handling.md
+++ b/thoughts/shared/tickets/GAME-032-scenario-loader-error-handling.md
@@ -1,0 +1,41 @@
+---
+id: GAME-032
+title: Improve scenario loader validation and error handling
+area: game, reliability
+status: open
+created: 2026-04-27
+---
+
+## Summary
+
+The scenario loader (`web/src/model/loader.ts`) fails silently on malformed JSON,
+preventing the game from loading with no user-visible error. When a criterion is
+missing a required field (e.g. `mean_median` without `party`), the loader throws
+deep in `requireString()` and the intro screen never appears — the player sees a
+blank page.
+
+Discovered during GAME-028 backport: scenario-004's `mean_median` criterion was
+missing the `party` field. The only diagnostic was a console error buried in the
+browser devtools.
+
+## Current State
+
+- `loadScenario()` throws on validation failure; caller catches and logs to console
+- No user-visible error message, no recovery path
+- Validation is strict (good) but error reporting is poor
+- Missing fields produce generic "expected string, got undefined" messages without
+  suggesting which field is wrong or what the valid options are
+
+## Goals / Acceptance Criteria
+
+- [ ] User-visible error screen when a scenario fails to load (not blank page)
+- [ ] Error message includes: scenario ID, which validation rule failed, and what
+      was expected (e.g. "mean_median criterion requires 'party' field")
+- [ ] Consider looser parsing with post-load validation: parse what you can, then
+      validate semantics, producing a list of all errors (not just the first)
+- [ ] e2e test: load a scenario with a known validation error, assert error screen shown
+
+## References
+
+- `web/src/model/loader.ts` — `loadScenario()`, `parseCriterion()`
+- GAME-028 — discovered during hex backport

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -98,6 +98,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-028-hex-shape-backport.md` | game, content | Backport hex-of-hexes shape to scenarios 002–006 + tutorial; regenerate JSON + rewrite e2e indices |
 | `GAME-029-about-page.md` | game, UX | About page: educational framing, designer intent, non-partisan stance, resource links |
 | `GAME-030-main-menu-and-campaigns.md` | game, UX, architecture | Main menu, campaign model, campaign select, layered navigation; replaces scenario-select-as-home |
+| `GAME-032-scenario-loader-error-handling.md` | game, reliability | Improve loader validation: user-visible error screen, collect all errors, helpful messages |
 | `GAME-031-gameplay-critique-followup.md` | game, content, balance | Review and act on external gameplay critique research (scenario difficulty, eval balance, design) |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Backport hex-of-hexes map shape to scenarios 002-006 + tutorial-002 (GAME-028)
- Scenarios 002 (R=5, 91 hexes), 003-006 (R=6, 127 hexes): generators rewritten from rectangular grids
- Tutorial-002: 14x14 rectangular → hex-of-hexes R=8 trimmed to 196 (circular shape, same precinct count)
- Tutorial-001 unchanged (already compact)
- `paintHexes()` test helper for readable hex-coordinate winnability tests
- Each winning assignment independently verified via Kotlin simulation scripts
- Filed GAME-032 for loader error handling (discovered during backport)

## Validation performed
- [x] `bazel test //web/...` — 11/11 targets pass (clean build)
- [x] All winnability tests verified via independent Kotlin scripts before coding
- [x] Each test asserts initial state fails (submit disabled) before painting winning assignment
- [x] Scenario-004 `mean_median` criterion fixed (missing `party` field)
- [ ] kubectl dry-run passed (N/A — no k8s)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services
- None — game content only

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- see GAME-028

## Rollback
- Revert merge commit
