### PR TITLE
chore: resolve GAME-047 and GAME-048 tickets

### DIFF
--- a/thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md
+++ b/thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md
@@ -2,7 +2,7 @@
 id: GAME-048
 title: Campaign-driven scenario select (routing + data wiring)
 area: game, UX
-status: open
+status: resolved
 created: 2026-04-29
 github_issue: 161
 github_pr: 162

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -99,7 +99,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
 | `GAME-046-panels-unit-tests.md` | game, testing | Unit tests for render/panels.ts (deferred): jsdom or extract-pure-helpers approach |
-| `GAME-048-campaign-driven-scenario-select.md` | game, UX | Scenario select accepts ?campaign= param; filters list to campaign; Back button to campaign select |
 | `GAME-049-campaign-select-screen.md` | game, UX | Campaign select screen: both campaigns with progress indicators; navigates into scenario select |
 | `GAME-050-main-menu.md` | game, UX | Main menu / title screen: Continue, New Campaign, About, greyed Load/Settings; replaces scenario-select-as-home |
 | `GAME-051-ingame-navigation-cleanup.md` | game, UX | Replace ← Scenarios with submenu: Return to Scenarios + Return to Main Menu |
@@ -117,6 +116,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | GAME-038: extract panel renderers | render/panels.ts created with renderResults, renderLegend, renderDistrictButtons, renderValidityPanel; mapRenderer.ts reduced by ~115 lines; main.ts import updated |
 | GAME-039: extract hex geometry | hex-geometry.ts created with hexToPixel, hexCorners, mapBounds, HEX_DIRECTIONS; generator.ts re-exports from it; adapter.ts + mapRenderer.ts updated; hex_geometry_lib added to model BUILD |
 | GAME-044: hex-geometry unit tests | 11 unit tests for hexToPixel, hexCorners, HEX_DIRECTIONS, mapBounds; hex_geometry_test Bazel target in model/BUILD.bazel; merged PR #153 |
+| GAME-048: campaign-driven scenario select | ?campaign= URL param filtering + Back button + input sanitization + cache-bust warn; 5 e2e tests; merged PR #162 |
 | GAME-047: campaign data model | Campaign interface + CAMPAIGN_REGISTRY + getCampaign() + save/loadLastPlayedScenario(); Tutorial (2 scenarios) + Educational (8 scenarios); 13 unit tests; merged PR #159 |
 | GAME-045: gameStore unit tests | 13 unit tests for initial state, setActiveDistrict, paintPrecinct, paintStroke, resetToInitial, restoreAssignments, undo via zundo; store/BUILD.bazel package created; react added as devDep; merged PR #153 |
 | BUILD-007: shared TAP test runner | test_runner.ts extracted to game/web/src/testing/; 9 exports (test, assertEqual, assertClose, assertNull, assertNotNull, assertTrue, assertFalse, assertDeepEqual, assertThrows, summarize); boilerplate eliminated from 4 existing test files |


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- Marks GAME-047 (campaign data model, PR #159) and GAME-048 (campaign scenario select, PR #162) as resolved in TICKETS.md and their respective ticket files

## Validation performed
- N/A — ticket bookkeeping only; no code changes

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see #158 (GAME-047)
- see #161 (GAME-048)

## Rollback
- N/A — additive change to markdown files only
