### PR TITLE
plan: S10 quality-tidy sprint — 12 tickets + roadmap update

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -29,7 +29,8 @@ see game-vision.compressed.md for full scope
 | S7 | shippable $v1 | about page; wrap-up screen; hex backport 002–006; visual consistency | complete — 2026-04-28 |
 | S8 | hardening | CSP; extract CSS; loader errors; scenario compression | complete — 2026-04-28 |
 | S9 | first release | deploy pastthepost.org; legal review; basic a11y | current |
-| S10 | design research+polish | achievement UX; demographic overlays; geo features; full a11y | backlog |
+| S10 | code quality + tidy | test coverage gaps; dedup; extract modules; refactor for polish readiness | backlog |
+| S11 | design research+polish | achievement UX; demographic overlays; geo features; full a11y | backlog |
 
 §SPRINT1 [COMPLETE 2026-04-25]
 goal: app renders tutorial-001.json; player paints+undoes; no sim/game-loop yet
@@ -96,14 +97,23 @@ scope:
 known tickets: DIST-001 LEGAL-001 GAME-008(partial)
 
 §SPRINT10 (backlog)
+goal: code quality + tidy — close test coverage gaps, eliminate duplication, extract modules
+rationale: pre-polish housekeeping; makes S11 design work safer to implement
+tier1(high-value,low-risk): BUILD-007 GAME-033 GAME-034 GAME-035 GAME-036 GAME-037
+tier2(moderate-effort,clear-win): GAME-038 GAME-039 GAME-040
+order: BUILD-007 first (shared test runner used by GAME-035/036/037); then tier1 dedup (GAME-033 GAME-034); then tests (GAME-035 GAME-036 GAME-037); then tier2 structural
+scope note: Tier 3 deferred (GAME-041 GAME-042 GAME-043) — too large for tidy sprint
+
+§SPRINT11 (backlog)
 goal: design research+polish — resolve open design questions then implement
 scope:
   DESIGN-001 achievement/star UX; DESIGN-005/006/007 demographic overlays
   DESIGN-008 geographic features; GAME-008 full a11y; GAME-031 gameplay critique
   animated criteria eval (needs ticket); electoral outcome diff (needs ticket)
 
-§SPRINT11+ (later)
+§SPRINT12+ (later)
 GAME-030 main menu+campaigns (architecture; own sprint)
+GAME-041 split loader; GAME-042 break up main.ts; GAME-043 unify type systems (own sprint)
 
 §BACKLOG (not sprint-assigned)
 BUILD-003 ts-rules spawn strategy          any
@@ -111,17 +121,11 @@ BUILD-004 playwright bzl macro             any
 CI-001    GH Action ticket-close sync      any (low priority)
 AGENT-003 infra PR review bot              any
 DESIGN-004 legend layout                   any
-LEGAL-001 content presentation risk        before public release
-DIST-001  Steam deployment research        before distribution decision
-
-§BACKLOG (not sprint-assigned)
-BUILD-003 ts-rules spawn strategy          any
-BUILD-004 playwright bzl macro             any
-CI-001    GH Action ticket-close sync      any (low priority)
-AGENT-003 infra PR review bot              any
-DESIGN-004 legend layout                   any
+GAME-041  split loader.ts                  before S12
+GAME-042  break up main.ts                 before S12
+GAME-043  unify type systems               before S12
 
 §BLOCKING_OPEN_QUESTIONS
-DESIGN-001 star/achievement UX → blocks S10
+DESIGN-001 star/achievement UX → blocks S11
 RESOLVED: OQ4 narrative asset resolution — deferred indefinitely
 RESOLVED: OQ9 StateContext redesign — deferrable past $v1

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -44,7 +44,8 @@ See `thoughts/shared/vision/game-vision.compressed.md` for full scope.
 | 7 | Shippable v1 | About page; wrap-up screen; hex backport to 002–006; all scenarios visually consistent | complete — 2026-04-28 |
 | 8 | Hardening | CSP, extract CSS, loader error handling, scenario compression | complete — 2026-04-28 |
 | 9 | First release | Deploy to pastthepost.org; legal review; basic accessibility | current |
-| 10 | Design research + polish | Achievement UX, demographic overlays, geographic features, full accessibility | backlog |
+| 10 | Code quality + tidy | Test coverage gaps, deduplication, module extraction, pre-polish housekeeping | backlog |
+| 11 | Design research + polish | Achievement UX, demographic overlays, geographic features, full accessibility | backlog |
 
 ---
 
