### PR TITLE
feat(GAME-050): main menu / title screen

### DIFF
--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -107,6 +107,7 @@ sh_test(
         "e2e/sprint2.spec.ts",
         "e2e/sprint3.spec.ts",
         "e2e/scenarios.spec.ts",
+        "e2e/main-menu.spec.ts",
         # Playwright packages as declared Bazel deps — ensures the cache key includes
         # the playwright version and the files are available in runfiles.
         "//:node_modules/@playwright/test",

--- a/game/web/e2e/main-menu.spec.ts
+++ b/game/web/e2e/main-menu.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * GAME-050: Main menu / title screen e2e tests.
+ *
+ * Tests the main menu that appears at app root (/), including Continue,
+ * New Campaign, About, Load, and Settings buttons.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const LAST_PLAYED_KEY = "redistricting-sim-last-played-scenario";
+
+test("main menu: / renders main menu (not scenario select)", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#scenario-select")).not.toBeVisible();
+});
+
+test("main menu: title 'Past the Post' is displayed", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#main-menu")).toContainText("Past the Post", { timeout: 10_000 });
+});
+
+test("main menu: New Campaign button navigates to ?view=campaigns", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#btn-main-new-campaign")).toBeVisible({ timeout: 10_000 });
+  await page.locator("#btn-main-new-campaign").click();
+  await expect(page).toHaveURL(/view=campaigns/);
+});
+
+test("main menu: About button opens about page", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#btn-main-about")).toBeVisible({ timeout: 10_000 });
+  await page.locator("#btn-main-about").click();
+  await expect(page.locator("#about-screen")).toBeVisible({ timeout: 5_000 });
+  await expect(page.locator("#main-menu")).not.toBeVisible();
+});
+
+test("main menu: Continue absent when no campaign progress exists", async ({ page }) => {
+  await page.goto("/");
+  // Ensure no last-played key
+  await page.evaluate((key) => localStorage.removeItem(key), LAST_PLAYED_KEY);
+  await page.reload();
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#btn-main-continue")).not.toBeVisible();
+});
+
+test("main menu: Continue present when lastPlayedScenarioId set in localStorage", async ({ page }) => {
+  await page.goto("/");
+  await page.evaluate(
+    ([key, val]) => localStorage.setItem(key, val),
+    [LAST_PLAYED_KEY, "tutorial-002"],
+  );
+  await page.reload();
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#btn-main-continue")).toBeVisible();
+});
+
+test("main menu: Continue navigates directly to last played scenario", async ({ page }) => {
+  await page.goto("/");
+  await page.evaluate(
+    ([key, val]) => localStorage.setItem(key, val),
+    [LAST_PLAYED_KEY, "tutorial-002"],
+  );
+  await page.reload();
+  await expect(page.locator("#btn-main-continue")).toBeVisible({ timeout: 10_000 });
+  await page.locator("#btn-main-continue").click();
+  await expect(page).toHaveURL(/s=tutorial-002/);
+});
+
+test("main menu: Load is visible but disabled", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#btn-main-load")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#btn-main-load")).toBeDisabled();
+  await expect(page.locator("#btn-main-load")).toContainText("coming soon");
+});
+
+test("main menu: Settings is visible but disabled", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#btn-main-settings")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#btn-main-settings")).toBeDisabled();
+  await expect(page.locator("#btn-main-settings")).toContainText("coming soon");
+});

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -742,7 +742,7 @@ test("scenario-009 winnability: ring-based split gives 3 Cat-safe districts", as
 
 test("scenario select: all cards visible and scrollable", async ({ page }) => {
   // Navigate first so localStorage is accessible, then seed progress and reload
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await page.evaluate(() => {
     localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ["tutorial-002"] }));
   });
@@ -866,7 +866,7 @@ test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", 
 // ─── GAME-029: About page ───────────────────────────────────────────────────
 
 test("about page: accessible from select screen and shows educational content", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await page.evaluate(() => {
     localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ["tutorial-002"] }));
   });
