### PR TITLE
chore: fix GAME-007 ticket status (open → resolved)

### DIFF
--- a/thoughts/shared/tickets/GAME-007-player-progress-persistence.md
+++ b/thoughts/shared/tickets/GAME-007-player-progress-persistence.md
@@ -2,7 +2,7 @@
 id: GAME-007
 title: Player progress persistence — save/resume game state
 area: game, storage
-status: open
+status: resolved
 created: 2026-04-25
 github_issue: 99
 ---


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Fix GAME-007 ticket file: `status: open` → `status: resolved` (was already resolved in TICKETS.md index)

## Validation performed
- [x] Ticket metadata only
- [ ] kubectl dry-run passed (N/A)
- [ ] sops decrypt verified (N/A)

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- GAME-007 status fix

## Rollback
- Revert merge commit