@@ -207,7 +208,37 @@ PRs: #119 #120 #121 #122
 
 ---
 
-## Sprint 10 — Design Research + Polish [BACKLOG]
+## Sprint 10 — Code Quality + Tidy [BACKLOG]
+
+**Goal**: Pre-polish housekeeping — close test coverage gaps, eliminate duplication,
+extract modules. Makes Sprint 11 design work safer and faster to implement.
+
+**Scope**:
+
+**Tier 1 — High value, low risk (do first):**
+- BUILD-007: Extract shared TAP test runner (eliminates boilerplate from 4+ test files)
+- GAME-033: Deduplicate `opLabel` constant in `evaluate.ts` (4 copies → 1)
+- GAME-034: Deduplicate error panel HTML in `main.ts` (2 blocks → `showLoadError()`)
+- GAME-035: Unit tests for `election.ts` (`runElection`, `simulateDistrict`)
+- GAME-036: Unit tests for WIP persistence in `progress.ts` (`saveWip`/`loadWip`/`clearWip`)
+- GAME-037: Unit tests for `adapter.ts` (`scenarioToSpike`)
+
+**Tier 2 — Moderate effort, clear structural win:**
+- GAME-038: Extract DOM panel renderers from `mapRenderer.ts` → `render/panels.ts`
+- GAME-039: Extract hex geometry utils from `generator.ts` → `model/hex-geometry.ts`
+- GAME-040: Name magic numbers in `mapRenderer.ts` (opacities, zoom step, lightness)
+
+**Recommended order**: BUILD-007 first (shared runner used by all new test files); then
+Tier 1 dedup (GAME-033, GAME-034); then Tier 1 tests (GAME-035, GAME-036, GAME-037);
+then Tier 2 structural (GAME-038, GAME-039, GAME-040).
+
+**Deferred (Tier 3 — too large for this sprint)**: GAME-041, GAME-042, GAME-043.
+
+**Known tickets**: BUILD-007, GAME-033 through GAME-040.
+
+---
+
+## Sprint 11 — Design Research + Polish [BACKLOG]
 
 **Goal**: Research-first sprint — resolve open design questions, then implement.
 
@@ -225,11 +256,14 @@ GAME-008, GAME-031. Two new tickets needed for animated criteria + electoral dif
 
 ---
 
-## Sprint 11+ (later)
+## Sprint 12+ (later)
 
 | Ticket | Area | Notes |
 |---|---|---|
 | GAME-030 | Main menu + campaigns | Architecture overhaul; own sprint |
+| GAME-041 | Split loader.ts | Structural; own sprint alongside GAME-042/043 |
+| GAME-042 | Break up main.ts | Structural; own sprint |
+| GAME-043 | Unify type systems | Largest refactor; own sprint; do last |
 
 ---
 
@@ -242,6 +276,9 @@ GAME-008, GAME-031. Two new tickets needed for animated criteria + electoral dif
 | CI-001 | GitHub Action ticket-close sync | Any (low priority) |
 | AGENT-003 | Infra PR review bot comment handling | Any |
 | DESIGN-004 | Legend layout (horizontal strip above map) | Any |
+| GAME-041 | Split loader.ts into focused modules | S12 |
+| GAME-042 | Break up main.ts god module | S12 |
+| GAME-043 | Unify spike + scenario type systems | S12 |
 
 ---
 
@@ -249,7 +286,7 @@ GAME-008, GAME-031. Two new tickets needed for animated criteria + electoral dif
 
 | Question | Blocks | ADR/spec reference |
 |---|---|---|
-| DESIGN-001: Star/achievement UX | Sprint 9 | DESIGN-001 ticket |
+| DESIGN-001: Star/achievement UX | Sprint 11 | DESIGN-001 ticket |
 
 **Resolved**:
 - OQ4 (narrative asset resolution) — intro slides shipped in Sprint 4 without image support; deferred indefinitely.

