### PR TITLE
feat(GAME-049): campaign select screen

### DIFF
--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -108,6 +108,7 @@ sh_test(
         "e2e/sprint3.spec.ts",
         "e2e/scenarios.spec.ts",
         "e2e/main-menu.spec.ts",
+        "e2e/campaign-select.spec.ts",
         # Playwright packages as declared Bazel deps — ensures the cache key includes
         # the playwright version and the files are available in runfiles.
         "//:node_modules/@playwright/test",

--- a/game/web/e2e/campaign-select.spec.ts
+++ b/game/web/e2e/campaign-select.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * GAME-049: Campaign select screen e2e tests.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const PROGRESS_KEY = "redistricting-sim-progress";
+
+test("campaign select: ?view=campaigns renders both campaign titles", async ({ page }) => {
+  await page.goto("/?view=campaigns");
+  await expect(page.locator("#campaign-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#campaign-select")).toContainText("Tutorial");
+  await expect(page.locator("#campaign-select")).toContainText("Educational Campaign");
+});
+
+test("campaign select: clicking Tutorial navigates to ?campaign=tutorial", async ({ page }) => {
+  await page.goto("/?view=campaigns");
+  await expect(page.locator(".campaign-card").first()).toBeVisible({ timeout: 10_000 });
+  await page.locator(".campaign-card").first().click();
+  await expect(page).toHaveURL(/campaign=tutorial/);
+});
+
+test("campaign select: clicking Educational Campaign navigates to ?campaign=educational", async ({ page }) => {
+  await page.goto("/?view=campaigns");
+  await expect(page.locator(".campaign-card").nth(1)).toBeVisible({ timeout: 10_000 });
+  await page.locator(".campaign-card").nth(1).click();
+  await expect(page).toHaveURL(/campaign=educational/);
+});
+
+test("campaign select: progress shows 0 / 2 for Tutorial with fresh localStorage", async ({ page }) => {
+  await page.goto("/?view=campaigns");
+  await page.evaluate((key) => localStorage.removeItem(key), PROGRESS_KEY);
+  await page.reload();
+  await expect(page.locator("#campaign-select")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".campaign-card").first()).toContainText("0 / 2 scenarios complete");
+});
+
+test("campaign select: Back button is present", async ({ page }) => {
+  await page.goto("/?view=campaigns");
+  await expect(page.locator("#btn-campaign-back")).toBeVisible({ timeout: 10_000 });
+});
+
+test("campaign select: Back button navigates to main menu", async ({ page }) => {
+  await page.goto("/?view=campaigns");
+  await expect(page.locator("#btn-campaign-back")).toBeVisible({ timeout: 10_000 });
+  await page.locator("#btn-campaign-back").click();
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 5_000 });
+});

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -22,6 +22,13 @@
       </nav>
     </div>
 
+    <!-- ── Campaign select screen (GAME-049) ───────────────────────────── -->
+    <div id="campaign-select" class="hidden" role="main" aria-label="Campaign Selection">
+      <button id="btn-campaign-back">← Main Menu</button>
+      <h1 id="campaign-select-title">Choose a Campaign</h1>
+      <div id="campaign-cards"></div>
+    </div>
+
     <!-- ── Scenario select screen (GAME-018) ────────────────────────────── -->
     <div id="scenario-select" class="hidden" role="region" aria-label="Scenario Selection">
       <button id="btn-back-to-campaign" hidden aria-label="Back to campaign select" style="background:none;border:1px solid #2a5a8c;color:#8898b0;padding:4px 12px;border-radius:4px;cursor:pointer;font-size:0.8rem;margin-bottom:8px;">← Back</button>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -255,6 +255,47 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		return `./?s=${scenarioId}`;
 	}
 
