### PR TITLE
feat(GAME-051): in-game nav-back submenu with campaign context

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -916,3 +916,92 @@ test("routing: unknown ?campaign= redirects to main menu", async ({ page }) => {
   await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator("#scenario-select")).not.toBeVisible();
 });
+
+// ── GAME-051: in-game nav-back submenu ────────────────────────────────────────
+
+test("in-game nav: back trigger is shown in header when playing a scenario via campaign", async ({ page }) => {
+  await page.goto("/?campaign=tutorial&s=tutorial-001");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await expect(page.locator("#btn-nav-back-trigger")).toBeVisible();
+  await expect(page.locator("#nav-back-menu")).toBeHidden();
+});
+
+test("in-game nav: clicking trigger reveals both Return to Scenarios and Return to Main Menu", async ({ page }) => {
+  await page.goto("/?campaign=tutorial&s=tutorial-001");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("#btn-nav-back-trigger").click();
+  await expect(page.locator("#nav-back-menu")).toBeVisible();
+  await expect(page.locator("#btn-back-to-scenarios")).toBeVisible();
+  await expect(page.locator("#btn-back-to-main-menu")).toBeVisible();
+});
+
+test("in-game nav: Return to Scenarios navigates to campaign scenario select", async ({ page }) => {
+  await page.goto("/?campaign=tutorial&s=tutorial-001");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("#btn-nav-back-trigger").click();
+  await page.locator("#btn-back-to-scenarios").click();
+  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
+  expect(page.url()).toContain("campaign=tutorial");
+});
+
+test("in-game nav: Return to Main Menu navigates to main menu", async ({ page }) => {
+  await page.goto("/?campaign=tutorial&s=tutorial-001");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("#btn-nav-back-trigger").click();
+  await page.locator("#btn-back-to-main-menu").click();
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+});
+
+test("in-game nav: Escape key closes the nav submenu", async ({ page }) => {
+  await page.goto("/?campaign=tutorial&s=tutorial-001");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("#btn-nav-back-trigger").click();
+  await expect(page.locator("#nav-back-menu")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#nav-back-menu")).toBeHidden();
+});
+
+test("in-game nav: clicking outside the submenu closes it", async ({ page }) => {
+  await page.goto("/?campaign=tutorial&s=tutorial-001");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("#btn-nav-back-trigger").click();
+  await expect(page.locator("#nav-back-menu")).toBeVisible();
+  // Click somewhere outside the menu (the map area)
+  await page.locator("path.hex").first().click();
+  await expect(page.locator("#nav-back-menu")).toBeHidden();
+});
+
+test("in-game nav: without campaign context, shows plain Main Menu button (no dropdown)", async ({ page }) => {
+  await page.goto("/?s=tutorial-002");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await expect(page.locator("#btn-nav-back-trigger")).toHaveText("← Main Menu");
+  await expect(page.locator("#btn-back-to-scenarios")).toBeHidden();
+});

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -121,7 +121,13 @@
     </div>
 
     <header id="app-header" style="display:none">
-      <button id="btn-back-to-scenarios" style="background:none;border:1px solid #2a5a8c;color:#8898b0;padding:4px 12px;border-radius:4px;cursor:pointer;font-size:0.8rem;">← Scenarios</button>
+      <div id="nav-back" class="nav-back-container">
+        <button id="btn-nav-back-trigger" class="nav-back-btn" aria-haspopup="menu" aria-expanded="false">← Back ▾</button>
+        <div id="nav-back-menu" class="nav-back-menu" role="menu" hidden>
+          <button id="btn-back-to-scenarios" role="menuitem">Return to Scenarios</button>
+          <button id="btn-back-to-main-menu" role="menuitem">Return to Main Menu</button>
+        </div>
+      </div>
       <h1>Redistricting Simulator</h1>
       <div id="controls">
         <span style="font-size:0.8rem;color:#888;">Draw district:</span>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -784,11 +784,56 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		resultScreen!.classList.add("hidden");
 	});
 