--- a/thoughts/shared/tickets/BUILD-007-shared-test-runner.md
+++ b/thoughts/shared/tickets/BUILD-007-shared-test-runner.md
@@ -1,0 +1,45 @@
+---
+id: BUILD-007
+title: Extract shared TAP test runner module
+area: build, testing
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+The TAP-style test runner boilerplate (`let testCount`, `function test()`, `function
+assertEqual()`, `function assertThrows()`, etc.) is copy-pasted into `loader_test.ts`,
+`evaluate_test.ts`, `validity_test.ts`, and `progress_test.ts` with minor variations.
+Each test file ships its own copy, making any fix or enhancement a four-file edit. Extract
+a shared `test_runner.ts` module that all unit test files import.
+
+## Current State
+
+~25 lines of identical test infrastructure in each of the four (and counting) `*_test.ts`
+files. `progress_test.ts` uses a slightly different variant with `passed`/`failed`/`total`
+counters; reconcile into one consistent API.
+
+## Goals / Acceptance Criteria
+
+- [ ] `game/web/src/test_runner.ts` (or `src/testing/test_runner.ts`) exports: `test()`,
+  `assertEqual()`, `assertThrows()`, `summarize()` (prints pass/fail/total summary)
+- [ ] `ts_library` (or appropriate Bazel target) for `test_runner.ts` in its BUILD.bazel
+- [ ] All four existing `*_test.ts` files updated to import from the shared module and remove
+  their inline boilerplate
+- [ ] New test files added in GAME-035 (election), GAME-036 (WIP), GAME-037 (adapter) also
+  use the shared module from the start
+- [ ] `bazel test //game/web/src/...` still passes in full
+
+## Test Coverage
+
+The shared runner is test infrastructure; its correctness is validated by the passing of
+all dependent test targets.
+
+## References
+
+- `game/web/src/model/loader_test.ts` (inline boilerplate)
+- `game/web/src/simulation/evaluate_test.ts` (inline boilerplate)
+- `game/web/src/simulation/validity_test.ts` (inline boilerplate)
+- `game/web/src/model/progress_test.ts` (slightly different variant)
+- GAME-035, GAME-036, GAME-037 (new tests that should use the shared runner)

--- a/thoughts/shared/tickets/GAME-033-oplabel-constant-dedup.md
+++ b/thoughts/shared/tickets/GAME-033-oplabel-constant-dedup.md
@@ -1,0 +1,34 @@
+---
+id: GAME-033
+title: Deduplicate opLabel constant in evaluate.ts
+area: game, code-quality
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+The `Record<CompareOp, string>` map `{ lt: "<", lte: "≤", eq: "=", gte: "≥", gt: ">" }` is
+declared four separate times inside `simulation/evaluate.ts` (lines ~199, 208, 259, 288) with
+slightly differing local names (`opLabel`, `opLabel`, `opLabel2`, `opLabel3`). Extract it once
+as a module-level constant.
+
+## Current State
+
+Four inline identical literals in `evaluateCriterion` and related functions. Any future operator
+addition requires four edits with no compiler enforcement.
+
+## Goals / Acceptance Criteria
+
+- [ ] Single module-level `const OP_LABEL: Record<CompareOp, string>` in `evaluate.ts`
+- [ ] All four inline usages replaced with the shared constant
+- [ ] `bazel test //game/web/src/simulation:evaluate_test` still passes (no behavior change)
+
+## Test Coverage
+
+- Existing `evaluate_test.ts` suite covers all code paths; re-run confirms no regression.
+- No new test cases needed — this is a pure constant extraction.
+
+## References
+
+- `game/web/src/simulation/evaluate.ts` lines ~199, 208, 259, 288

--- a/thoughts/shared/tickets/GAME-034-error-panel-dedup.md
+++ b/thoughts/shared/tickets/GAME-034-error-panel-dedup.md
@@ -1,0 +1,36 @@
+---
+id: GAME-034
+title: Deduplicate inline error panel HTML in main.ts
+area: game, code-quality
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+Two nearly identical `insertAdjacentHTML` error-panel blocks exist in `main.ts` (lines ~277–287
+for fetch errors, ~295–304 for validation errors). The only difference is the detail text.
+Extract them into a single `showLoadError(scenarioId: string, detail: string)` function.
+
+## Current State
+
+~60 lines of duplicated error HTML template; any styling or copy change must be made twice
+with no guarantee of consistency.
+
+## Goals / Acceptance Criteria
+
+- [ ] Single `showLoadError(scenarioId, detail)` function in `main.ts`
+- [ ] Both call-sites (fetch failure, validation failure) replaced with calls to the new function
+- [ ] Both error paths still display a user-visible error screen with scenario ID and detail
+- [ ] `bazel test //game/web/e2e:e2e_test` suite still passes
+
+## Test Coverage
+
+- Existing e2e tests exercise the error screen via load-failure scenarios; re-run confirms no
+  regression.
+- No new unit tests needed — behavior is covered by existing e2e.
+
+## References
+
+- `game/web/src/main.ts` lines ~277–304
+- GAME-032 (load error screen feature that introduced these blocks)

