### PR TITLE
docs: close S9, record S10 sprint progress, fix stale ticket statuses

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -1,6 +1,6 @@
 <!--COMPRESSED v1; source:2026-04-25-sprint-roadmap.md-->
 §META
-date:2026-04-25 last_updated:2026-04-28 status:active type:sprint-roadmap
+date:2026-04-25 last_updated:2026-04-29 status:active type:sprint-roadmap
 LIVING DOC — update at sprint start (fill tickets) + after demo (outcomes, re-evaluate next)
 
 §ABBREV
@@ -28,8 +28,8 @@ see game-vision.compressed.md for full scope
 | S6 | game infra + scenarios 5–7 | GAME-007 save/resume; scenarios 5–9; hex-of-hexes; demo feedback fixes | complete — 2026-04-27 |
 | S7 | shippable $v1 | about page; wrap-up screen; hex backport 002–006; visual consistency | complete — 2026-04-28 |
 | S8 | hardening | CSP; extract CSS; loader errors; scenario compression | complete — 2026-04-28 |
-| S9 | first release | deploy pastthepost.org; legal review; basic a11y | current |
-| S10 | code quality + tidy | test coverage gaps; dedup; extract modules; refactor for polish readiness | backlog |
+| S9 | first release | deploy pastthepost.org; legal review; basic a11y | complete — 2026-04-29 |
+| S10 | code quality + tidy | test coverage gaps; dedup; extract modules; refactor for polish readiness | current |
 | S11 | design research+polish | achievement UX; demographic overlays; geo features; full a11y | backlog |
 
 §SPRINT1 [COMPLETE 2026-04-25]
@@ -88,21 +88,22 @@ outcome: all tickets closed; CSP meta tag w/ temp unsafe-inline (BUILD-005); inl
 tickets (all resolved): BUILD-005 BUILD-006 GAME-032 GAME-006
 PRs: #119 #120 #121 #122
 
-§SPRINT9 [CURRENT]
+§SPRINT9 [COMPLETE 2026-04-29]
 goal: first release — ship v1 to public
-scope:
-  DIST-001: deploy to pastthepost.org (static hosting; DNS config)
-  LEGAL-001: content presentation risk review (disclaimers/framing)
-  GAME-008 (partial): basic a11y — keyboard nav, ARIA labels; release-blocking subset only
-known tickets: DIST-001 LEGAL-001 GAME-008(partial)
+outcome: all tickets closed
+  DIST-001: unified deploy scripts; Buildkite auto-deploy staging; prod deploy via scripts/deploy-prod.sh; PRs #127 #131 #132
+  LEGAL-001: content risk low; disclaimers added to about page + Valle Verde; PR #126
+  GAME-008(partial): keyboard nav (painting+scenario select); ARIA labels; PR #129
+  standalone fix: scenario-select always shown on initial load; PR #128
+tickets: DIST-001 LEGAL-001 GAME-008(partial)
+PRs: #126 #127 #128 #129 #131 #132
 
-§SPRINT10 (backlog)
+§SPRINT10 [CURRENT]
 goal: code quality + tidy — close test coverage gaps, eliminate duplication, extract modules
 rationale: pre-polish housekeeping; makes S11 design work safer to implement
