### PR TITLE
test(GAME-037): unit tests for scenarioToSpike in adapter.ts

### DIFF
--- a/game/web/src/model/BUILD.bazel
+++ b/game/web/src/model/BUILD.bazel
@@ -89,6 +89,40 @@ ts_project(
     visibility = ["//web:__subpackages__"],
 )
 
+# ── adapter_test_lib: compile adapter tests ───────────────────────────────────
+
+ts_project(
+    name = "adapter_test_lib",
+    srcs = ["adapter_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":adapter_lib",
+        ":model_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+# ── adapter_test: run adapter tests with Node ─────────────────────────────────
+
+js_test(
+    name = "adapter_test",
+    entry_point = "adapter_test.js",
+    data = [
+        ":adapter_test_lib",
+        ":adapter_lib",
+        ":model_lib",
+        ":types_lib",
+        ":generator_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # ── progress_typecheck_test: type-check passes ───────────────────────────────
 
 build_test(

--- a/game/web/src/model/adapter_test.ts
+++ b/game/web/src/model/adapter_test.ts
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for scenarioToSpike (GAME-037).
+ *
+ * Uses the shared TAP runner. Run via Bazel:
+ *   bazel test //web/src/model:adapter_test
+ *
+ * Coverage:
+ *   - correct precinct count produced from scenario
+ *   - party vote-share mapping: first party → R, second → D; population-weighted
+ *   - multi-group population-weighted vote shares
+ *   - neighbor array: adjacent hex precincts correctly wired; non-adjacent null
+ *   - district assignments: initial_district_id maps to 1-based spike district ID
+ *   - unassigned precincts (no initial_district_id) → null in assignments
+ *   - districtCount matches scenario.districts.length
+ *   - precinct IDs are 0-based array indices
+ */
+
+import { scenarioToSpike } from "./adapter.js";
+import type { Scenario, Party, District } from "./scenario.js";
+import type { PartyId, DistrictId, PrecinctId } from "./scenario.js";
+import { test, assertEqual, assertNull, assertNotNull, assertClose, summarize } from "../testing/test_runner.js";
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+function pid(s: string): PartyId { return s as unknown as PartyId; }
+function did(s: string): DistrictId { return s as unknown as DistrictId; }
+function pcid(s: string): PrecinctId { return s as unknown as PrecinctId; }
+
+const PARTY_R: Party = { id: pid("r_party"), name: "Red", abbreviation: "R" };
+const PARTY_D: Party = { id: pid("d_party"), name: "Blue", abbreviation: "D" };
+
+function makeScenario(overrides: Partial<Scenario> & Pick<Scenario, "parties" | "districts" | "precincts">): Scenario {
+	return {
+		format_version: "1",
+		id: "test-001" as unknown as Scenario["id"],
+		title: "Test",
+		election_type: "congressional",
+		region: { id: "r1" as unknown as Scenario["region"]["id"], name: "Test Region" },
+		geometry: { type: "hex_axial" },
+		events: [],
+		rules: { population_tolerance: 0.05, contiguity: "allowed" },
+		success_criteria: [],
+		narrative: {
+			character: { name: "T", role: "Tester", motivation: "Testing" },
+			intro_slides: [],
+			objective: "Test",
+		},
+		...overrides,
+	};
+}
+
+function makeGroup(partyShares: Record<string, number>, populationShare = 1.0) {
+	return {
+		id: pcid("g1") as unknown as import("./scenario.js").GroupId,
+		population_share: populationShare,
+		vote_shares: partyShares as unknown as Record<PartyId, number>,
+		turnout_rate: 1.0,
+	};
+}
+
+function makePrecinct(
+	q: number,
+	r: number,
+	groups: ReturnType<typeof makeGroup>[],
+	initialDistrictId?: string,
+) {
+	return {
+		id: pcid(`p${q}_${r}`),
+		editable: true,
+		position: { q, r },
+		total_population: 100,
+		demographic_groups: groups,
+		initial_district_id: initialDistrictId !== undefined ? did(initialDistrictId) : null,
+	};
+}
+
+// ─── Precinct count ───────────────────────────────────────────────────────────
+
+test("scenarioToSpike: produces correct number of precincts", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.6, [pid("d_party")]: 0.4 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [
+			makePrecinct(0, 0, [g], "d1"),
+			makePrecinct(1, 0, [g], "d1"),
+			makePrecinct(2, 0, [g], "d2"),
+		],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts.length, 3, "3 precincts produced");
+});
+
+// ─── Precinct IDs are 0-based array indices ───────────────────────────────────
+
+test("scenarioToSpike: precinct IDs are 0-based array indices", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g], "d1"), makePrecinct(1, 0, [g], "d1")],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.id, 0, "first precinct id=0");
+	assertEqual(precincts[1]!.id, 1, "second precinct id=1");
+});
+
+// ─── Party vote shares ────────────────────────────────────────────────────────
+
+test("scenarioToSpike: first party → R, second party → D (single group)", () => {
+	// 70% R, 30% D in a single demographic group
+	const g = makeGroup({ [pid("r_party")]: 0.7, [pid("d_party")]: 0.3 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	const p = precincts[0]!;
+	assertClose(p.partyShare.R, 0.7, 0.001, "R share");
+	assertClose(p.partyShare.D, 0.3, 0.001, "D share");
+	assertEqual(p.partyShare.L, 0, "L share");
+});
+
+test("scenarioToSpike: population-weighted across two groups", () => {
+	// Group 1: 60% of pop, votes 80% R / 20% D → contributes R: 0.48, D: 0.12
+	// Group 2: 40% of pop, votes 20% R / 80% D → contributes R: 0.08, D: 0.32
+	// Total: R=0.56, D=0.44
+	const g1 = makeGroup({ [pid("r_party")]: 0.8, [pid("d_party")]: 0.2 }, 0.6);
+	const g2 = makeGroup({ [pid("r_party")]: 0.2, [pid("d_party")]: 0.8 }, 0.4);
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g1, g2], "d1")],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	const p = precincts[0]!;
+	assertClose(p.partyShare.R, 0.56, 0.001, "R share");
+	assertClose(p.partyShare.D, 0.44, 0.001, "D share");
+});
+
+test("scenarioToSpike: R wins → winner R, correct margin", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.7, [pid("d_party")]: 0.3 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.previousResult.winner, "R", "winner");
+	assertClose(precincts[0]!.previousResult.margin, 0.4, 0.01, "margin");
+});
+
+test("scenarioToSpike: D wins when D >= R", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.previousResult.winner, "D", "D wins on exact tie (D >= R)");
+});
+
+// ─── Neighbor lists ───────────────────────────────────────────────────────────
+
+test("scenarioToSpike: neighbor lists — two adjacent precincts wired to each other", () => {
+	// P0 at (0,0), P1 at (1,0).
+	// HEX_DIRECTIONS[0]=[+1,0] → P0's edge-0 neighbor is at (1,0) = P1 (index 1)
+	// HEX_DIRECTIONS[3]=[-1,0] → P1's edge-3 neighbor is at (0,0) = P0 (index 0)
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g], "d1"), makePrecinct(1, 0, [g], "d1")],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	const p0 = precincts[0]!;
+	const p1 = precincts[1]!;
+
+	assertEqual(p0.neighbors.length, 6, "6-element neighbor array for p0");
+	assertEqual(p0.neighbors[0], 1, "p0 edge-0 neighbor is p1 (index 1)");
+	assertNull(p0.neighbors[1], "p0 edge-1 is null (no precinct there)");
+	assertNull(p0.neighbors[2], "p0 edge-2 is null");
+	assertNull(p0.neighbors[3], "p0 edge-3 is null");
+	assertNull(p0.neighbors[4], "p0 edge-4 is null");
+	assertNull(p0.neighbors[5], "p0 edge-5 is null");
+
+	assertEqual(p1.neighbors[3], 0, "p1 edge-3 neighbor is p0 (index 0)");
+	assertNull(p1.neighbors[0], "p1 edge-0 is null");
+});
+
+test("scenarioToSpike: isolated precinct has all-null neighbor array", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	const p = precincts[0]!;
+	assertEqual(p.neighbors.length, 6, "6 neighbors");
+	assertEqual(p.neighbors.filter(n => n === null).length, 6, "all null");
+});
+
+// ─── District assignments ─────────────────────────────────────────────────────
+
+test("scenarioToSpike: initial_district_id maps to 1-based spike district ID", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [
+			makePrecinct(0, 0, [g], "d1"), // → spike district 1
+			makePrecinct(1, 0, [g], "d2"), // → spike district 2
+		],
+	});
+	const { assignments } = scenarioToSpike(scenario);
+	assertEqual(assignments.get(0), 1, "precinct 0 → district 1");
+	assertEqual(assignments.get(1), 2, "precinct 1 → district 2");
+});
+
+test("scenarioToSpike: precinct with null initial_district_id → null assignment", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g])], // no initial_district_id
+	});
+	const { assignments } = scenarioToSpike(scenario);
+	assertNull(assignments.get(0), "unassigned precinct → null");
+});
+
+// ─── District count ───────────────────────────────────────────────────────────
+
+test("scenarioToSpike: districtCount matches scenario.districts.length", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }, { id: did("d3") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+	});
+	const { districtCount } = scenarioToSpike(scenario);
+	assertEqual(districtCount, 3, "districtCount = 3");
+});
+
+summarize();