--- a/thoughts/shared/tickets/GAME-035-election-unit-tests.md
+++ b/thoughts/shared/tickets/GAME-035-election-unit-tests.md
@@ -1,0 +1,39 @@
+---
+id: GAME-035
+title: Unit tests for election.ts
+area: game, testing
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`simulation/election.ts` contains `runElection()` and `simulateDistrict()` — the core
+election simulation engine. Neither function has any unit tests. They are exercised only
+indirectly via e2e tests. As a pure domain module with no DOM dependency, it is a strong
+unit-test candidate.
+
+## Current State
+
+No `election_test.ts` file exists. `runElection` and `simulateDistrict` are untested in
+isolation; breakage is only catchable at the e2e layer.
+
+## Goals / Acceptance Criteria
+
+- [ ] `game/web/src/simulation/election_test.ts` exists using the established TAP runner pattern
+- [ ] `simulateDistrict`: tests for a district with a clear R majority, D majority, and a
+  near-tie; assert winner and margin output
+- [ ] `runElection`: tests covering all districts assigned, some unassigned, and empty
+  assignment map; assert seat counts and per-district results
+- [ ] `js_test` target added to `game/web/src/simulation/BUILD.bazel`
+- [ ] `bazel test //game/web/src/simulation:election_test` passes
+
+## Test Coverage
+
+This ticket IS the test coverage work. No other tests needed beyond the unit suite above.
+
+## References
+
+- `game/web/src/simulation/election.ts`
+- `game/web/src/simulation/BUILD.bazel`
+- Existing pattern: `evaluate_test.ts`, `validity_test.ts`

--- a/thoughts/shared/tickets/GAME-036-wip-persistence-unit-tests.md
+++ b/thoughts/shared/tickets/GAME-036-wip-persistence-unit-tests.md
@@ -1,0 +1,38 @@
+---
+id: GAME-036
+title: Unit tests for WIP persistence functions in progress.ts
+area: game, testing
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`model/progress.ts` has `saveWip`, `loadWip`, and `clearWip` functions that manage in-progress
+district assignments in `localStorage`. The completion-tracking functions in the same file
+(`markCompleted`, `isCompleted`, `serialize`, `deserialize`) are already tested in
+`progress_test.ts`. The WIP functions are not.
+
+## Current State
+
+`progress_test.ts` covers the `Progress` completion model only. The WIP persistence surface
+(`saveWip`/`loadWip`/`clearWip`) has no test coverage despite being a non-trivial localStorage
+contract relied upon by the game's save/resume flow.
+
+## Goals / Acceptance Criteria
+
+- [ ] `saveWip` + `loadWip` round-trip: saved assignments can be loaded back unchanged
+- [ ] `loadWip` returns `null` when nothing has been saved for that scenario
+- [ ] `clearWip` removes a previously saved WIP; subsequent `loadWip` returns `null`
+- [ ] `loadWip` with a corrupt/malformed localStorage value returns `null` gracefully
+- [ ] All new tests added to existing `progress_test.ts`; `bazel test //game/web/src/model:progress_test` passes
+
+## Test Coverage
+
+This ticket IS the test coverage work.
+
+## References
+
+- `game/web/src/model/progress.ts`
+- `game/web/src/model/progress_test.ts`
+- `game/web/src/model/BUILD.bazel`

