### PR TITLE
docs: correct S9 outcome — staging auto-deploy was not shipped

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -91,7 +91,7 @@ PRs: #119 #120 #121 #122
 §SPRINT9 [COMPLETE 2026-04-29]
 goal: first release — ship v1 to public
 outcome: all tickets closed
-  DIST-001: unified deploy scripts; Buildkite auto-deploy staging; prod deploy via scripts/deploy-prod.sh; PRs #127 #131 #132
+  DIST-001: prepare-release.sh + deploy.sh (manual staging+prod); Buildkite auto-deploy drafted in #127 but dropped in #131 rewrite; PRs #127 #131 #132
   LEGAL-001: content risk low; disclaimers added to about page + Valle Verde; PR #126
   GAME-008(partial): keyboard nav (painting+scenario select); ARIA labels; PR #129
   standalone fix: scenario-select always shown on initial load; PR #128

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -193,8 +193,10 @@ PRs: #119 #120 #121 #122
 
 **Goal**: Ship v1 to the public. Deploy, legal review, basic accessibility.
 
-**Outcome**: All tickets closed. Unified deployment scripts: Buildkite
-auto-deploy to staging on merge, production deploy via `scripts/deploy-prod.sh`
+**Outcome**: All tickets closed. Unified manual deployment scripts:
+`prepare-release.sh` (build + tag) and `deploy.sh` (staging or production)
+replacing three earlier scripts; Buildkite auto-deploy was drafted in PR #127
+but removed in the PR #131 rewrite — deployments are manual for now
 (DIST-001; PRs #127 #131 #132). Content risk assessment: low-risk for v1 given
 educational framing, fictional regions, all pre-authored content; disclaimers
 added to about page and Valle Verde (LEGAL-001; PR #126). Basic a11y scoped to


### PR DESCRIPTION
## Summary

Correct the S9 outcome recorded in PR #146: the Buildkite staging auto-deploy was drafted in PR #127 but silently dropped when PR #131 rewrote the deployment scripts. Deployments are manual.

Changes:
- Sprint roadmap `.md` + `.compressed.md`: replace "Buildkite auto-deploy to staging on merge" with accurate description — manual `prepare-release.sh` + `deploy.sh`; note the regression

## Affected machines / services

None — documentation only.

## Validation performed

- [x] Current `.buildkite/pipeline.yml` has no deploy step; roadmap now matches reality

## Deployment steps

- [x] N/A — no deployment required

## Tickets addressed

- [x] N/A — retroactive documentation correction

## Rollback

Revert this commit; no state change to undo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