-tier1(high-value,low-risk): BUILD-007 GAME-033 GAME-034 GAME-035 GAME-036 GAME-037
-tier2(moderate-effort,clear-win): GAME-038 GAME-039 GAME-040
-order: BUILD-007 first (shared test runner used by GAME-035/036/037); then tier1 dedup (GAME-033 GAME-034); then tests (GAME-035 GAME-036 GAME-037); then tier2 structural
-scope note: Tier 3 deferred (GAME-041 GAME-042 GAME-043) — too large for tidy sprint
+done(tier1): BUILD-007(#134) GAME-033(#135) GAME-034(#136) GAME-035(#138) GAME-036(#140) GAME-037(#142) GAME-040(#144)
+remaining(tier2): GAME-038 GAME-039
+deferred(tier3): GAME-041 GAME-042 GAME-043 — too large for tidy sprint
 
 §SPRINT11 (backlog)
 goal: design research+polish — resolve open design questions then implement

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -2,7 +2,7 @@
 date: 2026-04-25
 status: active
 type: sprint-roadmap
-last_updated: 2026-04-28
+last_updated: 2026-04-29
 ---
 
 # Sprint Roadmap — Redistricting Simulator v1
@@ -43,8 +43,8 @@ See `thoughts/shared/vision/game-vision.compressed.md` for full scope.
 | 6 | Game infrastructure + scenarios 5–7 | In-progress save/resume; scenarios 5–7 authored; hex-of-hexes for 007–009 | complete — 2026-04-27 |
 | 7 | Shippable v1 | About page; wrap-up screen; hex backport to 002–006; all scenarios visually consistent | complete — 2026-04-28 |
 | 8 | Hardening | CSP, extract CSS, loader error handling, scenario compression | complete — 2026-04-28 |
-| 9 | First release | Deploy to pastthepost.org; legal review; basic accessibility | current |
-| 10 | Code quality + tidy | Test coverage gaps, deduplication, module extraction, pre-polish housekeeping | backlog |
+| 9 | First release | Deploy to pastthepost.org; legal review; basic accessibility | complete — 2026-04-29 |
+| 10 | Code quality + tidy | Test coverage gaps, deduplication, module extraction, pre-polish housekeeping | current |
 | 11 | Design research + polish | Achievement UX, demographic overlays, geographic features, full accessibility | backlog |
 
 ---
@@ -189,52 +189,45 @@ PRs: #119 #120 #121 #122
 
 ---
 
-## Sprint 9 — First Release [CURRENT]
+## Sprint 9 — First Release [COMPLETE 2026-04-29]
 
 **Goal**: Ship v1 to the public. Deploy, legal review, basic accessibility.
 
-**Scope**:
-- **DIST-001**: Deploy to pastthepost.org (or GH Pages as staging). Static
-  hosting; gzip served automatically. Configure DNS for pastthepost.org +
-  pastthepost.gg redirect.
-- **LEGAL-001**: Quick review of content presentation risks. The game is
-  educational, non-partisan, fictional regions — assess what disclaimers or
-  framing are needed before public release.
-- **Basic accessibility**: Keyboard navigation for district selection and
-  precinct painting. ARIA labels on interactive elements. Subset of GAME-008
-  scoped to release-blocking items only.
+**Outcome**: All tickets closed. Unified deployment scripts: Buildkite
+auto-deploy to staging on merge, production deploy via `scripts/deploy-prod.sh`
+(DIST-001; PRs #127 #131 #132). Content risk assessment: low-risk for v1 given
+educational framing, fictional regions, all pre-authored content; disclaimers
+added to about page and Valle Verde (LEGAL-001; PR #126). Basic a11y scoped to
+release-blocking items: keyboard navigation for painting and scenario select,
+ARIA labels on interactive elements (GAME-008 partial; PR #129). Plus a
+standalone startup fix: scenario-select screen always shown on initial load
+(PR #128).
 
-**Known tickets**: DIST-001, LEGAL-001, GAME-008 (partial).
+**Tickets**: DIST-001, LEGAL-001, GAME-008 (partial)
+PRs: #126 #127 #128 #129 #131 #132
 
 ---
 
-## Sprint 10 — Code Quality + Tidy [BACKLOG]
+## Sprint 10 — Code Quality + Tidy [CURRENT]
 
 **Goal**: Pre-polish housekeeping — close test coverage gaps, eliminate duplication,
 extract modules. Makes Sprint 11 design work safer and faster to implement.
 
-**Scope**:
+**Tier 1 — complete:**
+- BUILD-007: Shared TAP test runner extracted to `game/web/src/testing/test_runner.ts`;
+  boilerplate eliminated from 4 existing test files (PR #134)
+- GAME-033: `OP_LABEL` module-level const in `evaluate.ts` replaces 4 inline copies (PR #135)
+- GAME-034: `showLoadError()` helper in `main.ts` replaces 2 identical HTML blocks (PR #136)
+- GAME-035: 10 unit tests for `runElection` + `simulateDistrict`; `simulateDistrict` exported (PR #138)
+- GAME-036: 11 unit tests for `saveWip`/`loadWip`/`clearWip` with in-memory localStorage shim (PR #140)
+- GAME-037: 12 unit tests for `scenarioToSpike` in `adapter.ts` (PR #142)
+- GAME-040: 22 named `private static readonly` constants in `mapRenderer.ts` (PR #144)
 
-**Tier 1 — High value, low risk (do first):**
-- BUILD-007: Extract shared TAP test runner (eliminates boilerplate from 4+ test files)
-- GAME-033: Deduplicate `opLabel` constant in `evaluate.ts` (4 copies → 1)
-- GAME-034: Deduplicate error panel HTML in `main.ts` (2 blocks → `showLoadError()`)
-- GAME-035: Unit tests for `election.ts` (`runElection`, `simulateDistrict`)
-- GAME-036: Unit tests for WIP persistence in `progress.ts` (`saveWip`/`loadWip`/`clearWip`)
-- GAME-037: Unit tests for `adapter.ts` (`scenarioToSpike`)
-
-**Tier 2 — Moderate effort, clear structural win:**
+**Tier 2 — remaining:**
 - GAME-038: Extract DOM panel renderers from `mapRenderer.ts` → `render/panels.ts`
 - GAME-039: Extract hex geometry utils from `generator.ts` → `model/hex-geometry.ts`
-- GAME-040: Name magic numbers in `mapRenderer.ts` (opacities, zoom step, lightness)
-
-**Recommended order**: BUILD-007 first (shared runner used by all new test files); then
-Tier 1 dedup (GAME-033, GAME-034); then Tier 1 tests (GAME-035, GAME-036, GAME-037);
-then Tier 2 structural (GAME-038, GAME-039, GAME-040).
 
 **Deferred (Tier 3 — too large for this sprint)**: GAME-041, GAME-042, GAME-043.
-
-**Known tickets**: BUILD-007, GAME-033 through GAME-040.
 
 ---
 

--- a/thoughts/shared/tickets/BUILD-007-shared-test-runner.md
+++ b/thoughts/shared/tickets/BUILD-007-shared-test-runner.md
@@ -2,7 +2,7 @@
 id: BUILD-007
 title: Extract shared TAP test runner module
 area: build, testing
-status: open
+status: resolved
 created: 2026-04-29
 ---
 

--- a/thoughts/shared/tickets/GAME-033-oplabel-constant-dedup.md
+++ b/thoughts/shared/tickets/GAME-033-oplabel-constant-dedup.md
@@ -2,7 +2,7 @@
 id: GAME-033
 title: Deduplicate opLabel constant in evaluate.ts
 area: game, code-quality
-status: open
+status: resolved
 created: 2026-04-29
 ---
 

--- a/thoughts/shared/tickets/GAME-034-error-panel-dedup.md
+++ b/thoughts/shared/tickets/GAME-034-error-panel-dedup.md
@@ -2,7 +2,7 @@
 id: GAME-034
 title: Deduplicate inline error panel HTML in main.ts
 area: game, code-quality
-status: open
+status: resolved
 created: 2026-04-29
 ---
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -93,9 +93,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-030-main-menu-and-campaigns.md` | game, UX, architecture | Main menu, campaign model, campaign select, layered navigation; replaces scenario-select-as-home |
 | `GAME-031-gameplay-critique-followup.md` | game, content, balance | Review and act on external gameplay critique research (scenario difficulty, eval balance, design) |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
-| `BUILD-007-shared-test-runner.md` | build, testing | Extract shared TAP test runner module; eliminate boilerplate copied across 4+ test files |
-| `GAME-033-oplabel-constant-dedup.md` | game, code-quality | Deduplicate opLabel constant in evaluate.ts (4 inline copies → 1 module-level const) |
-| `GAME-034-error-panel-dedup.md` | game, code-quality | Deduplicate inline error panel HTML in main.ts (2 identical blocks → showLoadError function) |
 | `GAME-038-extract-panel-renderers.md` | game, code-quality | Extract DOM panel renderers out of mapRenderer.ts into render/panels.ts |
 | `GAME-039-extract-hex-geometry.md` | game, code-quality | Extract hex geometry utilities (hexToPixel, hexCorners, mapBounds) from generator.ts into hex-geometry.ts |
 | `GAME-041-split-loader.md` | game, code-quality | Split loader.ts: extract runtime-types.ts primitives; name validateScenario() internally |
@@ -110,6 +107,9 @@ tests should be written alongside or before implementation, not as a backfill. W
 |---|---|
 | LEGAL-001: content risk assessment | Low risk for v1; all pre-authored content, fictional entities, educational framing; disclaimers added to about page + Valle Verde; authoring tool deferred to post-v1 review |
 | GAME-006: scenario compression | HTTP gzip sufficient for v1; no code changes needed; .scenarioz deferred to community scenarios |
+| BUILD-007: shared TAP test runner | test_runner.ts extracted to game/web/src/testing/; 9 exports (test, assertEqual, assertClose, assertNull, assertNotNull, assertTrue, assertFalse, assertDeepEqual, assertThrows, summarize); boilerplate eliminated from 4 existing test files |
+| GAME-033: opLabel dedup | Single OP_LABEL module-level const in evaluate.ts replaces 4 inline copies; evaluate_test passes with no behavior change |
+| GAME-034: error panel dedup | showLoadError(bodyHtml, errorMsg) helper in main.ts replaces 2 identical insertAdjacentHTML blocks; both error paths preserved |
 | GAME-040: mapRenderer magic numbers | 22 named static readonly constants extracted (opacities, zoom step, lightness coefficients, fallback dims, dash patterns); no behavior change; typecheck passes |
 | GAME-037: adapter unit tests | 12 tests for scenarioToSpike: precinct count, party weights, multi-group pop-weighting, neighbor wiring, district assignments, null assignments, districtCount |
 | GAME-036: WIP persistence unit tests | 11 tests in separate progress_wip_test.ts with in-memory localStorage shim; round-trip, null cases, clear; all pass |


### PR DESCRIPTION
## Summary

Closes out stale documentation left behind by the S10 quality-tidy sprint work and the S9 first-release sprint.

**Changes:**

- **Sprint roadmap** (`.md` + `.compressed.md`): Sprint 9 marked complete (2026-04-29) with outcome recorded; Sprint 10 marked current with tier-1 done list + remaining tier-2 items
- **TICKETS.md**: BUILD-007, GAME-033, GAME-034 moved from Open → Resolved with resolution notes; GAME-040 was already moved in its own PR
- **Ticket files**: `status: open` → `status: resolved` for BUILD-007, GAME-033, GAME-034

No code changes. Documentation only.

## What was resolved in S9 (now recorded)

- DIST-001: unified deploy scripts + Buildkite staging auto-deploy (PRs #127 #131 #132)
- LEGAL-001: content risk assessment + disclaimers (PR #126)
- GAME-008 (partial): basic a11y — keyboard nav + ARIA labels (PR #129)
- Standalone fix: scenario-select always shown on initial load (PR #128)

## What was resolved in S10 tier 1 (now recorded)

- BUILD-007: shared TAP test runner (PR #134)
- GAME-033: opLabel dedup (PR #135)
- GAME-034: showLoadError dedup (PR #136)
- GAME-035: election unit tests (PR #138)
- GAME-036: WIP persistence unit tests (PR #140)
- GAME-037: adapter unit tests (PR #142)
- GAME-040: mapRenderer magic numbers (PR #144)

## Test plan

- [x] No code changes — documentation only
- [x] All ticket file `status` fields match merge reality
- [x] Sprint roadmap accurately reflects current sprint state (S10 current, tier-1 done)
- [x] TICKETS.md Open/Resolved counts consistent with ticket file statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
