### PR TITLE
docs: document task-list-completed PR check behavior in AGENTS files

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -51,6 +51,13 @@ SPIKE CHECKPOINTING: maintain PROGRESS.md in spike dir; update+commit with each 
   resuming agent: read ticket → PROGRESS.md → jj log; continue from Next up
   keep under 30 lines; skip anything evident from ticket or code
 
+§PR
+task-list-completed CI check scans ALL checkboxes — PR description AND every comment (inline included).
+ANY unchecked `- [ ]` blocks merge permanently; check does NOT time out.
+critique agents often post `- [ ]` items; once fixed, edit comment via gh api PATCH to `- [x]`.
+  gh api repos/<org>/<repo>/pulls/comments/<id> -X PATCH -F body=@/tmp/...
+exclude from blocking: add N/A|POST-MERGE|OPTIONAL keyword to the checkbox line.
+
 §TICKETS
 TICKETS.md=canonical index; do NOT maintain ticket inventories elsewhere
 any ticket file create|modify|resolve|delete → update TICKETS.md in same op

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,20 @@ Reference issues from PRs with `see #N` — never `fixes #N` or `closes #N`.
 
 ---
 
+## Pull Request Conventions
+
+### task-list-completed check
+
+This repo runs a `task-list-completed` GitHub Actions check that scans **every** checkbox in the PR — the description body **and** all comments (inline review comments included). Any unchecked `- [ ]` box anywhere blocks the check and prevents merge.
+
+Rules:
+- Never write `- [ ]` in a PR comment unless you intend to come back and check it off.
+- After a critique agent posts inline comments with `- [ ]` items (issues to fix), once each fix is applied, edit that comment to check the boxes (`- [x]`) via the GitHub API: `gh api repos/<org>/<repo>/pulls/comments/<id> -X PATCH -F body=@/tmp/...`
+- The check does **not** time out or resolve on its own — it stays permanently blocking until all boxes are checked.
+- To exclude an item from blocking merge, use the keywords `N/A`, `POST-MERGE`, or `OPTIONAL` in the checkbox line instead of leaving it bare and unchecked.
+
+---
+
 ## Development Process
 
 This project follows a **sprint-based development process** and **TDD-informed workflow**. Two documents govern how work is planned and executed — read both on every context load:


### PR DESCRIPTION
## Summary

Documents the `task-list-completed` CI check behavior in both AGENTS.md and AGENTS.compressed.md.

- New §PR section in AGENTS.compressed.md: explains that the check scans ALL checkboxes in PR description and every comment (inline included), never times out, and how to fix/exclude items
- New "Pull Request Conventions" section in AGENTS.md with the same rules in prose form
- Learned from PR #183 where a critique agent's inline comment with `- [ ]` boxes blocked merge until patched via gh API

## Affected machines / services

N/A — agent guidance docs only.

## Validation performed

- N/A — docs only

## Deployment steps

N/A

## Tickets addressed

N/A — operational learning, no ticket.

## Rollback

Revert this commit. No functional impact.
