### PR TITLE
feat(GAME-008): full accessibility pass — CVD-safe palettes, keyboard nav, focus rings, a11y tests

### DIFF
--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -109,6 +109,7 @@ sh_test(
         "e2e/scenarios.spec.ts",
         "e2e/main-menu.spec.ts",
         "e2e/campaign-select.spec.ts",
+        "e2e/a11y.spec.ts",
         # Playwright packages as declared Bazel deps — ensures the cache key includes
         # the playwright version and the files are available in runfiles.
         "//:node_modules/@playwright/test",

--- a/game/web/e2e/a11y.spec.ts
+++ b/game/web/e2e/a11y.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * GAME-008 Accessibility e2e tests.
+ *
+ * Targeted ARIA and keyboard assertions — no axe-core dependency.
+ * Covers:
+ *   1. HTML lang attribute
+ *   2. Main menu ARIA roles
+ *   3. Game screen ARIA labels
+ *   4. Control button tab order
+ *   5. SVG keyboard navigation
+ *   6. Keyboard district assignment
+ */
+
+// tutorial-001 is campaign-only; must include campaign param to bypass routing guard.
+const SCENARIO_URL = "/?campaign=tutorial&s=tutorial-001&debug=true";
+
+/** Navigate to the game editor, skip the intro, and wait for the hex grid. */
+async function loadEditor(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto(SCENARIO_URL);
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("#map-svg path.hex").first()).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("GAME-008 Accessibility", () => {
+  // ─── Test 1: HTML lang attribute ──────────────────────────────────────────
+
+  test("html element has lang attribute", async ({ page }) => {
+    await page.goto("/");
+    const lang = await page.evaluate(() => document.documentElement.lang);
+    expect(lang).toBeTruthy();
+  });
+
+  // ─── Test 2: Main menu ARIA roles ─────────────────────────────────────────
+
+  test("main menu has correct ARIA roles and focusable buttons", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+
+    // #main-menu must carry role="main"
+    const menuRole = await page.locator("#main-menu").getAttribute("role");
+    expect(menuRole).toBe("main");
+
+    // #main-menu-nav must declare its navigation purpose
+    const navRole = await page.locator("#main-menu-nav").getAttribute("role");
+    const navLabel = await page.locator("#main-menu-nav").getAttribute("aria-label");
+    expect(navRole === "navigation" || (navLabel !== null && navLabel.length > 0)).toBeTruthy();
+
+    // New Campaign button must be focusable
+    await page.locator("#btn-main-new-campaign").focus();
+    const focused = await page.evaluate(() => document.activeElement?.id);
+    expect(focused).toBe("btn-main-new-campaign");
+  });
+
+  // ─── Test 3: Game screen ARIA labels ──────────────────────────────────────
+
+  test("game screen elements have required ARIA labels and roles", async ({ page }) => {
+    await loadEditor(page);
+
+    // SVG map must be keyboard-accessible and labelled
+    const svg = page.locator("#map-svg");
+    const svgRole = await svg.getAttribute("role");
+    expect(svgRole).toBe("application");
+
+    const svgTabindex = await svg.getAttribute("tabindex");
+    expect(svgTabindex).toBe("0");
+
+    const svgAriaLabel = await svg.getAttribute("aria-label");
+    expect(svgAriaLabel).toBeTruthy();
+
+    // Results container must announce updates to assistive tech
+    const resultsLive = await page.locator("#results-container").getAttribute("aria-live");
+    expect(resultsLive).toBe("polite");
+
+    // All control buttons must have accessible labels
+    for (const id of ["btn-undo", "btn-redo", "btn-view-toggle", "btn-submit"]) {
+      const label = await page.locator(`#${id}`).getAttribute("aria-label");
+      expect(label, `#${id} must have a non-empty aria-label`).toBeTruthy();
+    }
+
+    // District button group must expose its group role
+    const groupRole = await page.locator("#district-buttons").getAttribute("role");
+    expect(groupRole).toBe("group");
+  });
+
+  // ─── Test 4: Control button tab order ─────────────────────────────────────
+
+  test("control buttons appear in tab sequence", async ({ page }) => {
+    await loadEditor(page);
+
+    const focused: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      await page.keyboard.press("Tab");
+      const id = await page.evaluate(() => document.activeElement?.id ?? "");
+      focused.push(id);
+      if (focused.length > 15 && focused.includes("btn-submit")) break;
+    }
+
+    // Only assert always-enabled buttons — disabled buttons (undo, redo, submit)
+    // are correctly excluded from tab order until actions enable them.
+    for (const id of ["btn-view-toggle", "btn-county-toggle", "btn-reset", "map-svg"]) {
+      expect(focused, `#${id} must appear in tab sequence`).toContain(id);
+    }
+  });
+
+  // ─── Test 5: SVG keyboard navigation ──────────────────────────────────────
+
+  test("SVG keyboard navigation focuses a precinct and updates aria-label", async ({ page }) => {
+    await loadEditor(page);
+
+    // Click SVG to focus it, then press ArrowDown to select first precinct
+    await page.locator("#map-svg").click();
+    await page.keyboard.press("ArrowDown");
+
+    const label = await page.locator("#map-svg").getAttribute("aria-label");
+    expect(label).toContain("focused:");
+  });
+
+  // ─── Test 6: Keyboard district assignment ─────────────────────────────────
+
+  test("keyboard district assignment leaves SVG functional with no errors", async ({ page }) => {
+    const jsErrors: string[] = [];
+    page.on("pageerror", (err) => jsErrors.push(err.message));
+
+    await loadEditor(page);
+
+    // Focus SVG, navigate to first precinct, assign to district 1
+    await page.locator("#map-svg").click();
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("1");
+    await page.waitForTimeout(200);
+
+    // SVG must still be visible and functional after keyboard assignment
+    await expect(page.locator("#map-svg")).toBeVisible();
+
+    // No JS errors must have been thrown
+    expect(jsErrors).toHaveLength(0);
+  });
+});

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -149,7 +149,7 @@
 
     <div id="main" style="display:none">
       <div id="map-container">
