### PR TITLE
feat(GAME-048): campaign-driven scenario select

### DIFF
--- a/game/release.main.kts
+++ b/game/release.main.kts
@@ -339,6 +339,24 @@ class Deploy : CliktCommand(
             }
             extractZip(stagedZip, deployRoot)
 
+            // Patch index.html: add version query string to bundle.js src so browsers
+            // treat each deploy as a unique resource and bypass stale cache entries.
+            // (BUILD-009 tracks the proper content-hash solution.)
+            val indexHtml = File(deployRoot, "index.html")
+            if (indexHtml.exists()) {
+                val original = indexHtml.readText()
+                val patched = original.replace(
+                    """s.src = "bundle.js";""",
+                    """s.src = "bundle.js?v=$version";"""
+                )
+                if (patched == original) {
+                    System.err.println("⚠ WARNING: cache-bust patch had no effect — 's.src = \"bundle.js\";' not found in index.html")
+                    System.err.println("  Browsers may serve a stale bundle. Check index.html and update release.main.kts.")
+                } else {
+                    indexHtml.writeText(patched)
+                }
+            }
+
             val deployMeta = DeployMetadata(
                 version = version,
                 commit = meta.commitId,

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -881,3 +881,45 @@ test("about page: accessible from select screen and shows educational content", 
   await expect(page.locator("#scenario-select")).toBeVisible();
   await expect(page.locator("#about-screen")).not.toBeVisible();
 });
+
+// ─── GAME-048: Campaign-driven scenario select ──────────────────────────────
+
+test("campaign select: ?campaign=tutorial shows only tutorial-001 and tutorial-002", async ({ page }) => {
+  await page.goto("/?campaign=tutorial");
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  const cards = page.locator(".scenario-card");
+  await expect(cards).toHaveCount(2);
+  await expect(cards.nth(0)).toContainText("Welcome to Redistricting");
+  await expect(cards.nth(1)).toContainText("Three-District Challenge");
+});
+
+test("campaign select: ?campaign=tutorial Back button is visible", async ({ page }) => {
+  await page.goto("/?campaign=tutorial");
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#btn-back-to-campaign")).toBeVisible();
+});
+
+test("campaign select: Back button absent without ?campaign= param", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#btn-back-to-campaign")).not.toBeVisible();
+});
+
+test("campaign select: no ?campaign= shows all 9 scenarios (fallback regression guard)", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  const cards = page.locator(".scenario-card");
+  const count = await cards.count();
+  expect(count).toBe(9);
+});
+
+test("campaign select: unknown ?campaign= falls back to all scenarios with Back button hidden", async ({ page }) => {
+  await page.goto("/?campaign=bogus");
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  // Unknown campaign → full manifest fallback (9 cards)
+  const cards = page.locator(".scenario-card");
+  const count = await cards.count();
+  expect(count).toBe(9);
+  // Back button must not be visible — bogus param must not leak
+  await expect(page.locator("#btn-back-to-campaign")).not.toBeVisible();
+});

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -12,6 +12,7 @@
   <body>
     <!-- ── Scenario select screen (GAME-018) ────────────────────────────── -->
     <div id="scenario-select" class="hidden" role="region" aria-label="Scenario Selection">
+      <button id="btn-back-to-campaign" hidden aria-label="Back to campaign select" style="background:none;border:1px solid #2a5a8c;color:#8898b0;padding:4px 12px;border-radius:4px;cursor:pointer;font-size:0.8rem;margin-bottom:8px;">← Back</button>
       <h1>Past the Post</h1>
       <div id="scenario-cards" role="list"></div>
       <div style="display:flex;gap:16px;margin-top:16px;align-items:center;">

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -30,6 +30,7 @@ import {
 	clearWip,
 	type WipState,
 } from "./model/progress.js";
+import { getCampaign, saveLastPlayedScenario } from "./model/campaigns.js";
 
 // ─── Scenario manifest (GAME-021) ─────────────────────────────────────────────
 // Static list of all available scenarios in play order.
@@ -48,6 +49,17 @@ const SCENARIO_MANIFEST = [
 ] as const;
 
 type ManifestEntry = (typeof SCENARIO_MANIFEST)[number];