@@ -900,13 +900,13 @@ test("campaign select: ?campaign=tutorial Back button is visible", async ({ page
 });
 
 test("campaign select: Back button absent without ?campaign= param", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#btn-back-to-campaign")).not.toBeVisible();
 });
 
 test("campaign select: no ?campaign= shows all 9 scenarios (fallback regression guard)", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   const cards = page.locator(".scenario-card");
   const count = await cards.count();

--- a/game/web/e2e/smoke.spec.ts
+++ b/game/web/e2e/smoke.spec.ts
@@ -22,7 +22,7 @@ test("app loads and renders hex map", async ({ page }) => {
     consoleErrors.push(`[pageerror] ${err.message}`);
   });
 
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   // New player sees scenario select first; click first scenario
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });

--- a/game/web/e2e/sprint1.spec.ts
+++ b/game/web/e2e/sprint1.spec.ts
@@ -43,7 +43,7 @@ async function paintHex(
 
 /** Navigate, dismiss the intro screen, and wait for the hex grid to be ready. */
 async function loadApp(page: import("@playwright/test").Page): Promise<void> {
-	await page.goto("/");
+	await page.goto("/?view=scenarios");
 	// New player sees scenario select first; click first scenario
 	await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
 	await page.locator(".scenario-card").first().locator(".sc-play-btn").click();

--- a/game/web/e2e/sprint2.spec.ts
+++ b/game/web/e2e/sprint2.spec.ts
@@ -15,7 +15,7 @@ import { test, expect } from "@playwright/test";
 
 /** Navigate, dismiss the intro screen, and wait for the hex grid to be ready. */
 async function loadApp(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   // New player sees scenario select first; click first scenario
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();

--- a/game/web/e2e/sprint3.spec.ts
+++ b/game/web/e2e/sprint3.spec.ts
@@ -34,7 +34,7 @@ import { test, expect } from "@playwright/test";
 
 /** Navigate, dismiss intro, wait for hex grid. */
 async function loadEditor(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   // New player sees scenario select first; click first scenario
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
@@ -56,7 +56,7 @@ async function paintHex(
 // ─── GAME-016: Scenario intro screen ─────────────────────────────────────────
 
 test("intro: screen is visible on initial load before editor", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   // Scenario select must be visible first; click to proceed to intro
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
@@ -67,7 +67,7 @@ test("intro: screen is visible on initial load before editor", async ({ page }) 
 });
 
 test("intro: character name and role are shown from scenario narrative", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
@@ -77,7 +77,7 @@ test("intro: character name and role are shown from scenario narrative", async (
 });
 
 test("intro: first slide heading is shown and Previous is disabled", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
@@ -86,7 +86,7 @@ test("intro: first slide heading is shown and Previous is disabled", async ({ pa
 });
 
 test("intro: Next advances to second slide; Previous returns to first", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
@@ -102,7 +102,7 @@ test("intro: Next advances to second slide; Previous returns to first", async ({
 });
 
 test("intro: Start Drawing button appears on last slide and reveals editor", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
@@ -123,7 +123,7 @@ test("intro: Start Drawing button appears on last slide and reveals editor", asy
 });
 
 test("intro: Skip intro immediately reveals editor without navigating slides", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
   await expect(page.locator("#btn-intro-skip")).toBeVisible({ timeout: 10_000 });
@@ -135,7 +135,7 @@ test("intro: Skip intro immediately reveals editor without navigating slides", a
 });
 
 test("intro: objective text is shown from scenario narrative", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
@@ -218,7 +218,7 @@ async function seedProgress(
 
 test("progression: scenario select screen is shown for returning players", async ({ page }) => {
   await seedProgress(page, ["tutorial-002"]);
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   // Scenario select must be visible; intro screen and editor must not be
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
@@ -228,7 +228,7 @@ test("progression: scenario select screen is shown for returning players", async
 
 test("progression: scenario card shows Completed status for completed scenario", async ({ page }) => {
   await seedProgress(page, ["tutorial-002"]);
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator(".sc-status.completed")).toBeVisible();
@@ -238,7 +238,7 @@ test("progression: scenario card shows Completed status for completed scenario",
 
 test("progression: Play Again from select screen shows intro then editor", async ({ page }) => {
   await seedProgress(page, ["tutorial-002"]);
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await page.locator(".sc-play-btn.replay").click();
@@ -253,7 +253,7 @@ test("progression: Play Again from select screen shows intro then editor", async
 
 test("progression: page reload restores completion state from localStorage", async ({ page }) => {
   await seedProgress(page, ["tutorial-002"]);
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   // First load: scenario select visible with completed status
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
@@ -267,7 +267,7 @@ test("progression: page reload restores completion state from localStorage", asy
 
 test("progression: new player (no localStorage) sees scenario select", async ({ page }) => {
   // No seedProgress call — fresh localStorage
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#intro-screen")).not.toBeVisible();
@@ -294,7 +294,7 @@ test("wip: scenario select shows 'In Progress' for scenario with saved WIP", asy
   // Seed completion for tutorial-002 so select screen appears, plus WIP for scenario-002
   await seedProgress(page, ["tutorial-002"]);
   await seedWip(page, "scenario-002", { "0": 1, "1": 2 }, 2);
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   // scenario-002 card must show "In Progress" status and "Continue" button
@@ -309,7 +309,7 @@ test("wip: scenario select shows 'In Progress' for scenario with saved WIP", asy
 test("wip: select screen shown when WIP exists even for new player", async ({ page }) => {
   // No completed scenarios, but a WIP exists — should show select screen
   await seedWip(page, "tutorial-002", { "0": 1 }, 1);
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#intro-screen")).not.toBeVisible();
@@ -479,7 +479,7 @@ test("winnability: painting boundary precincts enables submit and produces a pas
 
 test("scale: tutorial-002 loads and renders 196 precincts (path.hex count)", async ({ page }) => {
   // tutorial-002 is the default scenario (196-precinct three-county map)
-  await page.goto("/");
+  await page.goto("/?view=scenarios");
 
   // New player sees scenario select first; click first scenario
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -10,6 +10,18 @@
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>
+    <!-- ── Main menu / title screen (GAME-050) ─────────────────────────── -->
+    <div id="main-menu" class="hidden" role="main" aria-label="Main Menu">
+      <h1 id="main-menu-title">Past the Post</h1>
+      <nav id="main-menu-nav" aria-label="Main navigation">
+        <button id="btn-main-continue" hidden>Continue</button>
+        <button id="btn-main-new-campaign">New Campaign</button>
+        <button id="btn-main-about">About</button>
+        <button id="btn-main-load" disabled>Load <span class="coming-soon">(coming soon)</span></button>
+        <button id="btn-main-settings" disabled>Settings <span class="coming-soon">(coming soon)</span></button>
+      </nav>
+    </div>
+
     <!-- ── Scenario select screen (GAME-018) ────────────────────────────── -->
     <div id="scenario-select" class="hidden" role="region" aria-label="Scenario Selection">
       <button id="btn-back-to-campaign" hidden aria-label="Back to campaign select" style="background:none;border:1px solid #2a5a8c;color:#8898b0;padding:4px 12px;border-radius:4px;cursor:pointer;font-size:0.8rem;margin-bottom:8px;">← Back</button>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -30,7 +30,7 @@ import {
 	clearWip,
 	type WipState,
 } from "./model/progress.js";
-import { getCampaign, saveLastPlayedScenario } from "./model/campaigns.js";
+import { CAMPAIGN_REGISTRY, getCampaign, loadLastPlayedScenario, saveLastPlayedScenario } from "./model/campaigns.js";
 
 // ─── Scenario manifest (GAME-021) ─────────────────────────────────────────────
 // Static list of all available scenarios in play order.
@@ -157,6 +157,9 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 				.filter((e): e is { id: string; title: string } => e !== undefined))
 		: (SCENARIO_MANIFEST as ReadonlyArray<{ id: string; title: string }>);
 
+	// URL to return to when leaving a scenario — preserves campaign context if present.
+	const backUrl = campaignParam !== "" ? `./?campaign=${campaignParam}` : "./?view=scenarios";
+
 	// ── Scenario select screen (GAME-018 / GAME-021) ──────────────────────────
 	// Rendered from the static manifest + localStorage progress.
 	// Card clicks navigate to /?s=<id> so the page reloads cleanly with the
@@ -240,6 +243,52 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		cancelBtn.addEventListener("click", onCancel);
 	}
 
+	function buildContinueUrl(scenarioId: string): string {
+		if (SCENARIO_MANIFEST.some((e) => e.id === scenarioId)) {
+			return `./?s=${scenarioId}`;
+		}
+		for (const campaign of CAMPAIGN_REGISTRY) {
+			if (campaign.scenarioIds.includes(scenarioId)) {
+				return `./?s=${scenarioId}&campaign=${campaign.id}`;
+			}
+		}
+		return `./?s=${scenarioId}`;
+	}
+
+	function showMainMenu() {
+		const mainMenuEl = document.getElementById("main-menu");
+		if (!mainMenuEl) return;
+
+		const lastPlayedId = loadLastPlayedScenario();
+		const continueBtn = document.getElementById("btn-main-continue") as HTMLButtonElement | null;
+		if (continueBtn) {
+			if (lastPlayedId !== null) {
+				continueBtn.hidden = false;
+				continueBtn.addEventListener("click", () => {
+					window.location.assign(buildContinueUrl(lastPlayedId));
+				});
+			} else {
+				continueBtn.hidden = true;
+			}
+		}
+
+		document.getElementById("btn-main-new-campaign")?.addEventListener("click", () => {
+			window.location.assign("./?view=campaigns");
+		});
+
+		document.getElementById("btn-main-about")?.addEventListener("click", () => {
+			mainMenuEl.classList.add("hidden");
+			document.getElementById("about-screen")?.classList.remove("hidden");
+		});
+
+		document.getElementById("btn-about-close")?.addEventListener("click", () => {
+			document.getElementById("about-screen")?.classList.add("hidden");
+			mainMenuEl.classList.remove("hidden");
+		});
+
+		mainMenuEl.classList.remove("hidden");
+	}
+
 	function showScenarioSelect() {
 		renderScenarioCards();
 		scenarioSelectEl?.classList.remove("hidden");
@@ -297,9 +346,14 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		}
 		entryToLoad = requestedEntry;
 	} else {
-		// No explicit ?s= param — show scenario select screen
-		// (new players, returning players, everyone)
-		showScenarioSelect();
+		const view = urlParams.get("view") ?? "";
+		if (campaignParam !== "" || view === "scenarios") {
+			showScenarioSelect();
+		} else if (view === "campaigns") {
+			showScenarioSelect(); // GAME-049 stub: campaign select not yet built
+		} else {
+			showMainMenu();
+		}
 		return;
 	}
 
@@ -312,7 +366,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 				<h1 style="color:#e94560;font-size:1.4rem;">Scenario Failed to Load</h1>
 				<p style="max-width:600px;text-align:center;">${bodyHtml}</p>
 				<pre style="background:#16213e;padding:12px 16px;border-radius:6px;max-width:600px;overflow-x:auto;font-size:0.8rem;color:#e94560;white-space:pre-wrap;">${errorMsg}</pre>
-				<button onclick="window.location.assign('./')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
+				<button onclick="window.location.assign('${backUrl}')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
 			</div>`,
 		);
 	}
@@ -660,7 +714,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			if (allComplete) {
 				document.getElementById("wrap-up-screen")?.classList.remove("hidden");
 			} else {
-				window.location.assign("./");
+				window.location.assign(backUrl);
 			}
 		});
 	}
@@ -672,7 +726,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	// "← Scenarios" button → flush WIP then return to scenario select
 	document.getElementById("btn-back-to-scenarios")?.addEventListener("click", () => {
 		flushWipSave();
-		window.location.assign("./");
+		window.location.assign(backUrl);
 	});
 
 	// "Next Scenario" → if all scenarios complete, show wrap-up; else select screen.
@@ -682,13 +736,13 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			resultScreen!.classList.add("hidden");
 			document.getElementById("wrap-up-screen")?.classList.remove("hidden");
 		} else {
-			window.location.assign("./");
+			window.location.assign(backUrl);
 		}
 	});
 
 	// Wrap-up "Play Again" → back to select screen
 	document.getElementById("btn-wrap-up-replay")?.addEventListener("click", () => {
-		window.location.assign("./");
+		window.location.assign(backUrl);
 	});
 
 	// ── Subscribe to state changes ────────────────────────────────────────────

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -302,6 +302,39 @@ body {
 
 /* ── Scenario select screen (GAME-018) ───────────────────────────────── */
 
+/* ── Main menu / title screen (GAME-050) ──────────────────────────── */
+#main-menu {
+  position: fixed; inset: 0;
+  background: #0d1b2e;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 48px; z-index: 90;
+}
+#main-menu.hidden { display: none; }
+#main-menu-title {
+  font-size: 2.4rem; font-weight: 700;
+  color: #e94560; letter-spacing: 0.04em;
+  text-align: center;
+}
+#main-menu-nav {
+  display: flex; flex-direction: column;
+  align-items: stretch; gap: 12px;
+  width: 260px;
+}
+#main-menu-nav button {
+  background: #16213e; color: #c0d0e8;
+  border: 1px solid #2a5a8c;
+  padding: 14px 24px; border-radius: 6px;
+  font-size: 1rem; cursor: pointer;
+  text-align: center;
+}
+#main-menu-nav button:hover:not(:disabled) { background: #1a3a5c; }
+#main-menu-nav button:disabled {
+  color: #555e6e; border-color: #222e40; cursor: default;
+}
+.coming-soon { font-size: 0.78rem; color: #555e6e; margin-left: 6px; }
+
+/* ── Scenario select screen (GAME-018) ────────────────────────────── */
 #scenario-select {
   position: fixed;
   inset: 0;

--- a/thoughts/shared/tickets/GAME-050-main-menu.md
+++ b/thoughts/shared/tickets/GAME-050-main-menu.md
@@ -4,6 +4,8 @@ title: Main menu / title screen
 area: game, UX
 status: open
 created: 2026-04-29
+github_issue: 164
+github_pr: 165
 ---
 
 ## Summary


### PR DESCRIPTION
## Prerequisites
- GAME-047 (campaign data model) — merged PR #159
- GAME-048 (campaign-driven scenario select) — merged PR #162

## Summary
- Adds main menu / title screen at app root `/`
- Title "Past the Post" with vertical nav: Continue (conditional), New Campaign, About, Load (disabled), Settings (disabled)
- Continue navigates directly to last played scenario (campaign-aware URL if needed)
- Routing updated: `/` → main menu; `/?view=scenarios` → scenario select; `/?campaign=<id>` → campaign scenario select
- All in-game "back" navigation updated to preserve campaign context (`backUrl`)
- 9 new e2e tests in `main-menu.spec.ts`
- All existing e2e test `goto("/")` calls updated to `goto("/?view=scenarios")` where they expect scenario select

## Validation performed
- `bazel build //web:app_typecheck_lib` — passes
- `bazel test //web:e2e_test --cache_test_results=no` — 90/90 pass (includes 9 new main-menu tests)

## Affected machines / services
- pastthepost.gg (game front-end)

## Deployment steps (POST-MERGE)
- N/A — standard deploy via release.main.kts

## Tickets addressed
- see #164 (GAME-050)

## Rollback
- Revert PR; no data migration needed