-        <svg id="map-svg" role="image" aria-label="District map. Use mouse to paint precincts into districts. Current assignments shown as colored hexagons."></svg>
+        <svg id="map-svg" role="application" tabindex="0" aria-label="District map. Use mouse or keyboard to paint precincts. Arrow keys navigate precincts, number keys 1–5 assign to a district."></svg>
       </div>
       <aside id="sidebar">
         <h2>Precinct Info</h2>

--- a/game/web/src/model/types.ts
+++ b/game/web/src/model/types.ts
@@ -120,19 +120,26 @@ export interface StrokeDiff {
 	changes: Map<number, { from: DistrictId | null; to: DistrictId | null }>;
 }
 
-/** District color palette (index 0 = district 1, etc.) */
+/** District color palette — Okabe-Ito (2008) color-blind-safe 8-color set, 5 used here.
+ *  Source: https://jfly.uni-koeln.de/color/
+ *  Safe for deuteranopia, protanopia, and tritanopia.
+ *  Chosen to avoid collision with party colors D=#3a7bd5 and R=#e94560.
+ */
 export const DISTRICT_COLORS: readonly string[] = [
-	"#4e79a7",
-	"#f28e2b",
-	"#e15759",
-	"#76b7b2",
-	"#59a14f",
+	"#E69F00", // amber
+	"#56B4E9", // sky blue
+	"#009E73", // bluish green
+	"#CC79A7", // mauve
+	"#D55E00", // vermilion
 ] as const;
 
