### PR TITLE
feat(DESIGN-001): achievement/star system research — variable per-criterion stars

### DIFF
--- a/thoughts/shared/research/2026-05-02-design-001-achievement-star-system.compressed.md
+++ b/thoughts/shared/research/2026-05-02-design-001-achievement-star-system.compressed.md
@@ -1,0 +1,37 @@
+<!--COMPRESSED v1; source:2026-05-02-design-001-achievement-star-system.md-->
+§META date:2026-05-02 ticket:DESIGN-001 status:accepted researcher:agent topic:achievement-star-system tags:game-design,ux,scoring
+
+§ABBREV
+sc=SuccessCriterion req=required:true opt=required:false
+
+§SUMMARY
+Recommend variable per-criterion stars; no format change needed. 1 base star (all $req pass) + 1 per $opt criterion passed. Campaign total = sum stars earned / sum stars available. Rejected fixed-3 (arbitrary tier boundary, implies $opt hierarchy). Rejected pure badges (no campaign hook).
+
+§FINDINGS
+Angry Birds/Cut the Rope: fixed-3 star, single performance axis — works because $opt objectives same axis as $req.
+Monument Valley: no stars — appropriate for art game, wrong for educational game w/ explicit learning goals.
+Zachtronics histograms: multi-metric continuous optimization — inapplicable; PtP criteria are boolean not continuous.
+Khan Academy/Duolingo: binary completion + separate XP/badges; no per-exercise star count.
+Research (Blair, Game Developer): measurement achievements (variable stars) > completion achievements (binary) for educational contexts; achievements should focus attention on learning strategies not artificial incentives.
+
+§MODELS
+A fixed-3-tier: "some optional" undefined for variable $opt counts; collapses when 1 $opt; implies $opt hierarchy; needs weight/tier field → format change → rejected
+B N/M campaign: consequence of per-scenario model not itself a model; adopted as aggregate layer
+C per-criterion badges only: educationally accurate; no campaign hook; partially adopted
+
+§RECOMMENDATION
+Variable per-criterion stars.
+1 base star: all $req criteria pass
++1 star per $opt criterion that passes
+scenario max = 1 + count($opt criteria)
+campaign progress = sum(earned) / sum(max) across scenarios
+Steam achievements = separate campaign milestone layer; not 1:1 with per-scenario $opt criteria; don't let Steam 100-achievement cap constrain per-scenario design
+
+§FORMAT_CHANGES
+None. req:boolean already encodes all needed info.
+Engine: base=(all $req pass ? 1 : 0); bonus=count(passing $opt); total=base+bonus; max=1+count($opt)
+New data in player save state only (criteria_passed: Set<CriterionId>), not scenario format.
+
+§REFS
+ADR:thoughts/shared/decisions/2026-04-24-scenario-data-format.md — SuccessCriterion schema (required:boolean)
+Research:2026-05-02-design-001-achievement-star-system.md — full findings