--- a/thoughts/shared/tickets/GAME-037-adapter-unit-tests.md
+++ b/thoughts/shared/tickets/GAME-037-adapter-unit-tests.md
@@ -2,7 +2,7 @@
 id: GAME-037
 title: Unit tests for adapter.ts (scenarioToSpike)
 area: game, testing
-status: open
+status: resolved
 created: 2026-04-29
 ---
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -96,7 +96,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `BUILD-007-shared-test-runner.md` | build, testing | Extract shared TAP test runner module; eliminate boilerplate copied across 4+ test files |
 | `GAME-033-oplabel-constant-dedup.md` | game, code-quality | Deduplicate opLabel constant in evaluate.ts (4 inline copies → 1 module-level const) |
 | `GAME-034-error-panel-dedup.md` | game, code-quality | Deduplicate inline error panel HTML in main.ts (2 identical blocks → showLoadError function) |
-| `GAME-037-adapter-unit-tests.md` | game, testing | Unit tests for adapter.ts scenarioToSpike (party weights, neighbor lists, district assignments) |
 | `GAME-038-extract-panel-renderers.md` | game, code-quality | Extract DOM panel renderers out of mapRenderer.ts into render/panels.ts |
 | `GAME-039-extract-hex-geometry.md` | game, code-quality | Extract hex geometry utilities (hexToPixel, hexCorners, mapBounds) from generator.ts into hex-geometry.ts |
 | `GAME-040-maprenderer-magic-numbers.md` | game, code-quality | Name magic numbers in mapRenderer.ts (opacity values, zoom step, lightness coefficients, fallback dimensions) |