--- a/thoughts/shared/tickets/GAME-037-adapter-unit-tests.md
+++ b/thoughts/shared/tickets/GAME-037-adapter-unit-tests.md
@@ -1,0 +1,40 @@
+---
+id: GAME-037
+title: Unit tests for adapter.ts (scenarioToSpike)
+area: game, testing
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`model/adapter.ts` contains `scenarioToSpike()` — the bridge that converts scenario-format
+data into the spike internal type system used by the renderer and simulation. This function
+performs party-share weighting, neighbor array construction, and district assignment passthrough.
+It has no unit tests.
+
+## Current State
+
+No `adapter_test.ts` exists. The adapter is exercised only via e2e, making its internal
+transformations (e.g. party key ordering, neighbor ID lists) invisible to the unit test layer.
+
+## Goals / Acceptance Criteria
+
+- [ ] `game/web/src/model/adapter_test.ts` exists using the established TAP runner pattern
+- [ ] Test: correct number of precincts produced for a given scenario fixture
+- [ ] Test: party vote-share values passed through correctly for a precinct with known partisan data
+- [ ] Test: neighbor lists populated (precinct with 2 neighbors → 2 entries in `neighbors`)
+- [ ] Test: all precincts assigned to their initial district from scenario assignments map
+- [ ] `js_test` target added to `game/web/src/model/BUILD.bazel`
+- [ ] `bazel test //game/web/src/model:adapter_test` passes
+
+## Test Coverage
+
+This ticket IS the test coverage work. Construct minimal scenario fixtures inline in the
+test file; do not load JSON from disk.
+
+## References
+
+- `game/web/src/model/adapter.ts`
+- `game/web/src/model/BUILD.bazel`
+- Existing pattern: `loader_test.ts`, `progress_test.ts`

--- a/thoughts/shared/tickets/GAME-038-extract-panel-renderers.md
+++ b/thoughts/shared/tickets/GAME-038-extract-panel-renderers.md
@@ -1,0 +1,42 @@
+---
+id: GAME-038
+title: Extract DOM panel renderers out of mapRenderer.ts
+area: game, code-quality
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`render/mapRenderer.ts` ends with four standalone functions — `renderResults`,
+`renderLegend`, `renderDistrictButtons`, and `renderValidityPanel` — that build raw HTML
+strings for DOM panels outside the SVG canvas. They do not belong in the SVG renderer
+module; they are presentation logic for sidebar and overlay elements. Extract them to a
+dedicated `render/panels.ts` module.
+
+## Current State
+
+`mapRenderer.ts` is 718 lines. The four panel functions at lines ~608–718 each build
+`innerHTML`-style HTML strings for DOM elements that are structurally separate from the
+D3 SVG. Any future panel work requires editing the renderer file.
+
+## Goals / Acceptance Criteria
+
+- [ ] New file `game/web/src/render/panels.ts` contains `renderResults`, `renderLegend`,
+  `renderDistrictButtons`, `renderValidityPanel`
+- [ ] `mapRenderer.ts` imports the panel functions from `panels.ts` (if it calls them) or
+  call-sites in `main.ts` are updated to import from `panels.ts` directly
+- [ ] `mapRenderer.ts` reduced by ~110 lines with no behavior change
+- [ ] `ts_library` target for `panels.ts` added to `game/web/src/render/BUILD.bazel`
+- [ ] `bazel build //game/web/...` and full e2e suite pass
+
+## Test Coverage
+
+No new unit tests required — panel functions build HTML strings for DOM; covered by
+existing Playwright e2e tests that assert visible panel content.
+
+## References
+
+- `game/web/src/render/mapRenderer.ts` lines ~608–718
+- `game/web/src/main.ts` (call-sites for panel functions)
+- `game/web/src/render/BUILD.bazel`

--- a/thoughts/shared/tickets/GAME-039-extract-hex-geometry.md
+++ b/thoughts/shared/tickets/GAME-039-extract-hex-geometry.md
@@ -1,0 +1,44 @@
+---
+id: GAME-039
+title: Extract hex geometry utilities from generator.ts
+area: game, code-quality
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`model/generator.ts` (267 lines) contains two distinct concerns: (1) a procedural precinct
+generator (`generatePrecincts`, `makePrng`, `gaussianContribution`, `makePartisanField`,
+`Epicenter`) that is dead code in the scenario-driven game path, and (2) pure hex geometry
+utilities (`hexToPixel`, `hexCorners`, `mapBounds`, `HEX_DIRECTIONS`) that are actively
+imported by `adapter.ts` and `mapRenderer.ts`. Extract the geometry utilities to a leaner
+`model/hex-geometry.ts` so the dead generator code can be safely isolated.
+
+## Current State
+
+Production code imports `hexToPixel`, `hexCorners`, `mapBounds`, `HEX_DIRECTIONS` from
+`generator.ts`. The generator itself (`generatePrecincts` and friends) is not called in
+any scenario-path code — it was the original spike procedural approach.
+
+## Goals / Acceptance Criteria
+
+- [ ] New `game/web/src/model/hex-geometry.ts` exports `hexToPixel`, `hexCorners`,
+  `mapBounds`, `HEX_DIRECTIONS` (and `HexCoord` type if needed)
+- [ ] `ts_library` target for `hex-geometry.ts` in `game/web/src/model/BUILD.bazel`
+- [ ] All imports in `adapter.ts` and `mapRenderer.ts` updated to import from `hex-geometry.ts`
+- [ ] `generator.ts` updated to import from `hex-geometry.ts` (so it still compiles if kept)
+  or clearly marked as spike-only with a comment; it need not be deleted in this ticket
+- [ ] `bazel build //game/web/...` and full test suite pass
+
+## Test Coverage
+
+No new tests required — hex geometry functions are pure math; their correctness is already
+implicitly validated by rendering tests and e2e suite.
+
+## References
+
+- `game/web/src/model/generator.ts`
+- `game/web/src/model/adapter.ts` (imports hex utils)
+- `game/web/src/render/mapRenderer.ts` (imports hex utils)
+- `game/web/src/model/BUILD.bazel`

