### PR TITLE
docs: close S10 — all tier 1 + tier 2 tickets complete

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -29,7 +29,7 @@ see game-vision.compressed.md for full scope
 | S7 | shippable $v1 | about page; wrap-up screen; hex backport 002–006; visual consistency | complete — 2026-04-28 |
 | S8 | hardening | CSP; extract CSS; loader errors; scenario compression | complete — 2026-04-28 |
 | S9 | first release | deploy pastthepost.org; legal review; basic a11y | complete — 2026-04-29 |
-| S10 | code quality + tidy | test coverage gaps; dedup; extract modules; refactor for polish readiness | current |
+| S10 | code quality + tidy | test coverage gaps; dedup; extract modules; refactor for polish readiness | complete — 2026-04-29 |
 | S11 | design research+polish | achievement UX; demographic overlays; geo features; full a11y | backlog |
 
 §SPRINT1 [COMPLETE 2026-04-25]
@@ -98,11 +98,11 @@ outcome: all tickets closed
 tickets: DIST-001 LEGAL-001 GAME-008(partial)
 PRs: #126 #127 #128 #129 #131 #132
 
-§SPRINT10 [CURRENT]
+§SPRINT10 [COMPLETE 2026-04-29]
 goal: code quality + tidy — close test coverage gaps, eliminate duplication, extract modules
-rationale: pre-polish housekeeping; makes S11 design work safer to implement
-done(tier1): BUILD-007(#134) GAME-033(#135) GAME-034(#136) GAME-035(#138) GAME-036(#140) GAME-037(#142) GAME-040(#144)
-remaining(tier2): GAME-038 GAME-039
+outcome: all tier1+tier2 tickets closed
+tier1: BUILD-007(#134) GAME-033(#135) GAME-034(#136) GAME-035(#138) GAME-036(#140) GAME-037(#142) GAME-040(#144)
+tier2: GAME-039(#149) GAME-038(#151)
 deferred(tier3): GAME-041 GAME-042 GAME-043 — too large for tidy sprint
 
 §SPRINT11 (backlog)

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -44,7 +44,7 @@ See `thoughts/shared/vision/game-vision.compressed.md` for full scope.
 | 7 | Shippable v1 | About page; wrap-up screen; hex backport to 002–006; all scenarios visually consistent | complete — 2026-04-28 |
 | 8 | Hardening | CSP, extract CSS, loader error handling, scenario compression | complete — 2026-04-28 |
 | 9 | First release | Deploy to pastthepost.org; legal review; basic accessibility | complete — 2026-04-29 |
-| 10 | Code quality + tidy | Test coverage gaps, deduplication, module extraction, pre-polish housekeeping | current |
+| 10 | Code quality + tidy | Test coverage gaps, deduplication, module extraction, pre-polish housekeeping | complete — 2026-04-29 |
 | 11 | Design research + polish | Achievement UX, demographic overlays, geographic features, full accessibility | backlog |
 
 ---
@@ -210,12 +210,14 @@ PRs: #126 #127 #128 #129 #131 #132
 
 ---
 
-## Sprint 10 — Code Quality + Tidy [CURRENT]
+## Sprint 10 — Code Quality + Tidy [COMPLETE 2026-04-29]
 
 **Goal**: Pre-polish housekeeping — close test coverage gaps, eliminate duplication,
 extract modules. Makes Sprint 11 design work safer and faster to implement.
 
-**Tier 1 — complete:**
+**Outcome**: All Tier 1 and Tier 2 tickets closed.
+
+**Tier 1:**
 - BUILD-007: Shared TAP test runner extracted to `game/web/src/testing/test_runner.ts`;
   boilerplate eliminated from 4 existing test files (PR #134)
 - GAME-033: `OP_LABEL` module-level const in `evaluate.ts` replaces 4 inline copies (PR #135)
@@ -225,9 +227,9 @@ extract modules. Makes Sprint 11 design work safer and faster to implement.
 - GAME-037: 12 unit tests for `scenarioToSpike` in `adapter.ts` (PR #142)
 - GAME-040: 22 named `private static readonly` constants in `mapRenderer.ts` (PR #144)
 
-**Tier 2 — remaining:**
-- GAME-038: Extract DOM panel renderers from `mapRenderer.ts` → `render/panels.ts`
-- GAME-039: Extract hex geometry utils from `generator.ts` → `model/hex-geometry.ts`
+**Tier 2:**
+- GAME-039: `hex-geometry.ts` created; `generator.ts` re-exports; `adapter.ts` + `mapRenderer.ts` updated (PR #149)
+- GAME-038: `render/panels.ts` created with 4 panel functions; `mapRenderer.ts` reduced ~115 lines (PR #151)
 
 **Deferred (Tier 3 — too large for this sprint)**: GAME-041, GAME-042, GAME-043.
 


### PR DESCRIPTION
## Summary

Marks Sprint 10 complete in the sprint roadmap. All Tier 1 and Tier 2 tickets are now merged (PR #151 was the last).

**Changes:**
- Sprint overview table: S10 → `complete — 2026-04-29`
- Sprint 10 section: `[CURRENT]` → `[COMPLETE 2026-04-29]`; outcome recorded with full PR list for both tiers
- Compressed roadmap updated to match

No code changes. Documentation only.

## Affected machines / services

None.

## Validation performed

- [x] All S10 ticket PRs (#134–#144, #149, #151) confirmed merged
- [x] Tier 3 deferred items (GAME-041, GAME-042, GAME-043) correctly noted

## Deployment steps

- [x] N/A

## Tickets addressed

- [x] N/A — sprint close bookkeeping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
