### PR TITLE
feat(LEGAL-001): content risk assessment + disclaimers for v1 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Christian Edward Jackson-Gruber
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/game/scenarios/gen-scenario-005.main.kts
+++ b/game/scenarios/gen-scenario-005.main.kts
@@ -232,7 +232,7 @@ $precincts
       },
       {
         "heading": "A Tradeoff You'll See",
-        "body": "Creating a majority-Latino district solves the legal problem — but notice what happens to the surrounding districts. Concentrating a cohesive voting bloc into one place can shift the balance everywhere else.\n\nThis is one of the real tensions in redistricting. Even compliance with a fairness law reshapes who wins and loses. There is no map without consequences."
+        "body": "Creating a majority-Latino district solves the legal problem — but notice what happens to the surrounding districts. Concentrating a cohesive voting bloc into one place can shift the balance everywhere else.\n\nThis is one of the real tensions in redistricting. Even compliance with a fairness law reshapes who wins and loses. There is no map without consequences.\n\nNote: This scenario uses simplified demographic data to illustrate VRA concepts. Real-world redistricting involves far more complex demographic analysis and legal requirements."
       }
     ],
     "objective": "Draw at least one majority-Latino district (≥ 50% Latino population) to give the Valley community a fair chance to elect their preferred representative."

--- a/game/scenarios/scenario-005.json
+++ b/game/scenarios/scenario-005.json
@@ -3512,7 +3512,7 @@
       },
       {
         "heading": "A Tradeoff You'll See",
-        "body": "Creating a majority-Latino district solves the legal problem — but notice what happens to the surrounding districts. Concentrating a cohesive voting bloc into one place can shift the balance everywhere else.\n\nThis is one of the real tensions in redistricting. Even compliance with a fairness law reshapes who wins and loses. There is no map without consequences."
+        "body": "Creating a majority-Latino district solves the legal problem — but notice what happens to the surrounding districts. Concentrating a cohesive voting bloc into one place can shift the balance everywhere else.\n\nThis is one of the real tensions in redistricting. Even compliance with a fairness law reshapes who wins and loses. There is no map without consequences.\n\nNote: This scenario uses simplified demographic data to illustrate VRA concepts. Real-world redistricting involves far more complex demographic analysis and legal requirements."
       }
     ],
     "objective": "Draw at least one majority-Latino district (≥ 50% Latino population) to give the Valley community a fair chance to elect their preferred representative."

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -26,6 +26,7 @@
         <h1>Past the Post</h1>
         <p>An educational redistricting simulator. Draw district boundaries, simulate elections, and discover how the same voters can produce wildly different outcomes depending on where the lines are drawn.</p>
         <p>This game is not advocacy for or against any political party, position, or reform proposal. It presents multiple perspectives — partisan operatives, reform commissioners, bipartisan dealmakers — so that players leave with better questions, not predetermined answers.</p>
+        <p style="color:#8898b0;font-size:0.82rem;font-style:italic;">The scenarios in this campaign use fictional data. They do not model real elections, real voters, or real communities. Redistricting in practice is governed by federal and state law.</p>
         <h2>Learn More</h2>
         <ul id="about-links">
           <li><a href="https://www.brennancenter.org/issues/gerrymandering-fair-representation" target="_blank" rel="noopener">Brennan Center — Gerrymandering &amp; Fair Representation</a></li>