+	function showCampaignSelect() {
+		const el = document.getElementById("campaign-select");
+		if (!el) return;
+
+		const cardsEl = document.getElementById("campaign-cards");
+		if (cardsEl) {
+			cardsEl.innerHTML = "";
+			for (const campaign of CAMPAIGN_REGISTRY) {
+				const completed = campaign.scenarioIds.filter((id) => isCompleted(progress, id)).length;
+				const total = campaign.scenarioIds.length;
+				const card = document.createElement("div");
+				card.className = "campaign-card";
+				card.setAttribute("role", "button");
+				card.setAttribute("tabindex", "0");
+				card.setAttribute("aria-label", campaign.title);
+
+				const heading = document.createElement("h2");
+				heading.textContent = campaign.title;
+				const desc = document.createElement("p");
+				desc.textContent = campaign.description;
+				const prog = document.createElement("div");
+				prog.className = "campaign-progress";
+				prog.textContent = `${completed} / ${total} scenarios complete`;
+				card.append(heading, desc, prog);
+
+				const navigate = () => window.location.assign(`./?campaign=${campaign.id}`);
+				card.addEventListener("click", navigate);
+				card.addEventListener("keydown", (e: KeyboardEvent) => {
+					if (e.key === "Enter" || e.key === " ") { e.preventDefault(); navigate(); }
+				});
+				cardsEl.appendChild(card);
+			}
+		}
+
+		document.getElementById("btn-campaign-back")?.addEventListener("click", () => {
+			window.location.assign("./");
+		});
+
+		el.classList.remove("hidden");
+	}
+
 	function showMainMenu() {
 		const mainMenuEl = document.getElementById("main-menu");
 		if (!mainMenuEl) return;
@@ -350,7 +391,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		if (campaignParam !== "" || view === "scenarios") {
 			showScenarioSelect();
 		} else if (view === "campaigns") {
-			showScenarioSelect(); // GAME-049 stub: campaign select not yet built
+			showCampaignSelect();
 		} else {
 			showMainMenu();
 		}

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -334,6 +334,40 @@ body {
 }
 .coming-soon { font-size: 0.78rem; color: #555e6e; margin-left: 6px; }
 
+/* ── Campaign select screen (GAME-049) ────────────────────────────── */
+#campaign-select {
+  position: fixed; inset: 0;
+  background: #0d1b2e;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 32px; z-index: 88;
+}
+#campaign-select.hidden { display: none; }
+#campaign-select-title {
+  font-size: 1.8rem; font-weight: 700;
+  color: #c0d0e8; text-align: center;
+}
+#btn-campaign-back {
+  position: absolute; top: 16px; left: 16px;
+  background: none; border: 1px solid #2a5a8c;
+  color: #8898b0; padding: 4px 12px;
+  border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+}
+#btn-campaign-back:hover { background: #16213e; }
+#campaign-cards {
+  display: flex; flex-direction: column;
+  gap: 16px; width: 380px;
+}
+.campaign-card {
+  background: #16213e; border: 1px solid #2a5a8c;
+  border-radius: 8px; padding: 20px 24px;
+  cursor: pointer; text-align: left;
+}
+.campaign-card:hover { background: #1a3a5c; border-color: #4a8abf; }
+.campaign-card h2 { color: #c0d0e8; font-size: 1.1rem; margin: 0 0 6px; }
+.campaign-card p { color: #8898b0; font-size: 0.85rem; margin: 0 0 10px; }
+.campaign-progress { color: #5a8abf; font-size: 0.8rem; }
+
 /* ── Scenario select screen (GAME-018) ────────────────────────────── */
 #scenario-select {
   position: fixed;

--- a/thoughts/shared/tickets/GAME-049-campaign-select-screen.md
+++ b/thoughts/shared/tickets/GAME-049-campaign-select-screen.md
@@ -4,6 +4,7 @@ title: Campaign select screen
 area: game, UX
 status: open
 created: 2026-04-29
+github_issue: 168
 ---
 
 ## Summary


### PR DESCRIPTION
## Prerequisites
- N/A (GAME-050 already merged)

## Summary
- Adds campaign select screen at `?view=campaigns`: shows both campaigns (Tutorial, Educational) with title, description, and live progress indicator ("N / M scenarios complete") pulled from localStorage
- Clicking a campaign card navigates to `?campaign=<id>` (scenario select for that campaign)
- Back button returns to main menu (`./`)
- Replaces the GAME-049 stub that was routing `?view=campaigns` to the scenario select screen

## Validation performed
- 6 new e2e tests all pass locally (96 total tests pass)

## Affected machines / services
- game web frontend only

## Deployment steps (POST-MERGE)
- POST-MERGE: `cd game && ./release.main.kts -- prepare && ./release.main.kts -- deploy --env staging`

## Tickets addressed
- see #168 (GAME-049)

## Rollback
- Revert to parent commit