@@ -112,6 +111,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 |---|---|
 | LEGAL-001: content risk assessment | Low risk for v1; all pre-authored content, fictional entities, educational framing; disclaimers added to about page + Valle Verde; authoring tool deferred to post-v1 review |
 | GAME-006: scenario compression | HTTP gzip sufficient for v1; no code changes needed; .scenarioz deferred to community scenarios |
+| GAME-037: adapter unit tests | 12 tests for scenarioToSpike: precinct count, party weights, multi-group pop-weighting, neighbor wiring, district assignments, null assignments, districtCount |
 | GAME-036: WIP persistence unit tests | 11 tests in separate progress_wip_test.ts with in-memory localStorage shim; round-trip, null cases, clear; all pass |
 | GAME-035: election unit tests | 10 unit tests for runElection + simulateDistrict; exported simulateDistrict; js_test target added; all pass |
 | GAME-032: loader error handling | User-visible error screen with scenario ID, error message, and back button; replaces blank page on validation/fetch failures |


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary
- Adds `adapter_test.ts` with 12 unit tests for `scenarioToSpike` in `adapter.ts`, covering: precinct count, precinct IDs as 0-based indices, party vote-share mapping (first party → R, second → D), population-weighted vote shares across multiple demographic groups, neighbor array wiring for adjacent hex precincts, all-null neighbors for isolated precincts, district assignment mapping (initial_district_id → 1-based spike district ID), null for unassigned precincts, and districtCount.
- Adds `adapter_test_lib` and `adapter_test` Bazel targets to `model/BUILD.bazel`.
- Resolves GAME-037; updates ticket file + TICKETS.md.

## Validation performed
- [x] `bazel test //web/src/model:adapter_test` — 12 tests pass
- [x] `bazel test //web/src/model/...` — all 6 test targets pass, no regressions

## Affected machines / services
- Test-only; no runtime behavior affected

## Deployment steps (POST-MERGE)
- N/A — test-only

## Tickets addressed
- see #142

## Rollback
- Revert commit; push