-	// "← Scenarios" button → flush WIP then return to scenario select
-	document.getElementById("btn-back-to-scenarios")?.addEventListener("click", () => {
-		flushWipSave();
-		window.location.assign(backUrl);
-	});
+	// Nav-back submenu (GAME-051)
+	const navBackTrigger = document.getElementById("btn-nav-back-trigger") as HTMLButtonElement | null;
+	const navBackMenu = document.getElementById("nav-back-menu") as HTMLElement | null;
+	const btnBackToScenarios = document.getElementById("btn-back-to-scenarios") as HTMLButtonElement | null;
+	const btnBackToMainMenu = document.getElementById("btn-back-to-main-menu") as HTMLButtonElement | null;
+
+	// Hide "Return to Scenarios" when no campaign context is active.
+	if (!activeCampaign && btnBackToScenarios) btnBackToScenarios.hidden = true;
+
+	// When only one option, drop the dropdown affordance and act as a plain button.
+	if (!activeCampaign && navBackTrigger) {
+		navBackTrigger.textContent = "← Main Menu";
+		navBackTrigger.removeAttribute("aria-haspopup");
+		navBackTrigger.removeAttribute("aria-expanded");
+		navBackTrigger.addEventListener("click", () => {
+			flushWipSave();
+			window.location.assign("./");
+		});
+	} else {
+		function closeNavMenu() {
+			navBackMenu?.setAttribute("hidden", "");
+			navBackTrigger?.setAttribute("aria-expanded", "false");
+		}
+
+		navBackTrigger?.addEventListener("click", (e) => {
+			e.stopPropagation();
+			const isOpen = !navBackMenu?.hasAttribute("hidden");
+			if (isOpen) {
+				closeNavMenu();
+			} else {
+				navBackMenu?.removeAttribute("hidden");
+				navBackTrigger.setAttribute("aria-expanded", "true");
+			}
+		});
+
+		document.addEventListener("click", closeNavMenu);
+		document.addEventListener("keydown", (e: KeyboardEvent) => {
+			if (e.key === "Escape") closeNavMenu();
+		});
+
+		btnBackToScenarios?.addEventListener("click", () => {
+			flushWipSave();
+			window.location.assign(backUrl);
+		});
+
+		btnBackToMainMenu?.addEventListener("click", () => {
+			flushWipSave();
+			window.location.assign("./");
+		});
+	}
 
 	// "Next Scenario" → if all scenarios complete, show wrap-up; else select screen.
 	btnNextScenario!.addEventListener("click", () => {

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -811,3 +811,54 @@ body {
 #btn-intro-skip:hover {
   color: #808090;
 }
+
+.nav-back-container {
+  position: relative;
+}
+
+.nav-back-btn {
+  background: none;
+  border: 1px solid #2a5a8c;
+  color: #8898b0;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.nav-back-btn:hover {
+  color: #c0d0e8;
+  border-color: #4a7aac;
+}
+
+.nav-back-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: #16213e;
+  border: 1px solid #2a5a8c;
+  border-radius: 4px;
+  z-index: 100;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+}
+
+.nav-back-menu[hidden] {
+  display: none;
+}
+
+.nav-back-menu button {
+  background: none;
+  border: none;
+  color: #c0d0e8;
+  padding: 8px 14px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.nav-back-menu button:hover {
+  background: #1e3a6e;
+}

--- a/thoughts/shared/tickets/GAME-051-ingame-navigation-cleanup.md
+++ b/thoughts/shared/tickets/GAME-051-ingame-navigation-cleanup.md
@@ -2,7 +2,7 @@
 id: GAME-051
 title: In-game navigation cleanup
 area: game, UX
-status: open
+status: resolved
 created: 2026-04-29
 ---
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -99,7 +99,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
 | `GAME-046-panels-unit-tests.md` | game, testing | Unit tests for render/panels.ts (deferred): jsdom or extract-pure-helpers approach |
-| `GAME-051-ingame-navigation-cleanup.md` | game, UX | Replace ← Scenarios with submenu: Return to Scenarios + Return to Main Menu |
 | `GAME-052-animated-criteria-eval.md` | game, UX | Animated criteria reveal on result screen; blocked on DESIGN-001 |
 | `GAME-053-electoral-outcome-visual-diff.md` | game, UX | Electoral outcome comparison (player map vs baseline) on result screen; placeholder |
 
@@ -115,6 +114,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | GAME-039: extract hex geometry | hex-geometry.ts created with hexToPixel, hexCorners, mapBounds, HEX_DIRECTIONS; generator.ts re-exports from it; adapter.ts + mapRenderer.ts updated; hex_geometry_lib added to model BUILD |
 | GAME-044: hex-geometry unit tests | 11 unit tests for hexToPixel, hexCorners, HEX_DIRECTIONS, mapBounds; hex_geometry_test Bazel target in model/BUILD.bazel; merged PR #153 |
 | GAME-054: remove legacy scenario select | ?campaign=bogus+?view=scenarios+unknown ?s=+locked (no campaign) all redirect to main menu; ?s= in campaign→show campaign select; backUrl updated; 89 e2e tests pass; merged PR #172 |
+| GAME-051: in-game navigation cleanup | ← Scenarios replaced with submenu trigger; Return to Scenarios (campaign only) + Return to Main Menu; no-campaign shows flat ← Main Menu button; Escape+outside-click close; 6 e2e tests; 102 total pass |
 | GAME-049: campaign select screen | ?view=campaigns→campaign cards with progress indicators; click→?campaign=<id>; Back→main menu; tabindex+keydown a11y; 6 e2e tests; merged PR #169 |
 | GAME-050: main menu / title screen | Continue/New Campaign/About/Load+Settings(disabled); routing /→main menu; 9 e2e tests; merged PR #165 |
 | GAME-048: campaign-driven scenario select | ?campaign= URL param filtering + Back button + input sanitization + cache-bust warn; 5 e2e tests; merged PR #162 |


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- Replaces the flat `← Scenarios` button in the in-game header with a context-aware nav-back control
- When a campaign is active: shows `← Back ▾` trigger that opens a submenu with **Return to Scenarios** (→ `?campaign=<id>`) and **Return to Main Menu** (→ `/`)
- When no campaign context (direct URL access): shows a plain `← Main Menu` button with no dropdown
- Submenu closes on outside-click or Escape key
- `flushWipSave()` called on both navigation paths to preserve in-progress work
- ARIA: `aria-haspopup="menu"` + `aria-expanded` toggling on trigger; `role="menu"` + `role="menuitem"` on items
- 6 new e2e tests cover all AC items; 102 total pass

## Validation performed
- N/A (no server-side changes)
- 102/102 e2e tests pass locally

## Affected machines / services
- `pastthepost.gg` / `staging.pastthepost.gg` — UI change; deploy separately

## Deployment steps (POST-MERGE)
- N/A — deploy via release.main.kts as normal

## Tickets addressed
- see #175 (GAME-051)

## Rollback
- Revert PR
