### PR TITLE
fix(GAME-050): Continue greyed out when no progress; hide menu in showEditor

### DIFF
--- a/game/web/e2e/main-menu.spec.ts
+++ b/game/web/e2e/main-menu.spec.ts
@@ -35,16 +35,17 @@ test("main menu: About button opens about page", async ({ page }) => {
   await expect(page.locator("#main-menu")).not.toBeVisible();
 });
 
-test("main menu: Continue absent when no campaign progress exists", async ({ page }) => {
+test("main menu: Continue visible but disabled when no campaign progress exists", async ({ page }) => {
   await page.goto("/");
   // Ensure no last-played key
   await page.evaluate((key) => localStorage.removeItem(key), LAST_PLAYED_KEY);
   await page.reload();
   await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
-  await expect(page.locator("#btn-main-continue")).not.toBeVisible();
+  await expect(page.locator("#btn-main-continue")).toBeVisible();
+  await expect(page.locator("#btn-main-continue")).toBeDisabled();
 });
 
-test("main menu: Continue present when lastPlayedScenarioId set in localStorage", async ({ page }) => {
+test("main menu: Continue enabled when lastPlayedScenarioId set in localStorage", async ({ page }) => {
   await page.goto("/");
   await page.evaluate(
     ([key, val]) => localStorage.setItem(key, val),
@@ -53,6 +54,7 @@ test("main menu: Continue present when lastPlayedScenarioId set in localStorage"
   await page.reload();
   await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#btn-main-continue")).toBeVisible();
+  await expect(page.locator("#btn-main-continue")).toBeEnabled();
 });
 
 test("main menu: Continue navigates directly to last played scenario", async ({ page }) => {

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -14,7 +14,7 @@
     <div id="main-menu" class="hidden" role="main" aria-label="Main Menu">
       <h1 id="main-menu-title">Past the Post</h1>
       <nav id="main-menu-nav" aria-label="Main navigation">
-        <button id="btn-main-continue" hidden>Continue</button>
+        <button id="btn-main-continue" disabled>Continue</button>
         <button id="btn-main-new-campaign">New Campaign</button>
         <button id="btn-main-about">About</button>
         <button id="btn-main-load" disabled>Load <span class="coming-soon">(coming soon)</span></button>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -263,12 +263,12 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		const continueBtn = document.getElementById("btn-main-continue") as HTMLButtonElement | null;
 		if (continueBtn) {
 			if (lastPlayedId !== null) {
-				continueBtn.hidden = false;
+				continueBtn.disabled = false;
 				continueBtn.addEventListener("click", () => {
 					window.location.assign(buildContinueUrl(lastPlayedId));
 				});
 			} else {
-				continueBtn.hidden = true;
+				continueBtn.disabled = true;
 			}
 		}
 
@@ -502,6 +502,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		introController?.abort();
 		introController = null;
 		introScreen?.classList.add("hidden");
+		document.getElementById("main-menu")?.classList.add("hidden");
 		appHeader!.style.display = "";
 		mainEl!.style.display = "";
 	}


### PR DESCRIPTION
## Prerequisites
- N/A (parent PR #165 already merged)

## Summary
- Continue button is now always visible, disabled (greyed out) when no last-played scenario exists — fixes staging feedback requesting "present but greyed out for consistency"
- `showEditor()` now explicitly hides `#main-menu` as a defensive guard — fixes overlay bug where main menu appeared above the game editor after intro dismissal

## Validation performed
- e2e tests updated to reflect new disabled-not-hidden behavior for Continue button
- Full e2e suite passes locally (90 tests)

## Affected machines / services
- game web frontend only

## Deployment steps (POST-MERGE)
- POST-MERGE: `cd game && ./release.main.kts -- prepare && ./release.main.kts -- deploy --env staging`

## Tickets addressed
- see #164 (GAME-050)

## Rollback
- Revert to parent commit #165