--- a/thoughts/shared/research/2026-05-02-design-001-achievement-star-system.md
+++ b/thoughts/shared/research/2026-05-02-design-001-achievement-star-system.md
@@ -1,0 +1,57 @@
+---
+date: 2026-05-02
+ticket: DESIGN-001
+status: accepted
+researcher: agent
+---
+
+# Achievement / Star-Ranking System Design
+
+## Research Summary
+
+The dominant star-ranking pattern in puzzle games originates with Angry Birds (2009), which introduced a 0–3 star system awarded after each level based on a single score threshold. Before that release, roughly 20% of mobile games used a star rating; afterward the figure approached 80%. Cut the Rope adopted the same shape: three collectible stars per level, always exactly three possible, always on the same axis as the core challenge (collect the candy, collect the stars). Both games work well because the optional objectives are *on the same performance axis* as the required objective — the player does the same thing, just more efficiently or completely.
+
+Monument Valley stands as the deliberate counterpoint: no stars, no score, no rating. The experience is the reward. This is appropriate for a narrative art puzzle but would undermine an educational game that has explicit learning objectives players need feedback on. Zachtronics games (SpaceChem, Opus Magnum, Infinifactory) take a third path: multi-metric histograms comparing cycles, cost, and space against global leaderboards. This works because their solutions are genuinely open-ended on continuous axes with real trade-offs between metrics. It does not translate to Past the Post — success criteria here are boolean (a district plan either achieves majority-minority representation or it does not), not continuous optimization scores.
+
+Educational games show a different pattern still. Khan Academy and Duolingo treat completion as binary and track optional mastery through separate mechanisms — practice streaks, XP, badge milestones. Neither uses per-exercise star counts. Research on achievement design (Blair, Game Developer) identifies *measurement achievements* (variable stars based on performance level) as pedagogically superior to *completion achievements* (binary pass/fail) because they give players calibrated feedback that increases reflection and intrinsic motivation. The design literature further recommends that achievements in educational contexts "focus the player's attention on important lessons or strategies" rather than creating artificial incentives — which argues against a fixed 3-star system that implies a predetermined hierarchy of optional objectives.
+
+## Candidate Model Evaluation
+
+**Model A — Fixed 3-tier stars (1★ required; 2★ required + some optional; 3★ all optional):**
+The "some optional" definition is underspecified when scenario optional-criterion counts vary. With one optional criterion, 2★ and 3★ collapse. With five, the boundary between 2★ and 3★ is arbitrary. Enforcing fixed-3 requires adding `weight` or `tier` metadata to `SuccessCriterion` to distinguish which optional criteria count toward which tier — a format change that adds complexity without educational benefit. More importantly, it implies a ranking among optional objectives (achieving compactness is "better" than achieving partisan fairness), which is precisely the misrepresentation Past the Post should avoid. Rejected.
+
+**Model B — N/M campaign stars with freeform per-scenario counts:**
+This is the correct shape for campaign-level progress tracking ("34 of 47 stars"), but it says nothing about *within-scenario* structure. It is a consequence of a good per-scenario model, not itself a model. Compatible with the recommendation below.
+
+**Model C — Per-criterion achievements, no aggregate rank:**
+Treats each optional criterion as a completely independent badge. No star count, no campaign aggregate. This is educationally accurate but removes the campaign-level progress hook that motivates replay. Players need some sense of "how complete am I overall?" Pure per-criterion badges with no aggregate can feel diffuse on a scenario select screen. Partially adopted in the recommendation below, but with an aggregate layer added.
+
+## Recommendation: Variable Per-Criterion Stars
+
+Build the following system:
+
+- **1 base star** awarded when all `required: true` criteria are met (scenario complete).
+- **1 additional star per `required: false` criterion** that the player achieves.
+- A scenario with N optional criteria has N+1 possible stars.
+- **Campaign progress** = total stars earned / total stars available across all scenarios.
+- The scenario select screen shows per-scenario star counts inline (e.g., ★★★☆ on a 3-optional scenario).
+- The campaign screen shows aggregate progress (e.g., "34 of 47 stars").
+
+This is the right model for Past the Post for three reasons. First, it requires **no format change** — `required: boolean` on `SuccessCriterion` already encodes everything. Second, it makes each optional criterion an independent pedagogical learning beat rather than a tier in a predetermined hierarchy. Compactness and partisan fairness are not ranked against each other; achieving either is equally meaningful. Third, it provides the campaign-level feedback hook (total stars) that sustains replay motivation across scenarios without imposing false ordering within a scenario.
+
+**Steam achievements** are a separate layer. Steam achievements are campaign-scoped milestones ("complete all tutorial scenarios," "earn 10 majority-minority stars," "achieve all stars on the first campaign") mapped manually by scenario authors to the Steamworks achievement API. They are not 1:1 with per-scenario optional criteria. The in-game star model and the Steam achievement model are independent; do not let the Steam 100-achievement cap constrain per-scenario star design.
+
+## Minimal Format Change Required
+
+**None.** The recommendation is fully implementable with the current `SuccessCriterion` schema. The engine counts:
+
+```
+base_stars  = 1 if all required criteria pass else 0
+bonus_stars = count(optional criteria that pass)
+total       = base_stars + bonus_stars
+max         = 1 + count(optional criteria)
+```
+
+No new fields on `SuccessCriterion`. No `weight`, `tier`, or `star_value`. Scenario authors control per-scenario star counts by adding or removing `required: false` criteria.
+
+The only new data is in **player save state** (not scenario format): store `criteria_passed: Set<CriterionId>` per scenario attempt, from which stars are derived at render time.

--- a/thoughts/shared/tickets/DESIGN-001-achievement-star-system.md
+++ b/thoughts/shared/tickets/DESIGN-001-achievement-star-system.md
@@ -2,8 +2,9 @@
 id: DESIGN-001
 title: Achievement / star-ranking system game ergonomics research
 area: design
-status: open
+status: resolved
 created: 2026-04-24
+github_issue: 182
 ---
 
 ## Summary
@@ -21,22 +22,27 @@ criteria beyond "they exist."
 
 ## Goals / Acceptance Criteria
 
-- [ ] Research how comparable educational and puzzle games present multi-tier
+- [x] Research how comparable educational and puzzle games present multi-tier
       success (stars, ranks, medals, etc.).