+
+// Scenarios that exist as JSON + content but are only reachable via a campaign (not shown in
+// the fallback all-scenarios list). Add an entry here when a new scenario ships campaign-only.
+const CAMPAIGN_ONLY_SCENARIOS: { id: string; title: string }[] = [
+	{ id: "tutorial-001", title: "Welcome to Redistricting: Millbrook County" },
+];
+
+const MANIFEST_BY_ID = new Map<string, { id: string; title: string }>([
+	...SCENARIO_MANIFEST.map((e) => [e.id, e] as [string, { id: string; title: string }]),
+	...CAMPAIGN_ONLY_SCENARIOS.map((e) => [e.id, e] as [string, { id: string; title: string }]),
+]);
 
 // ─── DOM refs ─────────────────────────────────────────────────────────────────
 
@@ -132,6 +144,19 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 (async () => {
 	let progress = loadProgress();
 
+	// ── Campaign context (GAME-048) ───────────────────────────────────────────
+	// Parse ?campaign=<id> early so renderScenarioCards and routing can use it.
+	const urlParams = new URLSearchParams(window.location.search);
+	const campaignParam = (urlParams.get("campaign") ?? "").replace(/[^a-z0-9-]/g, "");
+	const activeCampaign = campaignParam !== "" ? getCampaign(campaignParam) : undefined;
+	// When a campaign is active, show only that campaign's scenarios in manifest order.
+	// Falls back to the full manifest when no (or unknown) ?campaign= is provided.
+	const activeList: ReadonlyArray<{ id: string; title: string }> = activeCampaign
+		? (activeCampaign.scenarioIds
+				.map((id) => MANIFEST_BY_ID.get(id))
+				.filter((e): e is { id: string; title: string } => e !== undefined))
+		: (SCENARIO_MANIFEST as ReadonlyArray<{ id: string; title: string }>);
+
 	// ── Scenario select screen (GAME-018 / GAME-021) ──────────────────────────
 	// Rendered from the static manifest + localStorage progress.
 	// Card clicks navigate to /?s=<id> so the page reloads cleanly with the
@@ -141,9 +166,9 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		if (!scenarioCardsEl) return;
 		const wip = loadWip();
 		scenarioCardsEl.innerHTML = "";
-		SCENARIO_MANIFEST.forEach((entry, i) => {
+		activeList.forEach((entry, i) => {
 			const completed = isCompleted(progress, entry.id);
-			const unlocked = i === 0 || isCompleted(progress, SCENARIO_MANIFEST[i - 1]?.id ?? "");
+			const unlocked = i === 0 || isCompleted(progress, activeList[i - 1]?.id ?? "");
 			const locked = !unlocked;
 			const inProgress = wip?.scenarioId === entry.id;
 
@@ -171,7 +196,10 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 						// Warn: switching will discard in-progress work on a different scenario
 						showWipWarning(currentWip.scenarioId, entry.id);
 					} else {
-						window.location.assign(`./?s=${entry.id}`);
+						const dest = activeCampaign
+							? `./?s=${entry.id}&campaign=${campaignParam}`
+							: `./?s=${entry.id}`;
+						window.location.assign(dest);
 					}
 				});
 			}
@@ -195,7 +223,10 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		const onConfirm = () => {
 			cleanup();
 			clearWip();
-			window.location.assign(`./?s=${targetId}`);
+			const dest = activeCampaign
+				? `./?s=${targetId}&campaign=${campaignParam}`
+				: `./?s=${targetId}`;
+			window.location.assign(dest);
 		};
 		const onCancel = () => {
 			cleanup();
@@ -212,6 +243,17 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	function showScenarioSelect() {
 		renderScenarioCards();
 		scenarioSelectEl?.classList.remove("hidden");
+
+		// Back button — visible only when a campaign is active (GAME-048)
+		const backBtn = document.getElementById("btn-back-to-campaign") as HTMLButtonElement | null;
+		if (backBtn) {
+			backBtn.hidden = !activeCampaign;
+			if (activeCampaign) {
+				backBtn.addEventListener("click", () => {
+					window.location.assign("./?view=campaigns");
+				});
+			}
+		}
 
 		// Reset campaign button — clears all progress and WIP
 		document.getElementById("btn-reset-campaign")?.addEventListener("click", () => {
@@ -233,24 +275,22 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		});
 	}
 
-	// ── Startup routing (GAME-021) ────────────────────────────────────────────
+	// ── Startup routing (GAME-021 / GAME-048) ────────────────────────────────
 	// Priority: explicit ?s= param > scenario select screen (for all other cases).
+	// When ?campaign= is set, only scenarios in activeList are accessible.
 
-	const urlParams = new URLSearchParams(window.location.search);
 	const requestedId = urlParams.get("s") ?? "";
-	const requestedEntry: ManifestEntry | undefined = SCENARIO_MANIFEST.find(
-		(e) => e.id === requestedId,
-	);
+	const requestedEntry = activeList.find((e) => e.id === requestedId);
 
-	let entryToLoad: ManifestEntry;
+	let entryToLoad: { id: string; title: string };
 	if (requestedId !== "" && requestedEntry === undefined) {
-		// Unknown scenario ID in URL — redirect to select screen
+		// Unknown scenario ID (or not in current campaign) — redirect to select screen
 		showScenarioSelect();
 		return;
 	} else if (requestedEntry !== undefined) {
-		// Check unlock: scenario must be first, or previous scenario completed (unless debug)
-		const idx = SCENARIO_MANIFEST.indexOf(requestedEntry);
-		const locked = idx > 0 && !isCompleted(progress, SCENARIO_MANIFEST[idx - 1]?.id ?? "");
+		// Check unlock: scenario must be first in activeList, or previous entry completed (unless debug)
+		const idx = activeList.findIndex((e) => e.id === requestedId);
+		const locked = idx > 0 && !isCompleted(progress, activeList[idx - 1]?.id ?? "");
 		if (locked && !IS_DEBUG) {
 			showScenarioSelect();
 			return;
@@ -276,6 +316,8 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			</div>`,
 		);
 	}
+
+	saveLastPlayedScenario(entryToLoad.id);
 
 	let json: unknown;
 	try {

--- a/thoughts/shared/tickets/BUILD-009-content-hash-bundle.md
+++ b/thoughts/shared/tickets/BUILD-009-content-hash-bundle.md
@@ -1,0 +1,48 @@
+---
+id: BUILD-009
+title: Content-hashed bundle filenames for cache-safe deploys
+area: build, deployment
+status: open
+created: 2026-04-30
+---
+
+## Summary
+
+Replace the fixed `bundle.js` output filename with a content-hashed filename
+(e.g. `bundle-a3f9c2.js`) so browsers and CDNs automatically invalidate stale
+cached files on every deploy. The current setup uses a 30-day `max-age` on
+`bundle.js` with no cache-busting, requiring users to manually clear browser
+data after a new deploy.
+
+A query-string kludge (`bundle.js?v=<version>`) was applied in `release.main.kts`
+as a short-term fix (see References). This ticket tracks the proper solution.
+
+## Current State
+
+- esbuild outputs `bundle.js` (fixed name, configured in `web/BUILD.bazel`)
+- Server (openresty/pixie-sh) sets `Cache-Control: public, max-age=2592000` on
+  all `.js` files
+- `index.html` hard-codes `<script src="bundle.js">`
+- Result: browsers cache the old bundle for up to 30 days after a new deploy
+
+Workaround in place: `release.main.kts` patches `index.html` at deploy time to
+use `bundle.js?v=<version>`. This works as long as `index.html` itself is served
+with short/no cache (currently served without explicit cache headers, so browsers
+use heuristic caching — still fragile).
+
+## Goals / Acceptance Criteria
+
+- [ ] esbuild output renamed to `[name]-[hash].js` (esbuild `entry_names` option)
+- [ ] Build step injects the hashed filename into `index.html` `<script>` tag
+  (either via esbuild's HTML injection or a Bazel genrule post-processing step)
+- [ ] `index.html` served with `Cache-Control: no-cache` (requires infra/server config change — coordinate with infra repo)
+- [ ] `bundle-[hash].js` served with `Cache-Control: public, max-age=31536000, immutable`
+- [ ] `release.main.kts` query-string kludge removed once this is in place
+- [ ] e2e tests continue to pass (bundle filename change must not break test harness)
+
+## References
+
+- `game/web/BUILD.bazel` — esbuild target (`name = "app"`, `output = "bundle.js"`)
+- `game/web/index.html` — hard-codes `<script src="bundle.js">`
+- `game/release.main.kts` — deploy-time query-string kludge (search for BUILD-009)
+- `thoughts/shared/tickets/DIST-001-steam-deployment-research.md` — deployment infra context

--- a/thoughts/shared/tickets/GAME-047-campaign-data-model.md
+++ b/thoughts/shared/tickets/GAME-047-campaign-data-model.md
@@ -2,7 +2,7 @@
 id: GAME-047
 title: Campaign data model + authored campaign definitions
 area: game, architecture
-status: open
+status: resolved
 created: 2026-04-29
 github_issue: 158
 ---

--- a/thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md
+++ b/thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md
@@ -4,6 +4,8 @@ title: Campaign-driven scenario select (routing + data wiring)
 area: game, UX
 status: open
 created: 2026-04-29
+github_issue: 161
+github_pr: 162
 ---
 
 ## Summary

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -82,6 +82,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `BUILD-003-ts-rules-spawn-strategy-research.md` | build, typescript | Research optimal spawn_strategy config for aspect_rules_ts on macOS (darwin-sandbox + multi-target packages) |
 | `BUILD-004-playwright-bzl-macro.md` | build, testing | Playwright sh_test macro: proper Bazel rule for virtual store path resolution, replacing ad-hoc readlink discovery |
 | `BUILD-008-switch-ci-to-pnpm.md` | build, ci | Switch CI from npm ci to pnpm --frozen-lockfile; remove package-lock.json |
+| `BUILD-009-content-hash-bundle.md` | build, deployment | Content-hashed bundle filenames (`bundle-[hash].js`) for proper CDN cache invalidation on deploy; replaces query-string kludge in release.main.kts |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
 | `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
@@ -98,7 +99,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
 | `GAME-046-panels-unit-tests.md` | game, testing | Unit tests for render/panels.ts (deferred): jsdom or extract-pure-helpers approach |
-| `GAME-047-campaign-data-model.md` | game, architecture | Campaign type + CAMPAIGN_REGISTRY + getCampaign(); Tutorial (2 scenarios) and Educational (9 scenarios) campaign definitions |
 | `GAME-048-campaign-driven-scenario-select.md` | game, UX | Scenario select accepts ?campaign= param; filters list to campaign; Back button to campaign select |
 | `GAME-049-campaign-select-screen.md` | game, UX | Campaign select screen: both campaigns with progress indicators; navigates into scenario select |
 | `GAME-050-main-menu.md` | game, UX | Main menu / title screen: Continue, New Campaign, About, greyed Load/Settings; replaces scenario-select-as-home |
@@ -117,6 +117,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | GAME-038: extract panel renderers | render/panels.ts created with renderResults, renderLegend, renderDistrictButtons, renderValidityPanel; mapRenderer.ts reduced by ~115 lines; main.ts import updated |
 | GAME-039: extract hex geometry | hex-geometry.ts created with hexToPixel, hexCorners, mapBounds, HEX_DIRECTIONS; generator.ts re-exports from it; adapter.ts + mapRenderer.ts updated; hex_geometry_lib added to model BUILD |
 | GAME-044: hex-geometry unit tests | 11 unit tests for hexToPixel, hexCorners, HEX_DIRECTIONS, mapBounds; hex_geometry_test Bazel target in model/BUILD.bazel; merged PR #153 |
+| GAME-047: campaign data model | Campaign interface + CAMPAIGN_REGISTRY + getCampaign() + save/loadLastPlayedScenario(); Tutorial (2 scenarios) + Educational (8 scenarios); 13 unit tests; merged PR #159 |
 | GAME-045: gameStore unit tests | 13 unit tests for initial state, setActiveDistrict, paintPrecinct, paintStroke, resetToInitial, restoreAssignments, undo via zundo; store/BUILD.bazel package created; react added as devDep; merged PR #153 |
 | BUILD-007: shared TAP test runner | test_runner.ts extracted to game/web/src/testing/; 9 exports (test, assertEqual, assertClose, assertNull, assertNotNull, assertTrue, assertFalse, assertDeepEqual, assertThrows, summarize); boilerplate eliminated from 4 existing test files |
 | GAME-033: opLabel dedup | Single OP_LABEL module-level const in evaluate.ts replaces 4 inline copies; evaluate_test passes with no behavior change |


### PR DESCRIPTION
feat(GAME-048): campaign-driven scenario select

Adds ?campaign=<id> URL parameter support to scenario select screen. Filters
scenario list to campaign's scenarioIds in campaign order; falls back to all 9
scenarios when absent/unknown. Back button visible only when campaign is active;
navigates to ./?view=campaigns. Calls saveLastPlayedScenario() on scenario load.

Also fixes 4 critique issues (campaign param leak in URLs, WIP confirm handler,
unknown-campaign test gap, Back button aria-label) and patches release.main.kts
to append ?v=<version> to bundle.js at deploy time (cache-busting kludge until
BUILD-009 lands).