-/** Party display colors */
+/** Party display colors — aligned with PuOr lean-view palette so party badges
+ *  and the lean map use a consistent color language.
+ *  D → purple (D-leaning end of PuOr), R → orange (R-leaning end of PuOr).
+ */
 export const PARTY_COLORS: Record<PartyKey, string> = {
-	R: "#e94560",
-	D: "#3a7bd5",
+	R: "#c96d00",
+	D: "#7b35a8",
 	L: "#f0c040",
 	G: "#50c878",
 	I: "#a0a0a0",

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -196,6 +196,10 @@ export class SvgMapRenderer implements MapRenderer {
 	private countySegments: Segment[] = [];
 	private countyBordersVisible = false;
 
+	// Keyboard precinct navigation state
+	private focusedPrecinctId: number | null = null;
+	private keyboardFocusPath: SVGPathElement | null = null;
+
 	constructor(
 		svgEl: SVGSVGElement,
 		getState: () => GameStore,
@@ -225,6 +229,7 @@ export class SvgMapRenderer implements MapRenderer {
 
 		this.initZoom();
 		this.initBrushEvents();
+		this.initKeyboardNav();
 		this.initHoverEvents();
 	}
 
@@ -323,6 +328,11 @@ export class SvgMapRenderer implements MapRenderer {
 				this.previewBorderGroup
 					.selectAll<SVGLineElement, Segment>("line.preview-boundary")
 					.attr("stroke-width", pw);
+				if (this.keyboardFocusPath !== null) {
+					d3.select(this.keyboardFocusPath)
+						.attr("stroke-width", 2 / this.currentK)
+						.attr("stroke-dasharray", `${4 / this.currentK},${2 / this.currentK}`);
+				}
 			});
 
 		// Prevent context menu on right-click so drag-pan isn't interrupted.
@@ -468,6 +478,7 @@ export class SvgMapRenderer implements MapRenderer {
 
 			if (this.hoveredPath !== path) {
 				this.clearHover();
+				if (path === this.keyboardFocusPath) return;
 				this.hoveredPath = path;
 				d3.select(path)
 					.attr("stroke", "#ffffff")
@@ -523,6 +534,10 @@ export class SvgMapRenderer implements MapRenderer {
 	/** Restores stroke/opacity only — never fill (hover never changes fill). */
 	private clearHover() {
 		if (this.hoveredPath === null) return;
+		if (this.hoveredPath === this.keyboardFocusPath) {
+			this.hoveredPath = null;
+			return;
+		}
 		const path = this.hoveredPath;
 		this.hoveredPath = null;
 		const { assignments } = this.getState();
@@ -609,8 +624,11 @@ export class SvgMapRenderer implements MapRenderer {
 	private hexFill(d: Precinct, assignments: GameStore["assignments"]): string {
 		if (this.viewMode === "lean") {
 			const lean = d.partyShare.D - d.partyShare.R;
-			const t = (lean + 1) / 2; // 0 = full R (red), 1 = full D (blue)
-			return d3.interpolateRdBu(t);
+			// PuOr (purple-orange): CVD-safe diverging palette; avoids party color collision.
+			// t=0 → orange (R-leaning), t=1 → purple (D-leaning). Clamped to [0.1,0.9] for dark-bg contrast.
+			// Source: ColorBrewer (Brewer 2003) https://colorbrewer2.org/
+			const t = Math.max(0.1, Math.min(0.9, (lean + 1) / 2));
+			return d3.interpolatePuOr(t);
 		}
 		const dId = assignments.get(d.id);
 		if (dId == null) return "#2a2a3e";
@@ -628,6 +646,124 @@ export class SvgMapRenderer implements MapRenderer {
 		if (this.viewMode === "lean") return SvgMapRenderer.LEAN_OPACITY;
 		const dId = assignments.get(d.id);
 		return dId != null ? SvgMapRenderer.ASSIGNED_OPACITY : SvgMapRenderer.UNASSIGNED_OPACITY;
+	}
+
+	// ─── Keyboard precinct navigation (GAME-008) ──────────────────────────────
+
+	private initKeyboardNav() {
+		const svgNode = this.svg.node()!;
+
+		svgNode.addEventListener("keydown", (e: KeyboardEvent) => {
+			const { precincts, activeDistrict, districtCount } = this.getState();
+			if (precincts.length === 0) return;
+
+			// Initialize focus to first precinct if none selected
+			if (this.focusedPrecinctId === null) {
+				this.setKeyboardFocus(precincts[0]!.id, precincts);
+				return;
+			}
+
+			const current = precincts.find(p => p.id === this.focusedPrecinctId);
+			if (current === undefined) return;
+
+			// Arrow key → neighbor direction mapping for flat-top hex grid
+			// Try primary then secondary direction to handle diagonal movement
+			const dirMap: Record<string, number[]> = {
+				ArrowUp:    [4],
+				ArrowDown:  [1],
+				ArrowRight: [5, 0],
+				ArrowLeft:  [3, 2],
+			};
+
+			const dirs = dirMap[e.key];
+			if (dirs !== undefined) {
+				e.preventDefault();
+				for (const dir of dirs) {
+					const nId = current.neighbors[dir];
+					if (nId !== null && nId !== undefined) {
+						this.setKeyboardFocus(nId, precincts);
+						break;
+					}
+				}
+				return;
+			}
+
+			// Number keys 1–5: assign focused precinct to that district
+			const num = parseInt(e.key, 10);
+			if (num >= 1 && num <= districtCount) {
+				e.preventDefault();
+				this.paintStroke([this.focusedPrecinctId], num);
+				const { precincts } = this.getState();
+				this.setKeyboardFocus(this.focusedPrecinctId, precincts);
+				return;
+			}
+
+			// Space: assign to active district
+			if (e.key === " ") {
+				e.preventDefault();
+				this.paintStroke([this.focusedPrecinctId], activeDistrict);
+				const { precincts } = this.getState();
+				this.setKeyboardFocus(this.focusedPrecinctId, precincts);
+			}
+		});
+
+		// Clear keyboard focus when SVG loses focus
+		svgNode.addEventListener("blur", () => {
+			this.clearKeyboardFocus();
+		});
+	}
+
+	private setKeyboardFocus(precinctId: number, precincts: Precinct[]) {
+		this.clearKeyboardFocus();
+		this.focusedPrecinctId = precinctId;
+
+		// Find the SVG path element for this precinct
+		const path = this.hexGroup
+			.select<SVGPathElement>(`path.hex[data-precinct-id="${precinctId}"]`)
+			.node();
+		if (path === null) return;
+		this.keyboardFocusPath = path;
+
+		// Yellow dashed focus ring — distinct from hover (white) and district fills
+		d3.select(path)
+			.attr("stroke", "#F0E442")
+			.attr("stroke-width", 2 / this.currentK)
+			.attr("stroke-dasharray", `${4 / this.currentK},${2 / this.currentK}`);
+
+		// Update SVG aria-label with current precinct context
+		const p = precincts.find(pr => pr.id === precinctId);
+		if (p !== undefined) {
+			const { assignments } = this.getState();
+			const dId = assignments.get(p.id);
+			const distLabel = dId != null ? `district ${dId}` : "unassigned";
+			const label = p.name ?? `Precinct ${p.id}`;
+			this.svg.attr("aria-label",
+				`District map — focused: ${label}, ${distLabel}. ` +
+				`Arrow keys navigate. Number keys 1–5 assign district. Space assigns active district.`
+			);
+		}
+	}
+
+	private clearKeyboardFocus() {
+		if (this.keyboardFocusPath !== null) {
+			const path = this.keyboardFocusPath;
+			this.keyboardFocusPath = null;
+			this.focusedPrecinctId = null;
+			const { assignments } = this.getState();
+			const d = d3.select<SVGPathElement, Precinct>(path).datum();
+			if (d !== undefined) {
+				d3.select(path)
+					.attr("stroke", "none")
+					.attr("stroke-dasharray", null)
+					.attr("stroke-width", 0.5)
+					.attr("opacity", this.hexOpacity(d, assignments));
+			}
+			// Restore default aria-label
+			this.svg.attr("aria-label",
+				"District map. Use mouse or keyboard to paint precincts. " +
+				"Arrow keys navigate precincts, number keys 1–5 assign to a district."
+			);
+		}
 	}
 }
 

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -210,7 +210,7 @@ body {
 .result-district .vote-bar {
   height: 8px;
   border-radius: 4px;
-  background: linear-gradient(to right, #3a7bd5 var(--d-pct), #e94560 var(--d-pct));
+  background: linear-gradient(to right, #7b35a8 var(--d-pct), #c96d00 var(--d-pct));
   margin-bottom: 4px;
 }
 
@@ -861,4 +861,33 @@ body {
 
 .nav-back-menu button:hover {
   background: #1e3a6e;
+}
+
+/* ── Accessibility: focus rings (WCAG 2.1 AA) ─────────────────────────── */
+
+/* Global visible focus ring for keyboard navigation */
+:focus-visible {
+  outline: 2px solid #56B4E9;
+  outline-offset: 2px;
+}
+
+/* District buttons: white outline matches active border convention */
+.district-btn:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* SVG map gets a container-level focus ring (role=application, tabindex=0) */
+#map-svg:focus-visible {
+  outline: 2px solid #56B4E9;
+  outline-offset: 4px;
+}
+
+/* ── Accessibility: reduced motion ─────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }

--- a/thoughts/shared/tickets/GAME-055-party-names-scenario-driven.md
+++ b/thoughts/shared/tickets/GAME-055-party-names-scenario-driven.md
@@ -1,0 +1,44 @@
+---
+id: GAME-055
+title: Party names should come from scenario data, not hardcoded labels
+area: game, content
+status: open
+created: 2026-05-01
+---
+
+## Summary
+
+Party names are currently hardcoded as "Red Party" and "Blue Party" (in `PARTY_LABELS`
+in `types.ts`) and "Blue X% · Red Y%" in `panels.ts`. Scenarios use fictional party
+names — Ken/Ryu in tutorial, Cat Party/Dog Party in scenario-009, etc. — but these
+names never appear in the UI. Players see "Blue Party wins" instead of "Ken wins",
+breaking immersion and making the results panel confusing.
+
+## Current State
+
+- `PARTY_LABELS` in `types.ts` has hardcoded: `{ R: "Red Party", D: "Blue Party", L: "Libertarian", G: "Green", I: "Independent" }`
+- `panels.ts` `renderResults()` uses `PARTY_LABELS[r.winner]` for winner badges
+- `panels.ts` also hardcodes `"Blue ${dPct}% · Red ${rPct}%"` in vote-details text
+- Scenario JSON has `parties` field with per-scenario party names (e.g. `"D": "Ken"`)
+
+## Goals / Acceptance Criteria
+
+- [ ] `renderResults()` and any other panel that shows party names accepts scenario
+  party name data and displays scenario-specific names (e.g. "Ken +12%" not "Blue Party +12%")
+- [ ] Vote details line (`"Blue X% · Red Y%"`) uses scenario party names
+- [ ] Winner badge on result screen uses scenario party names
+- [ ] Fallback to generic names (Red/Blue) if scenario has no party name data
+- [ ] `PARTY_LABELS` in `types.ts` remains as the fallback default only
+
+## Test Coverage
+
+- [ ] Unit test: `renderResults()` displays scenario-supplied party names when provided
+- [ ] Unit test: `renderResults()` falls back to PARTY_LABELS when no names supplied
+- [ ] e2e test: tutorial-001 winner badge shows "Ken" or "Ryu" (or scenario's actual names)
+
+## References
+
+- `game/web/src/model/types.ts` — `PARTY_LABELS`
+- `game/web/src/render/panels.ts` — `renderResults()`
+- `game/web/src/model/scenario.ts` — check for `parties` field in scenario JSON schema
+- `game/web/scenarios/tutorial-001.json` — example with named parties

--- a/thoughts/shared/tickets/GAME-056-playtest-feedback.md
+++ b/thoughts/shared/tickets/GAME-056-playtest-feedback.md
@@ -1,0 +1,42 @@
+---
+id: GAME-056
+title: Capture and act on playtest feedback — scenario balance and UX
+area: game, content, UX
+status: open
+created: 2026-05-01
+---
+
+## Summary
+
+Collect structured playtest feedback from real players and triage it into actionable
+improvements to scenarios, difficulty balance, and UX. This is the living intake
+ticket for v1 playtest feedback; specific sub-issues should be filed as separate
+tickets when they have clear acceptance criteria.
+
+## Current State
+
+- v1 scenarios ship to staging/production but no structured feedback loop exists yet
+- Some playtest feedback has been noted informally in conversation (2026-05-01 session)
+- GAME-031 covers external gameplay critique research; this ticket is for direct
+  player feedback gathered from live sessions
+
+## Goals / Acceptance Criteria
+
+- [ ] Establish a lightweight feedback intake format (even just notes in this file)
+- [ ] Triage each piece of feedback into: fix-in-place, new ticket, or won't-fix
+- [ ] At least one round of structured playtest feedback collected and triaged
+- [ ] Any actionable scenario-balance issues filed as sub-tickets (referencing this one)
+
+## Feedback Collected So Far
+
+*(Add dated entries as feedback arrives)*
+
+**2026-05-01 — Playtest session notes**
+- Party names show as "Red Party" / "Blue Party" in results panel — not scenario-specific names → filed as GAME-055
+- (Add more feedback items here as they come in)
+
+## References
+
+- GAME-031 — external gameplay critique research (complementary)
+- GAME-055 — party names scenario-driven (spun out from this feedback)
+- thoughts/shared/vision/game-vision.compressed.md — v1 scope and design intent

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -92,6 +92,8 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-006-zoom-adaptive-dot-density.md` | design, rendering | Zoom-adaptive dot density scaling + person glyph threshold (refinement on DESIGN-005, possibly post-v1) |
 | `DESIGN-007-dimensional-dot-map-demographic-overlay.md` | design, rendering | Dimensional dot map: demographic dimension switching (Option B adaptive encoding) + sorted placement toggle |
 | `GAME-008-accessibility.md` | game, accessibility | Full a11y pass: color-blind-safe palettes, ARIA labels, keyboard nav, screen reader support |
+| `GAME-055-party-names-scenario-driven.md` | game, content | Party names should come from scenario data (Ken/Ryu, Cat/Dog), not hardcoded "Red Party"/"Blue Party" |
+| `GAME-056-playtest-feedback.md` | game, content, UX | Capture and act on playtest feedback — scenario balance and UX |
 | `GAME-030-main-menu-and-campaigns.md` | game, UX, architecture | Main menu, campaign model, campaign select, layered navigation; replaces scenario-select-as-home |
 | `GAME-031-gameplay-critique-followup.md` | game, content, balance | Review and act on external gameplay critique research (scenario difficulty, eval balance, design) |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |


### PR DESCRIPTION
## Summary

Full WCAG 2.1 AA accessibility pass for GAME-008. Sprint 9 (PR #129) already added basic ARIA labels and aria-live regions; this PR completes the remaining AC: color-blind-safe palettes, keyboard precinct navigation, focus rings, and automated a11y e2e tests.

- **Color-blind-safe district palette** — replaced the old tableau-style 5 colors with the Okabe-Ito (2008) CVD-safe set (amber / sky-blue / bluish-green / mauve / vermilion); safe for deuteranopia, protanopia, and tritanopia
- **Lean view palette** — replaced `d3.interpolateRdBu` with `d3.interpolatePuOr` (purple-orange); avoids semantic collision with party colors (D=blue, R=red); clamped to [0.1, 0.9] for dark-background contrast
- **Party colors aligned with lean view** — D→purple (`#7b35a8`), R→orange (`#c96d00`); vote-bar CSS gradient updated to match; winner badges now use consistent color language across the whole UI
- **Keyboard precinct navigation** — SVG changed to `role="application"` + `tabindex="0"`; arrow keys navigate hex neighbors, number keys 1–5 assign district, Space assigns to active district; yellow dashed focus ring (#F0E442, Okabe-Ito); `aria-label` updates dynamically with focused precinct + district context
- **Focus rings** — `:focus-visible` global rule (2px sky-blue outline); district buttons use white outline to match active-border convention; SVG container gets 4px offset ring
- **`prefers-reduced-motion`** — media query collapses all transitions/animations to 0.01ms
- **6 new e2e a11y tests** (`e2e/a11y.spec.ts`): HTML lang, main-menu ARIA roles, game-screen ARIA labels, tab order, SVG keyboard nav, keyboard district assignment; 109 total tests pass

## Affected machines / services

- `game/web/` — TypeScript source, HTML, CSS, e2e tests
- No server-side changes; static browser app only

## Validation performed

- `bazel build //web:app_typecheck_test` — passes (no type errors)
- `bazel test //web:e2e_test` — 109/109 pass locally
- Deployed to dev (`vTEST-6474090261ca`) and manually verified:
  - District colors visually distinct and game-y on dark background
  - Lean view shows purple-orange gradient (not red-blue)
  - Party winner badges show orange/purple consistently with lean view
  - Keyboard nav: click SVG → ArrowDown focuses first precinct (yellow dashed ring) → number keys assign
  - Tab key cycles through all enabled controls with visible focus ring
  - VoiceOver test: manual — SVG aria-label updates correctly on keyboard nav (noted in PR, not automated)

## Deployment steps

Standard dev→staging→prod pipeline. Staging deploy follows merge.

## Tickets addressed

- see #176 (GAME-008 full accessibility pass)
- Also files GAME-055 (party names from scenario data) and GAME-056 (playtest feedback intake) as follow-on tickets — not blocked on this PR

## Rollback

Revert this commit. No data migrations; no server-side changes. District colors and lean palette revert to previous values.