--- a/thoughts/shared/tickets/GAME-040-maprenderer-magic-numbers.md
+++ b/thoughts/shared/tickets/GAME-040-maprenderer-magic-numbers.md
@@ -1,0 +1,41 @@
+---
+id: GAME-040
+title: Name magic numbers in mapRenderer.ts
+area: game, code-quality
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`render/mapRenderer.ts` contains several undocumented inline numeric literals whose purpose
+is not self-evident from context. Name them as module-level constants so future rendering
+work does not require reconstructing their meaning from surrounding code.
+
+## Current State
+
+Inline magic numbers in `mapRenderer.ts`:
+- `0.55` and `0.30` — lightness coefficients in population-density color calculation
+  (appears twice, identically, at lines ~573 and ~594)
+- `1.3` — zoom-step multiplier (lines ~313, ~315)
+- `0.7` — county border opacity (~line 237)
+- `0.6` — boundary opacity (~line 371)
+- `0.85` — preview border opacity (~line 413)
+- `0.95` — hover opacity (~line 447)
+- `800`, `600` — fallback SVG dimensions (~lines 255–256)
+
+## Goals / Acceptance Criteria
+
+- [ ] Each magic number above replaced with a named `const` at the top of `mapRenderer.ts`
+  (or grouped in a `RENDER_CONSTANTS` block)
+- [ ] The duplicated lightness calculation (`0.55 - normPop * 0.30`) is extracted to a
+  named helper or at minimum uses the named constants
+- [ ] No behavior change; `bazel build //game/web/...` and e2e suite pass
+
+## Test Coverage
+
+No new tests needed — this is a naming-only refactor; behavior is unchanged.
+
+## References
+
+- `game/web/src/render/mapRenderer.ts` lines ~237, 255–256, 313, 315, 371, 413, 447, 573, 594

--- a/thoughts/shared/tickets/GAME-041-split-loader.md
+++ b/thoughts/shared/tickets/GAME-041-split-loader.md
@@ -1,0 +1,41 @@
+---
+id: GAME-041
+title: Split loader.ts into focused modules
+area: game, code-quality
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`model/loader.ts` (894 lines) performs three distinct roles: (1) runtime type-checking
+primitives (`requireString`, `requireNumber`, etc.), (2) a suite of sub-parsers for
+individual JSON shapes, and (3) 12 validation invariants packed into a single
+~400-line function. Split into focused modules to improve navigability and testability.
+
+## Current State
+
+`loadScenario()` runs from line ~506 to 894. The primitive helpers (lines ~44–87) have no
+domain knowledge and are a natural standalone library. The invariant block is large enough
+to warrant its own `validateScenario()` private function or module.
+
+## Goals / Acceptance Criteria
+
+- [ ] `model/runtime-types.ts` exported module with `requireString`, `requireNumber`,
+  `requireBoolean`, `requireArray`, `requireObject`, and friends
+- [ ] `model/loader.ts` imports from `runtime-types.ts`; reduced by ~50 lines
+- [ ] `validateScenario(raw: unknown): Scenario` extracted as a named internal function
+  (not necessarily a separate file — the split can stay within `loader.ts` if preferred)
+- [ ] All existing `loader_test.ts` tests continue to pass unchanged
+- [ ] No behavior change; purely structural
+
+## Test Coverage
+
+No new tests needed — full loader test suite already covers the code being reorganized.
+`runtime-types.ts` primitives are implicitly tested via all `loader_test.ts` cases.
+
+## References
+
+- `game/web/src/model/loader.ts`
+- `game/web/src/model/loader_test.ts`
+- `game/web/src/model/BUILD.bazel`

