### PR TITLE
refactor(GAME-034): extract showLoadError to deduplicate error panel HTML in main.ts

### DIFF
--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -266,6 +266,19 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	}
 
 	// ── Fetch + validate scenario JSON ────────────────────────────────────────
+
+	function showLoadError(bodyHtml: string, errorMsg: string): void {
+		document.body.insertAdjacentHTML(
+			"afterbegin",
+			`<div style="position:fixed;inset:0;background:#0d1b2e;color:#c0d0e8;padding:2em;font-family:system-ui;z-index:999;display:flex;flex-direction:column;gap:16px;align-items:center;justify-content:center;">
+				<h1 style="color:#e94560;font-size:1.4rem;">Scenario Failed to Load</h1>
+				<p style="max-width:600px;text-align:center;">${bodyHtml}</p>
+				<pre style="background:#16213e;padding:12px 16px;border-radius:6px;max-width:600px;overflow-x:auto;font-size:0.8rem;color:#e94560;white-space:pre-wrap;">${errorMsg}</pre>
+				<button onclick="window.location.assign('./')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
+			</div>`,
+		);
+	}
+
 	let json: unknown;
 	try {
 		const resp = await fetch(`./scenarios/${entryToLoad.id}.json`);
@@ -274,15 +287,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
 		console.error(`[GAME-032] Failed to fetch scenario "${entryToLoad.id}":`, e);
-		document.body.insertAdjacentHTML(
-			"afterbegin",
-			`<div style="position:fixed;inset:0;background:#0d1b2e;color:#c0d0e8;padding:2em;font-family:system-ui;z-index:999;display:flex;flex-direction:column;gap:16px;align-items:center;justify-content:center;">
-				<h1 style="color:#e94560;font-size:1.4rem;">Scenario Failed to Load</h1>
-				<p style="max-width:600px;text-align:center;">Could not fetch scenario <strong>${entryToLoad.id}</strong>.</p>
-				<pre style="background:#16213e;padding:12px 16px;border-radius:6px;max-width:600px;overflow-x:auto;font-size:0.8rem;color:#e94560;white-space:pre-wrap;">${msg}</pre>
-				<button onclick="window.location.assign('./')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
-			</div>`,
-		);
+		showLoadError(`Could not fetch scenario <strong>${entryToLoad.id}</strong>.`, msg);
 		return;
 	}
 
@@ -292,15 +297,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
 		console.error(`[GAME-032] Scenario "${entryToLoad.id}" validation failed:`, e);
-		document.body.insertAdjacentHTML(
-			"afterbegin",
-			`<div style="position:fixed;inset:0;background:#0d1b2e;color:#c0d0e8;padding:2em;font-family:system-ui;z-index:999;display:flex;flex-direction:column;gap:16px;align-items:center;justify-content:center;">
-				<h1 style="color:#e94560;font-size:1.4rem;">Scenario Failed to Load</h1>
-				<p style="max-width:600px;text-align:center;">Scenario <strong>${entryToLoad.id}</strong> could not be loaded due to a validation error.</p>
-				<pre style="background:#16213e;padding:12px 16px;border-radius:6px;max-width:600px;overflow-x:auto;font-size:0.8rem;color:#e94560;white-space:pre-wrap;">${msg}</pre>
-				<button onclick="window.location.assign('./')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
-			</div>`,
-		);
+		showLoadError(`Scenario <strong>${entryToLoad.id}</strong> could not be loaded due to a validation error.`, msg);
 		return;
 	}
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary
- Extracts a `showLoadError(bodyHtml, errorMsg)` helper inside `main.ts`'s async IIFE, eliminating two nearly-identical `insertAdjacentHTML` error-panel blocks (fetch failure and validation failure). The HTML structure, styles, and back-button are identical; only the `<p>` body text differs.
- No behaviour change — callers pass the same strings that were previously inlined.

## Validation performed
- [x] `bazel build //web:app_typecheck_lib` passes — no type errors introduced
- [x] N/A — no unit tests needed; this is a pure HTML-string dedup with no logic change

## Affected machines / services
- Browser game only; no server changes

## Deployment steps (POST-MERGE)
- N/A — static assets; next game deploy picks up change automatically

## Tickets addressed
- see #137

## Rollback
- Revert commit; push
