### PR TITLE
chore: resolve GAME-049 ticket (#169)

### DIFF
--- a/thoughts/shared/tickets/GAME-049-campaign-select-screen.md
+++ b/thoughts/shared/tickets/GAME-049-campaign-select-screen.md
@@ -2,9 +2,10 @@
 id: GAME-049
 title: Campaign select screen
 area: game, UX
-status: open
+status: resolved
 created: 2026-04-29
 github_issue: 168
+github_pr: 169
 ---
 
 ## Summary

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -99,7 +99,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
 | `GAME-046-panels-unit-tests.md` | game, testing | Unit tests for render/panels.ts (deferred): jsdom or extract-pure-helpers approach |
-| `GAME-049-campaign-select-screen.md` | game, UX | Campaign select screen: both campaigns with progress indicators; navigates into scenario select |
 | `GAME-051-ingame-navigation-cleanup.md` | game, UX | Replace ← Scenarios with submenu: Return to Scenarios + Return to Main Menu |
 | `GAME-052-animated-criteria-eval.md` | game, UX | Animated criteria reveal on result screen; blocked on DESIGN-001 |
 | `GAME-053-electoral-outcome-visual-diff.md` | game, UX | Electoral outcome comparison (player map vs baseline) on result screen; placeholder |
@@ -115,6 +114,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | GAME-038: extract panel renderers | render/panels.ts created with renderResults, renderLegend, renderDistrictButtons, renderValidityPanel; mapRenderer.ts reduced by ~115 lines; main.ts import updated |
 | GAME-039: extract hex geometry | hex-geometry.ts created with hexToPixel, hexCorners, mapBounds, HEX_DIRECTIONS; generator.ts re-exports from it; adapter.ts + mapRenderer.ts updated; hex_geometry_lib added to model BUILD |
 | GAME-044: hex-geometry unit tests | 11 unit tests for hexToPixel, hexCorners, HEX_DIRECTIONS, mapBounds; hex_geometry_test Bazel target in model/BUILD.bazel; merged PR #153 |
+| GAME-049: campaign select screen | ?view=campaigns→campaign cards with progress indicators; click→?campaign=<id>; Back→main menu; tabindex+keydown a11y; 6 e2e tests; merged PR #169 |
 | GAME-050: main menu / title screen | Continue/New Campaign/About/Load+Settings(disabled); routing /→main menu, /?view=scenarios→scenario select; 9 e2e tests; merged PR #165 |
 | GAME-048: campaign-driven scenario select | ?campaign= URL param filtering + Back button + input sanitization + cache-bust warn; 5 e2e tests; merged PR #162 |
 | GAME-047: campaign data model | Campaign interface + CAMPAIGN_REGISTRY + getCampaign() + save/loadLastPlayedScenario(); Tutorial (2 scenarios) + Educational (8 scenarios); 13 unit tests; merged PR #159 |


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- Marks GAME-049 (campaign select screen, PR #169) as resolved in TICKETS.md and ticket file

## Validation performed
- N/A — ticket bookkeeping only; no code changes

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see #168 (GAME-049)

## Rollback
- N/A — additive change to markdown files only
