### PR TITLE
feat(GAME-054): remove legacy scenario select + fix invalid campaign redirect

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -741,8 +741,8 @@ test("scenario-009 winnability: ring-based split gives 3 Cat-safe districts", as
 // ─── Cross-cutting: demo feedback fixes ─────────────────────────────────────
 
 test("scenario select: all cards visible and scrollable", async ({ page }) => {
-  // Navigate first so localStorage is accessible, then seed progress and reload
-  await page.goto("/?view=scenarios");
+  // Navigate via educational campaign (8 scenarios) — enough to verify scroll
+  await page.goto("/?campaign=educational");
   await page.evaluate(() => {
     localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ["tutorial-002"] }));
   });
@@ -750,7 +750,7 @@ test("scenario select: all cards visible and scrollable", async ({ page }) => {
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   const cards = page.locator(".scenario-card");
   const count = await cards.count();
-  expect(count).toBeGreaterThanOrEqual(9);
+  expect(count).toBeGreaterThanOrEqual(8);
   // The last card should be scrollable into view, not clipped
   const lastCard = cards.last();
   await lastCard.scrollIntoViewIfNeeded();
@@ -778,8 +778,8 @@ test("debug force-win button: visible with ?debug param, marks scenario complete
   const debugBtn = page.locator("#btn-debug-win");
   await expect(debugBtn).toBeVisible();
   await debugBtn.click();
-  // Should navigate to select screen after force-win
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  // No campaign context — force-win navigates to main menu via backUrl
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
   const completed = await page.evaluate(() => {
     const raw = localStorage.getItem("redistricting-sim-progress");
     return raw ? JSON.parse(raw) : null;
@@ -798,7 +798,7 @@ test("debug force-win button: hidden without ?debug param", async ({ page }) => 
   await expect(debugBtn).not.toBeVisible();
 });
 
-test("lock gate: direct URL to locked scenario redirects to select screen", async ({ page }) => {
+test("lock gate: direct URL to locked scenario redirects to main menu", async ({ page }) => {
   // Ensure no progress — scenario-002 requires tutorial-002 completed
   await page.goto("/");
   await page.evaluate(() => {
@@ -806,8 +806,8 @@ test("lock gate: direct URL to locked scenario redirects to select screen", asyn
     localStorage.removeItem("redistricting-sim-wip");
   });
   await page.goto("/?s=scenario-002");
-  // Should NOT show the intro or hex grid — should show the select screen
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  // Should NOT show the intro or hex grid — should redirect to main menu
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("path.hex")).toHaveCount(0);
 });
 
@@ -820,6 +820,12 @@ test("lock gate: debug param bypasses lock on locked scenario", async ({ page })
   await page.goto("/?s=scenario-002&debug");
   // Should load the scenario, not redirect
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 15_000 });
+});
+
+test("routing: unknown ?s= without campaign redirects to main menu", async ({ page }) => {
+  await page.goto("/?s=this-scenario-does-not-exist");
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("path.hex")).toHaveCount(0);
 });
 
 // ─── GAME-020: Wrap-up screen after final scenario ──────────────────────────
@@ -866,7 +872,7 @@ test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", 
 // ─── GAME-029: About page ───────────────────────────────────────────────────
 
 test("about page: accessible from select screen and shows educational content", async ({ page }) => {
-  await page.goto("/?view=scenarios");
+  await page.goto("/?campaign=educational");
   await page.evaluate(() => {
     localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ["tutorial-002"] }));
   });
@@ -899,27 +905,14 @@ test("campaign select: ?campaign=tutorial Back button is visible", async ({ page
   await expect(page.locator("#btn-back-to-campaign")).toBeVisible();
 });
 
-test("campaign select: Back button absent without ?campaign= param", async ({ page }) => {
+test("routing: ?view=scenarios redirects to main menu (legacy URL)", async ({ page }) => {
   await page.goto("/?view=scenarios");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await expect(page.locator("#btn-back-to-campaign")).not.toBeVisible();
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#scenario-select")).not.toBeVisible();
 });
 
-test("campaign select: no ?campaign= shows all 9 scenarios (fallback regression guard)", async ({ page }) => {
-  await page.goto("/?view=scenarios");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  const cards = page.locator(".scenario-card");
-  const count = await cards.count();
-  expect(count).toBe(9);
-});
-
-test("campaign select: unknown ?campaign= falls back to all scenarios with Back button hidden", async ({ page }) => {
+test("routing: unknown ?campaign= redirects to main menu", async ({ page }) => {
   await page.goto("/?campaign=bogus");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  // Unknown campaign → full manifest fallback (9 cards)
-  const cards = page.locator(".scenario-card");
-  const count = await cards.count();
-  expect(count).toBe(9);
-  // Back button must not be visible — bogus param must not leak
-  await expect(page.locator("#btn-back-to-campaign")).not.toBeVisible();
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#scenario-select")).not.toBeVisible();
 });

--- a/game/web/e2e/smoke.spec.ts
+++ b/game/web/e2e/smoke.spec.ts
@@ -22,11 +22,7 @@ test("app loads and renders hex map", async ({ page }) => {
     consoleErrors.push(`[pageerror] ${err.message}`);
   });
 
-  await page.goto("/?view=scenarios");
-
-  // New player sees scenario select first; click first scenario
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
 
   // Dismiss intro screen (GAME-016): skip button appears after scenario loads.
   const skipBtn = page.locator("#btn-intro-skip");

--- a/game/web/e2e/sprint1.spec.ts
+++ b/game/web/e2e/sprint1.spec.ts
@@ -43,10 +43,7 @@ async function paintHex(
 
 /** Navigate, dismiss the intro screen, and wait for the hex grid to be ready. */
 async function loadApp(page: import("@playwright/test").Page): Promise<void> {
-	await page.goto("/?view=scenarios");
-	// New player sees scenario select first; click first scenario
-	await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-	await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+	await page.goto("/?s=tutorial-002");
 	// Dismiss intro screen (GAME-016)
 	const skip = page.locator("#btn-intro-skip");
 	await expect(skip).toBeVisible({ timeout: 10_000 });

--- a/game/web/e2e/sprint2.spec.ts
+++ b/game/web/e2e/sprint2.spec.ts
@@ -15,10 +15,7 @@ import { test, expect } from "@playwright/test";
 
 /** Navigate, dismiss the intro screen, and wait for the hex grid to be ready. */
 async function loadApp(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/?view=scenarios");
-  // New player sees scenario select first; click first scenario
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   // Dismiss intro screen (GAME-016)
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });

--- a/game/web/e2e/sprint3.spec.ts
+++ b/game/web/e2e/sprint3.spec.ts
@@ -34,10 +34,7 @@ import { test, expect } from "@playwright/test";
 
 /** Navigate, dismiss intro, wait for hex grid. */
 async function loadEditor(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/?view=scenarios");
-  // New player sees scenario select first; click first scenario
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });
   await skip.click();
@@ -56,10 +53,7 @@ async function paintHex(
 // ─── GAME-016: Scenario intro screen ─────────────────────────────────────────
 
 test("intro: screen is visible on initial load before editor", async ({ page }) => {
-  await page.goto("/?view=scenarios");
-  // Scenario select must be visible first; click to proceed to intro
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   // Intro screen must be visible; editor elements must be hidden
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#app-header")).not.toBeVisible();
@@ -67,9 +61,7 @@ test("intro: screen is visible on initial load before editor", async ({ page }) 
 });
 
 test("intro: character name and role are shown from scenario narrative", async ({ page }) => {
-  await page.goto("/?view=scenarios");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
   // tutorial-002.json character: name="You", role="Redistricting Commissioner, Millbrook County"
   await expect(page.locator("#char-name")).toHaveText("You");
@@ -77,18 +69,14 @@ test("intro: character name and role are shown from scenario narrative", async (
 });
 
 test("intro: first slide heading is shown and Previous is disabled", async ({ page }) => {
-  await page.goto("/?view=scenarios");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#intro-slide-heading")).toHaveText("Welcome to Millbrook County");
   await expect(page.locator("#btn-intro-prev")).toBeDisabled();
 });
 
 test("intro: Next advances to second slide; Previous returns to first", async ({ page }) => {
-  await page.goto("/?view=scenarios");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
 
   // Advance to slide 2
@@ -102,9 +90,7 @@ test("intro: Next advances to second slide; Previous returns to first", async ({
 });
 
 test("intro: Start Drawing button appears on last slide and reveals editor", async ({ page }) => {
-  await page.goto("/?view=scenarios");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
 
   // Start Drawing should not be visible on first slide
@@ -123,9 +109,7 @@ test("intro: Start Drawing button appears on last slide and reveals editor", asy
 });
 
 test("intro: Skip intro immediately reveals editor without navigating slides", async ({ page }) => {
-  await page.goto("/?view=scenarios");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   await expect(page.locator("#btn-intro-skip")).toBeVisible({ timeout: 10_000 });
 
   await page.locator("#btn-intro-skip").click();
@@ -135,9 +119,7 @@ test("intro: Skip intro immediately reveals editor without navigating slides", a
 });
 
 test("intro: objective text is shown from scenario narrative", async ({ page }) => {
-  await page.goto("/?view=scenarios");
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  await page.goto("/?s=tutorial-002");
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#objective-text")).toContainText("Balance the three districts");
 });
@@ -218,7 +200,7 @@ async function seedProgress(
 
 test("progression: scenario select screen is shown for returning players", async ({ page }) => {
   await seedProgress(page, ["tutorial-002"]);
-  await page.goto("/?view=scenarios");
+  await page.goto("/?campaign=tutorial");
 
   // Scenario select must be visible; intro screen and editor must not be
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
@@ -228,7 +210,7 @@ test("progression: scenario select screen is shown for returning players", async
 
 test("progression: scenario card shows Completed status for completed scenario", async ({ page }) => {
   await seedProgress(page, ["tutorial-002"]);
-  await page.goto("/?view=scenarios");
+  await page.goto("/?campaign=tutorial");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator(".sc-status.completed")).toBeVisible();
@@ -237,11 +219,12 @@ test("progression: scenario card shows Completed status for completed scenario",
 });
 
 test("progression: Play Again from select screen shows intro then editor", async ({ page }) => {
-  await seedProgress(page, ["tutorial-002"]);
-  await page.goto("/?view=scenarios");
+  // Seed both tutorial scenarios so tutorial-002 is accessible (not locked) and replayable
+  await seedProgress(page, ["tutorial-001", "tutorial-002"]);
+  await page.goto("/?campaign=tutorial");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".sc-play-btn.replay").click();
+  await page.locator(".sc-play-btn.replay").first().click();
 
   // Intro screen appears after clicking Play Again
   await expect(page.locator("#intro-screen")).toBeVisible({ timeout: 5_000 });
@@ -253,7 +236,7 @@ test("progression: Play Again from select screen shows intro then editor", async
 
 test("progression: page reload restores completion state from localStorage", async ({ page }) => {
   await seedProgress(page, ["tutorial-002"]);
-  await page.goto("/?view=scenarios");
+  await page.goto("/?campaign=tutorial");
 
   // First load: scenario select visible with completed status
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
@@ -267,7 +250,7 @@ test("progression: page reload restores completion state from localStorage", asy
 
 test("progression: new player (no localStorage) sees scenario select", async ({ page }) => {
   // No seedProgress call — fresh localStorage
-  await page.goto("/?view=scenarios");
+  await page.goto("/?campaign=tutorial");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#intro-screen")).not.toBeVisible();
@@ -294,12 +277,12 @@ test("wip: scenario select shows 'In Progress' for scenario with saved WIP", asy
   // Seed completion for tutorial-002 so select screen appears, plus WIP for scenario-002
   await seedProgress(page, ["tutorial-002"]);
   await seedWip(page, "scenario-002", { "0": 1, "1": 2 }, 2);
-  await page.goto("/?view=scenarios");
+  await page.goto("/?campaign=educational");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   // scenario-002 card must show "In Progress" status and "Continue" button
   const cards = page.locator(".scenario-card");
-  const scenario002Card = cards.nth(1); // second card in manifest
+  const scenario002Card = cards.nth(0); // first card in educational campaign
   await expect(scenario002Card.locator(".sc-status.in-progress")).toBeVisible();
   await expect(scenario002Card.locator(".sc-status.in-progress")).toContainText("In Progress");
   await expect(scenario002Card.locator(".sc-play-btn.continue")).toBeVisible();
@@ -309,7 +292,7 @@ test("wip: scenario select shows 'In Progress' for scenario with saved WIP", asy
 test("wip: select screen shown when WIP exists even for new player", async ({ page }) => {
   // No completed scenarios, but a WIP exists — should show select screen
   await seedWip(page, "tutorial-002", { "0": 1 }, 1);
-  await page.goto("/?view=scenarios");
+  await page.goto("/?campaign=tutorial");
 
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#intro-screen")).not.toBeVisible();
@@ -478,12 +461,8 @@ test("winnability: painting boundary precincts enables submit and produces a pas
 // ─── GAME-014: Scenario scale ─────────────────────────────────────────────────
 
 test("scale: tutorial-002 loads and renders 196 precincts (path.hex count)", async ({ page }) => {
-  // tutorial-002 is the default scenario (196-precinct three-county map)
-  await page.goto("/?view=scenarios");
-
-  // New player sees scenario select first; click first scenario
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator(".scenario-card").first().locator(".sc-play-btn").click();
+  // tutorial-002 is the 196-precinct three-county map
+  await page.goto("/?s=tutorial-002");
 
   // Skip intro to reveal editor
   const skip = page.locator("#btn-intro-skip");

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -149,16 +149,21 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	const urlParams = new URLSearchParams(window.location.search);
 	const campaignParam = (urlParams.get("campaign") ?? "").replace(/[^a-z0-9-]/g, "");
 	const activeCampaign = campaignParam !== "" ? getCampaign(campaignParam) : undefined;
+	// Unknown campaign ID → redirect to main menu rather than falling back to all scenarios.
+	if (campaignParam !== "" && activeCampaign === undefined) {
+		window.location.replace("./");
+		return;
+	}
 	// When a campaign is active, show only that campaign's scenarios in manifest order.
-	// Falls back to the full manifest when no (or unknown) ?campaign= is provided.
 	const activeList: ReadonlyArray<{ id: string; title: string }> = activeCampaign
 		? (activeCampaign.scenarioIds
 				.map((id) => MANIFEST_BY_ID.get(id))
 				.filter((e): e is { id: string; title: string } => e !== undefined))
 		: (SCENARIO_MANIFEST as ReadonlyArray<{ id: string; title: string }>);
 
-	// URL to return to when leaving a scenario — preserves campaign context if present.
-	const backUrl = campaignParam !== "" ? `./?campaign=${campaignParam}` : "./?view=scenarios";
+	// URL and label for returning from a scenario — preserves campaign context if present.
+	const backUrl = campaignParam !== "" ? `./?campaign=${campaignParam}` : "./";
+	const backLabel = campaignParam !== "" ? "← Back to Scenarios" : "← Main Menu";
 
 	// ── Scenario select screen (GAME-018 / GAME-021) ──────────────────────────
 	// Rendered from the static manifest + localStorage progress.
@@ -374,24 +379,38 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 
 	let entryToLoad: { id: string; title: string };
 	if (requestedId !== "" && requestedEntry === undefined) {
-		// Unknown scenario ID (or not in current campaign) — redirect to select screen
-		showScenarioSelect();
+		// Unknown scenario ID (or outside active campaign's list).
+		// Stay in campaign context if one is active; otherwise fall back to main menu.
+		if (activeCampaign) {
+			showScenarioSelect();
+		} else {
+			window.location.replace("./");
+		}
 		return;
 	} else if (requestedEntry !== undefined) {
 		// Check unlock: scenario must be first in activeList, or previous entry completed (unless debug)
 		const idx = activeList.findIndex((e) => e.id === requestedId);
 		const locked = idx > 0 && !isCompleted(progress, activeList[idx - 1]?.id ?? "");
 		if (locked && !IS_DEBUG) {
-			showScenarioSelect();
+			// In campaign context → show campaign's scenario select; otherwise → main menu
+			if (activeCampaign) {
+				showScenarioSelect();
+			} else {
+				window.location.replace("./");
+			}
 			return;
 		}
 		entryToLoad = requestedEntry;
 	} else {
 		const view = urlParams.get("view") ?? "";
-		if (campaignParam !== "" || view === "scenarios") {
+		if (campaignParam !== "") {
 			showScenarioSelect();
 		} else if (view === "campaigns") {
 			showCampaignSelect();
+		} else if (view === "scenarios") {
+			// Legacy URL — redirect to main menu
+			window.location.replace("./");
+			return;
 		} else {
 			showMainMenu();
 		}
@@ -407,7 +426,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 				<h1 style="color:#e94560;font-size:1.4rem;">Scenario Failed to Load</h1>
 				<p style="max-width:600px;text-align:center;">${bodyHtml}</p>
 				<pre style="background:#16213e;padding:12px 16px;border-radius:6px;max-width:600px;overflow-x:auto;font-size:0.8rem;color:#e94560;white-space:pre-wrap;">${errorMsg}</pre>
-				<button onclick="window.location.assign('${backUrl}')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">← Back to Scenarios</button>
+				<button onclick="window.location.assign('${backUrl}')" style="padding:8px 20px;background:#1a3a5c;color:#c0d0e8;border:1px solid #2a5a8c;border-radius:6px;cursor:pointer;">${backLabel}</button>
 			</div>`,
 		);
 	}

--- a/thoughts/shared/tickets/GAME-051-ingame-navigation-cleanup.md
+++ b/thoughts/shared/tickets/GAME-051-ingame-navigation-cleanup.md
@@ -26,12 +26,13 @@ reach the main menu from in-game without manually editing the URL.
 - [ ] "← Scenarios" button replaced with a submenu trigger (e.g. "← Back ▾" or
   a named button that reveals two options on click/tap)
 - [ ] Submenu contains:
-  - **Return to Scenarios** — navigates to `?campaign=<currentCampaignId>` (or
-    `?view=scenarios` if no campaign context); same behavior as old button
+  - **Return to Scenarios** — navigates to `?campaign=<currentCampaignId>`; only
+    shown when a campaign is active (no fallback to standalone scenario select,
+    which was removed in GAME-054)
   - **Return to Main Menu** — navigates to `/` (app root, main menu)
 - [ ] Submenu closes when clicking outside it (or pressing Escape)
 - [ ] If no campaign context is available (direct URL access to a scenario),
-  "Return to Scenarios" navigates to scenario select without campaign filter
+  only "Return to Main Menu" is shown (standalone scenario select was removed in GAME-054)
 - [ ] Campaign context propagated via URL parameter or in-page state so the
   in-game view knows which campaign to return to
 

--- a/thoughts/shared/tickets/GAME-054-remove-legacy-scenario-select.md
+++ b/thoughts/shared/tickets/GAME-054-remove-legacy-scenario-select.md
@@ -1,0 +1,48 @@
+---
+id: GAME-054
+title: Remove legacy scenario select and fix invalid campaign redirect
+area: game, UX, routing
+status: open
+created: 2026-04-30
+---
+
+## Summary
+
+The standalone `?view=scenarios` route (scenario select without campaign context) is now
+obsolete — all scenarios are reached via campaigns (GAME-048/GAME-049). Remove it as a
+user-facing entry point and redirect stale URLs to the main menu. Also fix `?campaign=<bogus>`
+which currently falls back to showing all 9 scenarios; it should redirect to main menu instead.
+
+## Current State
+
+- `?view=scenarios` shows a standalone scenario select listing all 9 scenarios (no campaign context).
+- `?campaign=bogus` falls back to showing all 9 scenarios with the Back button hidden.
+- Both are user-visible dead ends left over from before campaigns existed.
+
+## Goals / Acceptance Criteria
+
+- [ ] `?campaign=<invalid>` (any unrecognized id) → `window.location.replace("./")` → main menu
+- [ ] `?view=scenarios` → `window.location.replace("./")` → main menu
+- [ ] Unknown `?s=<id>` without campaign → `window.location.replace("./")` → main menu (was: scenario select)
+- [ ] Unknown `?s=<id>` with campaign → show campaign's scenario select (stay in campaign context)
+- [ ] Locked scenario (no campaign context) → main menu (was: scenario select)
+- [ ] `backUrl` for no-campaign scenarios points to `./` (main menu), not `./?view=scenarios`
+- [ ] Error screen back button label updated to "← Main Menu" for no-campaign context
+
+## Test Coverage
+
+- [ ] e2e: `?campaign=bogus` → `#main-menu` visible, `#scenario-select` not visible
+- [ ] e2e: `?view=scenarios` → `#main-menu` visible, `#scenario-select` not visible
+- [ ] e2e: All existing scenario-select-dependent tests updated to use campaign URLs
+- [ ] e2e: Lock gate test updated to expect `#main-menu` not `#scenario-select`
+- [ ] e2e: Debug force-win test updated (no-campaign → `backUrl` → main menu)
+- [ ] e2e: Unknown `?s=` without campaign → `#main-menu` visible
+
+## References
+
+- `game/web/src/main.ts` — routing block, campaignParam setup, backUrl, locked/unknown routing
+- `game/web/e2e/scenarios.spec.ts` — tests at lines 745, 868, 902, 908, 916
+- `game/web/e2e/sprint1.spec.ts`, `sprint2.spec.ts`, `sprint3.spec.ts` — `?view=scenarios` helpers
+- `game/web/e2e/smoke.spec.ts` — `?view=scenarios` usage
+- `thoughts/shared/tickets/GAME-048-campaign-driven-scenario-select.md` — campaign filtering
+- `thoughts/shared/tickets/GAME-050-main-menu.md` — main menu (redirect target)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -102,6 +102,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-051-ingame-navigation-cleanup.md` | game, UX | Replace ← Scenarios with submenu: Return to Scenarios + Return to Main Menu |
 | `GAME-052-animated-criteria-eval.md` | game, UX | Animated criteria reveal on result screen; blocked on DESIGN-001 |
 | `GAME-053-electoral-outcome-visual-diff.md` | game, UX | Electoral outcome comparison (player map vs baseline) on result screen; placeholder |
+| `GAME-054-remove-legacy-scenario-select.md` | game, UX, routing | Remove standalone `?view=scenarios` route and fix `?campaign=<bogus>` to redirect to main menu |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- `?campaign=<bogus>` now redirects to main menu instead of showing all 9 scenarios
- `?view=scenarios` (legacy URL) redirects to main menu; campaigns are now the only path to scenario select
- Unknown `?s=<id>` redirects to main menu instead of showing scenario select
- Locked scenario without campaign context redirects to main menu (in-campaign locked scenario still shows campaign's scenario select)
- `backUrl` for no-campaign context updated from `./?view=scenarios` to `./`; error screen back button label updated accordingly
- All affected e2e tests updated: helpers in sprint1/2/3 go directly to `/?s=tutorial-002`; progression/WIP tests use `?campaign=tutorial` or `?campaign=educational`; routing tests in scenarios.spec.ts inverted to verify new redirect behavior

## Validation performed
- [x] `bazel test //web:app_typecheck_test` passes
- [x] `bazel build //web:app` passes

## Affected machines / services
- pastthepost.gg (game web app — routing behavior change)

## Deployment steps (POST-MERGE)
- Deploy to staging: `./release.main.kts -- prepare && ./release.main.kts -- deploy --env staging`
- Smoke test: verify `?campaign=bogus` and `?view=scenarios` redirect to main menu
- Deploy to production: `./release.main.kts -- deploy --env production`

## Tickets addressed
- see #171 (GAME-054)

## Rollback
- Revert PR; redeploy previous version tag
