### PR TITLE
plan(S11): GAME-030 sub-tickets + sprint roadmap for campaigns/menu focus

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -30,7 +30,7 @@ see game-vision.compressed.md for full scope
 | S8 | hardening | CSP; extract CSS; loader errors; scenario compression | complete — 2026-04-28 |
 | S9 | first release | deploy pastthepost.org; legal review; basic a11y | complete — 2026-04-29 |
 | S10 | code quality + tidy | test coverage gaps; dedup; extract modules; refactor for polish readiness | complete — 2026-04-29 |
-| S11 | design research+polish | achievement UX; demographic overlays; geo features; full a11y | backlog |
+| S11 | main menu, campaigns + polish | title screen→campaign select→scenario flow; Tier2: design research, a11y | backlog |
 
 §SPRINT1 [COMPLETE 2026-04-25]
 goal: app renders tutorial-001.json; player paints+undoes; no sim/game-loop yet
@@ -106,27 +106,34 @@ tier2: GAME-039(#149) GAME-038(#151)
 deferred(tier3): GAME-041 GAME-042 GAME-043 — too large for tidy sprint
 
 §SPRINT11 (backlog)
-goal: design research+polish — resolve open design questions then implement
-scope:
-  DESIGN-001 achievement/star UX; DESIGN-005/006/007 demographic overlays
-  DESIGN-008 geographic features; GAME-008 full a11y; GAME-031 gameplay critique
-  animated criteria eval (needs ticket); electoral outcome diff (needs ticket)
+goal: main menu, campaigns + polish — proper title screen, campaign navigation model
+demo target: player lands on title screen → picks campaign → plays scenario → returns to menu
+tier1 (core): GAME-047 campaign data model; GAME-048 campaign-driven scenario select;
+  GAME-049 campaign select screen; GAME-050 main menu; GAME-051 in-game nav cleanup
+tier2 (if tier1 done): DESIGN-001 achievement UX; GAME-008 full a11y; GAME-031 critique;
+  GAME-052 animated criteria eval (blocked on DESIGN-001); GAME-053 electoral outcome diff
+deferred to S12: DESIGN-005/006/007 demographic overlays; DESIGN-008 geographic features
 
 §SPRINT12+ (later)
-GAME-030 main menu+campaigns (architecture; own sprint)
+DESIGN-005 population dot-density overlay (deferred S11)
+DESIGN-006 zoom-adaptive dot density (deferred S11)
+DESIGN-007 dimensional dot map demographic overlay (deferred S11)
+DESIGN-008 geographic features — decorative tiles (deferred S11)
 GAME-041 split loader; GAME-042 break up main.ts; GAME-043 unify type systems (own sprint)
 
 §BACKLOG (not sprint-assigned)
 BUILD-003 ts-rules spawn strategy          any
 BUILD-004 playwright bzl macro             any
+BUILD-008 switch CI to pnpm               any (low priority)
 CI-001    GH Action ticket-close sync      any (low priority)
 AGENT-003 infra PR review bot              any
 DESIGN-004 legend layout                   any
-GAME-041  split loader.ts                  before S12
-GAME-042  break up main.ts                 before S12
-GAME-043  unify type systems               before S12
+GAME-041  split loader.ts                  S12
+GAME-042  break up main.ts                 S12
+GAME-043  unify type systems               S12
+GAME-046  panels unit tests                S12
 
 §BLOCKING_OPEN_QUESTIONS
-DESIGN-001 star/achievement UX → blocks S11
+DESIGN-001 star/achievement UX → blocks S11 Tier2 (GAME-052 animated criteria eval)
 RESOLVED: OQ4 narrative asset resolution — deferred indefinitely
 RESOLVED: OQ9 StateContext redesign — deferrable past $v1

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -45,7 +45,7 @@ See `thoughts/shared/vision/game-vision.compressed.md` for full scope.
 | 8 | Hardening | CSP, extract CSS, loader error handling, scenario compression | complete — 2026-04-28 |
 | 9 | First release | Deploy to pastthepost.org; legal review; basic accessibility | complete — 2026-04-29 |
 | 10 | Code quality + tidy | Test coverage gaps, deduplication, module extraction, pre-polish housekeeping | complete — 2026-04-29 |
-| 11 | Design research + polish | Achievement UX, demographic overlays, geographic features, full accessibility | backlog |
+| 11 | Main menu, campaigns + polish | Title screen → campaign select → scenario flow; optional: design research, accessibility | backlog |
 
 ---
 
@@ -235,21 +235,35 @@ extract modules. Makes Sprint 11 design work safer and faster to implement.
 
 ---
 
-## Sprint 11 — Design Research + Polish [BACKLOG]
+## Sprint 11 — Main Menu, Campaigns + Polish [BACKLOG]
 
-**Goal**: Research-first sprint — resolve open design questions, then implement.
+**Goal**: First-impression polish sprint — proper main menu, campaign navigation
+model, and the most impactful UX improvements. Players should experience the
+game as a real game, not a scenario picker.
 
-**Scope**:
+**Demo target**: A player lands on a title screen, picks a campaign, plays a
+scenario, and returns to the menu — end-to-end navigation working.
+
+**Tier 1 (core delivery):**
+- GAME-047: Campaign data model + authored campaign definitions
+- GAME-048: Campaign-driven scenario select (routing + data wiring)
+- GAME-049: Campaign select screen
+- GAME-050: Main menu / title screen
+- GAME-051: In-game navigation cleanup
+
+**Tier 2 (if Tier 1 done early):**
 - DESIGN-001: Achievement/star UX research (blocks animated criteria eval)
-- DESIGN-005/006/007: Demographic overlay research → implementation
-- DESIGN-008: Geographic features (lakes, mountains as decorative tiles)
 - GAME-008: Full accessibility pass (remainder after S9 basics)
-- GAME-031: Gameplay critique followup (review + act on external feedback)
-- Animated criteria evaluation + party reactions (needs ticket; blocked on DESIGN-001)
-- Electoral outcome visual diff (needs ticket)
+- GAME-031: Gameplay critique followup
+- GAME-052: Animated criteria evaluation (blocked on DESIGN-001)
+- GAME-053: Electoral outcome visual diff (placeholder)
 
-**Known tickets**: DESIGN-001, DESIGN-005, DESIGN-006, DESIGN-007, DESIGN-008,
-GAME-008, GAME-031. Two new tickets needed for animated criteria + electoral diff.
+**Deferred to S12:** DESIGN-005/006/007 (demographic overlays), DESIGN-008
+(geographic features) — these require dedicated research + implementation time
+that would crowd out the navigation work.
+
+**Known tickets (Tier 1)**: GAME-047, GAME-048, GAME-049, GAME-050, GAME-051.
+**Known tickets (Tier 2)**: DESIGN-001, GAME-008, GAME-031, GAME-052, GAME-053.
 
 ---
 
@@ -257,7 +271,10 @@ GAME-008, GAME-031. Two new tickets needed for animated criteria + electoral dif
 
 | Ticket | Area | Notes |
 |---|---|---|
-| GAME-030 | Main menu + campaigns | Architecture overhaul; own sprint |
+| DESIGN-005 | Population dot-density overlay | Deferred from S11 |
+| DESIGN-006 | Zoom-adaptive dot density | Deferred from S11; refinement on DESIGN-005 |
+| DESIGN-007 | Dimensional dot map demographic overlay | Deferred from S11 |
+| DESIGN-008 | Geographic features (lakes, mountains) | Decorative tiles; blocks contiguity |
 | GAME-041 | Split loader.ts | Structural; own sprint alongside GAME-042/043 |
 | GAME-042 | Break up main.ts | Structural; own sprint |
 | GAME-043 | Unify type systems | Largest refactor; own sprint; do last |
@@ -270,12 +287,14 @@ GAME-008, GAME-031. Two new tickets needed for animated criteria + electoral dif
 |---|---|---|
 | BUILD-003 | ts-rules spawn strategy research | Any |
 | BUILD-004 | Playwright bzl macro | Any |
+| BUILD-008 | Switch CI from npm ci to pnpm | Any (low priority) |
 | CI-001 | GitHub Action ticket-close sync | Any (low priority) |
 | AGENT-003 | Infra PR review bot comment handling | Any |
 | DESIGN-004 | Legend layout (horizontal strip above map) | Any |
 | GAME-041 | Split loader.ts into focused modules | S12 |
 | GAME-042 | Break up main.ts god module | S12 |
 | GAME-043 | Unify spike + scenario type systems | S12 |
+| GAME-046 | Unit tests for render/panels.ts | S12 |
 
 ---
 
@@ -283,7 +302,7 @@ GAME-008, GAME-031. Two new tickets needed for animated criteria + electoral dif
 
 | Question | Blocks | ADR/spec reference |
 |---|---|---|
-| DESIGN-001: Star/achievement UX | Sprint 11 | DESIGN-001 ticket |
+| DESIGN-001: Star/achievement UX | Sprint 11 Tier 2 (animated criteria, GAME-052) | DESIGN-001 ticket |
 
 **Resolved**:
 - OQ4 (narrative asset resolution) — intro slides shipped in Sprint 4 without image support; deferred indefinitely.

--- a/thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md
+++ b/thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md
@@ -12,6 +12,9 @@ Replace the current scenario-select-as-home-screen with a proper main menu,
 campaign model, and layered navigation. The game should feel like a real game
 with a title screen, not a scenario picker that doubles as everything.
 
+This is the parent design document. Implementation is broken into five
+sub-tickets: GAME-047 through GAME-051.
+
 ## Current State
 
 The scenario select screen serves as the home screen — it's the first thing
@@ -21,55 +24,69 @@ Scenarios are hardcoded in SCENARIO_MANIFEST.
 
 ## Design
 
+### Campaign Model
+
+A campaign is a named, ordered collection of scenarios. Two campaigns ship
+with v1:
+
+- **Tutorial** — `tutorial-001` and `tutorial-002`; introduces map mechanics
+  before presenting the full scenario set
+- **Educational** — all nine main scenarios (001–009); the core game
+
+Campaign data structure:
+```typescript
+interface Campaign {
+  id: string;
+  title: string;
+  description: string;
+  scenarioIds: string[];
+}
+```
+
+Campaign completion tracked per-campaign in localStorage. Unlock logic
+(sequential progression) applies within each campaign independently.
+
 ### Main Menu Screen
 - Full-screen with game art/logo ("Past the Post")
-- Vertical menu on the left:
+- Vertical menu:
   - **Continue** (visible only when a campaign is in progress)
   - **New Campaign**
-  - **Load** (greyed out until save/load feature is ready)
-  - **Settings** (greyed out until settings feature is ready)
   - **About** (opens existing about page)
-
-### Campaign Model
-- A campaign is a named collection of scenarios with ordering
-- The v1 educational campaign is the only campaign; others are future
-- Campaign data structure: `{ id, title, description, scenarioIds: string[] }`
-- Campaign completion tracked per-campaign in localStorage
+  - **Load** (greyed out — post-v1)
+  - **Settings** (greyed out — post-v1)
 
 ### Campaign Select Screen
-- Shows available campaigns (initially just the one educational campaign)
-- Each campaign card: title, description, progress indicator
+- Shows both campaigns with progress indicator (N/M scenarios complete)
 - Back button returns to main menu
-- Clicking a campaign opens the scenario select screen
+- Clicking a campaign opens the scenario select screen for that campaign
 
 ### Scenario Select Screen
 - No longer the home screen — accessed through a campaign
-- Scenario list generated from the campaign's `scenarioIds`, not hardcoded
+- Scenario list generated from the campaign's `scenarioIds`
 - Back button returns to campaign select (not main menu)
 
 ### In-Game Navigation
-- The "← Scenarios" button becomes a menu with:
+- The "← Scenarios" button becomes a submenu:
   - "Return to Scenarios" (back to scenario select within current campaign)
-  - "Return to Main Menu" (back to main menu)
+  - "Return to Main Menu"
 
-## Goals / Acceptance Criteria
+## Sub-tickets (implementation)
 
-- [ ] Main menu screen with art/logo and vertical navigation
-- [ ] Campaign data model: id, title, description, scenarioIds
-- [ ] Campaign select screen showing available campaigns
-- [ ] Scenario select screen driven by campaign data (not hardcoded manifest)
-- [ ] In-game menu with "Return to Scenarios" and "Return to Main Menu" options
-- [ ] Continue button on main menu when a campaign is in progress
-- [ ] Load and Settings buttons present but greyed out / disabled
-- [ ] About opens existing about page
-- [ ] All existing e2e tests pass (may need updates for new navigation flow)
+Intended delivery order (each builds on the previous):
 
-## Test Coverage
+| Ticket | Scope | Depends on |
+|---|---|---|
+| GAME-047 | Campaign data model + authored campaign definitions | — |
+| GAME-048 | Campaign-driven scenario select (routing + data wiring) | GAME-047 |
+| GAME-050 | Main menu / title screen | GAME-047, GAME-048 |
+| GAME-049 | Campaign select screen | GAME-047, GAME-048, GAME-050 |
+| GAME-051 | In-game navigation cleanup | GAME-048, GAME-049, GAME-050 |
 
-- [ ] e2e: main menu visible on fresh load; About/New Campaign buttons work
-- [ ] e2e: New Campaign → campaign select → scenario select flow
-- [ ] e2e: in-game menu navigation back to scenarios and main menu
-- [ ] e2e: Continue button appears when campaign in progress
+GAME-050 ships before GAME-049 so the campaign select Back button has a real
+destination. The Continue button in GAME-050 requires per-campaign last-played
+tracking; GAME-047 must persist a `lastCampaignId` key in localStorage, or
+GAME-050 should soften Continue to navigate to campaign select rather than the
+most-recently-played campaign's scenario list.
 
 ## References
 

--- a/thoughts/shared/tickets/GAME-047-campaign-data-model.md
+++ b/thoughts/shared/tickets/GAME-047-campaign-data-model.md
@@ -1,0 +1,62 @@
+---
+id: GAME-047
+title: Campaign data model + authored campaign definitions
+area: game, architecture
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+Introduce a `Campaign` TypeScript type, author the two v1 campaign definitions
+(Tutorial and Educational), and wire them into the app as a static registry.
+This is the foundation for GAME-048 through GAME-051. No UI changes here —
+purely data model and authored content.
+
+## Current State
+
+Scenarios are referenced directly via `SCENARIO_MANIFEST` in `main.ts`. There
+is no campaign concept. Scenarios must be accessed through the manifest; there
+is no grouping or ordering layer above individual scenarios.
+
+## Goals / Acceptance Criteria
+
+- [ ] `Campaign` interface defined in a new `game/web/src/model/campaigns.ts`:
+  ```typescript
+  interface Campaign {
+    id: string;
+    title: string;
+    description: string;
+    scenarioIds: string[];
+  }
+  ```
+- [ ] Two campaign definitions authored:
+  - `tutorial` — title "Tutorial", scenarioIds `["tutorial-001", "tutorial-002"]`
+  - `educational` — title "Educational Campaign", scenarioIds `["001", "002", "003", "004", "005", "006", "007", "008", "009"]`
+- [ ] `CAMPAIGN_REGISTRY: Campaign[]` exported from `campaigns.ts` (ordered: tutorial first)
+- [ ] `getCampaign(id: string): Campaign | undefined` helper exported
+- [ ] `saveLastPlayedScenario(scenarioId: string): void` and
+  `loadLastPlayedScenario(): string | null` helpers exported from `campaigns.ts`
+  (thin wrappers over localStorage key `"lastPlayedScenarioId"`); called by the
+  scenario entry path so Continue on the main menu knows where to resume
+- [ ] `campaigns_lib` Bazel target added to `model/BUILD.bazel`
+- [ ] `app_typecheck_lib` in `web/BUILD.bazel` updated to include `campaigns_lib`
+
+## Test Coverage
+
+- [ ] Unit test file `game/web/src/model/campaigns_test.ts`:
+  - CAMPAIGN_REGISTRY contains exactly 2 campaigns
+  - tutorial campaign has exactly 2 scenario IDs
+  - educational campaign has exactly 9 scenario IDs
+  - getCampaign("tutorial") returns the tutorial campaign
+  - getCampaign("educational") returns the educational campaign
+  - getCampaign("nonexistent") returns undefined
+  - saveLastPlayedScenario("001") → loadLastPlayedScenario() returns "001"
+  - loadLastPlayedScenario() returns null when localStorage is empty
+- [ ] `campaigns_test` js_test target in `model/BUILD.bazel`
+
+## References
+
+- `game/web/src/main.ts` — SCENARIO_MANIFEST (source of scenario IDs)
+- `thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md` — parent design doc
+- `game/web/src/testing/test_runner.ts` — TAP runner for unit tests

--- a/thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md
+++ b/thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md
@@ -1,0 +1,51 @@
+---
+id: GAME-048
+title: Campaign-driven scenario select (routing + data wiring)
+area: game, UX
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+Update the scenario select screen to operate within the context of a campaign.
+The screen receives a campaign ID via URL parameter, filters the scenario list
+to that campaign's `scenarioIds`, and provides a Back button that returns to
+the campaign select screen. This ticket does not build the campaign select or
+main menu screens — it makes the scenario select campaign-aware so those
+screens can navigate into it cleanly.
+
+## Current State
+
+The scenario select screen shows all scenarios from `SCENARIO_MANIFEST` and
+acts as the app home screen. There is no campaign parameter; the back button
+does not exist. Completion tracking uses scenario IDs directly.
+
+## Goals / Acceptance Criteria
+
+- [ ] URL parameter `?campaign=<id>` accepted by the scenario select screen
+- [ ] Scenario list filtered to the campaign's `scenarioIds` (order from campaign)
+- [ ] If `?campaign=` is absent or unknown, fall back to showing all scenarios
+  (preserves current behavior for direct URL access)
+- [ ] **Back** button added to scenario select header — visible only when a
+  `?campaign=` parameter is present; navigates to campaign select screen
+  (`/` or `?view=campaigns`, per GAME-049 routing decision)
+- [ ] Completion and unlock logic unchanged — still per-scenario-ID in localStorage
+- [ ] Existing e2e tests for scenario select continue to pass
+
+## Test Coverage
+
+- [ ] e2e test: navigating to `?campaign=tutorial` shows only tutorial-001 and
+  tutorial-002 in the list (not the nine main scenarios)
+- [ ] e2e test: Back button is visible when `?campaign=tutorial` is in the URL
+- [ ] e2e test: Back button is absent when no `?campaign=` parameter is present
+- [ ] e2e test: navigating without `?campaign=` still shows all scenarios
+  (regression guard on fallback behavior)
+
+## References
+
+- `game/web/src/main.ts` — scenario select rendering, URL param handling
+- `thoughts/shared/tickets/GAME-047-campaign-data-model.md` — Campaign type + registry (prerequisite)
+- `thoughts/shared/tickets/GAME-049-campaign-select-screen.md` — destination of Back button
+- `thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md` — parent design doc
+- `e2e/` — existing Playwright tests for scenario select

--- a/thoughts/shared/tickets/GAME-049-campaign-select-screen.md
+++ b/thoughts/shared/tickets/GAME-049-campaign-select-screen.md
@@ -1,0 +1,50 @@
+---
+id: GAME-049
+title: Campaign select screen
+area: game, UX
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+Build the campaign select screen: a page showing both v1 campaigns (Tutorial
+and Educational) with per-campaign progress indicators. Clicking a campaign
+navigates to the scenario select screen filtered to that campaign (GAME-048).
+A Back button returns to the main menu (GAME-050). This screen becomes the
+intermediate navigation layer between the main menu and individual scenarios.
+
+## Current State
+
+No campaign select screen exists. The scenario select screen is the only
+navigation layer above individual scenarios.
+
+## Goals / Acceptance Criteria
+
+- [ ] Campaign select screen renders at `?view=campaigns` (or equivalent routing)
+- [ ] Both campaigns displayed in order: Tutorial, then Educational Campaign
+- [ ] Each campaign card shows:
+  - Campaign title
+  - Campaign description
+  - Progress indicator: "N / M scenarios complete" (from localStorage completion data)
+- [ ] Clicking a campaign navigates to `?campaign=<id>` (scenario select for that campaign)
+- [ ] **Back** button navigates to the main menu (GAME-050 ships first; this ticket
+  depends on GAME-050 being complete)
+- [ ] Visual styling consistent with existing screen conventions (dark HUD chrome)
+
+## Test Coverage
+
+- [ ] e2e test: `?view=campaigns` renders both campaign titles
+- [ ] e2e test: clicking the Tutorial campaign navigates to `?campaign=tutorial`
+- [ ] e2e test: clicking the Educational Campaign navigates to `?campaign=educational`
+- [ ] e2e test: progress indicator shows "0 / 2 scenarios complete" for Tutorial
+  when no scenarios are complete (fresh localStorage state)
+- [ ] e2e test: Back button is present on the campaign select screen
+
+## References
+
+- `game/web/src/main.ts` — current routing and screen rendering
+- `thoughts/shared/tickets/GAME-047-campaign-data-model.md` — Campaign registry (prerequisite)
+- `thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md` — destination screen
+- `thoughts/shared/tickets/GAME-050-main-menu.md` — destination of Back button
+- `thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md` — parent design doc

--- a/thoughts/shared/tickets/GAME-050-main-menu.md
+++ b/thoughts/shared/tickets/GAME-050-main-menu.md
@@ -1,0 +1,55 @@
+---
+id: GAME-050
+title: Main menu / title screen
+area: game, UX
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+Build the main menu: a full-screen landing page with the game title ("Past the
+Post") and a vertical navigation menu. This becomes the app entry point,
+replacing the scenario select screen as the first thing a player sees.
+The scenario select screen is now accessed through Campaign Select → Campaign.
+
+## Current State
+
+The scenario select screen is the app home screen. There is no title screen,
+no "New Game" / "Continue" flow, and no top-level navigation.
+
+## Goals / Acceptance Criteria
+
+- [ ] Main menu renders at `/` (root, with no URL parameters) and is the default
+  app entry point
+- [ ] Game title "Past the Post" displayed prominently (logo or large heading)
+- [ ] Vertical menu with the following items in order:
+  - **Continue** — visible only when a `lastPlayedScenarioId` key exists in
+    localStorage (set whenever the player enters any scenario); navigates
+    directly to that scenario (bypasses both campaign select and scenario select)
+  - **New Campaign** — navigates to campaign select (`?view=campaigns`)
+  - **About** — opens the existing about page (GAME-029)
+  - **Load** — rendered but visually disabled/greyed out with "(coming soon)" label
+  - **Settings** — rendered but visually disabled/greyed out with "(coming soon)" label
+- [ ] Continue button is absent (not disabled) when no campaign progress exists
+- [ ] Existing About page reachable from main menu (not lost)
+
+## Test Coverage
+
+- [ ] e2e test: app root `/` renders the main menu (not the scenario select screen)
+- [ ] e2e test: "New Campaign" button navigates to `?view=campaigns`
+- [ ] e2e test: "About" button opens the about page
+- [ ] e2e test: "Continue" button absent when localStorage has no campaign progress
+- [ ] e2e test: "Continue" button present when `lastPlayedScenarioId` is set in localStorage
+- [ ] e2e test: "Continue" navigates directly to that scenario (not to campaign select)
+- [ ] e2e test: "Load" item is visible but not navigable (disabled state)
+- [ ] e2e test: "Settings" item is visible but not navigable (disabled state)
+
+## References
+
+- `game/web/src/main.ts` — current entry point and routing
+- `thoughts/shared/tickets/GAME-029-about-page.md` — about page (already implemented)
+- `thoughts/shared/tickets/GAME-049-campaign-select-screen.md` — destination of New Campaign
+- `thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md` — destination of Continue
+- `thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md` — parent design doc
+- `thoughts/shared/vision/game-vision.compressed.md` — §MENU: "New Game | Continue | Custom Level | Settings | About"

--- a/thoughts/shared/tickets/GAME-051-ingame-navigation-cleanup.md
+++ b/thoughts/shared/tickets/GAME-051-ingame-navigation-cleanup.md
@@ -1,0 +1,51 @@
+---
+id: GAME-051
+title: In-game navigation cleanup
+area: game, UX
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+Replace the flat "← Scenarios" back button in the in-game view with a context-
+aware submenu offering two options: "Return to Scenarios" (back to the scenario
+select within the current campaign) and "Return to Main Menu". This rounds out
+the navigation stack so a player can always reach the main menu without using
+the browser back button, and ensures the campaign context is preserved when
+returning to the scenario list.
+
+## Current State
+
+The in-game header has a single "← Scenarios" button that navigates directly
+back to the scenario select screen (no campaign context). There is no way to
+reach the main menu from in-game without manually editing the URL.
+
+## Goals / Acceptance Criteria
+
+- [ ] "← Scenarios" button replaced with a submenu trigger (e.g. "← Back ▾" or
+  a named button that reveals two options on click/tap)
+- [ ] Submenu contains:
+  - **Return to Scenarios** — navigates to `?campaign=<currentCampaignId>` (or
+    `?view=scenarios` if no campaign context); same behavior as old button
+  - **Return to Main Menu** — navigates to `/` (app root, main menu)
+- [ ] Submenu closes when clicking outside it (or pressing Escape)
+- [ ] If no campaign context is available (direct URL access to a scenario),
+  "Return to Scenarios" navigates to scenario select without campaign filter
+- [ ] Campaign context propagated via URL parameter or in-page state so the
+  in-game view knows which campaign to return to
+
+## Test Coverage
+
+- [ ] e2e test: in-game view has submenu trigger (no longer a direct "← Scenarios" link)
+- [ ] e2e test: clicking the trigger reveals "Return to Scenarios" and "Return to Main Menu"
+- [ ] e2e test: "Return to Scenarios" navigates to the campaign-filtered scenario select
+- [ ] e2e test: "Return to Main Menu" navigates to the app root
+- [ ] e2e test: submenu closes on Escape key
+
+## References
+
+- `game/web/src/main.ts` — in-game header and current back button
+- `thoughts/shared/tickets/GAME-050-main-menu.md` — destination of Return to Main Menu
+- `thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md` — destination of Return to Scenarios
+- `thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md` — parent design doc

--- a/thoughts/shared/tickets/GAME-052-animated-criteria-eval.md
+++ b/thoughts/shared/tickets/GAME-052-animated-criteria-eval.md
@@ -1,0 +1,42 @@
+---
+id: GAME-052
+title: Animated criteria evaluation on result screen
+area: game, UX
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+Animate the criteria evaluation sequence on the result screen — reveal each
+criterion pass/fail result with a brief animation and optional party reaction.
+Blocked on DESIGN-001 (achievement/star UX), which must settle the visual
+language for pass/fail before this can be implemented.
+
+## Current State
+
+The result screen renders all criteria pass/fail rows immediately with no
+animation. There are no party reactions.
+
+## Goals / Acceptance Criteria
+
+*Placeholder — to be fully specced after DESIGN-001 resolves the visual language.*
+
+- [ ] Criteria rows animate in sequentially on result screen load
+- [ ] Pass/fail state revealed per-row after brief delay (timing TBD per DESIGN-001)
+- [ ] Party reaction (emoji or character art) displayed for overall pass/fail outcome
+- [ ] Animation skippable (click/tap to fast-forward)
+
+## Test Coverage
+
+*Specify after DESIGN-001.*
+
+- [ ] e2e test: result screen does not show all criteria simultaneously before animation
+- [ ] e2e test: clicking during animation completes it immediately
+- [ ] e2e test: final state matches non-animated result (regression)
+
+## References
+
+- `thoughts/shared/tickets/DESIGN-001-achievement-star-system.md` — **blocks this ticket**
+- `game/web/src/main.ts` — result screen rendering
+- `thoughts/shared/tickets/GAME-030-main-menu-and-campaigns.md` — S11 context

--- a/thoughts/shared/tickets/GAME-053-electoral-outcome-visual-diff.md
+++ b/thoughts/shared/tickets/GAME-053-electoral-outcome-visual-diff.md
@@ -1,0 +1,41 @@
+---
+id: GAME-053
+title: Electoral outcome visual diff on result screen
+area: game, UX
+status: open
+created: 2026-04-29
+---
+
+## Summary
+
+After the player submits a map, show a visual comparison on the result screen
+between what the electoral outcome would be under the player's map vs. a
+baseline (e.g., proportional outcome, or the initial-assignment outcome). Helps
+players understand concretely what effect their districting choices had on
+election results.
+
+## Current State
+
+The result screen shows per-criterion pass/fail but does not show the underlying
+electoral outcome (seat counts, vote shares) in a visual or comparative form.
+
+## Goals / Acceptance Criteria
+
+*Placeholder — spec TBD. Likely requires its own design research spike.*
+
+- [ ] Result screen includes an electoral outcome section showing seat counts per party
+- [ ] Seat counts shown for player's map alongside a reference baseline
+- [ ] Visual encoding TBD (bar chart, seat grid, etc.)
+- [ ] Section collapsed or secondary to avoid overwhelming the pass/fail summary
+
+## Test Coverage
+
+*Specify after design research.*
+
+- [ ] e2e test: result screen includes an electoral outcome section
+- [ ] e2e test: seat count totals across districts sum to the total district count
+
+## References
+
+- `game/web/src/simulation/election.ts` — simulation output (seat counts, vote shares)
+- `game/web/src/main.ts` — result screen rendering

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -98,6 +98,13 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
 | `GAME-046-panels-unit-tests.md` | game, testing | Unit tests for render/panels.ts (deferred): jsdom or extract-pure-helpers approach |
+| `GAME-047-campaign-data-model.md` | game, architecture | Campaign type + CAMPAIGN_REGISTRY + getCampaign(); Tutorial (2 scenarios) and Educational (9 scenarios) campaign definitions |
+| `GAME-048-campaign-driven-scenario-select.md` | game, UX | Scenario select accepts ?campaign= param; filters list to campaign; Back button to campaign select |
+| `GAME-049-campaign-select-screen.md` | game, UX | Campaign select screen: both campaigns with progress indicators; navigates into scenario select |
+| `GAME-050-main-menu.md` | game, UX | Main menu / title screen: Continue, New Campaign, About, greyed Load/Settings; replaces scenario-select-as-home |
+| `GAME-051-ingame-navigation-cleanup.md` | game, UX | Replace ← Scenarios with submenu: Return to Scenarios + Return to Main Menu |
+| `GAME-052-animated-criteria-eval.md` | game, UX | Animated criteria reveal on result screen; blocked on DESIGN-001 |
+| `GAME-053-electoral-outcome-visual-diff.md` | game, UX | Electoral outcome comparison (player map vs baseline) on result screen; placeholder |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A — planning documents only

## Summary
- Decomposes GAME-030 (main menu + campaigns) into five implementation sub-tickets (GAME-047–051) for incremental S11 delivery
- Updates GAME-030 as a parent design doc with campaign model (Tutorial: tutorial-001+002; Educational: 001–009) and sub-ticket reference table
- Files GAME-047: Campaign data model + authored definitions
- Files GAME-048: Campaign-driven scenario select (routing + data wiring)
- Files GAME-049: Campaign select screen
- Files GAME-050: Main menu / title screen
- Files GAME-051: In-game navigation cleanup
- Files GAME-052: Animated criteria eval (stub; blocked on DESIGN-001)
- Files GAME-053: Electoral outcome visual diff (stub/placeholder)
- Reorients S11 sprint scope: Tier 1 = navigation overhaul (GAME-047–051); Tier 2 = design research + a11y if time allows; DESIGN-005/006/007/008 deferred to S12
- Adds BUILD-008 and GAME-046 to Backlog section in roadmap

## Validation performed
- [x] N/A — documentation only; no code changes

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see GAME-030 (parent design doc updated)
- see GAME-047 (new)
- see GAME-048 (new)
- see GAME-049 (new)
- see GAME-050 (new)
- see GAME-051 (new)
- see GAME-052 (new stub)
- see GAME-053 (new stub)

## Rollback
- N/A — documentation only
