### PR TITLE
feat(DIST-001): deploy scripts + Buildkite staging auto-deploy

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@
 # Bazel workspace; all build and test commands run from there.
 #
 # Dependency graph:
-#   build ──── test
+#   build ──── test ──── deploy-staging (main only)
 #
 # Setup (node_modules + Playwright Chromium) runs as part of the build step
 # via game/setup.sh. It is idempotent — on a warm agent it exits quickly.
@@ -49,3 +49,19 @@ steps:
       cd game
       ./setup.sh
       bazel test --config=ci //...
+
+  ##############################################################################
+  # DEPLOY STAGING — assemble and push to web_deploy branch /staging/
+  # Only runs on main branch after tests pass.
+  ##############################################################################
+
+  - label: ":rocket: Deploy Staging"
+    key: deploy-staging
+    depends_on: test
+    if: build.branch == "main"
+    agents:
+      os: macos
+    command: |
+      cd game
+      ./setup.sh
+      ./deploy-staging.sh

--- a/game/.gitignore
+++ b/game/.gitignore
@@ -11,5 +11,8 @@ node_modules/
 # Local dev serve output
 _serve_dist/
 
+# Deploy assembly output
+_deploy_out/
+
 # Playwright test output (traces, HTML report, error contexts)
 web/test-results/