--- a/thoughts/shared/research/2026-04-28-legal-content-risk-assessment.md
+++ b/thoughts/shared/research/2026-04-28-legal-content-risk-assessment.md
@@ -1,0 +1,129 @@
+---
+date: 2026-04-28
+researcher: claude
+repository: redistricting-sim
+topic: Content presentation legal risk assessment for v1 release
+tags: [legal, content, release, disclaimer]
+status: complete
+last_updated: 2026-04-28
+last_updated_by: claude
+---
+
+# Content Presentation Legal Risk Assessment — v1 Release
+
+## Scope
+
+This assessment covers the v1 release of "Past the Post," an educational
+redistricting simulator. It does NOT cover the future community authoring tool
+(post-v1), which has a materially different risk profile.
+
+## v1 Content Inventory
+
+The v1 game ships with:
+- 9 pre-authored scenarios + 1 tutorial (all content by project team)
+- Fictional party names: Ken/Ryu (8 scenarios), Cat/Dog (1 scenario)
+- Fictional region names (Clearwater County, Riverport, etc.)
+- One scenario (005 Valle Verde) uses ethnicity as a demographic dimension
+  (Latino/Anglo) to teach VRA concepts — no eligibility restrictions applied
+- About page with explicit educational and non-partisan framing
+- No user-generated content capability
+- No eligibility restrictions on any demographic group in any scenario
+- Open-source (MIT license anticipated)
+
+## Risk Analysis
+
+### 1. Partisan bias / political endorsement
+
+**Risk level: LOW.**
+
+The game presents redistricting from multiple perspectives: partisan operative
+(scenarios 002-004, 006, 009), reform commissioner (007-008), VRA compliance
+(005). No party maps to a real-world party. The about page explicitly states
+the game is "not advocacy for or against any political party, position, or
+reform proposal."
+
+**Mitigation already in place**: About page framing, fictional parties, symmetric
+scenario design (both parties get gerrymandering scenarios).
+
+### 2. Racial/ethnic content sensitivity
+
+**Risk level: LOW-MODERATE.**
+
+Scenario 005 (Valle Verde) models a majority-minority district using
+Latino/Anglo demographic groups. This directly teaches Section 2 of the Voting
+Rights Act — a real law with real implications. The scenario is carefully framed:
+the player is a court-appointed coordinator fixing a VRA violation, not choosing
+to discriminate.
+
+**Potential concern**: A player could interpret the scenario as trivializing the
+real-world impact of VRA compliance. The narrative text addresses this explicitly
+("Even compliance with a fairness law reshapes who wins and loses").
+
+**Mitigation**: The scenario narrative provides educational context. No scenario
+depicts voter suppression or eligibility restrictions.
+
+### 3. Eligibility restrictions / discriminatory modeling
+
+**Risk level: NONE for v1.**
+
+The original LEGAL-001 concern was about the authoring tool allowing users to
+create scenarios with arbitrary eligibility restrictions. This is entirely
+post-v1. The v1 game engine supports demographic groups but has no eligibility
+restriction feature in any shipped scenario.
+
+### 4. Educational use in schools
+
+**Risk level: LOW.**
+
+The game is explicitly designed for secondary education and engaged adults.
+Scenario narratives provide context for each exercise. The about page links to
+diverse external resources. Teachers would likely present specific scenarios
+with classroom discussion.
+
+**Potential concern**: A student playing unsupervised might encounter the
+bipartisan gerrymander (scenario 006) or the packing/cracking scenarios without
+understanding the ethical implications. The narrative text in each scenario
+addresses this, but it's not mandatory reading.
+
+### 5. Open-source liability
+
+**Risk level: VERY LOW.**
+
+The MIT license (if used) includes standard disclaimer of warranty. The
+open-source nature means anyone can modify the code, but the project's own
+content is carefully curated. Forks that add problematic content are not the
+project's responsibility.
+
+## Recommendations
+
+### For v1 release (required):
+
+1. **Add a disclaimer to the about page** (alongside existing framing):
+   "The scenarios in this campaign use fictional data. They do not model
+   real elections, real voters, or real communities. Redistricting in practice
+   is governed by federal and state law."
+
+2. **Add a brief disclaimer to scenario-005 (Valle Verde)** intro text:
+   "This scenario uses simplified demographic data to illustrate VRA concepts.
+   Real-world redistricting involves far more complex demographic analysis and
+   legal requirements."
+
+3. **Choose and apply a license**: MIT or Apache 2.0. Include standard
+   warranty disclaimer.
+
+### For post-v1 (when authoring tool ships):
+
+4. Revisit LEGAL-001 in full — the authoring tool changes the risk profile
+   significantly by enabling user-generated content with arbitrary dimensions.
+
+5. Consider: blanket disclaimer on all user-created scenarios, moderation
+   policy for shared scenarios, and whether to restrict eligibility restriction
+   modeling.
+
+## Conclusion
+
+The v1 release has low legal risk. The content is pre-authored, educational,
+non-partisan, and uses fictional entities. Two small disclaimer additions
+(about page + Valle Verde intro) provide adequate framing. A formal legal
+review is recommended before the authoring tool ships (post-v1) but is not
+blocking for v1.

--- a/thoughts/shared/tickets/LEGAL-001-content-presentation-risks.md
+++ b/thoughts/shared/tickets/LEGAL-001-content-presentation-risks.md
@@ -2,7 +2,7 @@
 id: LEGAL-001
 title: Content presentation legal risk research
 area: legal, content, presentation
-status: open
+status: resolved
 created: 2026-04-24
 ---
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -82,7 +82,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `BUILD-003-ts-rules-spawn-strategy-research.md` | build, typescript | Research optimal spawn_strategy config for aspect_rules_ts on macOS (darwin-sandbox + multi-target packages) |
 | `BUILD-004-playwright-bzl-macro.md` | build, testing | Playwright sh_test macro: proper Bazel rule for virtual store path resolution, replacing ad-hoc readlink discovery |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
-| `LEGAL-001-content-presentation-risks.md` | legal, content | Research legal risk from partial/no eligibility-restriction warnings in sim authoring tool |
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
 | `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
 | `AGENT-003-infra-pr-review-bot-comment-handling.md` | agentic workflow, infra | Propose bot comment handling (Copilot, CodeQL) to infra pr-review-cycle workflow |
@@ -101,6 +100,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| LEGAL-001: content risk assessment | Low risk for v1; all pre-authored content, fictional entities, educational framing; disclaimers added to about page + Valle Verde; authoring tool deferred to post-v1 review |
 | GAME-006: scenario compression | HTTP gzip sufficient for v1; no code changes needed; .scenarioz deferred to community scenarios |
 | GAME-032: loader error handling | User-visible error screen with scenario ID, error message, and back button; replaces blank page on validation/fetch failures |
 | BUILD-006: extract inline styles | Inline `<style>` block extracted to styles.css; `'unsafe-inline'` remains in style-src for HTML element inline styles; serve + e2e updated |


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Content risk assessment research document for v1 release
- v1 has low legal risk: all pre-authored content, fictional entities, educational framing
- Added educational disclaimer to about page
- Added VRA simplification note to scenario-005 (Valle Verde) intro
- Authoring tool content risks deferred to post-v1 review

## Validation performed
- [x] `bazel test //web/...` — 11/11 targets pass (clean build)
- [x] Research document reviewed risk across 5 categories

## Affected machines / services
- None

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- see LEGAL-001

## Rollback
- Revert merge commit