--- a/thoughts/shared/tickets/GAME-042-break-up-main.md
+++ b/thoughts/shared/tickets/GAME-042-break-up-main.md
@@ -1,0 +1,49 @@
+---
+id: GAME-042
+title: Break up main.ts god module into testable units
+area: game, code-quality
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`main.ts` (667 lines) is a single large IIFE containing URL routing, screen management,
+WIP lifecycle, keyboard shortcuts, button handlers, result rendering, debug mode, and the
+store subscription loop. All functions are lexically scoped inside the async IIFE, making
+them untestable in isolation. This ticket decomposes the file into focused, importable
+modules.
+
+## Current State
+
+One top-level async IIFE. No functions are exported. Nothing in `main.ts` can be unit
+tested without launching the full browser environment.
+
+## Goals / Acceptance Criteria
+
+- [ ] `ui/scenarioSelect.ts` — `renderScenarioCards`, `showWipWarning`, `showScenarioSelect`
+  (~95 lines of scenario-select logic)
+- [ ] `ui/resultScreen.ts` — `showResultScreen` and result HTML rendering (~80 lines)
+- [ ] `ui/introFlow.ts` — `startScenarioIntro`, `showEditor` intro-slide logic (~50 lines)
+- [ ] `main.ts` reduced to a thin coordinator: routing, screen dispatch, store subscription,
+  keyboard wiring
+- [ ] Each extracted module is a `ts_library` target in BUILD.bazel
+- [ ] Extracted pure logic functions have unit tests where feasible
+- [ ] `bazel build //game/web/...` and full e2e suite pass with no behavior change
+
+## Test Coverage
+
+- [ ] At minimum: `showLoadError`, error-path helpers in extracted modules get unit tests
+- [ ] E2e suite continues to pass as the primary behavioral validation
+
+## Notes
+
+This is the highest-effort ticket in the quality backlog. Do not undertake alongside other
+simultaneous structural changes. Recommend a dedicated PR with thorough e2e validation before
+merge.
+
+## References
+
+- `game/web/src/main.ts`
+- `game/web/src/BUILD.bazel` (or wherever `main.ts` target lives)
+- GAME-034 (error panel dedup — complete before this ticket to reduce noise)