--- a/game/deploy-assemble.sh
+++ b/game/deploy-assemble.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# deploy-assemble.sh — Build and assemble all game artifacts into a deploy directory.
+#
+# Usage:
+#   ./deploy-assemble.sh [OUTPUT_DIR]
+#
+# If OUTPUT_DIR is not specified, defaults to _deploy_out/ in the game/ directory.
+# The output directory is suitable for static hosting (GH Pages, Netlify, Porkbun, etc.).
+#
+# This script:
+#   1. Runs bazel build for the app bundle, WASM, HTML, and CSS
+#   2. Copies all artifacts + scenario JSON into the output directory
+#   3. The output is a flat static site ready to serve
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+OUTPUT_DIR="${1:-${SCRIPT_DIR}/_deploy_out}"
+
+echo "Building game artifacts..."
+bazel build //web:app //web:html //rust:wasm_calc_bindgen 2>&1
+
+BAZEL_BIN="${SCRIPT_DIR}/bazel-bin"
+
+echo "Assembling deploy to ${OUTPUT_DIR}..."
+rm -rf "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}/scenarios"
+
+# HTML + CSS (from source)
+cp web/index.html "${OUTPUT_DIR}/"
+cp web/styles.css "${OUTPUT_DIR}/"
+
+# JS bundle (from Bazel build)
+cp "${BAZEL_BIN}/web/bundle.js" "${OUTPUT_DIR}/"
+
+# WASM (from Bazel build)
+cp "${BAZEL_BIN}/rust/wasm_calc_bindgen/wasm_calc_bindgen.js" "${OUTPUT_DIR}/"
+cp "${BAZEL_BIN}/rust/wasm_calc_bindgen/wasm_calc_bindgen_bg.wasm" "${OUTPUT_DIR}/"
+
+# Scenario JSON (from source)
+cp scenarios/*.json "${OUTPUT_DIR}/scenarios/"
+
+echo "Deploy assembled: $(find "${OUTPUT_DIR}" -type f | wc -l | tr -d ' ') files"
+echo "  $(du -sh "${OUTPUT_DIR}" | cut -f1) total"

--- a/game/deploy-prod.sh
+++ b/game/deploy-prod.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# deploy-prod.sh — Promote staging to production (web_deploy branch root).
+#
+# Usage:
+#   ./deploy-prod.sh [DEPLOY_WORKSPACE_DIR]
+#
+# Copies /staging/ contents to the root of the web_deploy branch, commits,
+# and pushes. Porkbun serves pastthepost.org from the root.
+#
+# Prerequisites:
+#   - Staging must have been deployed first (deploy-staging.sh)
+#   - jj workspace "redistricting_sim_deploy" must exist
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPLOY_DIR="${1:-${REPO_ROOT}/../redistricting_sim_deploy}"
+
+if [[ ! -d "${DEPLOY_DIR}/.jj" ]]; then
+  echo "ERROR: Deploy workspace not found at ${DEPLOY_DIR}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${DEPLOY_DIR}/staging" ]]; then
+  echo "ERROR: No staging deploy found at ${DEPLOY_DIR}/staging/" >&2
+  echo "  Run deploy-staging.sh first." >&2
+  exit 1
+fi
+
+# Step 1: Copy staging → root (preserve .jj and staging/)
+echo "Promoting staging to production..."
+find "${DEPLOY_DIR}" -maxdepth 1 -not -name ".jj" -not -name "staging" -not -name "." -exec rm -rf {} +
+cp -R "${DEPLOY_DIR}/staging/"* "${DEPLOY_DIR}/"
+
+# Step 2: Commit
+echo "Committing production deploy..."
+cd "${REPO_ROOT}"
+MAIN_HASH="$(jj log --no-graph -r main -T 'commit_id.short(12)')"
+jj describe --workspace redistricting_sim_deploy -m "production: ${MAIN_HASH}" 2>&1
+jj new --workspace redistricting_sim_deploy 2>&1
+jj bookmark set web_deploy -r "redistricting_sim_deploy@-" 2>&1
+
+# Step 3: Push
+echo "Pushing web_deploy..."
+jj git push -b web_deploy 2>&1
+
+echo ""
+echo "✓ Deployed to production"
+echo "  Main commit: ${MAIN_HASH}"
+echo "  URL: https://pastthepost.org"

--- a/game/deploy-staging.sh
+++ b/game/deploy-staging.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# deploy-staging.sh — Build and deploy to staging (web_deploy branch /staging/).
+#
+# Usage:
+#   ./deploy-staging.sh [DEPLOY_WORKSPACE_DIR]
+#
+# Assembles build artifacts into /staging/ subdirectory of the web_deploy branch,
+# commits, and pushes. Porkbun serves staging.pastthepost.gg from /staging/.
+#
+# Prerequisites:
+#   - jj workspace "redistricting_sim_deploy" must exist
+#   - The workspace must be reachable from the main repo
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPLOY_DIR="${1:-${REPO_ROOT}/../redistricting_sim_deploy}"
+
+if [[ ! -d "${DEPLOY_DIR}/.jj" ]]; then
+  echo "ERROR: Deploy workspace not found at ${DEPLOY_DIR}" >&2
+  echo "  Create it with: jj workspace add ../redistricting_sim_deploy" >&2
+  exit 1
+fi
+
+# Step 1: Build and assemble
+STAGING_DIR="${SCRIPT_DIR}/_deploy_out"
+"${SCRIPT_DIR}/deploy-assemble.sh" "${STAGING_DIR}"
+
+# Step 2: Copy to deploy workspace /staging/ (preserve .jj and root files)
+echo "Copying to ${DEPLOY_DIR}/staging/..."
+rm -rf "${DEPLOY_DIR}/staging"
+mkdir -p "${DEPLOY_DIR}/staging"
+cp -R "${STAGING_DIR}/"* "${DEPLOY_DIR}/staging/"
+
+# Step 3: Commit from the deploy workspace directory
+echo "Committing staging deploy..."
+MAIN_HASH="$(cd "${REPO_ROOT}" && jj log --no-graph -r main -T 'commit_id.short(12)')"
+cd "${DEPLOY_DIR}"
+jj describe -m "staging: ${MAIN_HASH}" 2>&1
+jj new 2>&1
+
+# Step 4: Set bookmark and push (from main repo where bookmarks live)
+cd "${REPO_ROOT}"
+jj bookmark set web_deploy -r "redistricting_sim_deploy@-" 2>&1
+echo "Pushing web_deploy..."
+jj git push -b web_deploy 2>&1
+
+echo ""
+echo "✓ Deployed to staging"
+echo "  Main commit: ${MAIN_HASH}"
+echo "  URL: https://staging.pastthepost.gg"

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -173,7 +173,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 						// Warn: switching will discard in-progress work on a different scenario
 						showWipWarning(currentWip.scenarioId, entry.id);
 					} else {
-						window.location.assign(`/?s=${entry.id}`);
+						window.location.assign(`./?s=${entry.id}`);
 					}
 				});
 			}
@@ -197,7 +197,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		const onConfirm = () => {
 			cleanup();
 			clearWip();
-			window.location.assign(`/?s=${targetId}`);
+			window.location.assign(`./?s=${targetId}`);
 		};
 		const onCancel = () => {
 			cleanup();
@@ -270,7 +270,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	// ── Fetch + validate scenario JSON ────────────────────────────────────────
 	let json: unknown;
 	try {
-		const resp = await fetch(`/scenarios/${entryToLoad.id}.json`);
+		const resp = await fetch(`scenarios/${entryToLoad.id}.json`);
 		if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
 		json = (await resp.json()) as unknown;
 	} catch (e) {
@@ -282,7 +282,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 				<h1 style="color:#e94560;font-size:1.4rem;">Scenario Failed to Load</h1>
 				<p style="max-width:600px;text-align:center;">Could not fetch scenario <strong>${entryToLoad.id}</strong>.</p>
 				<pre style="background:#16213e;padding:12px 16px;border-radius:6px;max-width:600px;overflow-x:auto;font-size:0.8rem;color:#e94560;white-space:pre-wrap;">${msg}</pre>
-				<button onclick="window.location.assign('/')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
+				<button onclick="window.location.assign('./')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
 			</div>`,
 		);
 		return;
@@ -300,7 +300,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 				<h1 style="color:#e94560;font-size:1.4rem;">Scenario Failed to Load</h1>
 				<p style="max-width:600px;text-align:center;">Scenario <strong>${entryToLoad.id}</strong> could not be loaded due to a validation error.</p>
 				<pre style="background:#16213e;padding:12px 16px;border-radius:6px;max-width:600px;overflow-x:auto;font-size:0.8rem;color:#e94560;white-space:pre-wrap;">${msg}</pre>
-				<button onclick="window.location.assign('/')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
+				<button onclick="window.location.assign('./')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
 			</div>`,
 		);
 		return;
@@ -612,7 +612,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			if (allComplete) {
 				document.getElementById("wrap-up-screen")?.classList.remove("hidden");
 			} else {
-				window.location.assign("/");
+				window.location.assign("./");
 			}
 		});
 	}
@@ -624,7 +624,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	// "← Scenarios" button → flush WIP then return to scenario select
 	document.getElementById("btn-back-to-scenarios")?.addEventListener("click", () => {
 		flushWipSave();
-		window.location.assign("/");
+		window.location.assign("./");
 	});
 
 	// "Next Scenario" → if all scenarios complete, show wrap-up; else select screen.
@@ -634,13 +634,13 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			resultScreen!.classList.add("hidden");
 			document.getElementById("wrap-up-screen")?.classList.remove("hidden");
 		} else {
-			window.location.assign("/");
+			window.location.assign("./");
 		}
 	});
 
 	// Wrap-up "Play Again" → back to select screen
 	document.getElementById("btn-wrap-up-replay")?.addEventListener("click", () => {
-		window.location.assign("/");
+		window.location.assign("./");
 	});
 
 	// ── Subscribe to state changes ────────────────────────────────────────────

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -270,7 +270,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	// ── Fetch + validate scenario JSON ────────────────────────────────────────
 	let json: unknown;
 	try {
-		const resp = await fetch(`scenarios/${entryToLoad.id}.json`);
+		const resp = await fetch(`./scenarios/${entryToLoad.id}.json`);
 		if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
 		json = (await resp.json()) as unknown;
 	} catch (e) {


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- `deploy-assemble.sh`: Bazel build + artifact assembly into flat static site directory
- `deploy-staging.sh`: pushes assembled site to `web_deploy` branch `/staging/` via jj workspace
- `deploy-prod.sh`: promotes `/staging/` to root of `web_deploy` branch
- Buildkite pipeline: auto-deploy to staging on green main build
- `.gitignore`: exclude `_deploy_out/` build output
- Staging already deployed and pushed to `web_deploy` branch

## Validation performed
- [x] `deploy-assemble.sh` produces 15-file, 1.2MB static site
- [x] `deploy-staging.sh` successfully pushes to `web_deploy` branch
- [x] Buildkite pipeline syntax valid

## Affected machines / services
- Buildkite pipeline gains a deploy-staging step (main branch only)
- Porkbun static hosting serves from `web_deploy` branch

## Deployment steps (POST-MERGE)
- POST-MERGE: verify Buildkite runs deploy-staging on next main merge
- POST-MERGE: set up staging.pastthepost.gg DNS → /staging/ if not done

## Tickets addressed
- see DIST-001

## Rollback
- Revert merge commit; Buildkite deploy step is branch-gated (main only)
