### PR TITLE
feat(BUILD-007): extract shared TAP test runner module

### DIFF
--- a/game/web/src/model/BUILD.bazel
+++ b/game/web/src/model/BUILD.bazel
@@ -104,7 +104,10 @@ ts_project(
     srcs = ["progress_test.ts"],
     tsconfig = ":tsconfig",
     declaration = True,
-    deps = [":progress_lib"],
+    deps = [
+        ":progress_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
     testonly = True,
 )
 
@@ -116,6 +119,7 @@ js_test(
     data = [
         ":progress_test_lib",
         ":progress_lib",
+        "//web/src/testing:test_runner_lib",
     ],
     node_options = [
         "--experimental-vm-modules",
@@ -138,19 +142,15 @@ ts_project(
     srcs = ["loader_test.ts"],
     tsconfig = ":tsconfig",
     declaration = True,
-    deps = [":loader_lib", ":model_lib"],
+    deps = [
+        ":loader_lib",
+        ":model_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
     testonly = True,
 )
 
 # ── loader_test: run tests with Node built-in test runner ─────────────────────
-#
-# aspect_rules_js js_test runs the entry JS file with Node.js.
-# The compiled output of loader_test_lib is loader_test.js (ES2022 modules).
-# Node 18+ supports ESM natively via --input-type or .mjs; however the compiled
-# output from ts_project is .js with ES module syntax.
-#
-# We pass --experimental-vm-modules (Node ≥ 18) and use the js_test entry_point
-# to point at the compiled .js file.
 
 js_test(
     name = "loader_test",
@@ -159,6 +159,7 @@ js_test(
         ":loader_test_lib",
         ":loader_lib",
         ":model_lib",
+        "//web/src/testing:test_runner_lib",
     ],
     node_options = [
         "--experimental-vm-modules",

--- a/game/web/src/model/loader_test.ts
+++ b/game/web/src/model/loader_test.ts
@@ -1,12 +1,7 @@
 /**
  * Unit tests for loadScenario.
  *
- * Uses a minimal hand-rolled test runner (no external test framework dependencies)
- * so the test file type-checks under the existing tsconfig without @types/node.
- *
- * The runner prints TAP-like output: "ok N - description" / "not ok N - description".
- * Exit code 1 if any test fails.
- *
+ * Uses the shared TAP runner from //web/src/testing:test_runner_lib.
  * Run via Bazel: bazel test //web/src/model:loader_test
  *
  * Coverage:
@@ -20,55 +15,7 @@
  */
 
 import { loadScenario } from "./loader.js";
-
-// ─── Minimal test runner ──────────────────────────────────────────────────────
-
-let testCount = 0;
-let failCount = 0;
-
-function test(name: string, fn: () => void): void {
-  testCount++;
-  try {
-    fn();
-    console.log(`ok ${testCount} - ${name}`);
-  } catch (e) {
-    failCount++;
-    console.log(`not ok ${testCount} - ${name}`);
-    console.error(`  # ${e instanceof Error ? e.message : String(e)}`);
-  }
-}
-
-function assertEqual<T>(actual: T, expected: T, msg?: string): void {
-  if (actual !== expected) {
-    throw new Error(`${msg ?? "assertEqual"}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
-  }
-}
-
-function assertThrows(fn: () => unknown, pattern: RegExp, msg?: string): void {
-  let threw = false;
-  try {
-    fn();
-  } catch (e) {
-    threw = true;
-    const message = e instanceof Error ? e.message : String(e);
-    if (!pattern.test(message)) {
-      throw new Error(
-        `${msg ?? "assertThrows"}: error thrown but message "${message}" did not match ${pattern}`
-      );
-    }
-  }
-  if (!threw) {
-    throw new Error(`${msg ?? "assertThrows"}: expected function to throw but it did not`);
-  }
-}
-
-function assertDoesNotThrow(fn: () => unknown, msg?: string): void {
-  try {
-    fn();
-  } catch (e) {
-    throw new Error(`${msg ?? "assertDoesNotThrow"}: expected no throw but got: ${e instanceof Error ? e.message : String(e)}`);
-  }
-}
+import { test, assertEqual, assertThrows, assertDoesNotThrow, summarize } from "../testing/test_runner.js";
 
 // ─── Minimal valid scenario factory ──────────────────────────────────────────
 
@@ -827,13 +774,4 @@ test("events with dimension group_filter (no group_ids) pass without group exist
   assertEqual(result.events.length, 1);
 });
 
-// ─── Report results ───────────────────────────────────────────────────────────
-
-console.log(`\n1..${testCount}`);
-if (failCount > 0) {
-  console.error(`\n# ${failCount} of ${testCount} tests failed`);
-  // Throw to cause non-zero exit via unhandled exception
-  throw new Error(`Test suite failed: ${failCount} of ${testCount} tests failed`);
-} else {
-  console.log(`\n# All ${testCount} tests passed`);
-}
+summarize();

--- a/game/web/src/model/progress_test.ts
+++ b/game/web/src/model/progress_test.ts
@@ -1,7 +1,5 @@
 /**
  * Unit tests for progress.ts — pure serialization and mutation functions.
- * Hand-rolled TAP runner (no external test framework); compatible with Node 18+.
- *
  * Run via: bazel test //web/src/model:progress_test
  */
 
@@ -12,140 +10,107 @@ import {
 	isCompleted,
 	type Progress,
 } from "./progress.js";
-
-let passed = 0;
-let failed = 0;
-let total = 0;
-
-function assert(description: string, condition: boolean): void {
-	total++;
-	if (condition) {
-		console.log(`ok ${total} - ${description}`);
-		passed++;
-	} else {
-		console.log(`not ok ${total} - ${description}`);
-		failed++;
-	}
-}
-
-function assertDeepEqual(description: string, actual: unknown, expected: unknown): void {
-	assert(description, JSON.stringify(actual) === JSON.stringify(expected));
-}
+import { test, assertEqual, assertDeepEqual, assertTrue, assertFalse, summarize } from "../testing/test_runner.js";
 
 // ─── serializeProgress ────────────────────────────────────────────────────────
 
-{
+test("serializeProgress: empty completed is valid JSON", () => {
 	const p: Progress = { completed: [] };
 	const json = serializeProgress(p);
-	assert("serializeProgress: empty completed is valid JSON", (() => {
-		try { JSON.parse(json); return true; } catch { return false; }
-	})());
-}
+	JSON.parse(json); // throws if invalid
+});
 
-{
+test("serializeProgress: round-trips a single id", () => {
 	const p: Progress = { completed: ["tutorial-001"] };
-	const json = serializeProgress(p);
-	const parsed = JSON.parse(json) as { completed: string[] };
-	assertDeepEqual("serializeProgress: round-trips a single id", parsed.completed, ["tutorial-001"]);
-}
+	const parsed = JSON.parse(serializeProgress(p)) as { completed: string[] };
+	assertDeepEqual(parsed.completed, ["tutorial-001"]);
+});
 
-{
+test("serializeProgress: round-trips multiple ids", () => {
 	const p: Progress = { completed: ["tutorial-001", "level-002"] };
-	const json = serializeProgress(p);
-	const parsed = JSON.parse(json) as { completed: string[] };
-	assertDeepEqual("serializeProgress: round-trips multiple ids", parsed.completed, ["tutorial-001", "level-002"]);
-}
+	const parsed = JSON.parse(serializeProgress(p)) as { completed: string[] };
+	assertDeepEqual(parsed.completed, ["tutorial-001", "level-002"]);
+});
 
 // ─── deserializeProgress ─────────────────────────────────────────────────────
 
-{
+test("deserializeProgress: parses valid JSON", () => {
 	const p = deserializeProgress('{"completed":["tutorial-001"]}');
-	assertDeepEqual("deserializeProgress: parses valid JSON", p.completed, ["tutorial-001"]);
-}
+	assertDeepEqual(p.completed, ["tutorial-001"]);
+});
 
-{
+test("deserializeProgress: parses empty completed", () => {
 	const p = deserializeProgress('{"completed":[]}');
-	assertDeepEqual("deserializeProgress: parses empty completed", p.completed, []);
-}
+	assertDeepEqual(p.completed, []);
+});
 
-{
+test("deserializeProgress: malformed JSON returns empty", () => {
 	const p = deserializeProgress("not-json");
-	assertDeepEqual("deserializeProgress: malformed JSON returns empty", p.completed, []);
-}
+	assertDeepEqual(p.completed, []);
+});
 
-{
+test("deserializeProgress: filters non-string items", () => {
 	const p = deserializeProgress('{"completed":["a",42,null,"b"]}');
-	assertDeepEqual("deserializeProgress: filters non-string items", p.completed, ["a", "b"]);
-}
+	assertDeepEqual(p.completed, ["a", "b"]);
+});
 
-{
+test("deserializeProgress: missing completed returns empty", () => {
 	const p = deserializeProgress('{"other":"field"}');
-	assertDeepEqual("deserializeProgress: missing completed returns empty", p.completed, []);
-}
+	assertDeepEqual(p.completed, []);
+});
 
-{
+test("deserializeProgress: null JSON returns empty", () => {
 	const p = deserializeProgress("null");
-	assertDeepEqual("deserializeProgress: null JSON returns empty", p.completed, []);
-}
+	assertDeepEqual(p.completed, []);
+});
 
 // ─── round-trip ───────────────────────────────────────────────────────────────
 
-{
+test("round-trip: serialize then deserialize preserves ids", () => {
 	const original: Progress = { completed: ["a", "b", "c"] };
 	const roundTripped = deserializeProgress(serializeProgress(original));
-	assertDeepEqual("round-trip: serialize then deserialize preserves ids", roundTripped.completed, original.completed);
-}
+	assertDeepEqual(roundTripped.completed, original.completed);
+});
 
 // ─── markCompleted ────────────────────────────────────────────────────────────
 
-{
+test("markCompleted: adds id to empty progress", () => {
 	const p: Progress = { completed: [] };
-	const updated = markCompleted(p, "tutorial-001");
-	assertDeepEqual("markCompleted: adds id to empty progress", updated.completed, ["tutorial-001"]);
-}
+	assertDeepEqual(markCompleted(p, "tutorial-001").completed, ["tutorial-001"]);
+});
 
-{
+test("markCompleted: does not duplicate existing id", () => {
 	const p: Progress = { completed: ["tutorial-001"] };
-	const updated = markCompleted(p, "tutorial-001");
-	assertDeepEqual("markCompleted: does not duplicate existing id", updated.completed, ["tutorial-001"]);
-}
+	assertDeepEqual(markCompleted(p, "tutorial-001").completed, ["tutorial-001"]);
+});
 
-{
+test("markCompleted: appends new id to existing", () => {
 	const p: Progress = { completed: ["tutorial-001"] };
-	const updated = markCompleted(p, "level-002");
-	assertDeepEqual("markCompleted: appends new id to existing", updated.completed, ["tutorial-001", "level-002"]);
-}
+	assertDeepEqual(markCompleted(p, "level-002").completed, ["tutorial-001", "level-002"]);
+});
 
-{
+test("markCompleted: returns new object (immutable)", () => {
 	const p: Progress = { completed: ["a"] };
 	const updated = markCompleted(p, "b");
-	assert("markCompleted: returns new object (immutable)", updated !== p);
-	assertDeepEqual("markCompleted: original unchanged", p.completed, ["a"]);
-}
+	assertTrue(updated !== p, "should return a new object");
+	assertDeepEqual(p.completed, ["a"], "original unchanged");
+});
 
 // ─── isCompleted ──────────────────────────────────────────────────────────────
 
-{
+test("isCompleted: true for present id", () => {
 	const p: Progress = { completed: ["tutorial-001"] };
-	assert("isCompleted: true for present id", isCompleted(p, "tutorial-001"));
-}
+	assertTrue(isCompleted(p, "tutorial-001"));
+});
 
-{
+test("isCompleted: false for absent id", () => {
 	const p: Progress = { completed: ["tutorial-001"] };
-	assert("isCompleted: false for absent id", !isCompleted(p, "level-002"));
-}
+	assertFalse(isCompleted(p, "level-002"));
+});
 
-{
+test("isCompleted: false for empty progress", () => {
 	const p: Progress = { completed: [] };
-	assert("isCompleted: false for empty progress", !isCompleted(p, "tutorial-001"));
-}
+	assertFalse(isCompleted(p, "tutorial-001"));
+});
 
-// ─── Summary ──────────────────────────────────────────────────────────────────
-
-console.log(`\n1..${total}`);
-if (failed > 0) {
-	console.error(`# ${failed} of ${total} tests failed`);
-	throw new Error(`Test suite failed: ${failed} of ${total} tests failed`);
-} else {
-	console.log(`# All ${total} tests passed`);
-}
+summarize();

--- a/game/web/src/simulation/BUILD.bazel
+++ b/game/web/src/simulation/BUILD.bazel
@@ -66,6 +66,7 @@ ts_project(
         ":validity_lib",
         "//web/src/model:types_lib",
         "//web/src/model:model_lib",
+        "//web/src/testing:test_runner_lib",
     ],
     testonly = True,
 )
@@ -80,6 +81,7 @@ js_test(
         ":validity_lib",
         "//web/src/model:types_lib",
         "//web/src/model:model_lib",
+        "//web/src/testing:test_runner_lib",
     ],
     node_options = [
         "--experimental-vm-modules",
@@ -124,6 +126,7 @@ ts_project(
         ":election_lib",
         "//web/src/model:types_lib",
         "//web/src/model:model_lib",
+        "//web/src/testing:test_runner_lib",
     ],
     testonly = True,
 )
@@ -140,6 +143,7 @@ js_test(
         ":election_lib",
         "//web/src/model:types_lib",
         "//web/src/model:model_lib",
+        "//web/src/testing:test_runner_lib",
     ],
     node_options = [
         "--experimental-vm-modules",

--- a/game/web/src/simulation/evaluate_test.ts
+++ b/game/web/src/simulation/evaluate_test.ts
@@ -29,38 +29,7 @@ import { runElection } from "./election.js";
 import type { Precinct, GameState, AssignmentMap } from "../model/types.js";
 import type { ScenarioRules, SuccessCriterion, Precinct as ScenarioPrecinct } from "../model/scenario.js";
 
-// ─── Minimal test runner ──────────────────────────────────────────────────────
-
-let testCount = 0;
-let failCount = 0;
-
-function test(name: string, fn: () => void): void {
-  testCount++;
-  try {
-    fn();
-    console.log(`ok ${testCount} - ${name}`);
-  } catch (e) {
-    failCount++;
-    console.log(`not ok ${testCount} - ${name}`);
-    console.log(`  # ${e instanceof Error ? e.message : String(e)}`);
-  }
-}
-
-function assertEqual<T>(actual: T, expected: T, msg?: string): void {
-  if (actual !== expected) {
-    throw new Error(
-      `${msg ?? "assertEqual"}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
-    );
-  }
-}
-
-function assertTrue(actual: boolean, msg?: string): void {
-  if (!actual) throw new Error(`${msg ?? "assertTrue"}: expected true`);
-}
-
-function assertFalse(actual: boolean, msg?: string): void {
-  if (actual) throw new Error(`${msg ?? "assertFalse"}: expected false`);
-}
+import { test, assertEqual, assertTrue, assertFalse, summarize } from "../testing/test_runner.js";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -554,7 +523,4 @@ test("majority_minority: no scenario precincts provided → fail with message", 
   assertFalse(result.criterionResults[0]!.passed, "missing scenario precincts → fail");
 });
 
-// ─── TAP summary ─────────────────────────────────────────────────────────────
-
-console.log(`\n1..${testCount}`);
-if (failCount > 0) throw new Error(`${failCount} test(s) failed`);
+summarize();

--- a/game/web/src/simulation/validity_test.ts
+++ b/game/web/src/simulation/validity_test.ts
@@ -25,50 +25,7 @@ import { computeValidityStats } from "./validity.js";
 import type { Precinct } from "../model/types.js";
 import type { ScenarioRules } from "../model/scenario.js";
 
-// ─── Minimal test runner ──────────────────────────────────────────────────────
-
-let testCount = 0;
-let failCount = 0;
-
-function test(name: string, fn: () => void): void {
-  testCount++;
-  try {
-    fn();
-    console.log(`ok ${testCount} - ${name}`);
-  } catch (e) {
-    failCount++;
-    console.log(`not ok ${testCount} - ${name}`);
-    console.log(`  # ${e instanceof Error ? e.message : String(e)}`);
-  }
-}
-
-function assertEqual<T>(actual: T, expected: T, msg?: string): void {
-  if (actual !== expected) {
-    throw new Error(
-      `${msg ?? "assertEqual"}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
-    );
-  }
-}
-
-function assertNull(actual: unknown, msg?: string): void {
-  if (actual !== null) {
-    throw new Error(`${msg ?? "assertNull"}: expected null, got ${JSON.stringify(actual)}`);
-  }
-}
-
-function assertNotNull(actual: unknown, msg?: string): void {
-  if (actual === null || actual === undefined) {
-    throw new Error(`${msg ?? "assertNotNull"}: expected non-null, got ${String(actual)}`);
-  }
-}
-
-function assertClose(actual: number, expected: number, tolerance: number, msg?: string): void {
-  if (Math.abs(actual - expected) > tolerance) {
-    throw new Error(
-      `${msg ?? "assertClose"}: expected ${expected} ±${tolerance}, got ${actual}`,
-    );
-  }
-}
+import { test, assertEqual, assertNull, assertNotNull, assertClose, summarize } from "../testing/test_runner.js";
 
 // ─── Test fixtures ────────────────────────────────────────────────────────────
 
@@ -244,8 +201,4 @@ test("contiguity: two non-adjacent precincts in same district — not contiguous
   assertEqual(stats.contiguity!.get(2), true, "single-precinct district 2 is contiguous");
 });
 
-// ─── Report ───────────────────────────────────────────────────────────────────
-
-console.log(`\n1..${testCount}`);
-console.log(`# ${testCount - failCount} passed, ${failCount} failed`);
-if (failCount > 0) throw new Error(`${failCount} test(s) failed`);
+summarize();

--- a/game/web/src/testing/BUILD.bazel
+++ b/game/web/src/testing/BUILD.bazel
@@ -1,0 +1,24 @@
+"""
+Bazel targets for shared test infrastructure.
+
+  test_runner_lib — shared TAP-style runner imported by all *_test.ts files (BUILD-007)
+"""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//web/src/testing:__pkg__"],
+)
+
+# ── test_runner_lib: shared TAP runner (BUILD-007) ────────────────────────────
+
+ts_project(
+    name = "test_runner_lib",
+    srcs = ["test_runner.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    testonly = True,
+    visibility = ["//web:__subpackages__"],
+)

--- a/game/web/src/testing/test_runner.ts
+++ b/game/web/src/testing/test_runner.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared TAP-style test runner for all unit test files (BUILD-007).
+ *
+ * Run via Bazel js_test targets — each test file is a separate Node process so
+ * the module-level counters reset between test suites automatically.
+ *
+ * Usage in a test file:
+ *   import { test, assertEqual, summarize, ... } from "../testing/test_runner.js";
+ *   test("description", () => { assertEqual(actual, expected); });
+ *   summarize();
+ */
+
+let _count = 0;
+let _failed = 0;
+
+export function test(name: string, fn: () => void): void {
+  _count++;
+  try {
+    fn();
+    console.log(`ok ${_count} - ${name}`);
+  } catch (e) {
+    _failed++;
+    console.log(`not ok ${_count} - ${name}`);
+    console.error(`  # ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export function assertEqual<T>(actual: T, expected: T, msg?: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      `${msg ?? "assertEqual"}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+export function assertDeepEqual(actual: unknown, expected: unknown, msg?: string): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${msg ?? "assertDeepEqual"}: expected ${e}, got ${a}`);
+  }
+}
+
+export function assertTrue(actual: boolean, msg?: string): void {
+  if (!actual) throw new Error(`${msg ?? "assertTrue"}: expected true`);
+}
+
+export function assertFalse(actual: boolean, msg?: string): void {
+  if (actual) throw new Error(`${msg ?? "assertFalse"}: expected false`);
+}
+
+export function assertNull(actual: unknown, msg?: string): void {
+  if (actual !== null) {
+    throw new Error(`${msg ?? "assertNull"}: expected null, got ${JSON.stringify(actual)}`);
+  }
+}
+
+export function assertNotNull(actual: unknown, msg?: string): void {
+  if (actual === null || actual === undefined) {
+    throw new Error(`${msg ?? "assertNotNull"}: expected non-null, got ${String(actual)}`);
+  }
+}
+
+export function assertClose(
+  actual: number,
+  expected: number,
+  tolerance: number,
+  msg?: string,
+): void {
+  if (Math.abs(actual - expected) > tolerance) {
+    throw new Error(
+      `${msg ?? "assertClose"}: expected ${expected} ±${tolerance}, got ${actual}`,
+    );
+  }
+}
+
+export function assertThrows(fn: () => unknown, pattern?: RegExp, msg?: string): void {
+  let threw = false;
+  try {
+    fn();
+  } catch (e) {
+    threw = true;
+    if (pattern !== undefined) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (!pattern.test(message)) {
+        throw new Error(
+          `${msg ?? "assertThrows"}: error thrown but message "${message}" did not match ${pattern}`,
+        );
+      }
+    }
+  }
+  if (!threw) {
+    throw new Error(`${msg ?? "assertThrows"}: expected function to throw but it did not`);
+  }
+}
+
+export function assertDoesNotThrow(fn: () => unknown, msg?: string): void {
+  try {
+    fn();
+  } catch (e) {
+    throw new Error(
+      `${msg ?? "assertDoesNotThrow"}: expected no throw but got: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+export function summarize(): void {
+  console.log(`\n1..${_count}`);
+  if (_failed > 0) {
+    console.error(`# ${_failed} of ${_count} tests failed`);
+    throw new Error(`Test suite failed: ${_failed} of ${_count} tests failed`);
+  } else {
+    console.log(`# All ${_count} tests passed`);
+  }
+}

--- a/game/web/src/testing/tsconfig.json
+++ b/game/web/src/testing/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "declaration": true
+  }
+}


### PR DESCRIPTION
## Prerequisites
- [ ] N/A — no parent PR

## Summary

- Extracts a shared TAP-style test runner (`game/web/src/testing/test_runner.ts`) with a unified API: `test`, `assertEqual`, `assertDeepEqual`, `assertTrue`, `assertFalse`, `assertNull`, `assertNotNull`, `assertClose`, `assertThrows`, `assertDoesNotThrow`, `summarize`
- Removes ~25-line boilerplate from all four existing test files (`loader_test.ts`, `evaluate_test.ts`, `validity_test.ts`, `progress_test.ts`)
- Reconciles `progress_test.ts` from `assert(description, condition)` bare-block style to the unified `test(name, fn)` callback style used by the other three files
- Updates `model/BUILD.bazel` and `simulation/BUILD.bazel` to declare `//web/src/testing:test_runner_lib` as a dep on all test targets
- New test files added in GAME-035/036/037 will import from the shared runner from the start

## Validation performed

- [x] `bazel test //web/src/model:loader_test //web/src/model:progress_test //web/src/simulation:evaluate_test //web/src/simulation:validity_test` — all 4 pass locally

## Affected machines / services

- N/A — test infrastructure only; no production code changed

## Deployment steps (POST-MERGE)

- N/A

## Tickets addressed

- see BUILD-007

## Rollback

- Revert commit; all test files restore their inline boilerplate
