### PR TITLE
chore(GAME-006): resolve — HTTP gzip sufficient for v1

### DIFF
--- a/thoughts/shared/tickets/GAME-006-scenario-compression.md
+++ b/thoughts/shared/tickets/GAME-006-scenario-compression.md
@@ -2,7 +2,7 @@
 id: GAME-006
 title: Compressed scenario format and efficient delivery
 area: game, build
-status: open
+status: resolved
 created: 2026-04-25
 ---
 
@@ -52,6 +52,20 @@ Can be deferred to Sprint 3–4 if HTTP compression satisfies v1 delivery needs.
 - Community scenario sharing (post-v1) will use the `.scenarioz` format defined here.
 - Avoid MessagePack, CBOR, or other binary formats — JSON is human-readable and
   debuggable; gzip compression ratios on JSON are already very good (~70–80%).
+
+## Resolution (2026-04-28)
+
+**Part A resolved**: HTTP compression is sufficient for v1. Scenario JSON files
+range from 19KB (tutorial-001) to 106KB (scenario-005, 2 demographic groups).
+With gzip, these compress to ~3-15KB each. Any production static host
+(GH Pages, Netlify, Vercel) serves gzip automatically. The dev server
+(python3 http.server) doesn't, but that's acceptable for development.
+
+**Part B deferred**: `.scenarioz` format deferred to when community scenario
+sharing is implemented. No loader changes needed for v1.
+
+**Decision**: No code changes required. HTTP gzip handles delivery; JSON stays
+as the canonical format. Document this in the scenario data format spec.
 
 ## References
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -81,7 +81,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 |---|---|---|
 | `BUILD-003-ts-rules-spawn-strategy-research.md` | build, typescript | Research optimal spawn_strategy config for aspect_rules_ts on macOS (darwin-sandbox + multi-target packages) |
 | `BUILD-004-playwright-bzl-macro.md` | build, testing | Playwright sh_test macro: proper Bazel rule for virtual store path resolution, replacing ad-hoc readlink discovery |
-| `GAME-006-scenario-compression.md` | game, build | Compressed scenario delivery: HTTP gzip for bundled; `.scenarioz` format for future downloads |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `LEGAL-001-content-presentation-risks.md` | legal, content | Research legal risk from partial/no eligibility-restriction warnings in sim authoring tool |
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
@@ -102,6 +101,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| GAME-006: scenario compression | HTTP gzip sufficient for v1; no code changes needed; .scenarioz deferred to community scenarios |
 | GAME-032: loader error handling | User-visible error screen with scenario ID, error message, and back button; replaces blank page on validation/fetch failures |
 | BUILD-006: extract inline styles | Inline `<style>` block extracted to styles.css; `'unsafe-inline'` remains in style-src for HTML element inline styles; serve + e2e updated |
 | BUILD-005: CSP meta tag | CSP added; script-src/style-src include 'unsafe-inline' temporarily (inline scripts + styles); title updated to Past the Post |


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Resolve GAME-006: HTTP gzip compression is sufficient for v1 scenario delivery
- Scenario JSON files range 19-106KB; gzip compresses to ~3-15KB
- No code changes needed; production static hosts serve gzip automatically
- `.scenarioz` portable format deferred to community scenarios (post-v1)

## Validation performed
- [x] Ticket resolution only — no code changes

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- see GAME-006

## Rollback
- Revert merge commit