--- a/thoughts/shared/tickets/GAME-043-unify-type-systems.md
+++ b/thoughts/shared/tickets/GAME-043-unify-type-systems.md
@@ -1,0 +1,62 @@
+---
+id: GAME-043
+title: Unify spike and scenario type systems (retire adapter.ts / types.ts)
+area: game, code-quality
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+The codebase maintains two parallel type systems: `model/scenario.ts` (canonical
+scenario-format types, e.g. `Scenario`, `Precinct`) and `model/types.ts` (spike internal
+types, e.g. the flat `Precinct` with `neighbors`, `partyVotes`). `adapter.ts` bridges them
+at runtime. This split was an explicit Sprint 1 shortcut ("Sprint 3 will replace spike types
+entirely") that was never cleaned up. It is the root cause of: the adapter translation layer,
+the `partyIdToKey` indirection in `main.ts`, the dummy `demographics` field, the
+`SPIKE_PARTY_KEYS` constant, and the vestigial `Demographics` interface.
+
+## Current State
+
+`adapter.ts` (112 lines) converts `scenario.ts` types → `types.ts` types at load time.
+`election.ts`, `validity.ts`, and `evaluate.ts` all operate on `types.ts` types.
+`mapRenderer.ts` also uses `types.ts` types. The scenario-format types in `scenario.ts`
+are never used directly by simulation or rendering.
+
+## Goals / Acceptance Criteria
+
+- [ ] A single unified runtime precinct/district model (either extend `scenario.ts` types
+  or define a new `model/runtime.ts`); no separate spike types
+- [ ] `election.ts`, `validity.ts`, `evaluate.ts`, `mapRenderer.ts`, `gameStore.ts` all
+  operate on the unified model
+- [ ] `adapter.ts` eliminated (or reduced to a trivial load-time parse with no structural
+  translation)
+- [ ] `model/types.ts` eliminated or reduced to just the shared utility types that remain
+- [ ] `partyIdToKey` indirection, `SPIKE_PARTY_KEYS`, dummy `demographics` field removed
+- [ ] All unit tests and e2e tests pass
+
+## Test Coverage
+
+- [ ] All existing unit tests (`loader_test`, `evaluate_test`, `validity_test`, `progress_test`,
+  `election_test`, `adapter_test`) must pass against the unified model with no behavior change
+- [ ] All Playwright e2e tests pass
+- Scope note: this refactor has no new testable behaviors of its own — it is a structural
+  change; correctness is validated by the existing test suites continuing to pass
+
+## Notes
+
+This is the largest refactor in the backlog. It touches the simulation engine, renderer,
+store, and main orchestrator simultaneously. It should be its own sprint with thorough design
+upfront (what does the unified model look like?). Do not combine with other structural
+changes. Recommend completing GAME-039 (hex geometry extraction) and GAME-041 (loader split)
+first to reduce moving parts.
+
+## References
+
+- `game/web/src/model/adapter.ts`
+- `game/web/src/model/types.ts`
+- `game/web/src/model/scenario.ts`
+- `game/web/src/simulation/election.ts`, `evaluate.ts`, `validity.ts`
+- `game/web/src/render/mapRenderer.ts`
+- `game/web/src/store/gameStore.ts`
+- `game/web/src/main.ts` (partyIdToKey)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -93,6 +93,18 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-030-main-menu-and-campaigns.md` | game, UX, architecture | Main menu, campaign model, campaign select, layered navigation; replaces scenario-select-as-home |
 | `GAME-031-gameplay-critique-followup.md` | game, content, balance | Review and act on external gameplay critique research (scenario difficulty, eval balance, design) |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
+| `BUILD-007-shared-test-runner.md` | build, testing | Extract shared TAP test runner module; eliminate boilerplate copied across 4+ test files |
+| `GAME-033-oplabel-constant-dedup.md` | game, code-quality | Deduplicate opLabel constant in evaluate.ts (4 inline copies → 1 module-level const) |
+| `GAME-034-error-panel-dedup.md` | game, code-quality | Deduplicate inline error panel HTML in main.ts (2 identical blocks → showLoadError function) |
+| `GAME-035-election-unit-tests.md` | game, testing | Unit tests for election.ts (runElection + simulateDistrict; currently no unit coverage) |
+| `GAME-036-wip-persistence-unit-tests.md` | game, testing | Unit tests for WIP persistence functions in progress.ts (saveWip/loadWip/clearWip) |
+| `GAME-037-adapter-unit-tests.md` | game, testing | Unit tests for adapter.ts scenarioToSpike (party weights, neighbor lists, district assignments) |
+| `GAME-038-extract-panel-renderers.md` | game, code-quality | Extract DOM panel renderers out of mapRenderer.ts into render/panels.ts |
+| `GAME-039-extract-hex-geometry.md` | game, code-quality | Extract hex geometry utilities (hexToPixel, hexCorners, mapBounds) from generator.ts into hex-geometry.ts |
+| `GAME-040-maprenderer-magic-numbers.md` | game, code-quality | Name magic numbers in mapRenderer.ts (opacity values, zoom step, lightness coefficients, fallback dimensions) |
+| `GAME-041-split-loader.md` | game, code-quality | Split loader.ts: extract runtime-types.ts primitives; name validateScenario() internally |
+| `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
+| `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [ ] N/A — no parent PR

## Summary

- Files 12 new tickets (GAME-033–043, BUILD-007) covering the S10 quality-tidy sprint: test coverage gaps, code deduplication, and module extraction
- Updates sprint roadmap: inserts S10 (quality/tidy) between S9 (current release) and the former S10 (now S11 design/polish); adds Tier 3 structural tickets to backlog and S12+
- Both `.md` and `.compressed.md` forms updated for the sprint roadmap

## Validation performed

- [ ] N/A — prose/planning only; no code changes

## Affected machines / services

- N/A — planning documents only

## Deployment steps (POST-MERGE)

- N/A

## Tickets addressed

- see GAME-033, GAME-034, GAME-035, GAME-036, GAME-037, GAME-038, GAME-039, GAME-040, GAME-041, GAME-042, GAME-043, BUILD-007

## Rollback

- Revert commit; no state changes outside of thoughts/ docs
