### PR TITLE
refactor(GAME-038): extract DOM panel renderers to render/panels.ts

### DIFF
--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -10,15 +10,13 @@
 
 import { loadScenario } from "./model/loader.js";
 import type { Scenario } from "./model/scenario.js";
+import { type MapRenderer, type ViewMode, SvgMapRenderer } from "./render/mapRenderer.js";
 import {
-	type MapRenderer,
-	type ViewMode,
-	SvgMapRenderer,
 	renderDistrictButtons,
 	renderLegend,
 	renderResults,
 	renderValidityPanel,
-} from "./render/mapRenderer.js";
+} from "./render/panels.js";
 import { createGameStore } from "./store/gameStore.js";
 import { evaluateCriteria, isMapSubmittable } from "./simulation/evaluate.js";
 import { computeValidityStats } from "./simulation/validity.js";

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -22,10 +22,8 @@
 
 import * as d3 from "d3";
 import { hexCorners, mapBounds } from "../model/hex-geometry.js";
-import type { ScenarioRules } from "../model/scenario.js";
 import type { Precinct } from "../model/types.js";
-import { DISTRICT_COLORS, PARTY_COLORS, PARTY_LABELS } from "../model/types.js";
-import { computeValidityStats } from "../simulation/validity.js";
+import { DISTRICT_COLORS, PARTY_LABELS } from "../model/types.js";
 import type { GameStore } from "../store/gameStore.js";
 
 // ─── Public interface ─────────────────────────────────────────────────────────
@@ -633,116 +631,3 @@ export class SvgMapRenderer implements MapRenderer {
 	}
 }
 
-// ─── Election results renderer ────────────────────────────────────────────────
-
-export function renderResults(container: HTMLElement, state: GameStore): void {
-	if (state.simulationResult === null || state.simulationResult.districtResults.length === 0) {
-		container.innerHTML =
-			'<div style="color:#606080;font-size:0.85rem;">Draw districts to see results</div>';
-		return;
-	}
-
-	const { districtResults } = state.simulationResult;
-	const html = districtResults
-		.map((r) => {
-			const color = DISTRICT_COLORS[r.districtId - 1] ?? "#888";
-			const winnerColor = PARTY_COLORS[r.winner];
-			const winnerLabel = PARTY_LABELS[r.winner];
-			const dPct = (r.voteTotals.D * 100).toFixed(1);
-			const rPct = (r.voteTotals.R * 100).toFixed(1);
-			const marginPct = (r.margin * 100).toFixed(1);
-			return `
-      <div class="result-district" style="border-left-color:${color}">
-        <div class="dist-name">District ${r.districtId}</div>
-        <div class="winner-badge" style="background:${winnerColor};color:#fff">${winnerLabel} +${marginPct}%</div>
-        <div class="vote-bar" style="--d-pct:${dPct}%"></div>
-        <div class="vote-details">
-          Blue ${dPct}% · Red ${rPct}% · ${r.precinctCount} precincts · pop ${r.population.toLocaleString()}
-        </div>
-      </div>`;
-		})
-		.join("");
-
-	container.innerHTML = html;
-}
-
-export function renderLegend(container: HTMLElement, districtCount: number): void {
-	const items = Array.from({ length: districtCount }, (_, i) => {
-		const color = DISTRICT_COLORS[i] ?? "#888";
-		return `<div class="legend-item">
-      <div class="legend-swatch" style="background:${color}"></div>
-      <span>District ${i + 1}</span>
-    </div>`;
-	});
-	container.innerHTML = items.join("");
-}
-
-export function renderDistrictButtons(
-	container: HTMLElement,
-	districtCount: number,
-	activeDistrict: number,
-	onSelect: (id: number) => void,
-): void {
-	container.innerHTML = "";
-	for (let i = 1; i <= districtCount; i++) {
-		const color = DISTRICT_COLORS[i - 1] ?? "#888";
-		const btn = document.createElement("button");
-		btn.className = `district-btn${i === activeDistrict ? " active" : ""}`;
-		btn.textContent = `District ${i}`;
-		btn.style.background = color;
-		btn.style.color = "#fff";
-		btn.addEventListener("click", () => onSelect(i));
-		container.appendChild(btn);
-	}
-}
-
-export function renderValidityPanel(
-	container: HTMLElement,
-	state: GameStore,
-	rules: ScenarioRules,
-): void {
-	const { precincts, assignments, districtCount } = state;
-	const stats = computeValidityStats(precincts, assignments, districtCount, rules);
-
-	let html = "";
-
-	// Unassigned count
-	const unassignedCls = stats.unassignedCount > 0 ? "validity-warn" : "validity-ok";
-	const unassignedLabel =
-		stats.unassignedCount === 1 ? "1 precinct" : `${stats.unassignedCount} precincts`;
-	html += `<div class="validity-row ${unassignedCls}">`;
-	html += `<span>Unassigned</span><span class="validity-badge">${unassignedLabel}</span>`;
-	html += `</div>`;
-
-	// Population balance
-	html += `<div class="validity-section-label">Population balance</div>`;
-	for (const d of stats.districtPop) {
-		const color = DISTRICT_COLORS[d.districtId - 1] ?? "#888";
-		const sign = d.deviationPct >= 0 ? "+" : "";
-		const cls = d.status === "ok" ? "validity-ok" : "validity-error";
-		const statusLabel = d.status === "ok" ? "ok" : d.status;
-		html += `<div class="validity-row ${cls}" style="border-left-color:${color}">`;
-		html += `<span>D${d.districtId}: ${d.population.toLocaleString()}</span>`;
-		html += `<span class="validity-badge">${sign}${d.deviationPct.toFixed(1)}% ${statusLabel}</span>`;
-		html += `</div>`;
-	}
-
-	// Contiguity (skipped when "allowed")
-	if (stats.contiguity !== null) {
-		html += `<div class="validity-section-label">Contiguity</div>`;
-		for (const [did, ok] of stats.contiguity) {
-			const color = DISTRICT_COLORS[did - 1] ?? "#888";
-			const cls = ok
-				? "validity-ok"
-				: rules.contiguity === "required"
-					? "validity-error"
-					: "validity-warn";
-			const label = ok ? "Connected" : "Non-contiguous";
-			html += `<div class="validity-row ${cls}" style="border-left-color:${color}">`;
-			html += `<span>D${did}</span><span class="validity-badge">${label}</span>`;
-			html += `</div>`;
-		}
-	}
-
-	container.innerHTML = html;
-}