-- [ ] Evaluate candidate models:
+- [x] Evaluate candidate models:
       - 3-tier stars: 1 star = all required; 2 stars = required + some optional;
         3 stars = all optional
       - N/M stars: 34/45 campaign stars, 1/1 per scenario, etc. (freeform)
       - Per-criterion achievements: no aggregate rank, each optional criterion is
         an independent badge
-- [ ] Determine whether star count should be fixed (always 3) or variable per
+- [x] Determine whether star count should be fixed (always 3) or variable per
       scenario (driven by optional criteria count).
-- [ ] Identify what format changes, if any, are needed to support the chosen model
+- [x] Identify what format changes, if any, are needed to support the chosen model
       (e.g., `weight`, `tier`, or `star_value` on `SuccessCriterion`).
-- [ ] Summarize recommendation with reasoning. No implementation required yet.
+- [x] Summarize recommendation with reasoning. No implementation required yet.
+
+## Resolution
+
+Research complete. Recommendation: variable per-criterion stars — 1 base star (all required criteria met) + 1 per optional criterion achieved. No format change needed; `required: boolean` on `SuccessCriterion` already encodes everything. Fixed-3 rejected (arbitrary tier boundary, implies false hierarchy between optional criteria). Campaign aggregate = total stars earned / total available.
 
 ## References
 
 - Scenario data format spec: `thoughts/shared/decisions/2026-04-24-scenario-data-format.md`
   (Open Question 10; `SuccessCriterion.required`)
 - DIST-001: Steam deployment research (Steam achievements API may inform this)
+- Research doc: `thoughts/shared/research/2026-05-02-design-001-achievement-star-system.md`

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -85,7 +85,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `BUILD-009-content-hash-bundle.md` | build, deployment | Content-hashed bundle filenames (`bundle-[hash].js`) for proper CDN cache invalidation on deploy; replaces query-string kludge in release.main.kts |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `DIST-001-steam-deployment-research.md` | distribution, platform | Research Steam free/educational program, achievements API, web-vs-Steam tradeoffs |
-| `DESIGN-001-achievement-star-system.md` | design, UX | Game ergonomics research for star/achievement ranking system (required vs. optional criteria) |
 | `AGENT-003-infra-pr-review-bot-comment-handling.md` | agentic workflow, infra | Propose bot comment handling (Copilot, CodeQL) to infra pr-review-cycle workflow |
 | `DESIGN-004-legend-layout.md` | design, UX | Move legend to horizontal strip above map; free sidebar space for data panels |
 | `DESIGN-005-population-dot-density-overlay.md` | design, rendering | Population dot density overlay: dot count per precinct proportional to population; hue-aware dot color; colorblind-safe palette |
@@ -108,6 +107,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| DESIGN-001: achievement/star system research | Variable per-criterion stars: 1 base + 1 per optional criterion; no format change needed; fixed-3 rejected; research doc written 2026-05-02 |
 | GAME-055: scenario-driven party names | `renderResults()` accepts partyLabels param; scenario party names (Ken/Ryu, Cat/Dog) shown in results panel; fallback to "Party 1"/"Party 2"; 2 e2e tests; merged PR #180 |
 | GAME-008: full accessibility pass | Okabe-Ito CVD-safe district palette, PuOr lean view, aligned party colors, keyboard precinct nav (arrow+number keys), focus rings, prefers-reduced-motion, 6 e2e a11y tests; merged PR #177, deployed v0.0.13 |
 | LEGAL-001: content risk assessment | Low risk for v1; all pre-authored content, fictional entities, educational framing; disclaimers added to about page + Valle Verde; authoring tool deferred to post-v1 review |


### PR DESCRIPTION
## Summary

Research complete for DESIGN-001 (achievement/star-ranking system ergonomics).

- Surveyed comparable games: Angry Birds/Cut the Rope (fixed-3), Monument Valley (no stars), Zachtronics (multi-metric histograms), Khan Academy/Duolingo (binary + badges)
- Evaluated 3 candidate models: fixed-3-tier stars, N/M campaign stars, per-criterion achievements
- **Recommendation: variable per-criterion stars** — 1 base star (all required criteria met) + 1 additional star per optional criterion achieved; no scenario format change needed
- Research doc written to `thoughts/shared/research/2026-05-02-design-001-achievement-star-system.md` (+ compressed form)
- Ticket DESIGN-001 marked resolved; TICKETS.md updated

## Affected machines / services

None — research docs and ticket metadata only. No code changes.

## Validation performed

- N/A — research/metadata only

## Deployment steps

None.

## Tickets addressed

- see #182 (DESIGN-001)

## Rollback

Revert this commit. No functional impact.
