### PR TITLE
refactor(GAME-040): name magic numbers in mapRenderer.ts

### DIFF
--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -164,6 +164,36 @@ export class SvgMapRenderer implements MapRenderer {
 	private static readonly PREVIEW_BASE_WIDTH = 2.5;
 	private static readonly COUNTY_BASE_WIDTH = 3;
 
+	// Zoom parameters
+	private static readonly ZOOM_STEP = 1.3;
+	private static readonly MAX_ZOOM_MULTIPLIER = 8;
+	private static readonly VIEWPORT_PADDING = 20;
+	private static readonly FALLBACK_SVG_WIDTH = 800;
+	private static readonly FALLBACK_SVG_HEIGHT = 600;
+	private static readonly ZOOM_DURATION_SHORT = 200;
+	private static readonly ZOOM_DURATION_RESET = 300;
+
+	// Opacity values
+	private static readonly BOUNDARY_OPACITY = 0.6;
+	private static readonly COUNTY_OPACITY = 0.7;
+	private static readonly PREVIEW_OPACITY = 0.85;
+	private static readonly LEAN_OPACITY = 0.9;
+	private static readonly ASSIGNED_OPACITY = 0.75;
+	private static readonly UNASSIGNED_OPACITY = 0.35;
+	private static readonly HOVER_OPACITY = 0.95;
+	private static readonly HOVER_STROKE_WIDTH = 1.5;
+
+	// Lightness coefficients for population-density district color shading
+	// District hex lightness = HEX_LIGHTNESS_BASE − normPop × HEX_LIGHTNESS_RANGE
+	private static readonly HEX_LIGHTNESS_BASE = 0.55;
+	private static readonly HEX_LIGHTNESS_RANGE = 0.30;
+
+	// Dash patterns (on,off in map units before zoom correction)
+	private static readonly COUNTY_DASH_ON = 6;
+	private static readonly COUNTY_DASH_OFF = 4;
+	private static readonly PREVIEW_DASH_ON = 5;
+	private static readonly PREVIEW_DASH_OFF = 4;
+
 	// County border overlay (GAME-012): computed once at load, toggled on/off
 	private countySegments: Segment[] = [];
 	private countyBordersVisible = false;
@@ -233,8 +263,8 @@ export class SvgMapRenderer implements MapRenderer {
 			.attr("y2", (d) => d.y2)
 			.attr("stroke", "#606060")
 			.attr("stroke-width", SvgMapRenderer.COUNTY_BASE_WIDTH / this.currentK)
-			.attr("stroke-dasharray", `${6 / this.currentK},${4 / this.currentK}`)
-			.attr("opacity", 0.7);
+			.attr("stroke-dasharray", `${SvgMapRenderer.COUNTY_DASH_ON / this.currentK},${SvgMapRenderer.COUNTY_DASH_OFF / this.currentK}`)
+			.attr("opacity", SvgMapRenderer.COUNTY_OPACITY);
 	}
 
 	// ─── Zoom init (GAME-009) ─────────────────────────────────────────────────
@@ -252,10 +282,10 @@ export class SvgMapRenderer implements MapRenderer {
 
 		// SVG element fills its container; getBoundingClientRect gives pixel dims.
 		const svgRect = svgNode.getBoundingClientRect();
-		const svgW = svgRect.width > 0 ? svgRect.width : 800;
-		const svgH = svgRect.height > 0 ? svgRect.height : 600;
+		const svgW = svgRect.width > 0 ? svgRect.width : SvgMapRenderer.FALLBACK_SVG_WIDTH;
+		const svgH = svgRect.height > 0 ? svgRect.height : SvgMapRenderer.FALLBACK_SVG_HEIGHT;
 
-		const padding = 20; // screen-pixel padding around the scenario at min zoom
+		const padding = SvgMapRenderer.VIEWPORT_PADDING;
 
 		// Compute the scale that fits the scenario within the SVG with padding.
 		const fitScale = Math.min(
@@ -272,8 +302,8 @@ export class SvgMapRenderer implements MapRenderer {
 
 		this.zoomBehavior = d3
 			.zoom<SVGSVGElement, unknown>()
-			// Floor = full scenario view; ceiling = 8× (3-4 precincts fill screen)
-			.scaleExtent([fitScale, fitScale * 8])
+			// Floor = full scenario view; ceiling = MAX_ZOOM_MULTIPLIER× (3-4 precincts fill screen)
+			.scaleExtent([fitScale, fitScale * SvgMapRenderer.MAX_ZOOM_MULTIPLIER])
 			// Only allow scroll-wheel zoom and right-click (button 2) drag pan.
 			// Left-click mousedown passes through to the paint brush unchanged.
 			.filter((event: Event) => {
@@ -310,15 +340,15 @@ export class SvgMapRenderer implements MapRenderer {
 			if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
 			if (e.key === "=" || e.key === "+") {
 				e.preventDefault();
-				this.svg.transition().duration(200).call(this.zoomBehavior.scaleBy, 1.3);
+				this.svg.transition().duration(SvgMapRenderer.ZOOM_DURATION_SHORT).call(this.zoomBehavior.scaleBy, SvgMapRenderer.ZOOM_STEP);
 			} else if (e.key === "-") {
 				e.preventDefault();
-				this.svg.transition().duration(200).call(this.zoomBehavior.scaleBy, 1 / 1.3);
+				this.svg.transition().duration(SvgMapRenderer.ZOOM_DURATION_SHORT).call(this.zoomBehavior.scaleBy, 1 / SvgMapRenderer.ZOOM_STEP);
 			} else if (e.key === "0") {
 				e.preventDefault();
 				this.svg
 					.transition()
-					.duration(300)
+					.duration(SvgMapRenderer.ZOOM_DURATION_RESET)
 					.call(this.zoomBehavior.transform, this.initialTransform);
 			}
 		});
@@ -368,7 +398,7 @@ export class SvgMapRenderer implements MapRenderer {
 			.attr("y2", (d) => d.y2)
 			.attr("stroke", "#ffffff")
 			.attr("stroke-width", strokeWidth)
-			.attr("opacity", 0.6)
+			.attr("opacity", SvgMapRenderer.BOUNDARY_OPACITY)
 			.attr("stroke-dasharray", null);
 	}
 
@@ -410,8 +440,8 @@ export class SvgMapRenderer implements MapRenderer {
 			.attr("y2", (d) => d.y2)
 			.attr("stroke", "#ffffff")
 			.attr("stroke-width", strokeWidth)
-			.attr("stroke-dasharray", `${5 / this.currentK},${4 / this.currentK}`)
-			.attr("opacity", 0.85);
+			.attr("stroke-dasharray", `${SvgMapRenderer.PREVIEW_DASH_ON / this.currentK},${SvgMapRenderer.PREVIEW_DASH_OFF / this.currentK}`)
+			.attr("opacity", SvgMapRenderer.PREVIEW_OPACITY);
 	}
 
 	private clearBoundaryPreview() {
@@ -443,8 +473,8 @@ export class SvgMapRenderer implements MapRenderer {
 				this.hoveredPath = path;
 				d3.select(path)
 					.attr("stroke", "#ffffff")
-					.attr("stroke-width", 1.5 / this.currentK)
-					.attr("opacity", 0.95);
+					.attr("stroke-width", SvgMapRenderer.HOVER_STROKE_WIDTH / this.currentK)
+					.attr("opacity", SvgMapRenderer.HOVER_OPACITY);
 
 				const { assignments } = this.getState();
 				const dId = assignments.get(d.id);
@@ -571,9 +601,9 @@ export class SvgMapRenderer implements MapRenderer {
 		const c = d3.hsl(base);
 		if (d !== undefined && this.popMax > this.popMin) {
 			const normPop = (d.population - this.popMin) / (this.popMax - this.popMin);
-			c.l = 0.55 - normPop * 0.30;
+			c.l = SvgMapRenderer.HEX_LIGHTNESS_BASE - normPop * SvgMapRenderer.HEX_LIGHTNESS_RANGE;
 		}
-		d3.select(path).attr("fill", c.formatHex()).attr("opacity", 0.75);
+		d3.select(path).attr("fill", c.formatHex()).attr("opacity", SvgMapRenderer.ASSIGNED_OPACITY);
 	}
 
 	// ─── Fill / opacity helpers ───────────────────────────────────────────────
@@ -592,14 +622,14 @@ export class SvgMapRenderer implements MapRenderer {
 				? (d.population - this.popMin) / (this.popMax - this.popMin)
 				: 0.5;
 		const c = d3.hsl(base);
-		c.l = 0.55 - normPop * 0.30;
+		c.l = SvgMapRenderer.HEX_LIGHTNESS_BASE - normPop * SvgMapRenderer.HEX_LIGHTNESS_RANGE;
 		return c.formatHex();
 	}
 
 	private hexOpacity(d: Precinct, assignments: GameStore["assignments"]): number {
-		if (this.viewMode === "lean") return 0.9;
+		if (this.viewMode === "lean") return SvgMapRenderer.LEAN_OPACITY;
 		const dId = assignments.get(d.id);
-		return dId != null ? 0.75 : 0.35;
+		return dId != null ? SvgMapRenderer.ASSIGNED_OPACITY : SvgMapRenderer.UNASSIGNED_OPACITY;
 	}
 }
 

--- a/thoughts/shared/tickets/GAME-040-maprenderer-magic-numbers.md
+++ b/thoughts/shared/tickets/GAME-040-maprenderer-magic-numbers.md
@@ -2,7 +2,7 @@
 id: GAME-040
 title: Name magic numbers in mapRenderer.ts
 area: game, code-quality
-status: open
+status: resolved
 created: 2026-04-29
 ---
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -98,7 +98,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-034-error-panel-dedup.md` | game, code-quality | Deduplicate inline error panel HTML in main.ts (2 identical blocks → showLoadError function) |
 | `GAME-038-extract-panel-renderers.md` | game, code-quality | Extract DOM panel renderers out of mapRenderer.ts into render/panels.ts |
 | `GAME-039-extract-hex-geometry.md` | game, code-quality | Extract hex geometry utilities (hexToPixel, hexCorners, mapBounds) from generator.ts into hex-geometry.ts |
-| `GAME-040-maprenderer-magic-numbers.md` | game, code-quality | Name magic numbers in mapRenderer.ts (opacity values, zoom step, lightness coefficients, fallback dimensions) |
 | `GAME-041-split-loader.md` | game, code-quality | Split loader.ts: extract runtime-types.ts primitives; name validateScenario() internally |
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
@@ -111,6 +110,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 |---|---|
 | LEGAL-001: content risk assessment | Low risk for v1; all pre-authored content, fictional entities, educational framing; disclaimers added to about page + Valle Verde; authoring tool deferred to post-v1 review |
 | GAME-006: scenario compression | HTTP gzip sufficient for v1; no code changes needed; .scenarioz deferred to community scenarios |
+| GAME-040: mapRenderer magic numbers | 22 named static readonly constants extracted (opacities, zoom step, lightness coefficients, fallback dims, dash patterns); no behavior change; typecheck passes |
 | GAME-037: adapter unit tests | 12 tests for scenarioToSpike: precinct count, party weights, multi-group pop-weighting, neighbor wiring, district assignments, null assignments, districtCount |
 | GAME-036: WIP persistence unit tests | 11 tests in separate progress_wip_test.ts with in-memory localStorage shim; round-trip, null cases, clear; all pass |
 | GAME-035: election unit tests | 10 unit tests for runElection + simulateDistrict; exported simulateDistrict; js_test target added; all pass |


### PR DESCRIPTION
## Summary

Names all undocumented inline numeric literals in `mapRenderer.ts` as `private static readonly` class constants. No behavior change — pure naming refactor.

**22 constants extracted:**

- `ZOOM_STEP = 1.3` — zoom multiplier per step (used in zoom-in/out handlers)
- `MAX_ZOOM_MULTIPLIER = 8` — upper bound for zoom scale
- `VIEWPORT_PADDING = 20` — px padding in fitView calculation
- `FALLBACK_SVG_WIDTH = 800`, `FALLBACK_SVG_HEIGHT = 600` — fallback dimensions when container size unavailable
- `ZOOM_DURATION_SHORT = 200`, `ZOOM_DURATION_RESET = 300` — d3 transition durations (ms)
- `BOUNDARY_OPACITY = 0.6` — district boundary lines
- `COUNTY_OPACITY = 0.7` — county border overlay
- `PREVIEW_OPACITY = 0.85` — paint-preview border
- `LEAN_OPACITY = 0.9` — partisan lean fill
- `ASSIGNED_OPACITY = 0.75` — assigned precinct fill
- `UNASSIGNED_OPACITY = 0.35` — unassigned precinct fill
- `HOVER_OPACITY = 0.95` — hover state overlay
- `HOVER_STROKE_WIDTH = 1.5` — hover state stroke width
- `HEX_LIGHTNESS_BASE = 0.55`, `HEX_LIGHTNESS_RANGE = 0.30` — population density color (lightness = base − normPop × range); both call sites now use named constants
- `COUNTY_DASH_ON = 6`, `COUNTY_DASH_OFF = 4` — county border dash pattern
- `PREVIEW_DASH_ON = 5`, `PREVIEW_DASH_OFF = 4` — preview border dash pattern

## Test plan

- [x] `bazel build //web:app_typecheck_lib` passes (no type errors)
- [x] No behavior change — all constants match their previous inline values exactly
- [x] `bazel build //web/...` passes
- [x] New tests: N/A — naming-only refactor per ticket spec ("No new tests needed")

## Ticket

see #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