--- a/game/web/src/render/panels.ts
+++ b/game/web/src/render/panels.ts
@@ -1,0 +1,116 @@
+import type { ScenarioRules } from "../model/scenario.js";
+import { DISTRICT_COLORS, PARTY_COLORS, PARTY_LABELS } from "../model/types.js";
+import { computeValidityStats } from "../simulation/validity.js";
+import type { GameStore } from "../store/gameStore.js";
+
+export function renderResults(container: HTMLElement, state: GameStore): void {
+	if (state.simulationResult === null || state.simulationResult.districtResults.length === 0) {
+		container.innerHTML =
+			'<div style="color:#606080;font-size:0.85rem;">Draw districts to see results</div>';
+		return;
+	}
+
+	const { districtResults } = state.simulationResult;
+	const html = districtResults
+		.map((r) => {
+			const color = DISTRICT_COLORS[r.districtId - 1] ?? "#888";
+			const winnerColor = PARTY_COLORS[r.winner];
+			const winnerLabel = PARTY_LABELS[r.winner];
+			const dPct = (r.voteTotals.D * 100).toFixed(1);
+			const rPct = (r.voteTotals.R * 100).toFixed(1);
+			const marginPct = (r.margin * 100).toFixed(1);
+			return `
+      <div class="result-district" style="border-left-color:${color}">
+        <div class="dist-name">District ${r.districtId}</div>
+        <div class="winner-badge" style="background:${winnerColor};color:#fff">${winnerLabel} +${marginPct}%</div>
+        <div class="vote-bar" style="--d-pct:${dPct}%"></div>
+        <div class="vote-details">
+          Blue ${dPct}% · Red ${rPct}% · ${r.precinctCount} precincts · pop ${r.population.toLocaleString()}
+        </div>
+      </div>`;
+		})
+		.join("");
+
+	container.innerHTML = html;
+}
+
+export function renderLegend(container: HTMLElement, districtCount: number): void {
+	const items = Array.from({ length: districtCount }, (_, i) => {
+		const color = DISTRICT_COLORS[i] ?? "#888";
+		return `<div class="legend-item">
+      <div class="legend-swatch" style="background:${color}"></div>
+      <span>District ${i + 1}</span>
+    </div>`;
+	});
+	container.innerHTML = items.join("");
+}
+
+export function renderDistrictButtons(
+	container: HTMLElement,
+	districtCount: number,
+	activeDistrict: number,
+	onSelect: (id: number) => void,
+): void {
+	container.innerHTML = "";
+	for (let i = 1; i <= districtCount; i++) {
+		const color = DISTRICT_COLORS[i - 1] ?? "#888";
+		const btn = document.createElement("button");
+		btn.className = `district-btn${i === activeDistrict ? " active" : ""}`;
+		btn.textContent = `District ${i}`;
+		btn.style.background = color;
+		btn.style.color = "#fff";
+		btn.addEventListener("click", () => onSelect(i));
+		container.appendChild(btn);
+	}
+}
+
+export function renderValidityPanel(
+	container: HTMLElement,
+	state: GameStore,
+	rules: ScenarioRules,
+): void {
+	const { precincts, assignments, districtCount } = state;
+	const stats = computeValidityStats(precincts, assignments, districtCount, rules);
+
+	let html = "";
+
+	// Unassigned count
+	const unassignedCls = stats.unassignedCount > 0 ? "validity-warn" : "validity-ok";
+	const unassignedLabel =
+		stats.unassignedCount === 1 ? "1 precinct" : `${stats.unassignedCount} precincts`;
+	html += `<div class="validity-row ${unassignedCls}">`;
+	html += `<span>Unassigned</span><span class="validity-badge">${unassignedLabel}</span>`;
+	html += `</div>`;
+
+	// Population balance
+	html += `<div class="validity-section-label">Population balance</div>`;
+	for (const d of stats.districtPop) {
+		const color = DISTRICT_COLORS[d.districtId - 1] ?? "#888";
+		const sign = d.deviationPct >= 0 ? "+" : "";
+		const cls = d.status === "ok" ? "validity-ok" : "validity-error";
+		const statusLabel = d.status === "ok" ? "ok" : d.status;
+		html += `<div class="validity-row ${cls}" style="border-left-color:${color}">`;
+		html += `<span>D${d.districtId}: ${d.population.toLocaleString()}</span>`;
+		html += `<span class="validity-badge">${sign}${d.deviationPct.toFixed(1)}% ${statusLabel}</span>`;
+		html += `</div>`;
+	}
+
+	// Contiguity (skipped when "allowed")
+	if (stats.contiguity !== null) {
+		html += `<div class="validity-section-label">Contiguity</div>`;
+		for (const [did, ok] of stats.contiguity) {
+			const color = DISTRICT_COLORS[did - 1] ?? "#888";
+			const cls = ok
+				? "validity-ok"
+				: rules.contiguity === "required"
+					? "validity-error"
+					: "validity-warn";
+			const label = ok ? "Connected" : "Non-contiguous";
+			html += `<div class="validity-row ${cls}" style="border-left-color:${color}">`;
+			html += `<span>D${did}</span><span class="validity-badge">${label}</span>`;
+			html += `</div>`;
+		}
+	}
+
+	container.innerHTML = html;
+}

