### PR TITLE
test(GAME-044,GAME-045): unit tests for hex-geometry and gameStore

### DIFF
--- a/game/package-lock.json
+++ b/game/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
-        "@types/d3": "^7.4.3"
+        "@types/d3": "^7.4.3",
+        "react": "^18.3.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -779,6 +780,26 @@
         "node": ">=12"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
@@ -809,6 +830,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/robust-predicates": {

--- a/game/package.json
+++ b/game/package.json
@@ -10,7 +10,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
-    "@types/d3": "^7.4.3"
+    "@types/d3": "^7.4.3",
+    "react": "^18.3.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": []

--- a/game/pnpm-lock.yaml
+++ b/game/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 7.9.0
       zundo:
         specifier: ^2.3.0
-        version: 2.3.0(zustand@5.0.12)
+        version: 2.3.0(zustand@5.0.12(react@18.3.1))
       zustand:
         specifier: ^5.0.3
-        version: 5.0.12
+        version: 5.0.12(react@18.3.1)
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1
@@ -24,6 +24,9 @@ importers:
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
 
 packages:
 
@@ -275,6 +278,13 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -284,6 +294,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -609,6 +623,12 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -617,14 +637,20 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   robust-predicates@3.0.3: {}
 
   rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
 
-  zundo@2.3.0(zustand@5.0.12):
+  zundo@2.3.0(zustand@5.0.12(react@18.3.1)):
     dependencies:
-      zustand: 5.0.12
+      zustand: 5.0.12(react@18.3.1)
 
-  zustand@5.0.12: {}
+  zustand@5.0.12(react@18.3.1):
+    optionalDependencies:
+      react: 18.3.1

--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -31,6 +31,7 @@ ts_project(
         "//web/src/simulation:election_lib",
         "//web/src/simulation:validity_lib",
         "//web/src/simulation:evaluate_lib",
+        "//web/src/store:gameStore_lib",
     ],
 )
 
@@ -62,6 +63,7 @@ esbuild(
         "//web/src/simulation:election_lib",
         "//web/src/simulation:validity_lib",
         "//web/src/simulation:evaluate_lib",
+        "//web/src/store:gameStore_lib",
     ],
     output = "bundle.js",
     format = "esm",

--- a/game/web/src/model/BUILD.bazel
+++ b/game/web/src/model/BUILD.bazel
@@ -202,6 +202,38 @@ js_test(
     visibility = ["//visibility:public"],
 )
 