--- a/thoughts/shared/tickets/GAME-038-extract-panel-renderers.md
+++ b/thoughts/shared/tickets/GAME-038-extract-panel-renderers.md
@@ -2,7 +2,7 @@
 id: GAME-038
 title: Extract DOM panel renderers out of mapRenderer.ts
 area: game, code-quality
-status: open
+status: resolved
 created: 2026-04-29
 ---
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -93,7 +93,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-030-main-menu-and-campaigns.md` | game, UX, architecture | Main menu, campaign model, campaign select, layered navigation; replaces scenario-select-as-home |
 | `GAME-031-gameplay-critique-followup.md` | game, content, balance | Review and act on external gameplay critique research (scenario difficulty, eval balance, design) |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
-| `GAME-038-extract-panel-renderers.md` | game, code-quality | Extract DOM panel renderers out of mapRenderer.ts into render/panels.ts |
 | `GAME-041-split-loader.md` | game, code-quality | Split loader.ts: extract runtime-types.ts primitives; name validateScenario() internally |
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
@@ -106,6 +105,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 |---|---|
 | LEGAL-001: content risk assessment | Low risk for v1; all pre-authored content, fictional entities, educational framing; disclaimers added to about page + Valle Verde; authoring tool deferred to post-v1 review |
 | GAME-006: scenario compression | HTTP gzip sufficient for v1; no code changes needed; .scenarioz deferred to community scenarios |
+| GAME-038: extract panel renderers | render/panels.ts created with renderResults, renderLegend, renderDistrictButtons, renderValidityPanel; mapRenderer.ts reduced by ~115 lines; main.ts import updated |
 | GAME-039: extract hex geometry | hex-geometry.ts created with hexToPixel, hexCorners, mapBounds, HEX_DIRECTIONS; generator.ts re-exports from it; adapter.ts + mapRenderer.ts updated; hex_geometry_lib added to model BUILD |
 | BUILD-007: shared TAP test runner | test_runner.ts extracted to game/web/src/testing/; 9 exports (test, assertEqual, assertClose, assertNull, assertNotNull, assertTrue, assertFalse, assertDeepEqual, assertThrows, summarize); boilerplate eliminated from 4 existing test files |
 | GAME-033: opLabel dedup | Single OP_LABEL module-level const in evaluate.ts replaces 4 inline copies; evaluate_test passes with no behavior change |


### PR DESCRIPTION
## Summary

Extracts the four DOM panel renderer functions from `mapRenderer.ts` into a new `render/panels.ts` module. These functions build HTML strings for sidebar/overlay elements and have no dependency on the D3 SVG renderer — they don't belong in the same file.

**Changes:**
- New `game/web/src/render/panels.ts`: `renderResults`, `renderLegend`, `renderDistrictButtons`, `renderValidityPanel` (exact same code, moved)
- `mapRenderer.ts`: four functions removed; `ScenarioRules` import removed; `computeValidityStats` import removed; `PARTY_COLORS` removed from types import (was only used by panels); file reduced by ~115 lines
- `main.ts`: `SvgMapRenderer`, `MapRenderer`, `ViewMode` still imported from `mapRenderer.js`; panel functions now imported from `panels.js`

No behavior change. The web glob picks up `panels.ts` automatically — no BUILD.bazel changes needed.

## Affected machines / services

None — refactor only.

## Validation performed

- [x] `bazel build //web:app_typecheck_lib` passes; `panels.js` appears in outputs
- [x] No behavior change — functions are identical, only the module boundary moved

## Deployment steps

- [x] N/A

## Tickets addressed

see #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