+# ── hex_geometry_test_lib: compile hex-geometry tests ────────────────────────
+
+ts_project(
+    name = "hex_geometry_test_lib",
+    srcs = ["hex-geometry_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":hex_geometry_lib",
+        ":types_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+# ── hex_geometry_test: run tests with Node ────────────────────────────────────
+
+js_test(
+    name = "hex_geometry_test",
+    entry_point = "hex-geometry_test.js",
+    data = [
+        ":hex_geometry_test_lib",
+        ":hex_geometry_lib",
+        ":types_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # ── loader_typecheck_test: type-check passes ──────────────────────────────────
 
 build_test(

--- a/game/web/src/model/hex-geometry_test.ts
+++ b/game/web/src/model/hex-geometry_test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for hex-geometry.ts (GAME-044).
+ *
+ * Run via Bazel:
+ *   bazel test //web/src/model:hex_geometry_test
+ *
+ * Coverage:
+ *   - hexToPixel: origin, q-axis, r-axis
+ *   - hexCorners: 6 points all at HEX_SIZE distance; first corner at (center.x+36, center.y);
+ *     offset center propagates
+ *   - HEX_DIRECTIONS: 6 entries; each opposite pair sums to (0,0)
+ *   - mapBounds: single-precinct box; two-precinct box spans both centers
+ */
+
+import { hexToPixel, hexCorners, mapBounds, HEX_DIRECTIONS } from "./hex-geometry.js";
+import type { Precinct } from "./types.js";
+import { test, assertEqual, assertClose, assertTrue, summarize } from "../testing/test_runner.js";
+
+const HEX_SIZE = 36;
+
+// ─── hexToPixel ───────────────────────────────────────────────────────────────
+
+test("hexToPixel: origin (0,0) → {x:0, y:0}", () => {
+	const p = hexToPixel(0, 0);
+	assertEqual(p.x, 0, "x=0");
+	assertEqual(p.y, 0, "y=0");
+});
+
+test("hexToPixel: q=1,r=0 — x = 36*1.5 = 54", () => {
+	const p = hexToPixel(1, 0);
+	assertClose(p.x, 54, 0.001, "x=54");
+	assertClose(p.y, HEX_SIZE * (Math.sqrt(3) / 2), 0.001, "y = 36*sqrt(3)/2");
+});
+
+test("hexToPixel: q=0,r=1 — x=0, y = 36*sqrt(3)", () => {
+	const p = hexToPixel(0, 1);
+	assertClose(p.x, 0, 0.001, "x=0");
+	assertClose(p.y, HEX_SIZE * Math.sqrt(3), 0.001, "y = 36*sqrt(3)");
+});
+
+test("hexToPixel: q=2,r=0 — x=108, y = 36*sqrt(3)", () => {
+	const p = hexToPixel(2, 0);
+	assertClose(p.x, 108, 0.001, "x=108");
+	assertClose(p.y, HEX_SIZE * Math.sqrt(3), 0.001, "y = 36*sqrt(3)");
+});
+
+// ─── hexCorners ──────────────────────────────────────────────────────────────
+
+test("hexCorners: returns 6 corners", () => {
+	const corners = hexCorners({ x: 0, y: 0 });
+	assertEqual(corners.length, 6, "6 corners");
+});
+
+test("hexCorners: all corners at distance HEX_SIZE from center", () => {
+	const center = { x: 0, y: 0 };
+	const corners = hexCorners(center);
+	for (let i = 0; i < 6; i++) {
+		const [cx, cy] = corners[i]!;
+		const dist = Math.sqrt(cx * cx + cy * cy);
+		assertClose(dist, HEX_SIZE, 0.001, `corner ${i} distance = 36`);
+	}
+});
+
+test("hexCorners: first corner at (center.x + 36, center.y) for flat-top", () => {
+	const corners = hexCorners({ x: 0, y: 0 });
+	assertClose(corners[0]![0], 36, 0.001, "corner[0].x = 36");
+	assertClose(corners[0]![1], 0, 0.001, "corner[0].y = 0");
+});
+
+test("hexCorners: offset center propagates to all corners", () => {
+	const cx = 100;
+	const cy = 50;
+	const corners = hexCorners({ x: cx, y: cy });
+	// First corner: angle 0° → (cx + 36, cy)
+	assertClose(corners[0]![0], cx + HEX_SIZE, 0.001, "corner[0].x = cx+36");
+	assertClose(corners[0]![1], cy, 0.001, "corner[0].y = cy");
+	// Check all corners are still at distance HEX_SIZE from (cx, cy)
+	for (let i = 0; i < 6; i++) {
+		const dx = corners[i]![0] - cx;
+		const dy = corners[i]![1] - cy;
+		const dist = Math.sqrt(dx * dx + dy * dy);
+		assertClose(dist, HEX_SIZE, 0.001, `corner ${i} distance from offset center`);
+	}
+});
+
+// ─── HEX_DIRECTIONS ──────────────────────────────────────────────────────────
+
+test("HEX_DIRECTIONS: 6 directions", () => {
+	assertEqual(HEX_DIRECTIONS.length, 6, "6 directions");
+});
+
+test("HEX_DIRECTIONS: each opposite pair sums to (0,0)", () => {
+	for (let i = 0; i < 3; i++) {
+		const [q1, r1] = HEX_DIRECTIONS[i]!;
+		const [q2, r2] = HEX_DIRECTIONS[i + 3]!;
+		assertEqual(q1 + q2, 0, `directions ${i} and ${i + 3} q-sum = 0`);
+		assertEqual(r1 + r2, 0, `directions ${i} and ${i + 3} r-sum = 0`);
+	}
+});
+
+// ─── mapBounds ───────────────────────────────────────────────────────────────
+
+function makePrecinct(x: number, y: number): Precinct {
+	return { center: { x, y } } as Precinct;
+}
+
+test("mapBounds: single precinct at origin — symmetric box of size 2*pad", () => {
+	const pad = HEX_SIZE * 1.2;
+	const bounds = mapBounds([makePrecinct(0, 0)]);
+	assertClose(bounds.minX, -pad, 0.001, "minX = -pad");
+	assertClose(bounds.minY, -pad, 0.001, "minY = -pad");
+	assertClose(bounds.width, 2 * pad, 0.001, "width = 2*pad");
+	assertClose(bounds.height, 2 * pad, 0.001, "height = 2*pad");
+});
+
+test("mapBounds: two precincts span both centers with padding on each side", () => {
+	const pad = HEX_SIZE * 1.2;
+	// precinct A at (0, 0), precinct B at (54, 0)
+	const bounds = mapBounds([makePrecinct(0, 0), makePrecinct(54, 0)]);
+	assertClose(bounds.minX, 0 - pad, 0.001, "minX");
+	assertClose(bounds.minY, 0 - pad, 0.001, "minY");
+	assertClose(bounds.width, 54 + 2 * pad, 0.001, "width spans 54px + 2*pad");
+	assertClose(bounds.height, 2 * pad, 0.001, "height = 2*pad (same y)");
+});
+
+test("mapBounds: two precincts — correct width and height for diagonal placement", () => {
+	const pad = HEX_SIZE * 1.2;
+	const x2 = 54;
+	const y2 = HEX_SIZE * Math.sqrt(3);
+	const bounds = mapBounds([makePrecinct(0, 0), makePrecinct(x2, y2)]);
+	assertClose(bounds.width, x2 + 2 * pad, 0.001, "width");
+	assertClose(bounds.height, y2 + 2 * pad, 0.001, "height");
+	assertTrue(bounds.width > 0, "width positive");
+	assertTrue(bounds.height > 0, "height positive");
+});
+
+summarize();

--- a/game/web/src/simulation/BUILD.bazel
+++ b/game/web/src/simulation/BUILD.bazel
@@ -30,7 +30,7 @@ ts_project(
     deps = [
         "//web/src/model:types_lib",
     ],
-    visibility = ["//web:__pkg__", "//web/src/simulation:__pkg__"],
+    visibility = ["//web:__subpackages__"],
 )
 
 # ── validity_lib: computeValidityStats ────────────────────────────────────────

--- a/game/web/src/store/BUILD.bazel
+++ b/game/web/src/store/BUILD.bazel
@@ -1,0 +1,76 @@
+"""
+Bazel targets for the game store layer.
+
+  gameStore_lib — gameStore.ts (Zustand + zundo state machine; GAME-005)
+
+Creating this BUILD.bazel makes src/store/ a separate Bazel package, so
+game/web/BUILD.bazel's glob(["src/**/*.ts"]) no longer covers this directory.
+game/web/BUILD.bazel lists gameStore_lib as an explicit dep on app_typecheck_lib
+and the esbuild bundle.
+"""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//web/src/store:__pkg__"],
+)
+
+# ── gameStore_lib: Zustand + zundo state machine ──────────────────────────────
+
+ts_project(
+    name = "gameStore_lib",
+    srcs = ["gameStore.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        "//:node_modules/zustand",
+        "//:node_modules/zundo",
+        "//web/src/model:adapter_lib",
+        "//web/src/model:model_lib",
+        "//web/src/model:types_lib",
+        "//web/src/simulation:election_lib",
+    ],
+    visibility = ["//web:__subpackages__"],
+)
+
+# ── gameStore_test_lib: compile tests ─────────────────────────────────────────
+
+ts_project(
+    name = "gameStore_test_lib",
+    srcs = ["gameStore_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":gameStore_lib",
+        "//web/src/model:model_lib",
+        "//web/src/model:types_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+# ── gameStore_test: run tests with Node ──────────────────────────────────────
+
+js_test(
+    name = "gameStore_test",
+    entry_point = "gameStore_test.js",
+    data = [
+        ":gameStore_test_lib",
+        ":gameStore_lib",
+        "//:node_modules/zustand",
+        "//:node_modules/zundo",
+        "//web/src/model:adapter_lib",
+        "//web/src/model:model_lib",
+        "//web/src/model:types_lib",
+        "//web/src/model:hex_geometry_lib",
+        "//web/src/simulation:election_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/game/web/src/store/gameStore_test.ts
+++ b/game/web/src/store/gameStore_test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for gameStore.ts (GAME-045).
+ *
+ * Both zustand/vanilla and zundo work in Node without a DOM, so all store
+ * behaviors are exercisable here without Playwright.
+ *
+ * Run via Bazel:
+ *   bazel test //web/src/store:gameStore_test
+ *
+ * Coverage:
+ *   - initial state: activeDistrict, assignments, simulationResult
+ *   - setActiveDistrict
+ *   - paintPrecinct: assignment update, no-op guard, simulationResult non-null
+ *   - paintStroke: batch assignment; no-op when all precincts already in target
+ *   - resetToInitial: restores original assignments after changes
+ *   - restoreAssignments: sets provided map and active district
+ *   - undo: reverting a paintPrecinct restores prior assignment
+ */
+
+import { createGameStore } from "./gameStore.js";
+import type { Scenario, Party, District, Precinct as ScenarioPrecinct } from "../model/scenario.js";
+import type { PartyId, DistrictId, PrecinctId } from "../model/scenario.js";
+import type { AssignmentMap } from "../model/types.js";
+import { test, assertEqual, assertNotNull, assertNull, assertTrue, summarize } from "../testing/test_runner.js";
+
+// ─── Scenario fixture helpers ─────────────────────────────────────────────────
+
+function pid(s: string): PartyId { return s as unknown as PartyId; }
+function did(s: string): DistrictId { return s as unknown as DistrictId; }
+function pcid(s: string): PrecinctId { return s as unknown as PrecinctId; }
+
+const PARTY_R: Party = { id: pid("r"), name: "Red", abbreviation: "R" };
+const PARTY_D: Party = { id: pid("d"), name: "Blue", abbreviation: "D" };
+const DISTRICT_1: District = { id: did("d1") };
+const DISTRICT_2: District = { id: did("d2") };
+
+function makeGroup(rShare: number) {
+	return {
+		id: pcid("g1") as unknown as import("../model/scenario.js").GroupId,
+		population_share: 1.0,
+		vote_shares: { [pid("r")]: rShare, [pid("d")]: 1 - rShare } as unknown as Record<PartyId, number>,
+		turnout_rate: 1.0,
+	};
+}
+
+function makePrecinct(q: number, r: number, districtId: string): ScenarioPrecinct {
+	return {
+		id: pcid(`p${q}_${r}`),
+		editable: true,
+		position: { q, r },
+		total_population: 100,
+		demographic_groups: [makeGroup(0.6)],
+		initial_district_id: did(districtId),
+	};
+}
+
+/**
+ * Minimal 3-precinct, 2-district scenario:
+ *   p0 at (0,0) → d1  (spike district 1)
+ *   p1 at (1,0) → d1  (spike district 1)
+ *   p2 at (0,1) → d2  (spike district 2)
+ */
+function makeScenario(): Scenario {
+	return {
+		format_version: "1",
+		id: "test-001" as unknown as Scenario["id"],
+		title: "Test",
+		election_type: "congressional",
+		region: { id: "r1" as unknown as Scenario["region"]["id"], name: "Test Region" },
+		geometry: { type: "hex_axial" },
+		events: [],
+		rules: { population_tolerance: 0.05, contiguity: "allowed" },
+		success_criteria: [],
+		narrative: {
+			character: { name: "T", role: "Tester", motivation: "Testing" },
+			intro_slides: [],
+			objective: "Test",
+		},
+		parties: [PARTY_R, PARTY_D],
+		districts: [DISTRICT_1, DISTRICT_2],
+		precincts: [
+			makePrecinct(0, 0, "d1"),
+			makePrecinct(1, 0, "d1"),
+			makePrecinct(0, 1, "d2"),
+		],
+	};
+}
+
+// ─── Initial state ────────────────────────────────────────────────────────────
+
+test("createGameStore: initial activeDistrict is 1", () => {
+	const { store } = createGameStore(makeScenario());
+	assertEqual(store.getState().activeDistrict, 1, "activeDistrict = 1");
+});
+
+test("createGameStore: initial assignments match scenario initial_district_id", () => {
+	const { store } = createGameStore(makeScenario());
+	const { assignments } = store.getState();
+	assertEqual(assignments.get(0), 1, "precinct 0 → district 1");
+	assertEqual(assignments.get(1), 1, "precinct 1 → district 1");
+	assertEqual(assignments.get(2), 2, "precinct 2 → district 2");
+});
+
+test("createGameStore: simulationResult is non-null on creation", () => {
+	const { store } = createGameStore(makeScenario());
+	assertNotNull(store.getState().simulationResult, "simulationResult present");
+});
+
+// ─── setActiveDistrict ────────────────────────────────────────────────────────
+
+test("setActiveDistrict: changes activeDistrict", () => {
+	const { store } = createGameStore(makeScenario());
+	store.getState().setActiveDistrict(2);
+	assertEqual(store.getState().activeDistrict, 2, "activeDistrict = 2");
+});
+
+// ─── paintPrecinct ────────────────────────────────────────────────────────────
+
+test("paintPrecinct: moves precinct to active district", () => {
+	const { store } = createGameStore(makeScenario());
+	store.getState().setActiveDistrict(2);
+	store.getState().paintPrecinct(0); // move precinct 0 from d1 → d2
+	assertEqual(store.getState().assignments.get(0), 2, "precinct 0 → district 2");
+});
+
+test("paintPrecinct: simulationResult remains non-null after paint", () => {
+	const { store } = createGameStore(makeScenario());
+	store.getState().setActiveDistrict(2);
+	store.getState().paintPrecinct(0);
+	assertNotNull(store.getState().simulationResult, "simulationResult non-null after paint");
+});
+
+test("paintPrecinct: no-op if precinct already in target district", () => {
+	const { store } = createGameStore(makeScenario());
+	const before = store.getState().assignments;
+	store.getState().setActiveDistrict(1);
+	store.getState().paintPrecinct(0); // precinct 0 is already in district 1
+	assertTrue(store.getState().assignments === before, "assignments reference unchanged on no-op");
+});
+
+// ─── paintStroke ──────────────────────────────────────────────────────────────
+
+test("paintStroke: assigns batch of precincts to target district", () => {
+	const { store } = createGameStore(makeScenario());
+	store.getState().paintStroke([0, 2], 2); // move precincts 0 and 2 → district 2
+	assertEqual(store.getState().assignments.get(0), 2, "precinct 0 → district 2");
+	assertEqual(store.getState().assignments.get(2), 2, "precinct 2 → district 2");
+	assertEqual(store.getState().assignments.get(1), 1, "precinct 1 unchanged");
+});
+
+test("paintStroke: no-op when all precincts already in target district", () => {
+	const { store } = createGameStore(makeScenario());
+	const before = store.getState().assignments;
+	store.getState().paintStroke([0, 1], 1); // 0 and 1 are already in district 1
+	assertTrue(store.getState().assignments === before, "assignments reference unchanged");
+});
+
+// ─── resetToInitial ───────────────────────────────────────────────────────────
+
+test("resetToInitial: restores assignments after changes", () => {
+	const { store } = createGameStore(makeScenario());
+	// Make several changes
+	store.getState().setActiveDistrict(2);
+	store.getState().paintPrecinct(0);
+	store.getState().paintPrecinct(1);
+	assertEqual(store.getState().assignments.get(0), 2, "precinct 0 moved (pre-reset)");
+	// Reset
+	store.getState().resetToInitial();
+	const { assignments } = store.getState();
+	assertEqual(assignments.get(0), 1, "precinct 0 restored → district 1");
+	assertEqual(assignments.get(1), 1, "precinct 1 restored → district 1");
+	assertEqual(assignments.get(2), 2, "precinct 2 unchanged → district 2");
+});
+
+// ─── restoreAssignments ───────────────────────────────────────────────────────
+
+test("restoreAssignments: sets provided assignment map and active district", () => {
+	const { store } = createGameStore(makeScenario());
+	const custom: AssignmentMap = new Map([[0, 2], [1, 2], [2, 1]]);
+	store.getState().restoreAssignments(custom, 2);
+	const state = store.getState();
+	assertEqual(state.assignments.get(0), 2, "precinct 0 → district 2");
+	assertEqual(state.assignments.get(1), 2, "precinct 1 → district 2");
+	assertEqual(state.assignments.get(2), 1, "precinct 2 → district 1");
+	assertEqual(state.activeDistrict, 2, "activeDistrict = 2");
+});
+
+// ─── undo ─────────────────────────────────────────────────────────────────────
+
+test("undo: reverts a paintPrecinct to previous assignment", () => {
+	const { store } = createGameStore(makeScenario());
+	store.getState().setActiveDistrict(2);
+	store.getState().paintPrecinct(0); // move precinct 0 → district 2
+	assertEqual(store.getState().assignments.get(0), 2, "precinct 0 → district 2 (post-paint)");
+
+	// Access zundo temporal store and undo
+	const temporal = (store as unknown as { temporal: { getState: () => { undo: () => void } } }).temporal;
+	temporal.getState().undo();
+
+	assertEqual(store.getState().assignments.get(0), 1, "precinct 0 restored → district 1 (post-undo)");
+});
+
+summarize();

--- a/game/web/src/store/tsconfig.json
+++ b/game/web/src/store/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "declaration": true
+  }
+}

--- a/thoughts/shared/tickets/GAME-044-hex-geometry-unit-tests.md
+++ b/thoughts/shared/tickets/GAME-044-hex-geometry-unit-tests.md
@@ -1,0 +1,45 @@
+---
+id: GAME-044
+title: Unit tests for hex-geometry.ts
+area: game, code-quality, testing
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`hex-geometry.ts` (extracted in GAME-039) contains four pure functions:
+`hexToPixel`, `hexCorners`, `mapBounds`, and the `HEX_DIRECTIONS` constant.
+These functions drive all precinct layout and neighbor wiring across the
+entire game — they are high-value, zero-DOM, and trivially testable in Node.
+This ticket adds a unit test file covering their contracts.
+
+## Current State
+
+No tests exist for `hex-geometry.ts`. Coverage comes only indirectly through
+Playwright e2e tests that observe rendered map positions.
+
+## Goals / Acceptance Criteria
+
+- [ ] `game/web/src/model/hex-geometry_test.ts` created with TAP-runner tests
+- [ ] Tests cover:
+  - `hexToPixel(0, 0)` → `{x: 0, y: 0}`
+  - `hexToPixel(1, 0)` and `hexToPixel(0, 1)` — pixel offsets match flat-top axial formula
+  - `hexCorners`: returns 6 points; all at distance `HEX_SIZE` from center; first corner at `(center.x + 36, center.y)`
+  - `hexCorners`: offset center propagates correctly
+  - `HEX_DIRECTIONS`: 6 entries; each opposite pair sums to `(0, 0)`
+  - `mapBounds`: single-precinct bounding box (width/height = 2 * HEX_SIZE * 1.2 * 2)
+  - `mapBounds`: two-precinct bounding box spans both centers
+- [ ] Bazel targets `hex_geometry_test_lib` and `hex_geometry_test` added to
+  `game/web/src/model/BUILD.bazel`
+- [ ] `bazel test //web/src/model:hex_geometry_test` passes
+
+## Test Coverage
+
+All AC items above are the test coverage requirements.
+
+## References
+
+- `game/web/src/model/hex-geometry.ts`
+- `game/web/src/model/BUILD.bazel`
+- `game/web/src/testing/test_runner.ts`

--- a/thoughts/shared/tickets/GAME-045-gamestore-unit-tests.md
+++ b/thoughts/shared/tickets/GAME-045-gamestore-unit-tests.md
@@ -1,0 +1,55 @@
+---
+id: GAME-045
+title: Unit tests for gameStore.ts
+area: game, code-quality, testing
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`gameStore.ts` is the central state machine for the game: it manages district
+assignments, drives election re-simulation on every paint, and maintains
+undo/redo via zundo's temporal middleware. Both `zustand/vanilla` and `zundo`
+work in Node.js without a DOM, so these behaviors are testable as pure unit
+tests. This ticket adds a unit test file using a minimal in-memory scenario
+fixture.
+
+## Current State
+
+No unit tests exist for `gameStore.ts`. Coverage is entirely through Playwright
+e2e tests, which test rendered outcomes but cannot isolate store behavior.
+
+## Goals / Acceptance Criteria
+
+- [ ] `game/web/src/store/gameStore_test.ts` created with TAP-runner tests
+- [ ] Tests cover:
+  - Initial state: `activeDistrict = 1`; assignments match scenario
+    `initial_district_id` values; `simulationResult` is not null
+  - `setActiveDistrict`: changes `activeDistrict`
+  - `paintPrecinct`: updates assignment for the target precinct and sets
+    `simulationResult`; is a no-op if precinct already in target district
+  - `paintStroke`: assigns a batch of precincts atomically; is a no-op if all
+    precincts already in target district
+  - `resetToInitial`: restores original assignments regardless of changes made
+  - `restoreAssignments`: sets the provided assignment map and active district
+  - `undo`: reverting a `paintPrecinct` restores the previous assignment
+- [ ] `game/web/src/store/BUILD.bazel` created with `gameStore_lib` and
+  `gameStore_test` Bazel targets
+- [ ] `game/web/src/store/tsconfig.json` created (self-contained, mirrors
+  `src/simulation/tsconfig.json`)
+- [ ] `//web/src/store:gameStore_lib` added as explicit dep to both
+  `app_typecheck_lib` and `app` in `game/web/BUILD.bazel`
+- [ ] `bazel test //web/src/store:gameStore_test` passes
+
+## Test Coverage
+
+All AC items above are the test coverage requirements. DOM and D3 internals
+are explicitly out of scope.
+
+## References
+
+- `game/web/src/store/gameStore.ts`
+- `game/web/src/simulation/BUILD.bazel` (tsconfig + BUILD pattern to follow)
+- `game/web/src/model/adapter_test.ts` (scenario fixture helper pattern)
+- `game/web/BUILD.bazel` (explicit dep wiring after package creation)

--- a/thoughts/shared/tickets/GAME-046-panels-unit-tests.md
+++ b/thoughts/shared/tickets/GAME-046-panels-unit-tests.md
@@ -1,0 +1,53 @@
+---
+id: GAME-046
+title: Unit tests for render/panels.ts
+area: game, code-quality, testing
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+`render/panels.ts` (extracted in GAME-038) contains four HTML-string-generating
+functions: `renderResults`, `renderLegend`, `renderDistrictButtons`, and
+`renderValidityPanel`. These build DOM content for game sidebars and overlays.
+They currently have no unit tests; coverage is through e2e only.
+
+Two approaches exist for unit testing them:
+1. **jsdom** — install `jsdom` as a dev dependency; call functions against a
+   real DOM implementation; assert element presence and text content.
+2. **Extract pure helpers** — refactor each function to a pure `buildXxxHtml()`
+   string-builder, test the strings directly; keep the DOM-mutation wrapper
+   thin and untested.
+
+This ticket is deferred until after Sprint 11 design work lands. Implement
+whichever approach is chosen during Sprint 11 triage.
+
+## Current State
+
+`render/panels.ts` has no unit tests. All coverage is via Playwright e2e tests
+that assert visible panel content (sidebar text, district buttons, legend labels).
+The e2e coverage is reasonable but does not catch HTML structure regressions in
+isolation.
+
+## Goals / Acceptance Criteria
+
+- [ ] Choose approach (jsdom or pure extract) during Sprint 11 triage
+- [ ] `game/web/src/render/panels_test.ts` created with TAP-runner tests
+- [ ] Tests cover all four functions: `renderResults`, `renderLegend`,
+  `renderDistrictButtons`, `renderValidityPanel`
+- [ ] Each function has: happy-path structural check, at least one
+  boundary/edge-case check
+- [ ] Bazel targets added; `bazel test //web/...` passes
+
+## Test Coverage
+
+All AC items above are the test requirements.
+
+## References
+
+- `game/web/src/render/panels.ts`
+- `game/web/src/render/BUILD.bazel` (does not exist yet — render/ has no BUILD.bazel)
+- Option A (jsdom): https://github.com/jsdom/jsdom
+- Option B (extract pure helpers): refactor each function so HTML building is
+  separate from DOM mutation — no external deps needed

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -96,6 +96,9 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-041-split-loader.md` | game, code-quality | Split loader.ts: extract runtime-types.ts primitives; name validateScenario() internally |
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
+| `GAME-044-hex-geometry-unit-tests.md` | game, testing | Unit tests for hex-geometry.ts: hexToPixel, hexCorners, mapBounds, HEX_DIRECTIONS |
+| `GAME-045-gamestore-unit-tests.md` | game, testing | Unit tests for gameStore.ts: paint, stroke, reset, restore, undo/redo via zundo temporal |
+| `GAME-046-panels-unit-tests.md` | game, testing | Unit tests for render/panels.ts (deferred): jsdom or extract-pure-helpers approach |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary
- GAME-044: unit tests for `hex-geometry.ts` — 11 tests covering `hexToPixel`, `hexCorners`, `HEX_DIRECTIONS`, and `mapBounds`; Bazel targets added to `model/BUILD.bazel`
- GAME-045: unit tests for `gameStore.ts` — 13 tests covering initial state, `setActiveDistrict`, `paintPrecinct`, `paintStroke`, `resetToInitial`, `restoreAssignments`, and undo via zundo temporal store; new `store/BUILD.bazel` package; `gameStore_lib` wired into `web/BUILD.bazel`; `react` added to `devDependencies` to satisfy zundo's transitive peer dep in Node.js test runtime
- GAME-046: ticket filed (deferred) — `panels.ts` unit tests; no code changes
- `election_lib` visibility broadened to `//web:__subpackages__` so `//web/src/store` can depend on it

## Validation performed
- [x] `bazel test //web/src/model:hex_geometry_test` — 11 tests pass
- [x] `bazel test //web/src/store:gameStore_test` — 13 tests pass
- [x] `bazel test //web/src/model/... //web/src/simulation/... //web/src/store/... //web/src/testing/...` — all 13 unit test targets pass
- [x] `bazel test //web:app_typecheck_test` — passes

## Affected machines / services
- N/A — test and build infrastructure only; no production code changed

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see GAME-044
- see GAME-045
- see GAME-046

## Rollback
- Revert commit; no runtime impact
