### PR TITLE
feat(GAME-031): tighten scenario thresholds per gameplay critique

### DIFF
--- a/game/scenarios/scenario-002.json
+++ b/game/scenarios/scenario-002.json
@@ -7,16 +7,38 @@
     "id": "clearwater_county",
     "name": "Clearwater County"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
-    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+    {
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
+    },
+    {
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    },
+    {
+      "id": "d4",
+      "name": "District 4"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -24,7 +46,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 1538,
       "initial_district_id": "d1",
       "name": "West (0,-5)",
@@ -33,8 +58,11 @@
           "id": "p001-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6124, "ryu": 0.3876 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6124,
+            "ryu": 0.3876
+          }
         }
       ]
     },
@@ -42,7 +70,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 1508,
       "initial_district_id": "d1",
       "name": "Central (1,-5)",
@@ -52,7 +83,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5576, "ryu": 0.4424 }
+          "vote_shares": {
+            "ken": 0.5576,
+            "ryu": 0.4424
+          }
         }
       ]
     },
@@ -60,7 +94,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 1550,
       "initial_district_id": "d1",
       "name": "Central (2,-5)",
@@ -70,7 +107,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5338, "ryu": 0.4662 }
+          "vote_shares": {
+            "ken": 0.5338,
+            "ryu": 0.4662
+          }
         }
       ]
     },
@@ -78,7 +118,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 1425,
       "initial_district_id": "d2",
       "name": "Central (3,-5)",
@@ -88,7 +131,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5274, "ryu": 0.4726 }
+          "vote_shares": {
+            "ken": 0.5274,
+            "ryu": 0.4726
+          }
         }
       ]
     },
@@ -96,7 +142,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 1479,
       "initial_district_id": "d2",
       "name": "Central (4,-5)",
@@ -106,7 +155,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5185, "ryu": 0.4815 }
+          "vote_shares": {
+            "ken": 0.5185,
+            "ryu": 0.4815
+          }
         }
       ]
     },
@@ -114,7 +166,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 1600,
       "initial_district_id": "d3",
       "name": "Central (5,-5)",
@@ -123,8 +178,11 @@
           "id": "p006-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5054, "ryu": 0.4946 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.5054,
+            "ryu": 0.4946
+          }
         }
       ]
     },
@@ -132,7 +190,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 1357,
       "initial_district_id": "d1",
       "name": "West (-1,-4)",
@@ -142,7 +203,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6164, "ryu": 0.3836 }
+          "vote_shares": {
+            "ken": 0.6164,
+            "ryu": 0.3836
+          }
         }
       ]
     },
@@ -150,7 +214,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 1580,
       "initial_district_id": "d1",
       "name": "West (0,-4)",
@@ -160,7 +227,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5977, "ryu": 0.4023 }
+          "vote_shares": {
+            "ken": 0.5977,
+            "ryu": 0.4023
+          }
         }
       ]
     },
@@ -168,7 +238,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 1477,
       "initial_district_id": "d1",
       "name": "Central (1,-4)",
@@ -178,7 +251,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5423, "ryu": 0.4577 }
+          "vote_shares": {
+            "ken": 0.5423,
+            "ryu": 0.4577
+          }
         }
       ]
     },
@@ -186,7 +262,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 1367,
       "initial_district_id": "d2",
       "name": "Central (2,-4)",
@@ -196,7 +275,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5276, "ryu": 0.4724 }
+          "vote_shares": {
+            "ken": 0.5276,
+            "ryu": 0.4724
+          }
         }
       ]
     },
@@ -204,7 +286,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 1487,
       "initial_district_id": "d2",
       "name": "Central (3,-4)",
@@ -214,7 +299,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5588, "ryu": 0.4412 }
+          "vote_shares": {
+            "ken": 0.5588,
+            "ryu": 0.4412
+          }
         }
       ]
     },
@@ -222,7 +310,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 1602,
       "initial_district_id": "d3",
       "name": "Central (4,-4)",
@@ -232,7 +323,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5111, "ryu": 0.4889 }
+          "vote_shares": {
+            "ken": 0.5111,
+            "ryu": 0.4889
+          }
         }
       ]
     },
@@ -240,7 +334,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 1352,
       "initial_district_id": "d3",
       "name": "Central (5,-4)",
@@ -250,7 +347,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5120, "ryu": 0.4880 }
+          "vote_shares": {
+            "ken": 0.512,
+            "ryu": 0.488
+          }
         }
       ]
     },
@@ -258,7 +358,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 1598,
       "initial_district_id": "d1",
       "name": "West (-2,-3)",
@@ -268,7 +371,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6233, "ryu": 0.3767 }
+          "vote_shares": {
+            "ken": 0.6233,
+            "ryu": 0.3767
+          }
         }
       ]
     },
@@ -276,7 +382,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 1482,
       "initial_district_id": "d1",
       "name": "West (-1,-3)",
@@ -286,7 +395,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5974, "ryu": 0.4026 }
+          "vote_shares": {
+            "ken": 0.5974,
+            "ryu": 0.4026
+          }
         }
       ]
     },
@@ -294,7 +406,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 1377,
       "initial_district_id": "d1",
       "name": "West (0,-3)",
@@ -304,7 +419,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6123, "ryu": 0.3877 }
+          "vote_shares": {
+            "ken": 0.6123,
+            "ryu": 0.3877
+          }
         }
       ]
     },
@@ -312,7 +430,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 1490,
       "initial_district_id": "d2",
       "name": "East (1,-3)",
@@ -322,7 +443,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.2770, "ryu": 0.7230 }
+          "vote_shares": {
+            "ken": 0.277,
+            "ryu": 0.723
+          }
         }
       ]
     },
@@ -330,7 +454,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 1629,
       "initial_district_id": "d2",
       "name": "East (2,-3)",
@@ -340,7 +467,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.2468, "ryu": 0.7532 }
+          "vote_shares": {
+            "ken": 0.2468,
+            "ryu": 0.7532
+          }
         }
       ]
     },
@@ -348,7 +478,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 1375,
       "initial_district_id": "d3",
       "name": "East (3,-3)",
@@ -358,7 +491,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.2624, "ryu": 0.7376 }
+          "vote_shares": {
+            "ken": 0.2624,
+            "ryu": 0.7376
+          }
         }
       ]
     },
@@ -366,7 +502,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 1574,
       "initial_district_id": "d3",
       "name": "Central (4,-3)",
@@ -376,7 +515,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5308, "ryu": 0.4692 }
+          "vote_shares": {
+            "ken": 0.5308,
+            "ryu": 0.4692
+          }
         }
       ]
     },
@@ -384,7 +526,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 1630,
       "initial_district_id": "d4",
       "name": "Central (5,-3)",
@@ -394,7 +539,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5291, "ryu": 0.4709 }
+          "vote_shares": {
+            "ken": 0.5291,
+            "ryu": 0.4709
+          }
         }
       ]
     },
@@ -402,7 +550,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 1618,
       "initial_district_id": "d1",
       "name": "West (-3,-2)",
@@ -412,7 +563,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6033, "ryu": 0.3967 }
+          "vote_shares": {
+            "ken": 0.6033,
+            "ryu": 0.3967
+          }
         }
       ]
     },
@@ -420,7 +574,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 1617,
       "initial_district_id": "d1",
       "name": "West (-2,-2)",
@@ -430,7 +587,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6203, "ryu": 0.3797 }
+          "vote_shares": {
+            "ken": 0.6203,
+            "ryu": 0.3797
+          }
         }
       ]
     },
@@ -438,7 +598,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 1554,
       "initial_district_id": "d1",
       "name": "West (-1,-2)",
@@ -448,7 +611,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5832, "ryu": 0.4168 }
+          "vote_shares": {
+            "ken": 0.5832,
+            "ryu": 0.4168
+          }
         }
       ]
     },
@@ -456,7 +622,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 1640,
       "initial_district_id": "d2",
       "name": "West (0,-2)",
@@ -466,7 +635,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6577, "ryu": 0.3423 }
+          "vote_shares": {
+            "ken": 0.6577,
+            "ryu": 0.3423
+          }
         }
       ]
     },
@@ -474,7 +646,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 1364,
       "initial_district_id": "d2",
       "name": "East (1,-2)",
@@ -484,7 +659,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.2298, "ryu": 0.7702 }
+          "vote_shares": {
+            "ken": 0.2298,
+            "ryu": 0.7702
+          }
         }
       ]
     },
@@ -492,7 +670,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 1540,
       "initial_district_id": "d3",
       "name": "East (2,-2)",
@@ -501,8 +682,11 @@
           "id": "p027-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2471, "ryu": 0.7529 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.2471,
+            "ryu": 0.7529
+          }
         }
       ]
     },
@@ -510,7 +694,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 1520,
       "initial_district_id": "d3",
       "name": "East (3,-2)",
@@ -520,7 +707,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.2465, "ryu": 0.7535 }
+          "vote_shares": {
+            "ken": 0.2465,
+            "ryu": 0.7535
+          }
         }
       ]
     },
@@ -528,7 +718,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 1498,
       "initial_district_id": "d4",
       "name": "Central (4,-2)",
@@ -538,7 +731,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4864, "ryu": 0.5136 }
+          "vote_shares": {
+            "ken": 0.4864,
+            "ryu": 0.5136
+          }
         }
       ]
     },
@@ -546,7 +742,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 1527,
       "initial_district_id": "d4",
       "name": "Central (5,-2)",
@@ -556,7 +755,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4962, "ryu": 0.5038 }
+          "vote_shares": {
+            "ken": 0.4962,
+            "ryu": 0.5038
+          }
         }
       ]
     },
@@ -564,7 +766,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 1554,
       "initial_district_id": "d1",
       "name": "West (-4,-1)",
@@ -574,7 +779,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5931, "ryu": 0.4069 }
+          "vote_shares": {
+            "ken": 0.5931,
+            "ryu": 0.4069
+          }
         }
       ]
     },
@@ -582,7 +790,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 1371,
       "initial_district_id": "d1",
       "name": "West (-3,-1)",
@@ -592,7 +803,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6110, "ryu": 0.3890 }
+          "vote_shares": {
+            "ken": 0.611,
+            "ryu": 0.389
+          }
         }
       ]
     },
@@ -600,7 +814,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 1370,
       "initial_district_id": "d1",
       "name": "West (-2,-1)",
@@ -610,7 +827,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6268, "ryu": 0.3732 }
+          "vote_shares": {
+            "ken": 0.6268,
+            "ryu": 0.3732
+          }
         }
       ]
     },
@@ -618,7 +838,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 1379,
       "initial_district_id": "d2",
       "name": "West (-1,-1)",
@@ -627,8 +850,11 @@
           "id": "p034-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6596, "ryu": 0.3404 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6596,
+            "ryu": 0.3404
+          }
         }
       ]
     },
@@ -636,7 +862,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 1371,
       "initial_district_id": "d2",
       "name": "West (0,-1)",
@@ -646,7 +875,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5999, "ryu": 0.4001 }
+          "vote_shares": {
+            "ken": 0.5999,
+            "ryu": 0.4001
+          }
         }
       ]
     },
@@ -654,7 +886,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 1575,
       "initial_district_id": "d3",
       "name": "East (1,-1)",
@@ -664,7 +899,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.2402, "ryu": 0.7598 }
+          "vote_shares": {
+            "ken": 0.2402,
+            "ryu": 0.7598
+          }
         }
       ]
     },
@@ -672,7 +910,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 1648,
       "initial_district_id": "d3",
       "name": "East (2,-1)",
@@ -681,8 +922,11 @@
           "id": "p037-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.2313, "ryu": 0.7687 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.2313,
+            "ryu": 0.7687
+          }
         }
       ]
     },
@@ -690,7 +934,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 1512,
       "initial_district_id": "d4",
       "name": "East (3,-1)",
@@ -700,7 +947,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.2696, "ryu": 0.7304 }
+          "vote_shares": {
+            "ken": 0.2696,
+            "ryu": 0.7304
+          }
         }
       ]
     },
@@ -708,7 +958,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 1641,
       "initial_district_id": "d4",
       "name": "Central (4,-1)",
@@ -718,7 +971,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5384, "ryu": 0.4616 }
+          "vote_shares": {
+            "ken": 0.5384,
+            "ryu": 0.4616
+          }
         }
       ]
     },
@@ -726,7 +982,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 1412,
       "initial_district_id": "d4",
       "name": "Central (5,-1)",
@@ -736,7 +995,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4875, "ryu": 0.5125 }
+          "vote_shares": {
+            "ken": 0.4875,
+            "ryu": 0.5125
+          }
         }
       ]
     },
@@ -744,7 +1006,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 1410,
       "initial_district_id": "d1",
       "name": "West (-5,0)",
@@ -754,7 +1019,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6486, "ryu": 0.3514 }
+          "vote_shares": {
+            "ken": 0.6486,
+            "ryu": 0.3514
+          }
         }
       ]
     },
@@ -762,7 +1030,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 1559,
       "initial_district_id": "d1",
       "name": "West (-4,0)",
@@ -772,7 +1043,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6384, "ryu": 0.3616 }
+          "vote_shares": {
+            "ken": 0.6384,
+            "ryu": 0.3616
+          }
         }
       ]
     },
@@ -780,7 +1054,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 1531,
       "initial_district_id": "d1",
       "name": "West (-3,0)",
@@ -790,7 +1067,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6156, "ryu": 0.3844 }
+          "vote_shares": {
+            "ken": 0.6156,
+            "ryu": 0.3844
+          }
         }
       ]
     },
@@ -798,7 +1078,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 1617,
       "initial_district_id": "d2",
       "name": "West (-2,0)",
@@ -808,7 +1091,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5828, "ryu": 0.4172 }
+          "vote_shares": {
+            "ken": 0.5828,
+            "ryu": 0.4172
+          }
         }
       ]
     },
@@ -816,7 +1102,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 1534,
       "initial_district_id": "d2",
       "name": "West (-1,0)",
@@ -826,7 +1115,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6087, "ryu": 0.3913 }
+          "vote_shares": {
+            "ken": 0.6087,
+            "ryu": 0.3913
+          }
         }
       ]
     },
@@ -834,7 +1126,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 1517,
       "initial_district_id": "d3",
       "name": "West (0,0)",
@@ -844,7 +1139,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6239, "ryu": 0.3761 }
+          "vote_shares": {
+            "ken": 0.6239,
+            "ryu": 0.3761
+          }
         }
       ]
     },
@@ -852,7 +1150,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 1637,
       "initial_district_id": "d3",
       "name": "East (1,0)",
@@ -861,8 +1162,11 @@
           "id": "p047-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2449, "ryu": 0.7551 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.2449,
+            "ryu": 0.7551
+          }
         }
       ]
     },
@@ -870,7 +1174,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 1358,
       "initial_district_id": "d4",
       "name": "East (2,0)",
@@ -880,7 +1187,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.2309, "ryu": 0.7691 }
+          "vote_shares": {
+            "ken": 0.2309,
+            "ryu": 0.7691
+          }
         }
       ]
     },
@@ -888,7 +1198,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 1415,
       "initial_district_id": "d4",
       "name": "East (3,0)",
@@ -898,7 +1211,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.2353, "ryu": 0.7647 }
+          "vote_shares": {
+            "ken": 0.2353,
+            "ryu": 0.7647
+          }
         }
       ]
     },
@@ -906,7 +1222,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 1389,
       "initial_district_id": "d4",
       "name": "Central (4,0)",
@@ -916,7 +1235,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5460, "ryu": 0.4540 }
+          "vote_shares": {
+            "ken": 0.546,
+            "ryu": 0.454
+          }
         }
       ]
     },
@@ -924,7 +1246,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 1536,
       "initial_district_id": "d4",
       "name": "Central (5,0)",
@@ -933,8 +1258,11 @@
           "id": "p051-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5271, "ryu": 0.4729 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.5271,
+            "ryu": 0.4729
+          }
         }
       ]
     },
@@ -942,7 +1270,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 1359,
       "initial_district_id": "d1",
       "name": "West (-5,1)",
@@ -952,7 +1283,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6219, "ryu": 0.3781 }
+          "vote_shares": {
+            "ken": 0.6219,
+            "ryu": 0.3781
+          }
         }
       ]
     },
@@ -960,7 +1294,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 1579,
       "initial_district_id": "d1",
       "name": "West (-4,1)",
@@ -970,7 +1307,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6077, "ryu": 0.3923 }
+          "vote_shares": {
+            "ken": 0.6077,
+            "ryu": 0.3923
+          }
         }
       ]
     },
@@ -978,7 +1318,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 1444,
       "initial_district_id": "d2",
       "name": "West (-3,1)",
@@ -987,8 +1330,11 @@
           "id": "p054-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6264, "ryu": 0.3736 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6264,
+            "ryu": 0.3736
+          }
         }
       ]
     },
@@ -996,7 +1342,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 1551,
       "initial_district_id": "d2",
       "name": "West (-2,1)",
@@ -1006,7 +1355,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6488, "ryu": 0.3512 }
+          "vote_shares": {
+            "ken": 0.6488,
+            "ryu": 0.3512
+          }
         }
       ]
     },
@@ -1014,7 +1366,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 1504,
       "initial_district_id": "d3",
       "name": "West (-1,1)",
@@ -1024,7 +1379,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5938, "ryu": 0.4062 }
+          "vote_shares": {
+            "ken": 0.5938,
+            "ryu": 0.4062
+          }
         }
       ]
     },
@@ -1032,7 +1390,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 1496,
       "initial_district_id": "d3",
       "name": "West (0,1)",
@@ -1042,7 +1403,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6488, "ryu": 0.3512 }
+          "vote_shares": {
+            "ken": 0.6488,
+            "ryu": 0.3512
+          }
         }
       ]
     },
@@ -1050,7 +1414,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 1415,
       "initial_district_id": "d4",
       "name": "East (1,1)",
@@ -1060,7 +1427,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.2563, "ryu": 0.7437 }
+          "vote_shares": {
+            "ken": 0.2563,
+            "ryu": 0.7437
+          }
         }
       ]
     },
@@ -1068,7 +1438,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 1362,
       "initial_district_id": "d4",
       "name": "East (2,1)",
@@ -1078,7 +1451,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.2819, "ryu": 0.7181 }
+          "vote_shares": {
+            "ken": 0.2819,
+            "ryu": 0.7181
+          }
         }
       ]
     },
@@ -1086,7 +1462,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 1467,
       "initial_district_id": "d4",
       "name": "Central (3,1)",
@@ -1096,7 +1475,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5301, "ryu": 0.4699 }
+          "vote_shares": {
+            "ken": 0.5301,
+            "ryu": 0.4699
+          }
         }
       ]
     },
@@ -1104,7 +1486,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 1523,
       "initial_district_id": "d4",
       "name": "Central (4,1)",
@@ -1114,7 +1499,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4909, "ryu": 0.5091 }
+          "vote_shares": {
+            "ken": 0.4909,
+            "ryu": 0.5091
+          }
         }
       ]
     },
@@ -1122,7 +1510,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 1619,
       "initial_district_id": "d1",
       "name": "West (-5,2)",
@@ -1131,8 +1522,11 @@
           "id": "p062-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6217, "ryu": 0.3783 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6217,
+            "ryu": 0.3783
+          }
         }
       ]
     },
@@ -1140,7 +1534,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 1396,
       "initial_district_id": "d2",
       "name": "West (-4,2)",
@@ -1150,7 +1547,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6447, "ryu": 0.3553 }
+          "vote_shares": {
+            "ken": 0.6447,
+            "ryu": 0.3553
+          }
         }
       ]
     },
@@ -1158,7 +1558,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 1556,
       "initial_district_id": "d2",
       "name": "West (-3,2)",
@@ -1168,7 +1571,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6441, "ryu": 0.3559 }
+          "vote_shares": {
+            "ken": 0.6441,
+            "ryu": 0.3559
+          }
         }
       ]
     },
@@ -1176,7 +1582,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 1467,
       "initial_district_id": "d3",
       "name": "West (-2,2)",
@@ -1186,7 +1595,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5824, "ryu": 0.4176 }
+          "vote_shares": {
+            "ken": 0.5824,
+            "ryu": 0.4176
+          }
         }
       ]
     },
@@ -1194,7 +1606,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 1581,
       "initial_district_id": "d3",
       "name": "West (-1,2)",
@@ -1204,7 +1619,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6107, "ryu": 0.3893 }
+          "vote_shares": {
+            "ken": 0.6107,
+            "ryu": 0.3893
+          }
         }
       ]
     },
@@ -1212,7 +1630,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 1530,
       "initial_district_id": "d4",
       "name": "West (0,2)",
@@ -1222,7 +1643,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6259, "ryu": 0.3741 }
+          "vote_shares": {
+            "ken": 0.6259,
+            "ryu": 0.3741
+          }
         }
       ]
     },
@@ -1230,7 +1654,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "clearwater_east",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 1412,
       "initial_district_id": "d4",
       "name": "East (1,2)",
@@ -1240,7 +1667,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.2793, "ryu": 0.7207 }
+          "vote_shares": {
+            "ken": 0.2793,
+            "ryu": 0.7207
+          }
         }
       ]
     },
@@ -1248,7 +1678,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 1555,
       "initial_district_id": "d4",
       "name": "Central (2,2)",
@@ -1258,7 +1691,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5498, "ryu": 0.4502 }
+          "vote_shares": {
+            "ken": 0.5498,
+            "ryu": 0.4502
+          }
         }
       ]
     },
@@ -1266,7 +1702,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 1559,
       "initial_district_id": "d4",
       "name": "Central (3,2)",
@@ -1276,7 +1715,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5482, "ryu": 0.4518 }
+          "vote_shares": {
+            "ken": 0.5482,
+            "ryu": 0.4518
+          }
         }
       ]
     },
@@ -1284,7 +1726,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 1403,
       "initial_district_id": "d2",
       "name": "West (-5,3)",
@@ -1294,7 +1739,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6480, "ryu": 0.3520 }
+          "vote_shares": {
+            "ken": 0.648,
+            "ryu": 0.352
+          }
         }
       ]
     },
@@ -1302,7 +1750,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 1412,
       "initial_district_id": "d2",
       "name": "West (-4,3)",
@@ -1312,7 +1763,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6025, "ryu": 0.3975 }
+          "vote_shares": {
+            "ken": 0.6025,
+            "ryu": 0.3975
+          }
         }
       ]
     },
@@ -1320,7 +1774,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 1369,
       "initial_district_id": "d3",
       "name": "West (-3,3)",
@@ -1330,7 +1787,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6023, "ryu": 0.3977 }
+          "vote_shares": {
+            "ken": 0.6023,
+            "ryu": 0.3977
+          }
         }
       ]
     },
@@ -1338,7 +1798,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 1523,
       "initial_district_id": "d3",
       "name": "West (-2,3)",
@@ -1348,7 +1811,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6395, "ryu": 0.3605 }
+          "vote_shares": {
+            "ken": 0.6395,
+            "ryu": 0.3605
+          }
         }
       ]
     },
@@ -1356,7 +1822,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 1631,
       "initial_district_id": "d4",
       "name": "West (-1,3)",
@@ -1366,7 +1835,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6426, "ryu": 0.3574 }
+          "vote_shares": {
+            "ken": 0.6426,
+            "ryu": 0.3574
+          }
         }
       ]
     },
@@ -1374,7 +1846,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 1393,
       "initial_district_id": "d4",
       "name": "West (0,3)",
@@ -1384,7 +1859,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6460, "ryu": 0.3540 }
+          "vote_shares": {
+            "ken": 0.646,
+            "ryu": 0.354
+          }
         }
       ]
     },
@@ -1392,7 +1870,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 1566,
       "initial_district_id": "d4",
       "name": "Central (1,3)",
@@ -1402,7 +1883,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5476, "ryu": 0.4524 }
+          "vote_shares": {
+            "ken": 0.5476,
+            "ryu": 0.4524
+          }
         }
       ]
     },
@@ -1410,7 +1894,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 1456,
       "initial_district_id": "d4",
       "name": "Central (2,3)",
@@ -1420,7 +1907,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4831, "ryu": 0.5169 }
+          "vote_shares": {
+            "ken": 0.4831,
+            "ryu": 0.5169
+          }
         }
       ]
     },
@@ -1428,7 +1918,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 1576,
       "initial_district_id": "d2",
       "name": "West (-5,4)",
@@ -1438,7 +1931,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6533, "ryu": 0.3467 }
+          "vote_shares": {
+            "ken": 0.6533,
+            "ryu": 0.3467
+          }
         }
       ]
     },
@@ -1446,7 +1942,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 1522,
       "initial_district_id": "d3",
       "name": "West (-4,4)",
@@ -1456,7 +1955,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6396, "ryu": 0.3604 }
+          "vote_shares": {
+            "ken": 0.6396,
+            "ryu": 0.3604
+          }
         }
       ]
     },
@@ -1464,7 +1966,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 1576,
       "initial_district_id": "d3",
       "name": "West (-3,4)",
@@ -1474,7 +1979,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5868, "ryu": 0.4132 }
+          "vote_shares": {
+            "ken": 0.5868,
+            "ryu": 0.4132
+          }
         }
       ]
     },
@@ -1482,7 +1990,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 1622,
       "initial_district_id": "d4",
       "name": "West (-2,4)",
@@ -1492,7 +2003,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6040, "ryu": 0.3960 }
+          "vote_shares": {
+            "ken": 0.604,
+            "ryu": 0.396
+          }
         }
       ]
     },
@@ -1500,7 +2014,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 1493,
       "initial_district_id": "d4",
       "name": "West (-1,4)",
@@ -1510,7 +2027,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6168, "ryu": 0.3832 }
+          "vote_shares": {
+            "ken": 0.6168,
+            "ryu": 0.3832
+          }
         }
       ]
     },
@@ -1518,7 +2038,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 1618,
       "initial_district_id": "d4",
       "name": "West (0,4)",
@@ -1528,7 +2051,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6373, "ryu": 0.3627 }
+          "vote_shares": {
+            "ken": 0.6373,
+            "ryu": 0.3627
+          }
         }
       ]
     },
@@ -1536,7 +2062,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "clearwater_central",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 1360,
       "initial_district_id": "d4",
       "name": "Central (1,4)",
@@ -1546,7 +2075,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5046, "ryu": 0.4954 }
+          "vote_shares": {
+            "ken": 0.5046,
+            "ryu": 0.4954
+          }
         }
       ]
     },
@@ -1554,7 +2086,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 1497,
       "initial_district_id": "d3",
       "name": "West (-5,5)",
@@ -1564,7 +2099,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5915, "ryu": 0.4085 }
+          "vote_shares": {
+            "ken": 0.5915,
+            "ryu": 0.4085
+          }
         }
       ]
     },
@@ -1572,7 +2110,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 1454,
       "initial_district_id": "d3",
       "name": "West (-4,5)",
@@ -1582,7 +2123,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6170, "ryu": 0.3830 }
+          "vote_shares": {
+            "ken": 0.617,
+            "ryu": 0.383
+          }
         }
       ]
     },
@@ -1590,7 +2134,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 1615,
       "initial_district_id": "d4",
       "name": "West (-3,5)",
@@ -1600,7 +2147,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6357, "ryu": 0.3643 }
+          "vote_shares": {
+            "ken": 0.6357,
+            "ryu": 0.3643
+          }
         }
       ]
     },
@@ -1608,7 +2158,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 1426,
       "initial_district_id": "d4",
       "name": "West (-2,5)",
@@ -1618,7 +2171,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6468, "ryu": 0.3532 }
+          "vote_shares": {
+            "ken": 0.6468,
+            "ryu": 0.3532
+          }
         }
       ]
     },
@@ -1626,7 +2182,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 1363,
       "initial_district_id": "d4",
       "name": "West (-1,5)",
@@ -1636,7 +2195,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6305, "ryu": 0.3695 }
+          "vote_shares": {
+            "ken": 0.6305,
+            "ryu": 0.3695
+          }
         }
       ]
     },
@@ -1644,7 +2206,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "clearwater_west",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 1563,
       "initial_district_id": "d4",
       "name": "West (0,5)",
@@ -1654,7 +2219,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6323, "ryu": 0.3677 }
+          "vote_shares": {
+            "ken": 0.6323,
+            "ryu": 0.3677
+          }
         }
       ]
     }
@@ -1669,13 +2237,17 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All four districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
       "description": "All four districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-ken-seats",
@@ -1691,11 +2263,11 @@
     {
       "id": "sc-compactness",
       "required": false,
-      "description": "All districts are reasonably compact (≥ 40%).",
+      "description": "All districts are reasonably compact (\u2265 40%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
-        "threshold": 0.40
+        "threshold": 0.4
       }
     }
   ],
@@ -1703,20 +2275,20 @@
     "character": {
       "name": "You",
       "role": "Ken Party Campaign Strategist, Clearwater County",
-      "motivation": "The governor wants a reliable majority in Clearwater County. The current map splits the vote evenly — two Ken, two Ryu. That's not good enough. You've been brought in to redraw the lines so Ken wins three of four seats."
+      "motivation": "The governor wants a reliable majority in Clearwater County. The current map splits the vote evenly \u2014 two Ken, two Ryu. That's not good enough. You've been brought in to redraw the lines so Ken wins three of four seats."
     },
     "intro_slides": [
       {
         "heading": "The Governor's Problem",
-        "body": "Clearwater County elects four representatives. Right now, the map gives each party two seats. The governor — a Ken partisan — wants three.\n\nThe population hasn't changed. The voters haven't changed. But the lines can change."
+        "body": "Clearwater County elects four representatives. Right now, the map gives each party two seats. The governor \u2014 a Ken partisan \u2014 wants three.\n\nThe population hasn't changed. The voters haven't changed. But the lines can change."
       },
       {
         "heading": "How Redistricting Works",
-        "body": "Every ten years, district boundaries are redrawn. The official reason is to reflect population changes. The real reason, often, is to change who wins.\n\nYou're looking at a map of precincts — small geographic units with known voting patterns. Your job is to group them into districts that favor the Ken Party."
+        "body": "Every ten years, district boundaries are redrawn. The official reason is to reflect population changes. The real reason, often, is to change who wins.\n\nYou're looking at a map of precincts \u2014 small geographic units with known voting patterns. Your job is to group them into districts that favor the Ken Party."
       },
       {
         "heading": "Your First Gerrymander",
-        "body": "Look at the map. The southeast corner votes heavily Ryu. The north and southwest lean Ken.\n\nIf you can contain the Ryu stronghold in one district and spread Ken voters across the other three, the governor gets the majority. The tools are simple — the consequences are not."
+        "body": "Look at the map. The southeast corner votes heavily Ryu. The north and southwest lean Ken.\n\nIf you can contain the Ryu stronghold in one district and spread Ken voters across the other three, the governor gets the majority. The tools are simple \u2014 the consequences are not."
       }
     ],
     "objective": "Redraw the map so the Ken Party wins at least 3 of 4 districts."

--- a/game/scenarios/scenario-003.json
+++ b/game/scenarios/scenario-003.json
@@ -7,17 +7,42 @@
     "id": "riverport_metro",
     "name": "Riverport Metro Area"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
-    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+    {
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
+    },
+    {
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" },
-    { "id": "d5", "name": "District 5" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    },
+    {
+      "id": "d4",
+      "name": "District 4"
+    },
+    {
+      "id": "d5",
+      "name": "District 5"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -25,7 +50,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 0, "r": -6 },
+      "position": {
+        "q": 0,
+        "r": -6
+      },
       "total_population": 1526,
       "initial_district_id": "d1",
       "name": "Rural (0,-6)",
@@ -35,7 +63,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6578, "ryu": 0.3422 }
+          "vote_shares": {
+            "ken": 0.6578,
+            "ryu": 0.3422
+          }
         }
       ]
     },
@@ -43,7 +74,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 1, "r": -6 },
+      "position": {
+        "q": 1,
+        "r": -6
+      },
       "total_population": 1370,
       "initial_district_id": "d1",
       "name": "Rural (1,-6)",
@@ -53,7 +87,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6114, "ryu": 0.3886 }
+          "vote_shares": {
+            "ken": 0.6114,
+            "ryu": 0.3886
+          }
         }
       ]
     },
@@ -61,7 +98,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 2, "r": -6 },
+      "position": {
+        "q": 2,
+        "r": -6
+      },
       "total_population": 1436,
       "initial_district_id": "d2",
       "name": "Rural (2,-6)",
@@ -71,7 +111,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6438, "ryu": 0.3562 }
+          "vote_shares": {
+            "ken": 0.6438,
+            "ryu": 0.3562
+          }
         }
       ]
     },
@@ -79,7 +122,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 3, "r": -6 },
+      "position": {
+        "q": 3,
+        "r": -6
+      },
       "total_population": 1607,
       "initial_district_id": "d2",
       "name": "Rural (3,-6)",
@@ -89,7 +135,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6493, "ryu": 0.3507 }
+          "vote_shares": {
+            "ken": 0.6493,
+            "ryu": 0.3507
+          }
         }
       ]
     },
@@ -97,7 +146,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 4, "r": -6 },
+      "position": {
+        "q": 4,
+        "r": -6
+      },
       "total_population": 1552,
       "initial_district_id": "d2",
       "name": "Rural (4,-6)",
@@ -107,7 +159,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6800, "ryu": 0.3200 }
+          "vote_shares": {
+            "ken": 0.68,
+            "ryu": 0.32
+          }
         }
       ]
     },
@@ -115,7 +170,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 5, "r": -6 },
+      "position": {
+        "q": 5,
+        "r": -6
+      },
       "total_population": 1622,
       "initial_district_id": "d2",
       "name": "Rural (5,-6)",
@@ -124,8 +182,11 @@
           "id": "p006-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.50,
-          "vote_shares": { "ken": 0.6579, "ryu": 0.3421 }
+          "turnout_rate": 0.5,
+          "vote_shares": {
+            "ken": 0.6579,
+            "ryu": 0.3421
+          }
         }
       ]
     },
@@ -133,7 +194,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 6, "r": -6 },
+      "position": {
+        "q": 6,
+        "r": -6
+      },
       "total_population": 1512,
       "initial_district_id": "d2",
       "name": "Rural (6,-6)",
@@ -143,7 +207,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6457, "ryu": 0.3543 }
+          "vote_shares": {
+            "ken": 0.6457,
+            "ryu": 0.3543
+          }
         }
       ]
     },
@@ -151,7 +218,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -1, "r": -5 },
+      "position": {
+        "q": -1,
+        "r": -5
+      },
       "total_population": 1537,
       "initial_district_id": "d1",
       "name": "Rural (-1,-5)",
@@ -161,7 +231,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6410, "ryu": 0.3590 }
+          "vote_shares": {
+            "ken": 0.641,
+            "ryu": 0.359
+          }
         }
       ]
     },
@@ -169,7 +242,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 1534,
       "initial_district_id": "d1",
       "name": "Rural (0,-5)",
@@ -179,7 +255,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6354, "ryu": 0.3646 }
+          "vote_shares": {
+            "ken": 0.6354,
+            "ryu": 0.3646
+          }
         }
       ]
     },
@@ -187,7 +266,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 1564,
       "initial_district_id": "d1",
       "name": "Rural (1,-5)",
@@ -197,7 +279,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6770, "ryu": 0.3230 }
+          "vote_shares": {
+            "ken": 0.677,
+            "ryu": 0.323
+          }
         }
       ]
     },
@@ -205,7 +290,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 1504,
       "initial_district_id": "d2",
       "name": "Rural (2,-5)",
@@ -215,7 +303,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6789, "ryu": 0.3211 }
+          "vote_shares": {
+            "ken": 0.6789,
+            "ryu": 0.3211
+          }
         }
       ]
     },
@@ -223,7 +314,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 1643,
       "initial_district_id": "d2",
       "name": "Rural (3,-5)",
@@ -233,7 +327,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6879, "ryu": 0.3121 }
+          "vote_shares": {
+            "ken": 0.6879,
+            "ryu": 0.3121
+          }
         }
       ]
     },
@@ -241,7 +338,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 1606,
       "initial_district_id": "d2",
       "name": "Rural (4,-5)",
@@ -251,7 +351,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6402, "ryu": 0.3598 }
+          "vote_shares": {
+            "ken": 0.6402,
+            "ryu": 0.3598
+          }
         }
       ]
     },
@@ -259,7 +362,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 1421,
       "initial_district_id": "d2",
       "name": "Rural (5,-5)",
@@ -269,7 +375,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6239, "ryu": 0.3761 }
+          "vote_shares": {
+            "ken": 0.6239,
+            "ryu": 0.3761
+          }
         }
       ]
     },
@@ -277,7 +386,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 6, "r": -5 },
+      "position": {
+        "q": 6,
+        "r": -5
+      },
       "total_population": 1607,
       "initial_district_id": "d2",
       "name": "Rural (6,-5)",
@@ -287,7 +399,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6265, "ryu": 0.3735 }
+          "vote_shares": {
+            "ken": 0.6265,
+            "ryu": 0.3735
+          }
         }
       ]
     },
@@ -295,7 +410,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -2, "r": -4 },
+      "position": {
+        "q": -2,
+        "r": -4
+      },
       "total_population": 1456,
       "initial_district_id": "d1",
       "name": "Rural (-2,-4)",
@@ -305,7 +423,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6604, "ryu": 0.3396 }
+          "vote_shares": {
+            "ken": 0.6604,
+            "ryu": 0.3396
+          }
         }
       ]
     },
@@ -313,7 +434,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 1609,
       "initial_district_id": "d1",
       "name": "Rural (-1,-4)",
@@ -323,7 +447,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6329, "ryu": 0.3671 }
+          "vote_shares": {
+            "ken": 0.6329,
+            "ryu": 0.3671
+          }
         }
       ]
     },
@@ -331,7 +458,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 1400,
       "initial_district_id": "d1",
       "name": "Suburbs (0,-4)",
@@ -341,7 +471,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3992, "ryu": 0.6008 }
+          "vote_shares": {
+            "ken": 0.3992,
+            "ryu": 0.6008
+          }
         }
       ]
     },
@@ -349,7 +482,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 1477,
       "initial_district_id": "d2",
       "name": "Suburbs (1,-4)",
@@ -359,7 +495,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.3977, "ryu": 0.6023 }
+          "vote_shares": {
+            "ken": 0.3977,
+            "ryu": 0.6023
+          }
         }
       ]
     },
@@ -367,7 +506,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 1450,
       "initial_district_id": "d2",
       "name": "Suburbs (2,-4)",
@@ -377,7 +519,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4207, "ryu": 0.5793 }
+          "vote_shares": {
+            "ken": 0.4207,
+            "ryu": 0.5793
+          }
         }
       ]
     },
@@ -385,7 +530,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 1419,
       "initial_district_id": "d2",
       "name": "Suburbs (3,-4)",
@@ -394,8 +542,11 @@
           "id": "p021-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4326, "ryu": 0.5674 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4326,
+            "ryu": 0.5674
+          }
         }
       ]
     },
@@ -403,7 +554,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 1474,
       "initial_district_id": "d2",
       "name": "Suburbs (4,-4)",
@@ -413,7 +567,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.4187, "ryu": 0.5813 }
+          "vote_shares": {
+            "ken": 0.4187,
+            "ryu": 0.5813
+          }
         }
       ]
     },
@@ -421,7 +578,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 1353,
       "initial_district_id": "d2",
       "name": "Rural (5,-4)",
@@ -431,7 +591,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6401, "ryu": 0.3599 }
+          "vote_shares": {
+            "ken": 0.6401,
+            "ryu": 0.3599
+          }
         }
       ]
     },
@@ -439,7 +602,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 6, "r": -4 },
+      "position": {
+        "q": 6,
+        "r": -4
+      },
       "total_population": 1446,
       "initial_district_id": "d2",
       "name": "Rural (6,-4)",
@@ -449,7 +615,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6473, "ryu": 0.3527 }
+          "vote_shares": {
+            "ken": 0.6473,
+            "ryu": 0.3527
+          }
         }
       ]
     },
@@ -457,7 +626,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -3, "r": -3 },
+      "position": {
+        "q": -3,
+        "r": -3
+      },
       "total_population": 1509,
       "initial_district_id": "d1",
       "name": "Rural (-3,-3)",
@@ -467,7 +639,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6802, "ryu": 0.3198 }
+          "vote_shares": {
+            "ken": 0.6802,
+            "ryu": 0.3198
+          }
         }
       ]
     },
@@ -475,7 +650,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 1574,
       "initial_district_id": "d1",
       "name": "Rural (-2,-3)",
@@ -485,7 +663,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6729, "ryu": 0.3271 }
+          "vote_shares": {
+            "ken": 0.6729,
+            "ryu": 0.3271
+          }
         }
       ]
     },
@@ -493,7 +674,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 1632,
       "initial_district_id": "d1",
       "name": "Suburbs (-1,-3)",
@@ -503,7 +687,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4382, "ryu": 0.5618 }
+          "vote_shares": {
+            "ken": 0.4382,
+            "ryu": 0.5618
+          }
         }
       ]
     },
@@ -511,7 +698,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 1649,
       "initial_district_id": "d1",
       "name": "Suburbs (0,-3)",
@@ -521,7 +711,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4442, "ryu": 0.5558 }
+          "vote_shares": {
+            "ken": 0.4442,
+            "ryu": 0.5558
+          }
         }
       ]
     },
@@ -529,7 +722,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 1641,
       "initial_district_id": "d2",
       "name": "Suburbs (1,-3)",
@@ -539,7 +735,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.4498, "ryu": 0.5502 }
+          "vote_shares": {
+            "ken": 0.4498,
+            "ryu": 0.5502
+          }
         }
       ]
     },
@@ -547,7 +746,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 1548,
       "initial_district_id": "d2",
       "name": "Suburbs (2,-3)",
@@ -557,7 +759,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.3977, "ryu": 0.6023 }
+          "vote_shares": {
+            "ken": 0.3977,
+            "ryu": 0.6023
+          }
         }
       ]
     },
@@ -565,7 +770,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 1581,
       "initial_district_id": "d2",
       "name": "Suburbs (3,-3)",
@@ -575,7 +783,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.3840, "ryu": 0.6160 }
+          "vote_shares": {
+            "ken": 0.384,
+            "ryu": 0.616
+          }
         }
       ]
     },
@@ -583,7 +794,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 1520,
       "initial_district_id": "d2",
       "name": "Suburbs (4,-3)",
@@ -593,7 +807,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4171, "ryu": 0.5829 }
+          "vote_shares": {
+            "ken": 0.4171,
+            "ryu": 0.5829
+          }
         }
       ]
     },
@@ -601,7 +818,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 1572,
       "initial_district_id": "d2",
       "name": "Rural (5,-3)",
@@ -611,7 +831,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6820, "ryu": 0.3180 }
+          "vote_shares": {
+            "ken": 0.682,
+            "ryu": 0.318
+          }
         }
       ]
     },
@@ -619,7 +842,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 6, "r": -3 },
+      "position": {
+        "q": 6,
+        "r": -3
+      },
       "total_population": 1516,
       "initial_district_id": "d3",
       "name": "Rural (6,-3)",
@@ -629,7 +855,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6321, "ryu": 0.3679 }
+          "vote_shares": {
+            "ken": 0.6321,
+            "ryu": 0.3679
+          }
         }
       ]
     },
@@ -637,7 +866,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -4, "r": -2 },
+      "position": {
+        "q": -4,
+        "r": -2
+      },
       "total_population": 1414,
       "initial_district_id": "d1",
       "name": "Rural (-4,-2)",
@@ -647,7 +879,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6874, "ryu": 0.3126 }
+          "vote_shares": {
+            "ken": 0.6874,
+            "ryu": 0.3126
+          }
         }
       ]
     },
@@ -655,7 +890,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 1572,
       "initial_district_id": "d1",
       "name": "Rural (-3,-2)",
@@ -665,7 +903,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6648, "ryu": 0.3352 }
+          "vote_shares": {
+            "ken": 0.6648,
+            "ryu": 0.3352
+          }
         }
       ]
     },
@@ -673,7 +914,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 1554,
       "initial_district_id": "d1",
       "name": "Suburbs (-2,-2)",
@@ -683,7 +927,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.3894, "ryu": 0.6106 }
+          "vote_shares": {
+            "ken": 0.3894,
+            "ryu": 0.6106
+          }
         }
       ]
     },
@@ -691,7 +938,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 1565,
       "initial_district_id": "d1",
       "name": "Suburbs (-1,-2)",
@@ -701,7 +951,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.4148, "ryu": 0.5852 }
+          "vote_shares": {
+            "ken": 0.4148,
+            "ryu": 0.5852
+          }
         }
       ]
     },
@@ -709,7 +962,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 1560,
       "initial_district_id": "d1",
       "name": "Downtown (0,-2)",
@@ -719,7 +975,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.73,
-          "vote_shares": { "ken": 0.1815, "ryu": 0.8185 }
+          "vote_shares": {
+            "ken": 0.1815,
+            "ryu": 0.8185
+          }
         }
       ]
     },
@@ -727,7 +986,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 1570,
       "initial_district_id": "d2",
       "name": "Downtown (1,-2)",
@@ -737,7 +999,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.1152, "ryu": 0.8848 }
+          "vote_shares": {
+            "ken": 0.1152,
+            "ryu": 0.8848
+          }
         }
       ]
     },
@@ -745,7 +1010,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 1572,
       "initial_district_id": "d2",
       "name": "Downtown (2,-2)",
@@ -755,7 +1023,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.72,
-          "vote_shares": { "ken": 0.1277, "ryu": 0.8723 }
+          "vote_shares": {
+            "ken": 0.1277,
+            "ryu": 0.8723
+          }
         }
       ]
     },
@@ -763,7 +1034,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 1354,
       "initial_district_id": "d2",
       "name": "Suburbs (3,-2)",
@@ -772,8 +1046,11 @@
           "id": "p042-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.50,
-          "vote_shares": { "ken": 0.4146, "ryu": 0.5854 }
+          "turnout_rate": 0.5,
+          "vote_shares": {
+            "ken": 0.4146,
+            "ryu": 0.5854
+          }
         }
       ]
     },
@@ -781,7 +1058,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 1650,
       "initial_district_id": "d3",
       "name": "Suburbs (4,-2)",
@@ -791,7 +1071,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4067, "ryu": 0.5933 }
+          "vote_shares": {
+            "ken": 0.4067,
+            "ryu": 0.5933
+          }
         }
       ]
     },
@@ -799,7 +1082,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 1624,
       "initial_district_id": "d3",
       "name": "Rural (5,-2)",
@@ -809,7 +1095,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6167, "ryu": 0.3833 }
+          "vote_shares": {
+            "ken": 0.6167,
+            "ryu": 0.3833
+          }
         }
       ]
     },
@@ -817,7 +1106,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 6, "r": -2 },
+      "position": {
+        "q": 6,
+        "r": -2
+      },
       "total_population": 1410,
       "initial_district_id": "d3",
       "name": "Rural (6,-2)",
@@ -827,7 +1119,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6667, "ryu": 0.3333 }
+          "vote_shares": {
+            "ken": 0.6667,
+            "ryu": 0.3333
+          }
         }
       ]
     },
@@ -835,7 +1130,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -5, "r": -1 },
+      "position": {
+        "q": -5,
+        "r": -1
+      },
       "total_population": 1528,
       "initial_district_id": "d1",
       "name": "Rural (-5,-1)",
@@ -845,7 +1143,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6105, "ryu": 0.3895 }
+          "vote_shares": {
+            "ken": 0.6105,
+            "ryu": 0.3895
+          }
         }
       ]
     },
@@ -853,7 +1154,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 1601,
       "initial_district_id": "d1",
       "name": "Rural (-4,-1)",
@@ -863,7 +1167,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6182, "ryu": 0.3818 }
+          "vote_shares": {
+            "ken": 0.6182,
+            "ryu": 0.3818
+          }
         }
       ]
     },
@@ -871,7 +1178,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 1520,
       "initial_district_id": "d1",
       "name": "Suburbs (-3,-1)",
@@ -881,7 +1191,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.4169, "ryu": 0.5831 }
+          "vote_shares": {
+            "ken": 0.4169,
+            "ryu": 0.5831
+          }
         }
       ]
     },
@@ -889,7 +1202,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 1560,
       "initial_district_id": "d1",
       "name": "Suburbs (-2,-1)",
@@ -899,7 +1215,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.4496, "ryu": 0.5504 }
+          "vote_shares": {
+            "ken": 0.4496,
+            "ryu": 0.5504
+          }
         }
       ]
     },
@@ -907,7 +1226,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 1381,
       "initial_district_id": "d1",
       "name": "Downtown (-1,-1)",
@@ -917,7 +1239,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.1796, "ryu": 0.8204 }
+          "vote_shares": {
+            "ken": 0.1796,
+            "ryu": 0.8204
+          }
         }
       ]
     },
@@ -925,7 +1250,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 1569,
       "initial_district_id": "d1",
       "name": "Downtown (0,-1)",
@@ -935,7 +1263,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.1885, "ryu": 0.8115 }
+          "vote_shares": {
+            "ken": 0.1885,
+            "ryu": 0.8115
+          }
         }
       ]
     },
@@ -943,7 +1274,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 1597,
       "initial_district_id": "d2",
       "name": "Downtown (1,-1)",
@@ -953,7 +1287,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.1399, "ryu": 0.8601 }
+          "vote_shares": {
+            "ken": 0.1399,
+            "ryu": 0.8601
+          }
         }
       ]
     },
@@ -961,7 +1298,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 1382,
       "initial_district_id": "d3",
       "name": "Downtown (2,-1)",
@@ -971,7 +1311,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.74,
-          "vote_shares": { "ken": 0.1383, "ryu": 0.8617 }
+          "vote_shares": {
+            "ken": 0.1383,
+            "ryu": 0.8617
+          }
         }
       ]
     },
@@ -979,7 +1322,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 1474,
       "initial_district_id": "d3",
       "name": "Suburbs (3,-1)",
@@ -989,7 +1335,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.4005, "ryu": 0.5995 }
+          "vote_shares": {
+            "ken": 0.4005,
+            "ryu": 0.5995
+          }
         }
       ]
     },
@@ -997,7 +1346,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 1525,
       "initial_district_id": "d3",
       "name": "Suburbs (4,-1)",
@@ -1007,7 +1359,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.3968, "ryu": 0.6032 }
+          "vote_shares": {
+            "ken": 0.3968,
+            "ryu": 0.6032
+          }
         }
       ]
     },
@@ -1015,7 +1370,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 1513,
       "initial_district_id": "d3",
       "name": "Rural (5,-1)",
@@ -1025,7 +1383,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6471, "ryu": 0.3529 }
+          "vote_shares": {
+            "ken": 0.6471,
+            "ryu": 0.3529
+          }
         }
       ]
     },
@@ -1033,7 +1394,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 6, "r": -1 },
+      "position": {
+        "q": 6,
+        "r": -1
+      },
       "total_population": 1603,
       "initial_district_id": "d3",
       "name": "Rural (6,-1)",
@@ -1042,8 +1406,11 @@
           "id": "p057-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6332, "ryu": 0.3668 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6332,
+            "ryu": 0.3668
+          }
         }
       ]
     },
@@ -1051,7 +1418,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -6, "r": 0 },
+      "position": {
+        "q": -6,
+        "r": 0
+      },
       "total_population": 1505,
       "initial_district_id": "d5",
       "name": "Rural (-6,0)",
@@ -1061,7 +1431,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6828, "ryu": 0.3172 }
+          "vote_shares": {
+            "ken": 0.6828,
+            "ryu": 0.3172
+          }
         }
       ]
     },
@@ -1069,7 +1442,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 1401,
       "initial_district_id": "d5",
       "name": "Rural (-5,0)",
@@ -1079,7 +1455,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6726, "ryu": 0.3274 }
+          "vote_shares": {
+            "ken": 0.6726,
+            "ryu": 0.3274
+          }
         }
       ]
     },
@@ -1087,7 +1466,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 1368,
       "initial_district_id": "d5",
       "name": "Suburbs (-4,0)",
@@ -1097,7 +1479,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.4536, "ryu": 0.5464 }
+          "vote_shares": {
+            "ken": 0.4536,
+            "ryu": 0.5464
+          }
         }
       ]
     },
@@ -1105,7 +1490,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 1436,
       "initial_district_id": "d5",
       "name": "Suburbs (-3,0)",
@@ -1115,7 +1503,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4220, "ryu": 0.5780 }
+          "vote_shares": {
+            "ken": 0.422,
+            "ryu": 0.578
+          }
         }
       ]
     },
@@ -1123,7 +1514,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 1497,
       "initial_district_id": "d5",
       "name": "Downtown (-2,0)",
@@ -1133,7 +1527,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.75,
-          "vote_shares": { "ken": 0.1333, "ryu": 0.8667 }
+          "vote_shares": {
+            "ken": 0.1333,
+            "ryu": 0.8667
+          }
         }
       ]
     },
@@ -1141,7 +1538,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 1489,
       "initial_district_id": "d5",
       "name": "Downtown (-1,0)",
@@ -1151,7 +1551,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.73,
-          "vote_shares": { "ken": 0.1730, "ryu": 0.8270 }
+          "vote_shares": {
+            "ken": 0.173,
+            "ryu": 0.827
+          }
         }
       ]
     },
@@ -1159,7 +1562,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 1551,
       "initial_district_id": "d3",
       "name": "Downtown (0,0)",
@@ -1169,7 +1575,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.1249, "ryu": 0.8751 }
+          "vote_shares": {
+            "ken": 0.1249,
+            "ryu": 0.8751
+          }
         }
       ]
     },
@@ -1177,7 +1586,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 1428,
       "initial_district_id": "d3",
       "name": "Downtown (1,0)",
@@ -1187,7 +1599,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.1535, "ryu": 0.8465 }
+          "vote_shares": {
+            "ken": 0.1535,
+            "ryu": 0.8465
+          }
         }
       ]
     },
@@ -1195,7 +1610,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 1424,
       "initial_district_id": "d3",
       "name": "Downtown (2,0)",
@@ -1204,8 +1622,11 @@
           "id": "p066-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.1551, "ryu": 0.8449 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.1551,
+            "ryu": 0.8449
+          }
         }
       ]
     },
@@ -1213,7 +1634,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 1409,
       "initial_district_id": "d3",
       "name": "Suburbs (3,0)",
@@ -1223,7 +1647,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.3881, "ryu": 0.6119 }
+          "vote_shares": {
+            "ken": 0.3881,
+            "ryu": 0.6119
+          }
         }
       ]
     },
@@ -1231,7 +1658,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 1369,
       "initial_district_id": "d3",
       "name": "Suburbs (4,0)",
@@ -1241,7 +1671,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.3938, "ryu": 0.6062 }
+          "vote_shares": {
+            "ken": 0.3938,
+            "ryu": 0.6062
+          }
         }
       ]
     },
@@ -1249,7 +1682,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 1485,
       "initial_district_id": "d3",
       "name": "Rural (5,0)",
@@ -1259,7 +1695,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6307, "ryu": 0.3693 }
+          "vote_shares": {
+            "ken": 0.6307,
+            "ryu": 0.3693
+          }
         }
       ]
     },
@@ -1267,7 +1706,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 6, "r": 0 },
+      "position": {
+        "q": 6,
+        "r": 0
+      },
       "total_population": 1546,
       "initial_district_id": "d3",
       "name": "Rural (6,0)",
@@ -1277,7 +1719,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6138, "ryu": 0.3862 }
+          "vote_shares": {
+            "ken": 0.6138,
+            "ryu": 0.3862
+          }
         }
       ]
     },
@@ -1285,7 +1730,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -6, "r": 1 },
+      "position": {
+        "q": -6,
+        "r": 1
+      },
       "total_population": 1637,
       "initial_district_id": "d5",
       "name": "Rural (-6,1)",
@@ -1294,8 +1742,11 @@
           "id": "p071-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6865, "ryu": 0.3135 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6865,
+            "ryu": 0.3135
+          }
         }
       ]
     },
@@ -1303,7 +1754,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 1548,
       "initial_district_id": "d5",
       "name": "Rural (-5,1)",
@@ -1313,7 +1767,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6452, "ryu": 0.3548 }
+          "vote_shares": {
+            "ken": 0.6452,
+            "ryu": 0.3548
+          }
         }
       ]
     },
@@ -1321,7 +1778,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 1635,
       "initial_district_id": "d5",
       "name": "Suburbs (-4,1)",
@@ -1331,7 +1791,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.4199, "ryu": 0.5801 }
+          "vote_shares": {
+            "ken": 0.4199,
+            "ryu": 0.5801
+          }
         }
       ]
     },
@@ -1339,7 +1802,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 1509,
       "initial_district_id": "d5",
       "name": "Suburbs (-3,1)",
@@ -1349,7 +1815,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.3823, "ryu": 0.6177 }
+          "vote_shares": {
+            "ken": 0.3823,
+            "ryu": 0.6177
+          }
         }
       ]
     },
@@ -1357,7 +1826,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 1362,
       "initial_district_id": "d5",
       "name": "Downtown (-2,1)",
@@ -1367,7 +1839,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.74,
-          "vote_shares": { "ken": 0.1624, "ryu": 0.8376 }
+          "vote_shares": {
+            "ken": 0.1624,
+            "ryu": 0.8376
+          }
         }
       ]
     },
@@ -1375,7 +1850,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 1383,
       "initial_district_id": "d5",
       "name": "Downtown (-1,1)",
@@ -1385,7 +1863,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.1147, "ryu": 0.8853 }
+          "vote_shares": {
+            "ken": 0.1147,
+            "ryu": 0.8853
+          }
         }
       ]
     },
@@ -1393,7 +1874,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 1452,
       "initial_district_id": "d4",
       "name": "Downtown (0,1)",
@@ -1403,7 +1887,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.74,
-          "vote_shares": { "ken": 0.1830, "ryu": 0.8170 }
+          "vote_shares": {
+            "ken": 0.183,
+            "ryu": 0.817
+          }
         }
       ]
     },
@@ -1411,7 +1898,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 1404,
       "initial_district_id": "d3",
       "name": "Downtown (1,1)",
@@ -1420,8 +1910,11 @@
           "id": "p078-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.1418, "ryu": 0.8582 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.1418,
+            "ryu": 0.8582
+          }
         }
       ]
     },
@@ -1429,7 +1922,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 1405,
       "initial_district_id": "d3",
       "name": "Suburbs (2,1)",
@@ -1439,7 +1935,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.4203, "ryu": 0.5797 }
+          "vote_shares": {
+            "ken": 0.4203,
+            "ryu": 0.5797
+          }
         }
       ]
     },
@@ -1447,7 +1946,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 1597,
       "initial_district_id": "d3",
       "name": "Suburbs (3,1)",
@@ -1456,8 +1958,11 @@
           "id": "p080-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4054, "ryu": 0.5946 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4054,
+            "ryu": 0.5946
+          }
         }
       ]
     },
@@ -1465,7 +1970,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 1355,
       "initial_district_id": "d3",
       "name": "Rural (4,1)",
@@ -1475,7 +1983,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6631, "ryu": 0.3369 }
+          "vote_shares": {
+            "ken": 0.6631,
+            "ryu": 0.3369
+          }
         }
       ]
     },
@@ -1483,7 +1994,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 5, "r": 1 },
+      "position": {
+        "q": 5,
+        "r": 1
+      },
       "total_population": 1428,
       "initial_district_id": "d3",
       "name": "Rural (5,1)",
@@ -1493,7 +2007,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6204, "ryu": 0.3796 }
+          "vote_shares": {
+            "ken": 0.6204,
+            "ryu": 0.3796
+          }
         }
       ]
     },
@@ -1501,7 +2018,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -6, "r": 2 },
+      "position": {
+        "q": -6,
+        "r": 2
+      },
       "total_population": 1585,
       "initial_district_id": "d5",
       "name": "Rural (-6,2)",
@@ -1511,7 +2031,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6509, "ryu": 0.3491 }
+          "vote_shares": {
+            "ken": 0.6509,
+            "ryu": 0.3491
+          }
         }
       ]
     },
@@ -1519,7 +2042,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 1399,
       "initial_district_id": "d5",
       "name": "Rural (-5,2)",
@@ -1529,7 +2055,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6660, "ryu": 0.3340 }
+          "vote_shares": {
+            "ken": 0.666,
+            "ryu": 0.334
+          }
         }
       ]
     },
@@ -1537,7 +2066,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 1377,
       "initial_district_id": "d5",
       "name": "Suburbs (-4,2)",
@@ -1547,7 +2079,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4164, "ryu": 0.5836 }
+          "vote_shares": {
+            "ken": 0.4164,
+            "ryu": 0.5836
+          }
         }
       ]
     },
@@ -1555,7 +2090,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 1416,
       "initial_district_id": "d5",
       "name": "Suburbs (-3,2)",
@@ -1565,7 +2103,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.3939, "ryu": 0.6061 }
+          "vote_shares": {
+            "ken": 0.3939,
+            "ryu": 0.6061
+          }
         }
       ]
     },
@@ -1573,7 +2114,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 1443,
       "initial_district_id": "d5",
       "name": "Downtown (-2,2)",
@@ -1583,7 +2127,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.1596, "ryu": 0.8404 }
+          "vote_shares": {
+            "ken": 0.1596,
+            "ryu": 0.8404
+          }
         }
       ]
     },
@@ -1591,7 +2138,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 1393,
       "initial_district_id": "d4",
       "name": "Downtown (-1,2)",
@@ -1601,7 +2151,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.1267, "ryu": 0.8733 }
+          "vote_shares": {
+            "ken": 0.1267,
+            "ryu": 0.8733
+          }
         }
       ]
     },
@@ -1609,7 +2162,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "riverport_city",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 1609,
       "initial_district_id": "d4",
       "name": "Downtown (0,2)",
@@ -1618,8 +2174,11 @@
           "id": "p089-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.1464, "ryu": 0.8536 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.1464,
+            "ryu": 0.8536
+          }
         }
       ]
     },
@@ -1627,7 +2186,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 1444,
       "initial_district_id": "d4",
       "name": "Suburbs (1,2)",
@@ -1637,7 +2199,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.4182, "ryu": 0.5818 }
+          "vote_shares": {
+            "ken": 0.4182,
+            "ryu": 0.5818
+          }
         }
       ]
     },
@@ -1645,7 +2210,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 1418,
       "initial_district_id": "d3",
       "name": "Suburbs (2,2)",
@@ -1655,7 +2223,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.3833, "ryu": 0.6167 }
+          "vote_shares": {
+            "ken": 0.3833,
+            "ryu": 0.6167
+          }
         }
       ]
     },
@@ -1663,7 +2234,10 @@
       "id": "p092",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 1392,
       "initial_district_id": "d3",
       "name": "Rural (3,2)",
@@ -1673,7 +2247,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6207, "ryu": 0.3793 }
+          "vote_shares": {
+            "ken": 0.6207,
+            "ryu": 0.3793
+          }
         }
       ]
     },
@@ -1681,7 +2258,10 @@
       "id": "p093",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 4, "r": 2 },
+      "position": {
+        "q": 4,
+        "r": 2
+      },
       "total_population": 1488,
       "initial_district_id": "d3",
       "name": "Rural (4,2)",
@@ -1691,7 +2271,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6255, "ryu": 0.3745 }
+          "vote_shares": {
+            "ken": 0.6255,
+            "ryu": 0.3745
+          }
         }
       ]
     },
@@ -1699,7 +2282,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -6, "r": 3 },
+      "position": {
+        "q": -6,
+        "r": 3
+      },
       "total_population": 1374,
       "initial_district_id": "d5",
       "name": "Rural (-6,3)",
@@ -1709,7 +2295,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.6717, "ryu": 0.3283 }
+          "vote_shares": {
+            "ken": 0.6717,
+            "ryu": 0.3283
+          }
         }
       ]
     },
@@ -1717,7 +2306,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 1367,
       "initial_district_id": "d5",
       "name": "Rural (-5,3)",
@@ -1727,7 +2319,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6893, "ryu": 0.3107 }
+          "vote_shares": {
+            "ken": 0.6893,
+            "ryu": 0.3107
+          }
         }
       ]
     },
@@ -1735,7 +2330,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 1453,
       "initial_district_id": "d5",
       "name": "Suburbs (-4,3)",
@@ -1745,7 +2343,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4315, "ryu": 0.5685 }
+          "vote_shares": {
+            "ken": 0.4315,
+            "ryu": 0.5685
+          }
         }
       ]
     },
@@ -1753,7 +2354,10 @@
       "id": "p097",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 1525,
       "initial_district_id": "d5",
       "name": "Suburbs (-3,3)",
@@ -1763,7 +2367,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.4404, "ryu": 0.5596 }
+          "vote_shares": {
+            "ken": 0.4404,
+            "ryu": 0.5596
+          }
         }
       ]
     },
@@ -1771,7 +2378,10 @@
       "id": "p098",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 1514,
       "initial_district_id": "d4",
       "name": "Suburbs (-2,3)",
@@ -1781,7 +2391,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3818, "ryu": 0.6182 }
+          "vote_shares": {
+            "ken": 0.3818,
+            "ryu": 0.6182
+          }
         }
       ]
     },
@@ -1789,7 +2402,10 @@
       "id": "p099",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 1616,
       "initial_district_id": "d4",
       "name": "Suburbs (-1,3)",
@@ -1799,7 +2415,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4409, "ryu": 0.5591 }
+          "vote_shares": {
+            "ken": 0.4409,
+            "ryu": 0.5591
+          }
         }
       ]
     },
@@ -1807,7 +2426,10 @@
       "id": "p100",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 1490,
       "initial_district_id": "d4",
       "name": "Suburbs (0,3)",
@@ -1817,7 +2439,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.3850, "ryu": 0.6150 }
+          "vote_shares": {
+            "ken": 0.385,
+            "ryu": 0.615
+          }
         }
       ]
     },
@@ -1825,7 +2450,10 @@
       "id": "p101",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 1405,
       "initial_district_id": "d4",
       "name": "Suburbs (1,3)",
@@ -1835,7 +2463,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4034, "ryu": 0.5966 }
+          "vote_shares": {
+            "ken": 0.4034,
+            "ryu": 0.5966
+          }
         }
       ]
     },
@@ -1843,7 +2474,10 @@
       "id": "p102",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 1375,
       "initial_district_id": "d4",
       "name": "Rural (2,3)",
@@ -1853,7 +2487,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6121, "ryu": 0.3879 }
+          "vote_shares": {
+            "ken": 0.6121,
+            "ryu": 0.3879
+          }
         }
       ]
     },
@@ -1861,7 +2498,10 @@
       "id": "p103",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 3, "r": 3 },
+      "position": {
+        "q": 3,
+        "r": 3
+      },
       "total_population": 1599,
       "initial_district_id": "d3",
       "name": "Rural (3,3)",
@@ -1871,7 +2511,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6549, "ryu": 0.3451 }
+          "vote_shares": {
+            "ken": 0.6549,
+            "ryu": 0.3451
+          }
         }
       ]
     },
@@ -1879,7 +2522,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -6, "r": 4 },
+      "position": {
+        "q": -6,
+        "r": 4
+      },
       "total_population": 1439,
       "initial_district_id": "d5",
       "name": "Rural (-6,4)",
@@ -1888,8 +2534,11 @@
           "id": "p104-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.50,
-          "vote_shares": { "ken": 0.6132, "ryu": 0.3868 }
+          "turnout_rate": 0.5,
+          "vote_shares": {
+            "ken": 0.6132,
+            "ryu": 0.3868
+          }
         }
       ]
     },
@@ -1897,7 +2546,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 1557,
       "initial_district_id": "d5",
       "name": "Rural (-5,4)",
@@ -1907,7 +2559,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6346, "ryu": 0.3654 }
+          "vote_shares": {
+            "ken": 0.6346,
+            "ryu": 0.3654
+          }
         }
       ]
     },
@@ -1915,7 +2570,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 1459,
       "initial_district_id": "d5",
       "name": "Suburbs (-4,4)",
@@ -1925,7 +2583,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4114, "ryu": 0.5886 }
+          "vote_shares": {
+            "ken": 0.4114,
+            "ryu": 0.5886
+          }
         }
       ]
     },
@@ -1933,7 +2594,10 @@
       "id": "p107",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 1358,
       "initial_district_id": "d4",
       "name": "Suburbs (-3,4)",
@@ -1942,8 +2606,11 @@
           "id": "p107-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4391, "ryu": 0.5609 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4391,
+            "ryu": 0.5609
+          }
         }
       ]
     },
@@ -1951,7 +2618,10 @@
       "id": "p108",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 1504,
       "initial_district_id": "d4",
       "name": "Suburbs (-2,4)",
@@ -1961,7 +2631,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.4292, "ryu": 0.5708 }
+          "vote_shares": {
+            "ken": 0.4292,
+            "ryu": 0.5708
+          }
         }
       ]
     },
@@ -1969,7 +2642,10 @@
       "id": "p109",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 1647,
       "initial_district_id": "d4",
       "name": "Suburbs (-1,4)",
@@ -1979,7 +2655,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4112, "ryu": 0.5888 }
+          "vote_shares": {
+            "ken": 0.4112,
+            "ryu": 0.5888
+          }
         }
       ]
     },
@@ -1987,7 +2666,10 @@
       "id": "p110",
       "editable": true,
       "county_id": "riverport_suburbs",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 1485,
       "initial_district_id": "d4",
       "name": "Suburbs (0,4)",
@@ -1997,7 +2679,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.3862, "ryu": 0.6138 }
+          "vote_shares": {
+            "ken": 0.3862,
+            "ryu": 0.6138
+          }
         }
       ]
     },
@@ -2005,7 +2690,10 @@
       "id": "p111",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 1622,
       "initial_district_id": "d4",
       "name": "Rural (1,4)",
@@ -2015,7 +2703,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6810, "ryu": 0.3190 }
+          "vote_shares": {
+            "ken": 0.681,
+            "ryu": 0.319
+          }
         }
       ]
     },
@@ -2023,7 +2714,10 @@
       "id": "p112",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 2, "r": 4 },
+      "position": {
+        "q": 2,
+        "r": 4
+      },
       "total_population": 1648,
       "initial_district_id": "d4",
       "name": "Rural (2,4)",
@@ -2033,7 +2727,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6368, "ryu": 0.3632 }
+          "vote_shares": {
+            "ken": 0.6368,
+            "ryu": 0.3632
+          }
         }
       ]
     },
@@ -2041,7 +2738,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -6, "r": 5 },
+      "position": {
+        "q": -6,
+        "r": 5
+      },
       "total_population": 1488,
       "initial_district_id": "d5",
       "name": "Rural (-6,5)",
@@ -2051,7 +2751,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.6753, "ryu": 0.3247 }
+          "vote_shares": {
+            "ken": 0.6753,
+            "ryu": 0.3247
+          }
         }
       ]
     },
@@ -2059,7 +2762,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 1427,
       "initial_district_id": "d5",
       "name": "Rural (-5,5)",
@@ -2069,7 +2775,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6112, "ryu": 0.3888 }
+          "vote_shares": {
+            "ken": 0.6112,
+            "ryu": 0.3888
+          }
         }
       ]
     },
@@ -2077,7 +2786,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 1491,
       "initial_district_id": "d5",
       "name": "Rural (-4,5)",
@@ -2087,7 +2799,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6142, "ryu": 0.3858 }
+          "vote_shares": {
+            "ken": 0.6142,
+            "ryu": 0.3858
+          }
         }
       ]
     },
@@ -2095,7 +2810,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 1387,
       "initial_district_id": "d4",
       "name": "Rural (-3,5)",
@@ -2105,7 +2823,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6679, "ryu": 0.3321 }
+          "vote_shares": {
+            "ken": 0.6679,
+            "ryu": 0.3321
+          }
         }
       ]
     },
@@ -2113,7 +2834,10 @@
       "id": "p117",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 1619,
       "initial_district_id": "d4",
       "name": "Rural (-2,5)",
@@ -2123,7 +2847,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6297, "ryu": 0.3703 }
+          "vote_shares": {
+            "ken": 0.6297,
+            "ryu": 0.3703
+          }
         }
       ]
     },
@@ -2131,7 +2858,10 @@
       "id": "p118",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 1626,
       "initial_district_id": "d4",
       "name": "Rural (-1,5)",
@@ -2141,7 +2871,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6831, "ryu": 0.3169 }
+          "vote_shares": {
+            "ken": 0.6831,
+            "ryu": 0.3169
+          }
         }
       ]
     },
@@ -2149,7 +2882,10 @@
       "id": "p119",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 1429,
       "initial_district_id": "d4",
       "name": "Rural (0,5)",
@@ -2159,7 +2895,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6846, "ryu": 0.3154 }
+          "vote_shares": {
+            "ken": 0.6846,
+            "ryu": 0.3154
+          }
         }
       ]
     },
@@ -2167,7 +2906,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 1, "r": 5 },
+      "position": {
+        "q": 1,
+        "r": 5
+      },
       "total_population": 1499,
       "initial_district_id": "d4",
       "name": "Rural (1,5)",
@@ -2177,7 +2919,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6706, "ryu": 0.3294 }
+          "vote_shares": {
+            "ken": 0.6706,
+            "ryu": 0.3294
+          }
         }
       ]
     },
@@ -2185,7 +2930,10 @@
       "id": "p121",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -6, "r": 6 },
+      "position": {
+        "q": -6,
+        "r": 6
+      },
       "total_population": 1550,
       "initial_district_id": "d5",
       "name": "Rural (-6,6)",
@@ -2195,7 +2943,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6286, "ryu": 0.3714 }
+          "vote_shares": {
+            "ken": 0.6286,
+            "ryu": 0.3714
+          }
         }
       ]
     },
@@ -2203,7 +2954,10 @@
       "id": "p122",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -5, "r": 6 },
+      "position": {
+        "q": -5,
+        "r": 6
+      },
       "total_population": 1391,
       "initial_district_id": "d5",
       "name": "Rural (-5,6)",
@@ -2213,7 +2967,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6192, "ryu": 0.3808 }
+          "vote_shares": {
+            "ken": 0.6192,
+            "ryu": 0.3808
+          }
         }
       ]
     },
@@ -2221,7 +2978,10 @@
       "id": "p123",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -4, "r": 6 },
+      "position": {
+        "q": -4,
+        "r": 6
+      },
       "total_population": 1576,
       "initial_district_id": "d4",
       "name": "Rural (-4,6)",
@@ -2231,7 +2991,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6303, "ryu": 0.3697 }
+          "vote_shares": {
+            "ken": 0.6303,
+            "ryu": 0.3697
+          }
         }
       ]
     },
@@ -2239,7 +3002,10 @@
       "id": "p124",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -3, "r": 6 },
+      "position": {
+        "q": -3,
+        "r": 6
+      },
       "total_population": 1500,
       "initial_district_id": "d4",
       "name": "Rural (-3,6)",
@@ -2249,7 +3015,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6721, "ryu": 0.3279 }
+          "vote_shares": {
+            "ken": 0.6721,
+            "ryu": 0.3279
+          }
         }
       ]
     },
@@ -2257,7 +3026,10 @@
       "id": "p125",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -2, "r": 6 },
+      "position": {
+        "q": -2,
+        "r": 6
+      },
       "total_population": 1589,
       "initial_district_id": "d4",
       "name": "Rural (-2,6)",
@@ -2267,7 +3039,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.51,
-          "vote_shares": { "ken": 0.6845, "ryu": 0.3155 }
+          "vote_shares": {
+            "ken": 0.6845,
+            "ryu": 0.3155
+          }
         }
       ]
     },
@@ -2275,7 +3050,10 @@
       "id": "p126",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": -1, "r": 6 },
+      "position": {
+        "q": -1,
+        "r": 6
+      },
       "total_population": 1563,
       "initial_district_id": "d4",
       "name": "Rural (-1,6)",
@@ -2285,7 +3063,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6529, "ryu": 0.3471 }
+          "vote_shares": {
+            "ken": 0.6529,
+            "ryu": 0.3471
+          }
         }
       ]
     },
@@ -2293,7 +3074,10 @@
       "id": "p127",
       "editable": true,
       "county_id": "greenfield_county",
-      "position": { "q": 0, "r": 6 },
+      "position": {
+        "q": 0,
+        "r": 6
+      },
       "total_population": 1514,
       "initial_district_id": "d4",
       "name": "Rural (0,6)",
@@ -2303,7 +3087,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.6446, "ryu": 0.3554 }
+          "vote_shares": {
+            "ken": 0.6446,
+            "ryu": 0.3554
+          }
         }
       ]
     }
@@ -2318,13 +3105,17 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All five districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
       "description": "All five districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-ken-seats",
@@ -2340,7 +3131,7 @@
     {
       "id": "sc-efficiency-gap",
       "required": false,
-      "description": "Packing creates a large efficiency gap — can you keep it under 15%?",
+      "description": "Packing creates a large efficiency gap \u2014 can you keep it under 15%?",
       "criterion": {
         "type": "efficiency_gap",
         "operator": "lte",
@@ -2352,20 +3143,20 @@
     "character": {
       "name": "You",
       "role": "Ken Party Campaign Strategist, Riverport Metro",
-      "motivation": "The Ken Party controls the state legislature but is losing ground in Riverport's urban core. The Ryu Party's voters are concentrated downtown — a liability if you know how to exploit it. Your job: draw a map that locks in 4 of 5 seats by packing their voters into one unwinnable district."
+      "motivation": "The Ken Party controls the state legislature but is losing ground in Riverport's urban core. The Ryu Party's voters are concentrated downtown \u2014 a liability if you know how to exploit it. Your job: draw a map that locks in 4 of 5 seats by packing their voters into one unwinnable district."
     },
     "intro_slides": [
       {
         "heading": "The Urban Problem",
-        "body": "Riverport's downtown is a Ryu stronghold — dense, politically active, and growing. If you let those voters spread across multiple districts, they could flip seats.\n\nBut concentration is a weakness. If all those Ryu voters end up in the same district, they win it by a landslide — and waste thousands of votes that could have helped them elsewhere."
+        "body": "Riverport's downtown is a Ryu stronghold \u2014 dense, politically active, and growing. If you let those voters spread across multiple districts, they could flip seats.\n\nBut concentration is a weakness. If all those Ryu voters end up in the same district, they win it by a landslide \u2014 and waste thousands of votes that could have helped them elsewhere."
       },
       {
         "heading": "The Packing Play",
-        "body": "Packing means drawing one district that your opponents win overwhelmingly — 80%, 85%, even 90%. Every vote above 50%+1 is wasted. Meanwhile, you spread your own voters efficiently across the remaining districts, winning each by a comfortable but not wasteful margin.\n\nThe result: they win one seat by a landslide. You win four seats by steady margins."
+        "body": "Packing means drawing one district that your opponents win overwhelmingly \u2014 80%, 85%, even 90%. Every vote above 50%+1 is wasted. Meanwhile, you spread your own voters efficiently across the remaining districts, winning each by a comfortable but not wasteful margin.\n\nThe result: they win one seat by a landslide. You win four seats by steady margins."
       },
       {
         "heading": "The Efficiency Gap",
-        "body": "Political scientists measure this with the efficiency gap — the difference in wasted votes between the two parties. A packed map has a huge efficiency gap: the opposition wastes votes in their landslide district, while the mapmaker wastes very few.\n\nDraw your map. Then look at the efficiency gap and see what packing costs."
+        "body": "Political scientists measure this with the efficiency gap \u2014 the difference in wasted votes between the two parties. A packed map has a huge efficiency gap: the opposition wastes votes in their landslide district, while the mapmaker wastes very few.\n\nDraw your map. Then look at the efficiency gap and see what packing costs."
       }
     ],
     "objective": "Pack Ryu voters into as few districts as possible. Ken Party must win at least 4 of 5 seats."

--- a/game/scenarios/scenario-004.json
+++ b/game/scenarios/scenario-004.json
@@ -7,17 +7,42 @@
     "id": "lakeview_county",
     "name": "Lakeview County"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
-    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+    {
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
+    },
+    {
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" },
-    { "id": "d5", "name": "District 5" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    },
+    {
+      "id": "d4",
+      "name": "District 4"
+    },
+    {
+      "id": "d5",
+      "name": "District 5"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -25,7 +50,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 0, "r": -6 },
+      "position": {
+        "q": 0,
+        "r": -6
+      },
       "total_population": 1488,
       "initial_district_id": "d5",
       "name": "South (0,-6)",
@@ -35,7 +63,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6287, "ryu": 0.3713 }
+          "vote_shares": {
+            "ken": 0.6287,
+            "ryu": 0.3713
+          }
         }
       ]
     },
@@ -43,7 +74,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 1, "r": -6 },
+      "position": {
+        "q": 1,
+        "r": -6
+      },
       "total_population": 1536,
       "initial_district_id": "d5",
       "name": "South (1,-6)",
@@ -53,7 +87,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6796, "ryu": 0.3204 }
+          "vote_shares": {
+            "ken": 0.6796,
+            "ryu": 0.3204
+          }
         }
       ]
     },
@@ -61,7 +98,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 2, "r": -6 },
+      "position": {
+        "q": 2,
+        "r": -6
+      },
       "total_population": 1500,
       "initial_district_id": "d5",
       "name": "South (2,-6)",
@@ -71,7 +111,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6293, "ryu": 0.3707 }
+          "vote_shares": {
+            "ken": 0.6293,
+            "ryu": 0.3707
+          }
         }
       ]
     },
@@ -79,7 +122,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 3, "r": -6 },
+      "position": {
+        "q": 3,
+        "r": -6
+      },
       "total_population": 1366,
       "initial_district_id": "d5",
       "name": "South (3,-6)",
@@ -89,7 +135,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6849, "ryu": 0.3151 }
+          "vote_shares": {
+            "ken": 0.6849,
+            "ryu": 0.3151
+          }
         }
       ]
     },
@@ -97,7 +146,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 4, "r": -6 },
+      "position": {
+        "q": 4,
+        "r": -6
+      },
       "total_population": 1520,
       "initial_district_id": "d5",
       "name": "South (4,-6)",
@@ -107,7 +159,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6725, "ryu": 0.3275 }
+          "vote_shares": {
+            "ken": 0.6725,
+            "ryu": 0.3275
+          }
         }
       ]
     },
@@ -115,7 +170,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 5, "r": -6 },
+      "position": {
+        "q": 5,
+        "r": -6
+      },
       "total_population": 1519,
       "initial_district_id": "d5",
       "name": "South (5,-6)",
@@ -125,7 +183,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6431, "ryu": 0.3569 }
+          "vote_shares": {
+            "ken": 0.6431,
+            "ryu": 0.3569
+          }
         }
       ]
     },
@@ -133,7 +194,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 6, "r": -6 },
+      "position": {
+        "q": 6,
+        "r": -6
+      },
       "total_population": 1450,
       "initial_district_id": "d5",
       "name": "South (6,-6)",
@@ -143,7 +207,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6496, "ryu": 0.3504 }
+          "vote_shares": {
+            "ken": 0.6496,
+            "ryu": 0.3504
+          }
         }
       ]
     },
@@ -151,7 +218,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -1, "r": -5 },
+      "position": {
+        "q": -1,
+        "r": -5
+      },
       "total_population": 1458,
       "initial_district_id": "d5",
       "name": "South (-1,-5)",
@@ -161,7 +231,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6523, "ryu": 0.3477 }
+          "vote_shares": {
+            "ken": 0.6523,
+            "ryu": 0.3477
+          }
         }
       ]
     },
@@ -169,7 +242,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 1440,
       "initial_district_id": "d5",
       "name": "South (0,-5)",
@@ -179,7 +255,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6525, "ryu": 0.3475 }
+          "vote_shares": {
+            "ken": 0.6525,
+            "ryu": 0.3475
+          }
         }
       ]
     },
@@ -187,7 +266,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 1430,
       "initial_district_id": "d5",
       "name": "South (1,-5)",
@@ -197,7 +279,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6342, "ryu": 0.3658 }
+          "vote_shares": {
+            "ken": 0.6342,
+            "ryu": 0.3658
+          }
         }
       ]
     },
@@ -205,7 +290,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 1581,
       "initial_district_id": "d5",
       "name": "South (2,-5)",
@@ -215,7 +303,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6581, "ryu": 0.3419 }
+          "vote_shares": {
+            "ken": 0.6581,
+            "ryu": 0.3419
+          }
         }
       ]
     },
@@ -223,7 +314,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 1523,
       "initial_district_id": "d5",
       "name": "South (3,-5)",
@@ -233,7 +327,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6661, "ryu": 0.3339 }
+          "vote_shares": {
+            "ken": 0.6661,
+            "ryu": 0.3339
+          }
         }
       ]
     },
@@ -241,7 +338,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 1572,
       "initial_district_id": "d5",
       "name": "South (4,-5)",
@@ -251,7 +351,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6678, "ryu": 0.3322 }
+          "vote_shares": {
+            "ken": 0.6678,
+            "ryu": 0.3322
+          }
         }
       ]
     },
@@ -259,7 +362,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 1634,
       "initial_district_id": "d5",
       "name": "South (5,-5)",
@@ -269,7 +375,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6639, "ryu": 0.3361 }
+          "vote_shares": {
+            "ken": 0.6639,
+            "ryu": 0.3361
+          }
         }
       ]
     },
@@ -277,7 +386,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 6, "r": -5 },
+      "position": {
+        "q": 6,
+        "r": -5
+      },
       "total_population": 1417,
       "initial_district_id": "d5",
       "name": "South (6,-5)",
@@ -287,7 +399,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6651, "ryu": 0.3349 }
+          "vote_shares": {
+            "ken": 0.6651,
+            "ryu": 0.3349
+          }
         }
       ]
     },
@@ -295,7 +410,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -2, "r": -4 },
+      "position": {
+        "q": -2,
+        "r": -4
+      },
       "total_population": 1536,
       "initial_district_id": "d5",
       "name": "South (-2,-4)",
@@ -305,7 +423,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6833, "ryu": 0.3167 }
+          "vote_shares": {
+            "ken": 0.6833,
+            "ryu": 0.3167
+          }
         }
       ]
     },
@@ -313,7 +434,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 1555,
       "initial_district_id": "d5",
       "name": "South (-1,-4)",
@@ -323,7 +447,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6244, "ryu": 0.3756 }
+          "vote_shares": {
+            "ken": 0.6244,
+            "ryu": 0.3756
+          }
         }
       ]
     },
@@ -331,7 +458,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 1477,
       "initial_district_id": "d5",
       "name": "South (0,-4)",
@@ -341,7 +471,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6113, "ryu": 0.3887 }
+          "vote_shares": {
+            "ken": 0.6113,
+            "ryu": 0.3887
+          }
         }
       ]
     },
@@ -349,7 +482,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 1455,
       "initial_district_id": "d5",
       "name": "South (1,-4)",
@@ -359,7 +495,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6397, "ryu": 0.3603 }
+          "vote_shares": {
+            "ken": 0.6397,
+            "ryu": 0.3603
+          }
         }
       ]
     },
@@ -367,7 +506,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 1507,
       "initial_district_id": "d5",
       "name": "South (2,-4)",
@@ -377,7 +519,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6145, "ryu": 0.3855 }
+          "vote_shares": {
+            "ken": 0.6145,
+            "ryu": 0.3855
+          }
         }
       ]
     },
@@ -385,7 +530,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 1373,
       "initial_district_id": "d5",
       "name": "South (3,-4)",
@@ -394,8 +542,11 @@
           "id": "p021-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6643, "ryu": 0.3357 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6643,
+            "ryu": 0.3357
+          }
         }
       ]
     },
@@ -403,7 +554,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 1546,
       "initial_district_id": "d5",
       "name": "South (4,-4)",
@@ -413,7 +567,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6168, "ryu": 0.3832 }
+          "vote_shares": {
+            "ken": 0.6168,
+            "ryu": 0.3832
+          }
         }
       ]
     },
@@ -421,7 +578,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 1375,
       "initial_district_id": "d5",
       "name": "South (5,-4)",
@@ -430,8 +590,11 @@
           "id": "p023-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6739, "ryu": 0.3261 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6739,
+            "ryu": 0.3261
+          }
         }
       ]
     },
@@ -439,7 +602,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 6, "r": -4 },
+      "position": {
+        "q": 6,
+        "r": -4
+      },
       "total_population": 1583,
       "initial_district_id": "d5",
       "name": "South (6,-4)",
@@ -449,7 +615,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6287, "ryu": 0.3713 }
+          "vote_shares": {
+            "ken": 0.6287,
+            "ryu": 0.3713
+          }
         }
       ]
     },
@@ -457,7 +626,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -3, "r": -3 },
+      "position": {
+        "q": -3,
+        "r": -3
+      },
       "total_population": 1549,
       "initial_district_id": "d5",
       "name": "South (-3,-3)",
@@ -467,7 +639,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6295, "ryu": 0.3705 }
+          "vote_shares": {
+            "ken": 0.6295,
+            "ryu": 0.3705
+          }
         }
       ]
     },
@@ -475,7 +650,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 1555,
       "initial_district_id": "d5",
       "name": "South (-2,-3)",
@@ -485,7 +663,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6158, "ryu": 0.3842 }
+          "vote_shares": {
+            "ken": 0.6158,
+            "ryu": 0.3842
+          }
         }
       ]
     },
@@ -493,7 +674,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 1569,
       "initial_district_id": "d5",
       "name": "South (-1,-3)",
@@ -503,7 +687,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6382, "ryu": 0.3618 }
+          "vote_shares": {
+            "ken": 0.6382,
+            "ryu": 0.3618
+          }
         }
       ]
     },
@@ -511,7 +698,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 1621,
       "initial_district_id": "d5",
       "name": "South (0,-3)",
@@ -521,7 +711,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6687, "ryu": 0.3313 }
+          "vote_shares": {
+            "ken": 0.6687,
+            "ryu": 0.3313
+          }
         }
       ]
     },
@@ -529,7 +722,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 1461,
       "initial_district_id": "d5",
       "name": "South (1,-3)",
@@ -539,7 +735,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6739, "ryu": 0.3261 }
+          "vote_shares": {
+            "ken": 0.6739,
+            "ryu": 0.3261
+          }
         }
       ]
     },
@@ -547,7 +746,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 1598,
       "initial_district_id": "d5",
       "name": "South (2,-3)",
@@ -557,7 +759,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6365, "ryu": 0.3635 }
+          "vote_shares": {
+            "ken": 0.6365,
+            "ryu": 0.3635
+          }
         }
       ]
     },
@@ -565,7 +770,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 1568,
       "initial_district_id": "d5",
       "name": "South (3,-3)",
@@ -575,7 +783,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6209, "ryu": 0.3791 }
+          "vote_shares": {
+            "ken": 0.6209,
+            "ryu": 0.3791
+          }
         }
       ]
     },
@@ -583,7 +794,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 1541,
       "initial_district_id": "d5",
       "name": "South (4,-3)",
@@ -593,7 +807,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6554, "ryu": 0.3446 }
+          "vote_shares": {
+            "ken": 0.6554,
+            "ryu": 0.3446
+          }
         }
       ]
     },
@@ -601,7 +818,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 1482,
       "initial_district_id": "d5",
       "name": "South (5,-3)",
@@ -611,7 +831,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6573, "ryu": 0.3427 }
+          "vote_shares": {
+            "ken": 0.6573,
+            "ryu": 0.3427
+          }
         }
       ]
     },
@@ -619,7 +842,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 6, "r": -3 },
+      "position": {
+        "q": 6,
+        "r": -3
+      },
       "total_population": 1393,
       "initial_district_id": "d5",
       "name": "South (6,-3)",
@@ -629,7 +855,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6535, "ryu": 0.3465 }
+          "vote_shares": {
+            "ken": 0.6535,
+            "ryu": 0.3465
+          }
         }
       ]
     },
@@ -637,7 +866,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -4, "r": -2 },
+      "position": {
+        "q": -4,
+        "r": -2
+      },
       "total_population": 1612,
       "initial_district_id": "d4",
       "name": "South (-4,-2)",
@@ -647,7 +879,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6493, "ryu": 0.3507 }
+          "vote_shares": {
+            "ken": 0.6493,
+            "ryu": 0.3507
+          }
         }
       ]
     },
@@ -655,7 +890,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 1386,
       "initial_district_id": "d4",
       "name": "South (-3,-2)",
@@ -665,7 +903,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6118, "ryu": 0.3882 }
+          "vote_shares": {
+            "ken": 0.6118,
+            "ryu": 0.3882
+          }
         }
       ]
     },
@@ -673,7 +914,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 1637,
       "initial_district_id": "d4",
       "name": "South (-2,-2)",
@@ -683,7 +927,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6433, "ryu": 0.3567 }
+          "vote_shares": {
+            "ken": 0.6433,
+            "ryu": 0.3567
+          }
         }
       ]
     },
@@ -691,7 +938,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 1626,
       "initial_district_id": "d4",
       "name": "South (-1,-2)",
@@ -701,7 +951,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6688, "ryu": 0.3312 }
+          "vote_shares": {
+            "ken": 0.6688,
+            "ryu": 0.3312
+          }
         }
       ]
     },
@@ -709,7 +962,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 1458,
       "initial_district_id": "d4",
       "name": "South (0,-2)",
@@ -719,7 +975,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6864, "ryu": 0.3136 }
+          "vote_shares": {
+            "ken": 0.6864,
+            "ryu": 0.3136
+          }
         }
       ]
     },
@@ -727,7 +986,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 1521,
       "initial_district_id": "d4",
       "name": "South (1,-2)",
@@ -737,7 +999,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6250, "ryu": 0.3750 }
+          "vote_shares": {
+            "ken": 0.625,
+            "ryu": 0.375
+          }
         }
       ]
     },
@@ -745,7 +1010,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 1435,
       "initial_district_id": "d4",
       "name": "South (2,-2)",
@@ -755,7 +1023,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6518, "ryu": 0.3482 }
+          "vote_shares": {
+            "ken": 0.6518,
+            "ryu": 0.3482
+          }
         }
       ]
     },
@@ -763,7 +1034,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 1441,
       "initial_district_id": "d4",
       "name": "South (3,-2)",
@@ -772,8 +1046,11 @@
           "id": "p042-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6415, "ryu": 0.3585 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6415,
+            "ryu": 0.3585
+          }
         }
       ]
     },
@@ -781,7 +1058,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 1484,
       "initial_district_id": "d4",
       "name": "South (4,-2)",
@@ -791,7 +1071,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6229, "ryu": 0.3771 }
+          "vote_shares": {
+            "ken": 0.6229,
+            "ryu": 0.3771
+          }
         }
       ]
     },
@@ -799,7 +1082,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 1456,
       "initial_district_id": "d4",
       "name": "South (5,-2)",
@@ -809,7 +1095,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6824, "ryu": 0.3176 }
+          "vote_shares": {
+            "ken": 0.6824,
+            "ryu": 0.3176
+          }
         }
       ]
     },
@@ -817,7 +1106,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "lakeview_south",
-      "position": { "q": 6, "r": -2 },
+      "position": {
+        "q": 6,
+        "r": -2
+      },
       "total_population": 1540,
       "initial_district_id": "d4",
       "name": "South (6,-2)",
@@ -827,7 +1119,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6314, "ryu": 0.3686 }
+          "vote_shares": {
+            "ken": 0.6314,
+            "ryu": 0.3686
+          }
         }
       ]
     },
@@ -835,7 +1130,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -5, "r": -1 },
+      "position": {
+        "q": -5,
+        "r": -1
+      },
       "total_population": 1364,
       "initial_district_id": "d3",
       "name": "South (-5,-1)",
@@ -845,7 +1143,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6575, "ryu": 0.3425 }
+          "vote_shares": {
+            "ken": 0.6575,
+            "ryu": 0.3425
+          }
         }
       ]
     },
@@ -853,7 +1154,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 1602,
       "initial_district_id": "d3",
       "name": "South (-4,-1)",
@@ -863,7 +1167,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6116, "ryu": 0.3884 }
+          "vote_shares": {
+            "ken": 0.6116,
+            "ryu": 0.3884
+          }
         }
       ]
     },
@@ -871,7 +1178,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 1376,
       "initial_district_id": "d3",
       "name": "South (-3,-1)",
@@ -881,7 +1191,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6588, "ryu": 0.3412 }
+          "vote_shares": {
+            "ken": 0.6588,
+            "ryu": 0.3412
+          }
         }
       ]
     },
@@ -889,7 +1202,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 1608,
       "initial_district_id": "d3",
       "name": "South (-2,-1)",
@@ -899,7 +1215,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6159, "ryu": 0.3841 }
+          "vote_shares": {
+            "ken": 0.6159,
+            "ryu": 0.3841
+          }
         }
       ]
     },
@@ -907,7 +1226,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 1427,
       "initial_district_id": "d3",
       "name": "South (-1,-1)",
@@ -916,8 +1238,11 @@
           "id": "p050-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6856, "ryu": 0.3144 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6856,
+            "ryu": 0.3144
+          }
         }
       ]
     },
@@ -925,7 +1250,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 1492,
       "initial_district_id": "d3",
       "name": "South (0,-1)",
@@ -935,7 +1263,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6889, "ryu": 0.3111 }
+          "vote_shares": {
+            "ken": 0.6889,
+            "ryu": 0.3111
+          }
         }
       ]
     },
@@ -943,7 +1274,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 1518,
       "initial_district_id": "d3",
       "name": "South (1,-1)",
@@ -953,7 +1287,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6334, "ryu": 0.3666 }
+          "vote_shares": {
+            "ken": 0.6334,
+            "ryu": 0.3666
+          }
         }
       ]
     },
@@ -961,7 +1298,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 1415,
       "initial_district_id": "d3",
       "name": "South (2,-1)",
@@ -971,7 +1311,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6895, "ryu": 0.3105 }
+          "vote_shares": {
+            "ken": 0.6895,
+            "ryu": 0.3105
+          }
         }
       ]
     },
@@ -979,7 +1322,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 1470,
       "initial_district_id": "d3",
       "name": "South (3,-1)",
@@ -989,7 +1335,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6474, "ryu": 0.3526 }
+          "vote_shares": {
+            "ken": 0.6474,
+            "ryu": 0.3526
+          }
         }
       ]
     },
@@ -997,7 +1346,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 1380,
       "initial_district_id": "d3",
       "name": "South (4,-1)",
@@ -1007,7 +1359,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6476, "ryu": 0.3524 }
+          "vote_shares": {
+            "ken": 0.6476,
+            "ryu": 0.3524
+          }
         }
       ]
     },
@@ -1015,7 +1370,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 1538,
       "initial_district_id": "d3",
       "name": "South (5,-1)",
@@ -1025,7 +1383,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6866, "ryu": 0.3134 }
+          "vote_shares": {
+            "ken": 0.6866,
+            "ryu": 0.3134
+          }
         }
       ]
     },
@@ -1033,7 +1394,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 6, "r": -1 },
+      "position": {
+        "q": 6,
+        "r": -1
+      },
       "total_population": 1473,
       "initial_district_id": "d3",
       "name": "South (6,-1)",
@@ -1043,7 +1407,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6764, "ryu": 0.3236 }
+          "vote_shares": {
+            "ken": 0.6764,
+            "ryu": 0.3236
+          }
         }
       ]
     },
@@ -1051,7 +1418,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -6, "r": 0 },
+      "position": {
+        "q": -6,
+        "r": 0
+      },
       "total_population": 1598,
       "initial_district_id": "d3",
       "name": "Lakeshore (-6,0)",
@@ -1061,7 +1431,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1782, "ryu": 0.8218 }
+          "vote_shares": {
+            "ken": 0.1782,
+            "ryu": 0.8218
+          }
         }
       ]
     },
@@ -1069,7 +1442,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 1549,
       "initial_district_id": "d3",
       "name": "Lakeshore (-5,0)",
@@ -1079,7 +1455,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.1980, "ryu": 0.8020 }
+          "vote_shares": {
+            "ken": 0.198,
+            "ryu": 0.802
+          }
         }
       ]
     },
@@ -1087,7 +1466,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 1615,
       "initial_district_id": "d3",
       "name": "Lakeshore (-4,0)",
@@ -1097,7 +1479,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.1741, "ryu": 0.8259 }
+          "vote_shares": {
+            "ken": 0.1741,
+            "ryu": 0.8259
+          }
         }
       ]
     },
@@ -1105,7 +1490,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 1400,
       "initial_district_id": "d3",
       "name": "Lakeshore (-3,0)",
@@ -1115,7 +1503,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.2148, "ryu": 0.7852 }
+          "vote_shares": {
+            "ken": 0.2148,
+            "ryu": 0.7852
+          }
         }
       ]
     },
@@ -1123,7 +1514,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 1526,
       "initial_district_id": "d3",
       "name": "Lakeshore (-2,0)",
@@ -1133,7 +1527,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.1411, "ryu": 0.8589 }
+          "vote_shares": {
+            "ken": 0.1411,
+            "ryu": 0.8589
+          }
         }
       ]
     },
@@ -1141,7 +1538,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 1578,
       "initial_district_id": "d3",
       "name": "Lakeshore (-1,0)",
@@ -1151,7 +1551,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.1991, "ryu": 0.8009 }
+          "vote_shares": {
+            "ken": 0.1991,
+            "ryu": 0.8009
+          }
         }
       ]
     },
@@ -1159,7 +1562,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 1555,
       "initial_district_id": "d3",
       "name": "Lakeshore (0,0)",
@@ -1169,7 +1575,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.1618, "ryu": 0.8382 }
+          "vote_shares": {
+            "ken": 0.1618,
+            "ryu": 0.8382
+          }
         }
       ]
     },
@@ -1177,7 +1586,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 1549,
       "initial_district_id": "d3",
       "name": "Lakeshore (1,0)",
@@ -1187,7 +1599,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.2070, "ryu": 0.7930 }
+          "vote_shares": {
+            "ken": 0.207,
+            "ryu": 0.793
+          }
         }
       ]
     },
@@ -1195,7 +1610,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 1467,
       "initial_district_id": "d3",
       "name": "Lakeshore (2,0)",
@@ -1205,7 +1623,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.1711, "ryu": 0.8289 }
+          "vote_shares": {
+            "ken": 0.1711,
+            "ryu": 0.8289
+          }
         }
       ]
     },
@@ -1213,7 +1634,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 1373,
       "initial_district_id": "d3",
       "name": "Lakeshore (3,0)",
@@ -1223,7 +1647,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.1640, "ryu": 0.8360 }
+          "vote_shares": {
+            "ken": 0.164,
+            "ryu": 0.836
+          }
         }
       ]
     },
@@ -1231,7 +1658,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 1642,
       "initial_district_id": "d3",
       "name": "Lakeshore (4,0)",
@@ -1241,7 +1671,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.1528, "ryu": 0.8472 }
+          "vote_shares": {
+            "ken": 0.1528,
+            "ryu": 0.8472
+          }
         }
       ]
     },
@@ -1249,7 +1682,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 1523,
       "initial_district_id": "d3",
       "name": "Lakeshore (5,0)",
@@ -1258,8 +1694,11 @@
           "id": "p069-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.1964, "ryu": 0.8036 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.1964,
+            "ryu": 0.8036
+          }
         }
       ]
     },
@@ -1267,7 +1706,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 6, "r": 0 },
+      "position": {
+        "q": 6,
+        "r": 0
+      },
       "total_population": 1564,
       "initial_district_id": "d3",
       "name": "Lakeshore (6,0)",
@@ -1277,7 +1719,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.2066, "ryu": 0.7934 }
+          "vote_shares": {
+            "ken": 0.2066,
+            "ryu": 0.7934
+          }
         }
       ]
     },
@@ -1285,7 +1730,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -6, "r": 1 },
+      "position": {
+        "q": -6,
+        "r": 1
+      },
       "total_population": 1472,
       "initial_district_id": "d3",
       "name": "North (-6,1)",
@@ -1295,7 +1743,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6258, "ryu": 0.3742 }
+          "vote_shares": {
+            "ken": 0.6258,
+            "ryu": 0.3742
+          }
         }
       ]
     },
@@ -1303,7 +1754,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 1561,
       "initial_district_id": "d3",
       "name": "North (-5,1)",
@@ -1313,7 +1767,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6150, "ryu": 0.3850 }
+          "vote_shares": {
+            "ken": 0.615,
+            "ryu": 0.385
+          }
         }
       ]
     },
@@ -1321,7 +1778,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 1459,
       "initial_district_id": "d3",
       "name": "North (-4,1)",
@@ -1331,7 +1791,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6570, "ryu": 0.3430 }
+          "vote_shares": {
+            "ken": 0.657,
+            "ryu": 0.343
+          }
         }
       ]
     },
@@ -1339,7 +1802,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 1365,
       "initial_district_id": "d3",
       "name": "North (-3,1)",
@@ -1348,8 +1814,11 @@
           "id": "p074-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6703,
+            "ryu": 0.3297
+          }
         }
       ]
     },
@@ -1357,7 +1826,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 1576,
       "initial_district_id": "d3",
       "name": "North (-2,1)",
@@ -1367,7 +1839,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6607, "ryu": 0.3393 }
+          "vote_shares": {
+            "ken": 0.6607,
+            "ryu": 0.3393
+          }
         }
       ]
     },
@@ -1375,7 +1850,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 1537,
       "initial_district_id": "d3",
       "name": "North (-1,1)",
@@ -1385,7 +1863,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6156, "ryu": 0.3844 }
+          "vote_shares": {
+            "ken": 0.6156,
+            "ryu": 0.3844
+          }
         }
       ]
     },
@@ -1393,7 +1874,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 1408,
       "initial_district_id": "d3",
       "name": "North (0,1)",
@@ -1403,7 +1887,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6600, "ryu": 0.3400 }
+          "vote_shares": {
+            "ken": 0.66,
+            "ryu": 0.34
+          }
         }
       ]
     },
@@ -1411,7 +1898,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 1503,
       "initial_district_id": "d3",
       "name": "North (1,1)",
@@ -1420,8 +1910,11 @@
           "id": "p078-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6114, "ryu": 0.3886 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6114,
+            "ryu": 0.3886
+          }
         }
       ]
     },
@@ -1429,7 +1922,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 1467,
       "initial_district_id": "d3",
       "name": "North (2,1)",
@@ -1439,7 +1935,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6844, "ryu": 0.3156 }
+          "vote_shares": {
+            "ken": 0.6844,
+            "ryu": 0.3156
+          }
         }
       ]
     },
@@ -1447,7 +1946,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 1493,
       "initial_district_id": "d3",
       "name": "North (3,1)",
@@ -1457,7 +1959,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6295, "ryu": 0.3705 }
+          "vote_shares": {
+            "ken": 0.6295,
+            "ryu": 0.3705
+          }
         }
       ]
     },
@@ -1465,7 +1970,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 1354,
       "initial_district_id": "d3",
       "name": "North (4,1)",
@@ -1475,7 +1983,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6798, "ryu": 0.3202 }
+          "vote_shares": {
+            "ken": 0.6798,
+            "ryu": 0.3202
+          }
         }
       ]
     },
@@ -1483,7 +1994,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "lakeview_central",
-      "position": { "q": 5, "r": 1 },
+      "position": {
+        "q": 5,
+        "r": 1
+      },
       "total_population": 1419,
       "initial_district_id": "d3",
       "name": "North (5,1)",
@@ -1492,8 +2006,11 @@
           "id": "p082-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6812, "ryu": 0.3188 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6812,
+            "ryu": 0.3188
+          }
         }
       ]
     },
@@ -1501,7 +2018,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -6, "r": 2 },
+      "position": {
+        "q": -6,
+        "r": 2
+      },
       "total_population": 1527,
       "initial_district_id": "d2",
       "name": "North (-6,2)",
@@ -1510,8 +2030,11 @@
           "id": "p083-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6548, "ryu": 0.3452 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6548,
+            "ryu": 0.3452
+          }
         }
       ]
     },
@@ -1519,7 +2042,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 1433,
       "initial_district_id": "d2",
       "name": "North (-5,2)",
@@ -1529,7 +2055,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6496, "ryu": 0.3504 }
+          "vote_shares": {
+            "ken": 0.6496,
+            "ryu": 0.3504
+          }
         }
       ]
     },
@@ -1537,7 +2066,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 1355,
       "initial_district_id": "d2",
       "name": "North (-4,2)",
@@ -1547,7 +2079,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6529, "ryu": 0.3471 }
+          "vote_shares": {
+            "ken": 0.6529,
+            "ryu": 0.3471
+          }
         }
       ]
     },
@@ -1555,7 +2090,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 1390,
       "initial_district_id": "d2",
       "name": "North (-3,2)",
@@ -1565,7 +2103,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6456, "ryu": 0.3544 }
+          "vote_shares": {
+            "ken": 0.6456,
+            "ryu": 0.3544
+          }
         }
       ]
     },
@@ -1573,7 +2114,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 1463,
       "initial_district_id": "d2",
       "name": "North (-2,2)",
@@ -1583,7 +2127,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+          "vote_shares": {
+            "ken": 0.6703,
+            "ryu": 0.3297
+          }
         }
       ]
     },
@@ -1591,7 +2138,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 1646,
       "initial_district_id": "d2",
       "name": "North (-1,2)",
@@ -1601,7 +2151,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6744, "ryu": 0.3256 }
+          "vote_shares": {
+            "ken": 0.6744,
+            "ryu": 0.3256
+          }
         }
       ]
     },
@@ -1609,7 +2162,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 1528,
       "initial_district_id": "d2",
       "name": "North (0,2)",
@@ -1619,7 +2175,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6378, "ryu": 0.3622 }
+          "vote_shares": {
+            "ken": 0.6378,
+            "ryu": 0.3622
+          }
         }
       ]
     },
@@ -1627,7 +2186,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 1563,
       "initial_district_id": "d2",
       "name": "North (1,2)",
@@ -1636,8 +2198,11 @@
           "id": "p090-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6469, "ryu": 0.3531 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6469,
+            "ryu": 0.3531
+          }
         }
       ]
     },
@@ -1645,7 +2210,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 1612,
       "initial_district_id": "d2",
       "name": "North (2,2)",
@@ -1655,7 +2223,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6510, "ryu": 0.3490 }
+          "vote_shares": {
+            "ken": 0.651,
+            "ryu": 0.349
+          }
         }
       ]
     },
@@ -1663,7 +2234,10 @@
       "id": "p092",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 1535,
       "initial_district_id": "d2",
       "name": "North (3,2)",
@@ -1673,7 +2247,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6167, "ryu": 0.3833 }
+          "vote_shares": {
+            "ken": 0.6167,
+            "ryu": 0.3833
+          }
         }
       ]
     },
@@ -1681,7 +2258,10 @@
       "id": "p093",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 4, "r": 2 },
+      "position": {
+        "q": 4,
+        "r": 2
+      },
       "total_population": 1425,
       "initial_district_id": "d2",
       "name": "North (4,2)",
@@ -1690,8 +2270,11 @@
           "id": "p093-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6266, "ryu": 0.3734 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6266,
+            "ryu": 0.3734
+          }
         }
       ]
     },
@@ -1699,7 +2282,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -6, "r": 3 },
+      "position": {
+        "q": -6,
+        "r": 3
+      },
       "total_population": 1626,
       "initial_district_id": "d1",
       "name": "North (-6,3)",
@@ -1709,7 +2295,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6502, "ryu": 0.3498 }
+          "vote_shares": {
+            "ken": 0.6502,
+            "ryu": 0.3498
+          }
         }
       ]
     },
@@ -1717,7 +2306,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 1474,
       "initial_district_id": "d1",
       "name": "North (-5,3)",
@@ -1726,8 +2318,11 @@
           "id": "p095-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6254, "ryu": 0.3746 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6254,
+            "ryu": 0.3746
+          }
         }
       ]
     },
@@ -1735,7 +2330,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 1541,
       "initial_district_id": "d1",
       "name": "North (-4,3)",
@@ -1745,7 +2343,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6729, "ryu": 0.3271 }
+          "vote_shares": {
+            "ken": 0.6729,
+            "ryu": 0.3271
+          }
         }
       ]
     },
@@ -1753,7 +2354,10 @@
       "id": "p097",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 1550,
       "initial_district_id": "d1",
       "name": "North (-3,3)",
@@ -1763,7 +2367,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6685, "ryu": 0.3315 }
+          "vote_shares": {
+            "ken": 0.6685,
+            "ryu": 0.3315
+          }
         }
       ]
     },
@@ -1771,7 +2378,10 @@
       "id": "p098",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 1556,
       "initial_district_id": "d1",
       "name": "North (-2,3)",
@@ -1781,7 +2391,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6288, "ryu": 0.3712 }
+          "vote_shares": {
+            "ken": 0.6288,
+            "ryu": 0.3712
+          }
         }
       ]
     },
@@ -1789,7 +2402,10 @@
       "id": "p099",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 1537,
       "initial_district_id": "d1",
       "name": "North (-1,3)",
@@ -1799,7 +2415,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6619, "ryu": 0.3381 }
+          "vote_shares": {
+            "ken": 0.6619,
+            "ryu": 0.3381
+          }
         }
       ]
     },
@@ -1807,7 +2426,10 @@
       "id": "p100",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 1571,
       "initial_district_id": "d1",
       "name": "North (0,3)",
@@ -1817,7 +2439,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6356, "ryu": 0.3644 }
+          "vote_shares": {
+            "ken": 0.6356,
+            "ryu": 0.3644
+          }
         }
       ]
     },
@@ -1825,7 +2450,10 @@
       "id": "p101",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 1609,
       "initial_district_id": "d1",
       "name": "North (1,3)",
@@ -1835,7 +2463,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6829, "ryu": 0.3171 }
+          "vote_shares": {
+            "ken": 0.6829,
+            "ryu": 0.3171
+          }
         }
       ]
     },
@@ -1843,7 +2474,10 @@
       "id": "p102",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 1530,
       "initial_district_id": "d1",
       "name": "North (2,3)",
@@ -1853,7 +2487,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6817, "ryu": 0.3183 }
+          "vote_shares": {
+            "ken": 0.6817,
+            "ryu": 0.3183
+          }
         }
       ]
     },
@@ -1861,7 +2498,10 @@
       "id": "p103",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 3, "r": 3 },
+      "position": {
+        "q": 3,
+        "r": 3
+      },
       "total_population": 1358,
       "initial_district_id": "d1",
       "name": "North (3,3)",
@@ -1871,7 +2511,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6732, "ryu": 0.3268 }
+          "vote_shares": {
+            "ken": 0.6732,
+            "ryu": 0.3268
+          }
         }
       ]
     },
@@ -1879,7 +2522,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -6, "r": 4 },
+      "position": {
+        "q": -6,
+        "r": 4
+      },
       "total_population": 1446,
       "initial_district_id": "d1",
       "name": "North (-6,4)",
@@ -1888,8 +2534,11 @@
           "id": "p104-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6665, "ryu": 0.3335 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6665,
+            "ryu": 0.3335
+          }
         }
       ]
     },
@@ -1897,7 +2546,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 1506,
       "initial_district_id": "d1",
       "name": "North (-5,4)",
@@ -1907,7 +2559,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6819, "ryu": 0.3181 }
+          "vote_shares": {
+            "ken": 0.6819,
+            "ryu": 0.3181
+          }
         }
       ]
     },
@@ -1915,7 +2570,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 1452,
       "initial_district_id": "d1",
       "name": "North (-4,4)",
@@ -1925,7 +2583,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6333, "ryu": 0.3667 }
+          "vote_shares": {
+            "ken": 0.6333,
+            "ryu": 0.3667
+          }
         }
       ]
     },
@@ -1933,7 +2594,10 @@
       "id": "p107",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 1585,
       "initial_district_id": "d1",
       "name": "North (-3,4)",
@@ -1943,7 +2607,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6251, "ryu": 0.3749 }
+          "vote_shares": {
+            "ken": 0.6251,
+            "ryu": 0.3749
+          }
         }
       ]
     },
@@ -1951,7 +2618,10 @@
       "id": "p108",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 1479,
       "initial_district_id": "d1",
       "name": "North (-2,4)",
@@ -1961,7 +2631,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6726, "ryu": 0.3274 }
+          "vote_shares": {
+            "ken": 0.6726,
+            "ryu": 0.3274
+          }
         }
       ]
     },
@@ -1969,7 +2642,10 @@
       "id": "p109",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 1453,
       "initial_district_id": "d1",
       "name": "North (-1,4)",
@@ -1979,7 +2655,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6534, "ryu": 0.3466 }
+          "vote_shares": {
+            "ken": 0.6534,
+            "ryu": 0.3466
+          }
         }
       ]
     },
@@ -1987,7 +2666,10 @@
       "id": "p110",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 1596,
       "initial_district_id": "d1",
       "name": "North (0,4)",
@@ -1997,7 +2679,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6585, "ryu": 0.3415 }
+          "vote_shares": {
+            "ken": 0.6585,
+            "ryu": 0.3415
+          }
         }
       ]
     },
@@ -2005,7 +2690,10 @@
       "id": "p111",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 1573,
       "initial_district_id": "d1",
       "name": "North (1,4)",
@@ -2015,7 +2703,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6325, "ryu": 0.3675 }
+          "vote_shares": {
+            "ken": 0.6325,
+            "ryu": 0.3675
+          }
         }
       ]
     },
@@ -2023,7 +2714,10 @@
       "id": "p112",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 2, "r": 4 },
+      "position": {
+        "q": 2,
+        "r": 4
+      },
       "total_population": 1430,
       "initial_district_id": "d1",
       "name": "North (2,4)",
@@ -2033,7 +2727,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6552, "ryu": 0.3448 }
+          "vote_shares": {
+            "ken": 0.6552,
+            "ryu": 0.3448
+          }
         }
       ]
     },
@@ -2041,7 +2738,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -6, "r": 5 },
+      "position": {
+        "q": -6,
+        "r": 5
+      },
       "total_population": 1648,
       "initial_district_id": "d1",
       "name": "North (-6,5)",
@@ -2050,8 +2750,11 @@
           "id": "p113-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6777, "ryu": 0.3223 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6777,
+            "ryu": 0.3223
+          }
         }
       ]
     },
@@ -2059,7 +2762,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 1633,
       "initial_district_id": "d1",
       "name": "North (-5,5)",
@@ -2069,7 +2775,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6819, "ryu": 0.3181 }
+          "vote_shares": {
+            "ken": 0.6819,
+            "ryu": 0.3181
+          }
         }
       ]
     },
@@ -2077,7 +2786,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 1472,
       "initial_district_id": "d1",
       "name": "North (-4,5)",
@@ -2087,7 +2799,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6552, "ryu": 0.3448 }
+          "vote_shares": {
+            "ken": 0.6552,
+            "ryu": 0.3448
+          }
         }
       ]
     },
@@ -2095,7 +2810,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 1362,
       "initial_district_id": "d1",
       "name": "North (-3,5)",
@@ -2104,8 +2822,11 @@
           "id": "p116-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6547, "ryu": 0.3453 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6547,
+            "ryu": 0.3453
+          }
         }
       ]
     },
@@ -2113,7 +2834,10 @@
       "id": "p117",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 1364,
       "initial_district_id": "d1",
       "name": "North (-2,5)",
@@ -2123,7 +2847,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6563, "ryu": 0.3437 }
+          "vote_shares": {
+            "ken": 0.6563,
+            "ryu": 0.3437
+          }
         }
       ]
     },
@@ -2131,7 +2858,10 @@
       "id": "p118",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 1358,
       "initial_district_id": "d1",
       "name": "North (-1,5)",
@@ -2141,7 +2871,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6320, "ryu": 0.3680 }
+          "vote_shares": {
+            "ken": 0.632,
+            "ryu": 0.368
+          }
         }
       ]
     },
@@ -2149,7 +2882,10 @@
       "id": "p119",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 1388,
       "initial_district_id": "d1",
       "name": "North (0,5)",
@@ -2159,7 +2895,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6488, "ryu": 0.3512 }
+          "vote_shares": {
+            "ken": 0.6488,
+            "ryu": 0.3512
+          }
         }
       ]
     },
@@ -2167,7 +2906,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 1, "r": 5 },
+      "position": {
+        "q": 1,
+        "r": 5
+      },
       "total_population": 1644,
       "initial_district_id": "d1",
       "name": "North (1,5)",
@@ -2176,8 +2918,11 @@
           "id": "p120-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6696, "ryu": 0.3304 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6696,
+            "ryu": 0.3304
+          }
         }
       ]
     },
@@ -2185,7 +2930,10 @@
       "id": "p121",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -6, "r": 6 },
+      "position": {
+        "q": -6,
+        "r": 6
+      },
       "total_population": 1516,
       "initial_district_id": "d1",
       "name": "North (-6,6)",
@@ -2195,7 +2943,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6846, "ryu": 0.3154 }
+          "vote_shares": {
+            "ken": 0.6846,
+            "ryu": 0.3154
+          }
         }
       ]
     },
@@ -2203,7 +2954,10 @@
       "id": "p122",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -5, "r": 6 },
+      "position": {
+        "q": -5,
+        "r": 6
+      },
       "total_population": 1449,
       "initial_district_id": "d1",
       "name": "North (-5,6)",
@@ -2213,7 +2967,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6401, "ryu": 0.3599 }
+          "vote_shares": {
+            "ken": 0.6401,
+            "ryu": 0.3599
+          }
         }
       ]
     },
@@ -2221,7 +2978,10 @@
       "id": "p123",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -4, "r": 6 },
+      "position": {
+        "q": -4,
+        "r": 6
+      },
       "total_population": 1567,
       "initial_district_id": "d1",
       "name": "North (-4,6)",
@@ -2231,7 +2991,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6315, "ryu": 0.3685 }
+          "vote_shares": {
+            "ken": 0.6315,
+            "ryu": 0.3685
+          }
         }
       ]
     },
@@ -2239,7 +3002,10 @@
       "id": "p124",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -3, "r": 6 },
+      "position": {
+        "q": -3,
+        "r": 6
+      },
       "total_population": 1603,
       "initial_district_id": "d1",
       "name": "North (-3,6)",
@@ -2249,7 +3015,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6234, "ryu": 0.3766 }
+          "vote_shares": {
+            "ken": 0.6234,
+            "ryu": 0.3766
+          }
         }
       ]
     },
@@ -2257,7 +3026,10 @@
       "id": "p125",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -2, "r": 6 },
+      "position": {
+        "q": -2,
+        "r": 6
+      },
       "total_population": 1353,
       "initial_district_id": "d1",
       "name": "North (-2,6)",
@@ -2267,7 +3039,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6234, "ryu": 0.3766 }
+          "vote_shares": {
+            "ken": 0.6234,
+            "ryu": 0.3766
+          }
         }
       ]
     },
@@ -2275,7 +3050,10 @@
       "id": "p126",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": -1, "r": 6 },
+      "position": {
+        "q": -1,
+        "r": 6
+      },
       "total_population": 1419,
       "initial_district_id": "d1",
       "name": "North (-1,6)",
@@ -2285,7 +3063,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6315, "ryu": 0.3685 }
+          "vote_shares": {
+            "ken": 0.6315,
+            "ryu": 0.3685
+          }
         }
       ]
     },
@@ -2293,7 +3074,10 @@
       "id": "p127",
       "editable": true,
       "county_id": "lakeview_north",
-      "position": { "q": 0, "r": 6 },
+      "position": {
+        "q": 0,
+        "r": 6
+      },
       "total_population": 1445,
       "initial_district_id": "d1",
       "name": "North (0,6)",
@@ -2303,7 +3087,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6273, "ryu": 0.3727 }
+          "vote_shares": {
+            "ken": 0.6273,
+            "ryu": 0.3727
+          }
         }
       ]
     }
@@ -2318,18 +3105,22 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All five districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
       "description": "All five districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-ken-all-seats",
       "required": true,
-      "description": "Ken Party wins every seat — all 5 districts.",
+      "description": "Ken Party wins every seat \u2014 all 5 districts.",
       "criterion": {
         "type": "seat_count",
         "party": "ken",
@@ -2340,12 +3131,12 @@
     {
       "id": "sc-mean-median",
       "required": false,
-      "description": "How skewed is your map? Mean-median gap ≤ 10%.",
+      "description": "How skewed is your map? Mean-median gap \u2264 10%.",
       "criterion": {
         "type": "mean_median",
         "party": "ken",
         "operator": "lte",
-        "threshold": 0.10
+        "threshold": 0.1
       }
     }
   ],
@@ -2353,20 +3144,20 @@
     "character": {
       "name": "You",
       "role": "Ken Party Redistricting Director, Lakeview County",
-      "motivation": "Last cycle, the Ryu Party won a seat in Lakeview by concentrating their voters along the lakeshore corridor. The Ken Party wants that seat back — and every other seat too. Your job: split the corridor so Ryu voters can't form a majority anywhere."
+      "motivation": "Last cycle, the Ryu Party won a seat in Lakeview by concentrating their voters along the lakeshore corridor. The Ken Party wants that seat back \u2014 and every other seat too. Your job: split the corridor so Ryu voters can't form a majority anywhere."
     },
     "intro_slides": [
       {
         "heading": "The Corridor",
-        "body": "A narrow band of Ryu voters runs through the center of Lakeview County — along the lakeshore, where the apartments are dense and the politics lean hard Ryu.\n\nRight now, if those voters are in one district, they win it. Your predecessor let that happen. You won't."
+        "body": "A narrow band of Ryu voters runs through the center of Lakeview County \u2014 along the lakeshore, where the apartments are dense and the politics lean hard Ryu.\n\nRight now, if those voters are in one district, they win it. Your predecessor let that happen. You won't."
       },
       {
         "heading": "The Cracking Play",
-        "body": "Cracking is the opposite of packing. Instead of concentrating the opposition, you split them. Draw district lines that cut through the corridor, dividing Ryu voters across multiple districts.\n\nIn each district, the corridor's Ryu precincts are outnumbered by the surrounding Ken territory. Ryu voters still vote — but they lose everywhere."
+        "body": "Cracking is the opposite of packing. Instead of concentrating the opposition, you split them. Draw district lines that cut through the corridor, dividing Ryu voters across multiple districts.\n\nIn each district, the corridor's Ryu precincts are outnumbered by the surrounding Ken territory. Ryu voters still vote \u2014 but they lose everywhere."
       },
       {
         "heading": "The Disappearing Voice",
-        "body": "Notice what happens: a community that could win one seat now wins zero. Their total vote count hasn't changed. Their turnout hasn't dropped. But the lines moved, and their voice vanished.\n\nThis is what cracking does. It doesn't silence voters — it dilutes them until they don't matter."
+        "body": "Notice what happens: a community that could win one seat now wins zero. Their total vote count hasn't changed. Their turnout hasn't dropped. But the lines moved, and their voice vanished.\n\nThis is what cracking does. It doesn't silence voters \u2014 it dilutes them until they don't matter."
       }
     ],
     "objective": "Crack the Ryu corridor across all 5 districts. Ken Party must win every seat."

--- a/game/scenarios/scenario-005.json
+++ b/game/scenarios/scenario-005.json
@@ -7,21 +7,51 @@
     "id": "valle_verde_county",
     "name": "Valle Verde County"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "group_schema": {
-    "dimensions": { "ethnicity": ["latino", "anglo"] },
+    "dimensions": {
+      "ethnicity": [
+        "latino",
+        "anglo"
+      ]
+    },
     "eligibility_rules": []
   },
   "parties": [
-    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
-    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+    {
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
+    },
+    {
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" },
-    { "id": "d5", "name": "District 5" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    },
+    {
+      "id": "d4",
+      "name": "District 4"
+    },
+    {
+      "id": "d5",
+      "name": "District 5"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -29,7 +59,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 0, "r": -6 },
+      "position": {
+        "q": 0,
+        "r": -6
+      },
       "total_population": 1386,
       "initial_district_id": "d1",
       "name": "Rim (0,-6)",
@@ -39,16 +72,26 @@
           "name": "Latino residents",
           "population_share": 0.2332,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.8045, "ryu": 0.1955 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8045,
+            "ryu": 0.1955
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p001-anglo",
           "name": "Anglo residents",
           "population_share": 0.7668,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3671, "ryu": 0.6329 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3671,
+            "ryu": 0.6329
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -56,7 +99,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 1, "r": -6 },
+      "position": {
+        "q": 1,
+        "r": -6
+      },
       "total_population": 1597,
       "initial_district_id": "d1",
       "name": "Rim (1,-6)",
@@ -66,16 +112,26 @@
           "name": "Latino residents",
           "population_share": 0.1933,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.8029, "ryu": 0.1971 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8029,
+            "ryu": 0.1971
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p002-anglo",
           "name": "Anglo residents",
           "population_share": 0.8067,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3629, "ryu": 0.6371 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3629,
+            "ryu": 0.6371
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -83,7 +139,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 2, "r": -6 },
+      "position": {
+        "q": 2,
+        "r": -6
+      },
       "total_population": 1496,
       "initial_district_id": "d1",
       "name": "Rim (2,-6)",
@@ -91,18 +150,28 @@
         {
           "id": "p003-latino",
           "name": "Latino residents",
-          "population_share": 0.1980,
+          "population_share": 0.198,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.8041, "ryu": 0.1959 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8041,
+            "ryu": 0.1959
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p003-anglo",
           "name": "Anglo residents",
-          "population_share": 0.8020,
+          "population_share": 0.802,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3891, "ryu": 0.6109 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3891,
+            "ryu": 0.6109
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -110,7 +179,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 3, "r": -6 },
+      "position": {
+        "q": 3,
+        "r": -6
+      },
       "total_population": 1387,
       "initial_district_id": "d1",
       "name": "Rim (3,-6)",
@@ -118,18 +190,28 @@
         {
           "id": "p004-latino",
           "name": "Latino residents",
-          "population_share": 0.1610,
+          "population_share": 0.161,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7667, "ryu": 0.2333 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7667,
+            "ryu": 0.2333
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p004-anglo",
           "name": "Anglo residents",
-          "population_share": 0.8390,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3845, "ryu": 0.6155 },
-          "dimensions": { "ethnicity": "anglo" }
+          "population_share": 0.839,
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.3845,
+            "ryu": 0.6155
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -137,7 +219,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 4, "r": -6 },
+      "position": {
+        "q": 4,
+        "r": -6
+      },
       "total_population": 1591,
       "initial_district_id": "d2",
       "name": "Rim (4,-6)",
@@ -147,16 +232,26 @@
           "name": "Latino residents",
           "population_share": 0.1641,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7865, "ryu": 0.2135 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7865,
+            "ryu": 0.2135
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p005-anglo",
           "name": "Anglo residents",
           "population_share": 0.8359,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3760, "ryu": 0.6240 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.376,
+            "ryu": 0.624
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -164,7 +259,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 5, "r": -6 },
+      "position": {
+        "q": 5,
+        "r": -6
+      },
       "total_population": 1600,
       "initial_district_id": "d2",
       "name": "Rim (5,-6)",
@@ -174,16 +272,26 @@
           "name": "Latino residents",
           "population_share": 0.2155,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7993, "ryu": 0.2007 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7993,
+            "ryu": 0.2007
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p006-anglo",
           "name": "Anglo residents",
           "population_share": 0.7845,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3677, "ryu": 0.6323 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3677,
+            "ryu": 0.6323
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -191,7 +299,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 6, "r": -6 },
+      "position": {
+        "q": 6,
+        "r": -6
+      },
       "total_population": 1499,
       "initial_district_id": "d3",
       "name": "Rim (6,-6)",
@@ -201,16 +312,26 @@
           "name": "Latino residents",
           "population_share": 0.1643,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7684, "ryu": 0.2316 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7684,
+            "ryu": 0.2316
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p007-anglo",
           "name": "Anglo residents",
           "population_share": 0.8357,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3908, "ryu": 0.6092 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3908,
+            "ryu": 0.6092
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -218,7 +339,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -1, "r": -5 },
+      "position": {
+        "q": -1,
+        "r": -5
+      },
       "total_population": 1431,
       "initial_district_id": "d1",
       "name": "Rim (-1,-5)",
@@ -228,16 +352,26 @@
           "name": "Latino residents",
           "population_share": 0.2133,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.8100, "ryu": 0.1900 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.81,
+            "ryu": 0.19
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p008-anglo",
           "name": "Anglo residents",
           "population_share": 0.7867,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3676, "ryu": 0.6324 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3676,
+            "ryu": 0.6324
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -245,7 +379,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 1502,
       "initial_district_id": "d1",
       "name": "Rim (0,-5)",
@@ -253,18 +390,28 @@
         {
           "id": "p009-latino",
           "name": "Latino residents",
-          "population_share": 0.2330,
+          "population_share": 0.233,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7552, "ryu": 0.2448 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7552,
+            "ryu": 0.2448
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p009-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7670,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3513, "ryu": 0.6487 },
-          "dimensions": { "ethnicity": "anglo" }
+          "population_share": 0.767,
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.3513,
+            "ryu": 0.6487
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -272,7 +419,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 1430,
       "initial_district_id": "d1",
       "name": "Rim (1,-5)",
@@ -282,16 +432,26 @@
           "name": "Latino residents",
           "population_share": 0.2213,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7780, "ryu": 0.2220 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.778,
+            "ryu": 0.222
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p010-anglo",
           "name": "Anglo residents",
           "population_share": 0.7787,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3862, "ryu": 0.6138 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3862,
+            "ryu": 0.6138
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -299,7 +459,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 1550,
       "initial_district_id": "d1",
       "name": "Rim (2,-5)",
@@ -309,16 +472,26 @@
           "name": "Latino residents",
           "population_share": 0.2393,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7757, "ryu": 0.2243 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7757,
+            "ryu": 0.2243
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p011-anglo",
           "name": "Anglo residents",
           "population_share": 0.7607,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4087, "ryu": 0.5913 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4087,
+            "ryu": 0.5913
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -326,7 +499,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 1640,
       "initial_district_id": "d2",
       "name": "Rim (3,-5)",
@@ -336,16 +512,26 @@
           "name": "Latino residents",
           "population_share": 0.1879,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7616, "ryu": 0.2384 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7616,
+            "ryu": 0.2384
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p012-anglo",
           "name": "Anglo residents",
           "population_share": 0.8121,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3921, "ryu": 0.6079 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3921,
+            "ryu": 0.6079
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -353,7 +539,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 1626,
       "initial_district_id": "d2",
       "name": "Rim (4,-5)",
@@ -363,16 +552,26 @@
           "name": "Latino residents",
           "population_share": 0.2136,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.8075, "ryu": 0.1925 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8075,
+            "ryu": 0.1925
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p013-anglo",
           "name": "Anglo residents",
           "population_share": 0.7864,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3527, "ryu": 0.6473 },
-          "dimensions": { "ethnicity": "anglo" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.3527,
+            "ryu": 0.6473
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -380,7 +579,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 1487,
       "initial_district_id": "d3",
       "name": "Rim (5,-5)",
@@ -388,18 +590,28 @@
         {
           "id": "p014-latino",
           "name": "Latino residents",
-          "population_share": 0.2170,
+          "population_share": 0.217,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.8035, "ryu": 0.1965 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8035,
+            "ryu": 0.1965
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p014-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7830,
+          "population_share": 0.783,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3642, "ryu": 0.6358 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3642,
+            "ryu": 0.6358
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -407,7 +619,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 6, "r": -5 },
+      "position": {
+        "q": 6,
+        "r": -5
+      },
       "total_population": 1560,
       "initial_district_id": "d4",
       "name": "Rim (6,-5)",
@@ -417,16 +632,26 @@
           "name": "Latino residents",
           "population_share": 0.1717,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7682, "ryu": 0.2318 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7682,
+            "ryu": 0.2318
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p015-anglo",
           "name": "Anglo residents",
           "population_share": 0.8283,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4032, "ryu": 0.5968 },
-          "dimensions": { "ethnicity": "anglo" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4032,
+            "ryu": 0.5968
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -434,7 +659,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -2, "r": -4 },
+      "position": {
+        "q": -2,
+        "r": -4
+      },
       "total_population": 1552,
       "initial_district_id": "d1",
       "name": "Rim (-2,-4)",
@@ -444,16 +672,26 @@
           "name": "Latino residents",
           "population_share": 0.1875,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7781, "ryu": 0.2219 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7781,
+            "ryu": 0.2219
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p016-anglo",
           "name": "Anglo residents",
           "population_share": 0.8125,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3662, "ryu": 0.6338 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3662,
+            "ryu": 0.6338
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -461,7 +699,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 1426,
       "initial_district_id": "d1",
       "name": "Rim (-1,-4)",
@@ -469,18 +710,28 @@
         {
           "id": "p017-latino",
           "name": "Latino residents",
-          "population_share": 0.2170,
+          "population_share": 0.217,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7560, "ryu": 0.2440 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.756,
+            "ryu": 0.244
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p017-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7830,
+          "population_share": 0.783,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3892, "ryu": 0.6108 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3892,
+            "ryu": 0.6108
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -488,7 +739,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 1534,
       "initial_district_id": "d1",
       "name": "Rim (0,-4)",
@@ -498,16 +752,26 @@
           "name": "Latino residents",
           "population_share": 0.1921,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7778, "ryu": 0.2222 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7778,
+            "ryu": 0.2222
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p018-anglo",
           "name": "Anglo residents",
           "population_share": 0.8079,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3632, "ryu": 0.6368 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3632,
+            "ryu": 0.6368
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -515,7 +779,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 1366,
       "initial_district_id": "d1",
       "name": "Rim (1,-4)",
@@ -525,16 +792,26 @@
           "name": "Latino residents",
           "population_share": 0.2329,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.7577, "ryu": 0.2423 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7577,
+            "ryu": 0.2423
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p019-anglo",
           "name": "Anglo residents",
           "population_share": 0.7671,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3858, "ryu": 0.6142 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3858,
+            "ryu": 0.6142
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -542,7 +819,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 1440,
       "initial_district_id": "d2",
       "name": "Rim (2,-4)",
@@ -552,16 +832,26 @@
           "name": "Latino residents",
           "population_share": 0.1688,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7974, "ryu": 0.2026 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7974,
+            "ryu": 0.2026
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p020-anglo",
           "name": "Anglo residents",
           "population_share": 0.8312,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4015, "ryu": 0.5985 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4015,
+            "ryu": 0.5985
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -569,7 +859,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 1527,
       "initial_district_id": "d2",
       "name": "Rim (3,-4)",
@@ -579,16 +872,26 @@
           "name": "Latino residents",
           "population_share": 0.1932,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7615, "ryu": 0.2385 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7615,
+            "ryu": 0.2385
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p021-anglo",
           "name": "Anglo residents",
           "population_share": 0.8068,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3979, "ryu": 0.6021 },
-          "dimensions": { "ethnicity": "anglo" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.3979,
+            "ryu": 0.6021
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -596,7 +899,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 1564,
       "initial_district_id": "d3",
       "name": "Rim (4,-4)",
@@ -606,16 +912,26 @@
           "name": "Latino residents",
           "population_share": 0.1932,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.7785, "ryu": 0.2215 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7785,
+            "ryu": 0.2215
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p022-anglo",
           "name": "Anglo residents",
           "population_share": 0.8068,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4079, "ryu": 0.5921 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4079,
+            "ryu": 0.5921
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -623,7 +939,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 1365,
       "initial_district_id": "d4",
       "name": "Rim (5,-4)",
@@ -633,16 +952,26 @@
           "name": "Latino residents",
           "population_share": 0.2089,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.7840, "ryu": 0.2160 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.784,
+            "ryu": 0.216
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p023-anglo",
           "name": "Anglo residents",
           "population_share": 0.7911,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3952, "ryu": 0.6048 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3952,
+            "ryu": 0.6048
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -650,7 +979,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 6, "r": -4 },
+      "position": {
+        "q": 6,
+        "r": -4
+      },
       "total_population": 1437,
       "initial_district_id": "d4",
       "name": "Rim (6,-4)",
@@ -660,16 +992,26 @@
           "name": "Latino residents",
           "population_share": 0.1673,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7803, "ryu": 0.2197 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7803,
+            "ryu": 0.2197
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p024-anglo",
           "name": "Anglo residents",
           "population_share": 0.8327,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4099, "ryu": 0.5901 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4099,
+            "ryu": 0.5901
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -677,7 +1019,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -3, "r": -3 },
+      "position": {
+        "q": -3,
+        "r": -3
+      },
       "total_population": 1417,
       "initial_district_id": "d1",
       "name": "Rim (-3,-3)",
@@ -687,16 +1032,26 @@
           "name": "Latino residents",
           "population_share": 0.2187,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7828, "ryu": 0.2172 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7828,
+            "ryu": 0.2172
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p025-anglo",
           "name": "Anglo residents",
           "population_share": 0.7813,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3651, "ryu": 0.6349 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3651,
+            "ryu": 0.6349
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -704,7 +1059,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 1554,
       "initial_district_id": "d1",
       "name": "Rim (-2,-3)",
@@ -714,16 +1072,26 @@
           "name": "Latino residents",
           "population_share": 0.2008,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.8031, "ryu": 0.1969 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8031,
+            "ryu": 0.1969
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p026-anglo",
           "name": "Anglo residents",
           "population_share": 0.7992,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3937, "ryu": 0.6063 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3937,
+            "ryu": 0.6063
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -731,7 +1099,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 1643,
       "initial_district_id": "d1",
       "name": "Rim (-1,-3)",
@@ -741,16 +1112,26 @@
           "name": "Latino residents",
           "population_share": 0.1628,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.8097, "ryu": 0.1903 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8097,
+            "ryu": 0.1903
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p027-anglo",
           "name": "Anglo residents",
           "population_share": 0.8372,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3714, "ryu": 0.6286 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3714,
+            "ryu": 0.6286
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -758,7 +1139,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 1511,
       "initial_district_id": "d1",
       "name": "Rim (0,-3)",
@@ -768,16 +1152,26 @@
           "name": "Latino residents",
           "population_share": 0.2321,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.7540, "ryu": 0.2460 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.754,
+            "ryu": 0.246
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p028-anglo",
           "name": "Anglo residents",
           "population_share": 0.7679,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4090, "ryu": 0.5910 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.409,
+            "ryu": 0.591
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -785,7 +1179,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 1397,
       "initial_district_id": "d2",
       "name": "Rim (1,-3)",
@@ -795,16 +1192,26 @@
           "name": "Latino residents",
           "population_share": 0.1686,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.7980, "ryu": 0.2020 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.798,
+            "ryu": 0.202
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p029-anglo",
           "name": "Anglo residents",
           "population_share": 0.8314,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3997, "ryu": 0.6003 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3997,
+            "ryu": 0.6003
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -812,7 +1219,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 1507,
       "initial_district_id": "d2",
       "name": "Rim (2,-3)",
@@ -822,16 +1232,26 @@
           "name": "Latino residents",
           "population_share": 0.2001,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7834, "ryu": 0.2166 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7834,
+            "ryu": 0.2166
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p030-anglo",
           "name": "Anglo residents",
           "population_share": 0.7999,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3693, "ryu": 0.6307 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3693,
+            "ryu": 0.6307
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -839,7 +1259,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 1429,
       "initial_district_id": "d3",
       "name": "Rim (3,-3)",
@@ -849,16 +1272,26 @@
           "name": "Latino residents",
           "population_share": 0.2365,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7957, "ryu": 0.2043 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7957,
+            "ryu": 0.2043
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p031-anglo",
           "name": "Anglo residents",
           "population_share": 0.7635,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3740, "ryu": 0.6260 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.374,
+            "ryu": 0.626
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -866,7 +1299,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 1625,
       "initial_district_id": "d4",
       "name": "Rim (4,-3)",
@@ -876,16 +1312,26 @@
           "name": "Latino residents",
           "population_share": 0.2084,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7666, "ryu": 0.2334 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7666,
+            "ryu": 0.2334
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p032-anglo",
           "name": "Anglo residents",
           "population_share": 0.7916,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4094, "ryu": 0.5906 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4094,
+            "ryu": 0.5906
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -893,7 +1339,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 1491,
       "initial_district_id": "d4",
       "name": "Rim (5,-3)",
@@ -903,16 +1352,26 @@
           "name": "Latino residents",
           "population_share": 0.1972,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.7936, "ryu": 0.2064 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7936,
+            "ryu": 0.2064
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p033-anglo",
           "name": "Anglo residents",
           "population_share": 0.8028,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3801, "ryu": 0.6199 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3801,
+            "ryu": 0.6199
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -920,7 +1379,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 6, "r": -3 },
+      "position": {
+        "q": 6,
+        "r": -3
+      },
       "total_population": 1585,
       "initial_district_id": "d5",
       "name": "Rim (6,-3)",
@@ -929,17 +1391,27 @@
           "id": "p034-latino",
           "name": "Latino residents",
           "population_share": 0.1718,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7557, "ryu": 0.2443 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7557,
+            "ryu": 0.2443
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p034-anglo",
           "name": "Anglo residents",
           "population_share": 0.8282,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4026, "ryu": 0.5974 },
-          "dimensions": { "ethnicity": "anglo" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4026,
+            "ryu": 0.5974
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -947,7 +1419,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": -2 },
+      "position": {
+        "q": -4,
+        "r": -2
+      },
       "total_population": 1499,
       "initial_district_id": "d1",
       "name": "Rim (-4,-2)",
@@ -957,16 +1432,26 @@
           "name": "Latino residents",
           "population_share": 0.2007,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.8098, "ryu": 0.1902 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8098,
+            "ryu": 0.1902
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p035-anglo",
           "name": "Anglo residents",
           "population_share": 0.7993,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4023, "ryu": 0.5977 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4023,
+            "ryu": 0.5977
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -974,7 +1459,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 1649,
       "initial_district_id": "d1",
       "name": "Rim (-3,-2)",
@@ -984,16 +1472,26 @@
           "name": "Latino residents",
           "population_share": 0.1967,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7520, "ryu": 0.2480 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.752,
+            "ryu": 0.248
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p036-anglo",
           "name": "Anglo residents",
           "population_share": 0.8033,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3878, "ryu": 0.6122 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3878,
+            "ryu": 0.6122
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1001,7 +1499,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 1482,
       "initial_district_id": "d1",
       "name": "Rim (-2,-2)",
@@ -1010,17 +1511,27 @@
           "id": "p037-latino",
           "name": "Latino residents",
           "population_share": 0.2332,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7819, "ryu": 0.2181 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7819,
+            "ryu": 0.2181
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p037-anglo",
           "name": "Anglo residents",
           "population_share": 0.7668,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3863, "ryu": 0.6137 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3863,
+            "ryu": 0.6137
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1028,7 +1539,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 1473,
       "initial_district_id": "d1",
       "name": "Rim (-1,-2)",
@@ -1037,17 +1551,27 @@
           "id": "p038-latino",
           "name": "Latino residents",
           "population_share": 0.1933,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7593, "ryu": 0.2407 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7593,
+            "ryu": 0.2407
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p038-anglo",
           "name": "Anglo residents",
           "population_share": 0.8067,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3524, "ryu": 0.6476 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3524,
+            "ryu": 0.6476
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1055,7 +1579,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 1559,
       "initial_district_id": "d2",
       "name": "Rim (0,-2)",
@@ -1065,16 +1592,26 @@
           "name": "Latino residents",
           "population_share": 0.2025,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.7991, "ryu": 0.2009 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7991,
+            "ryu": 0.2009
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p039-anglo",
           "name": "Anglo residents",
           "population_share": 0.7975,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3541, "ryu": 0.6459 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3541,
+            "ryu": 0.6459
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1082,7 +1619,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 1494,
       "initial_district_id": "d2",
       "name": "Valley (1,-2)",
@@ -1092,16 +1632,26 @@
           "name": "Latino residents",
           "population_share": 0.7133,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7567, "ryu": 0.2433 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7567,
+            "ryu": 0.2433
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p040-anglo",
           "name": "Anglo residents",
           "population_share": 0.2867,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3661, "ryu": 0.6339 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3661,
+            "ryu": 0.6339
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1109,7 +1659,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 1492,
       "initial_district_id": "d3",
       "name": "Valley (2,-2)",
@@ -1119,16 +1672,26 @@
           "name": "Latino residents",
           "population_share": 0.7063,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.7619, "ryu": 0.2381 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7619,
+            "ryu": 0.2381
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p041-anglo",
           "name": "Anglo residents",
           "population_share": 0.2937,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3710, "ryu": 0.6290 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.371,
+            "ryu": 0.629
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1136,7 +1699,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 1611,
       "initial_district_id": "d4",
       "name": "Valley (3,-2)",
@@ -1146,16 +1712,26 @@
           "name": "Latino residents",
           "population_share": 0.6836,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.7835, "ryu": 0.2165 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7835,
+            "ryu": 0.2165
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p042-anglo",
           "name": "Anglo residents",
           "population_share": 0.3164,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3542, "ryu": 0.6458 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3542,
+            "ryu": 0.6458
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1163,7 +1739,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 1604,
       "initial_district_id": "d4",
       "name": "Valley (4,-2)",
@@ -1173,16 +1752,26 @@
           "name": "Latino residents",
           "population_share": 0.7049,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7609, "ryu": 0.2391 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7609,
+            "ryu": 0.2391
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p043-anglo",
           "name": "Anglo residents",
           "population_share": 0.2951,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4076, "ryu": 0.5924 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4076,
+            "ryu": 0.5924
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1190,7 +1779,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 1413,
       "initial_district_id": "d5",
       "name": "Valley (5,-2)",
@@ -1199,17 +1791,27 @@
           "id": "p044-latino",
           "name": "Latino residents",
           "population_share": 0.7109,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7798, "ryu": 0.2202 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7798,
+            "ryu": 0.2202
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p044-anglo",
           "name": "Anglo residents",
           "population_share": 0.2891,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3949, "ryu": 0.6051 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3949,
+            "ryu": 0.6051
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1217,7 +1819,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 6, "r": -2 },
+      "position": {
+        "q": 6,
+        "r": -2
+      },
       "total_population": 1389,
       "initial_district_id": "d5",
       "name": "Rim (6,-2)",
@@ -1227,16 +1832,26 @@
           "name": "Latino residents",
           "population_share": 0.1819,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7632, "ryu": 0.2368 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7632,
+            "ryu": 0.2368
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p045-anglo",
           "name": "Anglo residents",
           "population_share": 0.8181,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3643, "ryu": 0.6357 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3643,
+            "ryu": 0.6357
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1244,7 +1859,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -5, "r": -1 },
+      "position": {
+        "q": -5,
+        "r": -1
+      },
       "total_population": 1524,
       "initial_district_id": "d1",
       "name": "Rim (-5,-1)",
@@ -1254,16 +1872,26 @@
           "name": "Latino residents",
           "population_share": 0.1822,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7612, "ryu": 0.2388 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7612,
+            "ryu": 0.2388
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p046-anglo",
           "name": "Anglo residents",
           "population_share": 0.8178,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3931, "ryu": 0.6069 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3931,
+            "ryu": 0.6069
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1271,7 +1899,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 1497,
       "initial_district_id": "d1",
       "name": "Rim (-4,-1)",
@@ -1281,16 +1912,26 @@
           "name": "Latino residents",
           "population_share": 0.2038,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7791, "ryu": 0.2209 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7791,
+            "ryu": 0.2209
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p047-anglo",
           "name": "Anglo residents",
           "population_share": 0.7962,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3537, "ryu": 0.6463 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3537,
+            "ryu": 0.6463
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1298,7 +1939,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 1562,
       "initial_district_id": "d1",
       "name": "Rim (-3,-1)",
@@ -1308,16 +1952,26 @@
           "name": "Latino residents",
           "population_share": 0.1665,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7541, "ryu": 0.2459 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7541,
+            "ryu": 0.2459
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p048-anglo",
           "name": "Anglo residents",
           "population_share": 0.8335,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4047, "ryu": 0.5953 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4047,
+            "ryu": 0.5953
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1325,7 +1979,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 1400,
       "initial_district_id": "d1",
       "name": "Rim (-2,-1)",
@@ -1335,16 +1992,26 @@
           "name": "Latino residents",
           "population_share": 0.2101,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7979, "ryu": 0.2021 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7979,
+            "ryu": 0.2021
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p049-anglo",
           "name": "Anglo residents",
           "population_share": 0.7899,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3710, "ryu": 0.6290 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.371,
+            "ryu": 0.629
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1352,7 +2019,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 1572,
       "initial_district_id": "d2",
       "name": "Rim (-1,-1)",
@@ -1362,16 +2032,26 @@
           "name": "Latino residents",
           "population_share": 0.1899,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7825, "ryu": 0.2175 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7825,
+            "ryu": 0.2175
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p050-anglo",
           "name": "Anglo residents",
           "population_share": 0.8101,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3807, "ryu": 0.6193 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3807,
+            "ryu": 0.6193
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1379,7 +2059,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 1482,
       "initial_district_id": "d2",
       "name": "Rim (0,-1)",
@@ -1389,16 +2072,26 @@
           "name": "Latino residents",
           "population_share": 0.1753,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7700, "ryu": 0.2300 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.77,
+            "ryu": 0.23
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p051-anglo",
           "name": "Anglo residents",
           "population_share": 0.8247,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3579, "ryu": 0.6421 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3579,
+            "ryu": 0.6421
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1406,7 +2099,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 1623,
       "initial_district_id": "d3",
       "name": "Valley (1,-1)",
@@ -1416,16 +2112,26 @@
           "name": "Latino residents",
           "population_share": 0.6724,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7657, "ryu": 0.2343 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7657,
+            "ryu": 0.2343
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p052-anglo",
           "name": "Anglo residents",
           "population_share": 0.3276,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3676, "ryu": 0.6324 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3676,
+            "ryu": 0.6324
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1433,7 +2139,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 1430,
       "initial_district_id": "d4",
       "name": "Valley (2,-1)",
@@ -1441,18 +2150,28 @@
         {
           "id": "p053-latino",
           "name": "Latino residents",
-          "population_share": 0.6680,
+          "population_share": 0.668,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7756, "ryu": 0.2244 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7756,
+            "ryu": 0.2244
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p053-anglo",
           "name": "Anglo residents",
-          "population_share": 0.3320,
+          "population_share": 0.332,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3805, "ryu": 0.6195 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3805,
+            "ryu": 0.6195
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1460,7 +2179,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 1498,
       "initial_district_id": "d4",
       "name": "Valley (3,-1)",
@@ -1470,16 +2192,26 @@
           "name": "Latino residents",
           "population_share": 0.7066,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7700, "ryu": 0.2300 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.77,
+            "ryu": 0.23
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p054-anglo",
           "name": "Anglo residents",
           "population_share": 0.2934,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3760, "ryu": 0.6240 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.376,
+            "ryu": 0.624
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1487,7 +2219,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 1618,
       "initial_district_id": "d5",
       "name": "Valley (4,-1)",
@@ -1497,16 +2232,26 @@
           "name": "Latino residents",
           "population_share": 0.6667,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7764, "ryu": 0.2236 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7764,
+            "ryu": 0.2236
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p055-anglo",
           "name": "Anglo residents",
           "population_share": 0.3333,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4071, "ryu": 0.5929 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4071,
+            "ryu": 0.5929
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1514,7 +2259,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 1555,
       "initial_district_id": "d5",
       "name": "Valley (5,-1)",
@@ -1524,16 +2272,26 @@
           "name": "Latino residents",
           "population_share": 0.6743,
           "turnout_rate": 0.52,
-          "vote_shares": { "ken": 0.7912, "ryu": 0.2088 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7912,
+            "ryu": 0.2088
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p056-anglo",
           "name": "Anglo residents",
           "population_share": 0.3257,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3851, "ryu": 0.6149 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3851,
+            "ryu": 0.6149
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1541,7 +2299,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 6, "r": -1 },
+      "position": {
+        "q": 6,
+        "r": -1
+      },
       "total_population": 1510,
       "initial_district_id": "d5",
       "name": "Rim (6,-1)",
@@ -1551,16 +2312,26 @@
           "name": "Latino residents",
           "population_share": 0.2233,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.8009, "ryu": 0.1991 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8009,
+            "ryu": 0.1991
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p057-anglo",
           "name": "Anglo residents",
           "population_share": 0.7767,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3669, "ryu": 0.6331 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3669,
+            "ryu": 0.6331
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1568,7 +2339,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -6, "r": 0 },
+      "position": {
+        "q": -6,
+        "r": 0
+      },
       "total_population": 1645,
       "initial_district_id": "d1",
       "name": "Rim (-6,0)",
@@ -1578,16 +2352,26 @@
           "name": "Latino residents",
           "population_share": 0.1604,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.8090, "ryu": 0.1910 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.809,
+            "ryu": 0.191
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p058-anglo",
           "name": "Anglo residents",
           "population_share": 0.8396,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3837, "ryu": 0.6163 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3837,
+            "ryu": 0.6163
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1595,7 +2379,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 1530,
       "initial_district_id": "d1",
       "name": "Rim (-5,0)",
@@ -1604,17 +2391,27 @@
           "id": "p059-latino",
           "name": "Latino residents",
           "population_share": 0.1976,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7820, "ryu": 0.2180 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.782,
+            "ryu": 0.218
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p059-anglo",
           "name": "Anglo residents",
           "population_share": 0.8024,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3976, "ryu": 0.6024 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3976,
+            "ryu": 0.6024
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1622,7 +2419,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 1565,
       "initial_district_id": "d1",
       "name": "Rim (-4,0)",
@@ -1632,16 +2432,26 @@
           "name": "Latino residents",
           "population_share": 0.2387,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7988, "ryu": 0.2012 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7988,
+            "ryu": 0.2012
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p060-anglo",
           "name": "Anglo residents",
           "population_share": 0.7613,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3966, "ryu": 0.6034 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3966,
+            "ryu": 0.6034
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1649,7 +2459,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 1633,
       "initial_district_id": "d1",
       "name": "Rim (-3,0)",
@@ -1659,16 +2472,26 @@
           "name": "Latino residents",
           "population_share": 0.1673,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7615, "ryu": 0.2385 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7615,
+            "ryu": 0.2385
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p061-anglo",
           "name": "Anglo residents",
           "population_share": 0.8327,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3713, "ryu": 0.6287 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3713,
+            "ryu": 0.6287
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1676,7 +2499,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 1530,
       "initial_district_id": "d2",
       "name": "Rim (-2,0)",
@@ -1686,16 +2512,26 @@
           "name": "Latino residents",
           "population_share": 0.1784,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7681, "ryu": 0.2319 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7681,
+            "ryu": 0.2319
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p062-anglo",
           "name": "Anglo residents",
           "population_share": 0.8216,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.3613, "ryu": 0.6387 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3613,
+            "ryu": 0.6387
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1703,7 +2539,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 1388,
       "initial_district_id": "d2",
       "name": "Rim (-1,0)",
@@ -1713,16 +2552,26 @@
           "name": "Latino residents",
           "population_share": 0.2132,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.8042, "ryu": 0.1958 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8042,
+            "ryu": 0.1958
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p063-anglo",
           "name": "Anglo residents",
           "population_share": 0.7868,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4098, "ryu": 0.5902 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4098,
+            "ryu": 0.5902
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1730,7 +2579,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 1468,
       "initial_district_id": "d3",
       "name": "Rim (0,0)",
@@ -1740,16 +2592,26 @@
           "name": "Latino residents",
           "population_share": 0.1922,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7600, "ryu": 0.2400 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.76,
+            "ryu": 0.24
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p064-anglo",
           "name": "Anglo residents",
           "population_share": 0.8078,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3609, "ryu": 0.6391 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3609,
+            "ryu": 0.6391
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1757,7 +2619,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 1626,
       "initial_district_id": "d4",
       "name": "Valley (1,0)",
@@ -1767,16 +2632,26 @@
           "name": "Latino residents",
           "population_share": 0.6659,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7668, "ryu": 0.2332 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7668,
+            "ryu": 0.2332
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p065-anglo",
           "name": "Anglo residents",
           "population_share": 0.3341,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3530, "ryu": 0.6470 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.353,
+            "ryu": 0.647
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1784,7 +2659,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 1568,
       "initial_district_id": "d4",
       "name": "Valley (2,0)",
@@ -1794,16 +2672,26 @@
           "name": "Latino residents",
           "population_share": 0.7208,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7897, "ryu": 0.2103 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7897,
+            "ryu": 0.2103
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p066-anglo",
           "name": "Anglo residents",
           "population_share": 0.2792,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3569, "ryu": 0.6431 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3569,
+            "ryu": 0.6431
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1811,7 +2699,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 1506,
       "initial_district_id": "d5",
       "name": "Valley (3,0)",
@@ -1820,17 +2711,27 @@
           "id": "p067-latino",
           "name": "Latino residents",
           "population_share": 0.6969,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.8057, "ryu": 0.1943 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.8057,
+            "ryu": 0.1943
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p067-anglo",
           "name": "Anglo residents",
           "population_share": 0.3031,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3657, "ryu": 0.6343 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3657,
+            "ryu": 0.6343
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1838,7 +2739,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 1428,
       "initial_district_id": "d5",
       "name": "Valley (4,0)",
@@ -1848,16 +2752,26 @@
           "name": "Latino residents",
           "population_share": 0.7375,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.7944, "ryu": 0.2056 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7944,
+            "ryu": 0.2056
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p068-anglo",
           "name": "Anglo residents",
           "population_share": 0.2625,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4001, "ryu": 0.5999 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4001,
+            "ryu": 0.5999
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1865,7 +2779,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 1373,
       "initial_district_id": "d5",
       "name": "Valley (5,0)",
@@ -1875,16 +2792,26 @@
           "name": "Latino residents",
           "population_share": 0.6925,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7801, "ryu": 0.2199 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7801,
+            "ryu": 0.2199
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p069-anglo",
           "name": "Anglo residents",
           "population_share": 0.3075,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3911, "ryu": 0.6089 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3911,
+            "ryu": 0.6089
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1892,7 +2819,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 6, "r": 0 },
+      "position": {
+        "q": 6,
+        "r": 0
+      },
       "total_population": 1450,
       "initial_district_id": "d5",
       "name": "Rim (6,0)",
@@ -1902,16 +2832,26 @@
           "name": "Latino residents",
           "population_share": 0.1872,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.8022, "ryu": 0.1978 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8022,
+            "ryu": 0.1978
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p070-anglo",
           "name": "Anglo residents",
           "population_share": 0.8128,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3917, "ryu": 0.6083 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3917,
+            "ryu": 0.6083
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1919,7 +2859,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -6, "r": 1 },
+      "position": {
+        "q": -6,
+        "r": 1
+      },
       "total_population": 1577,
       "initial_district_id": "d1",
       "name": "Rim (-6,1)",
@@ -1929,16 +2872,26 @@
           "name": "Latino residents",
           "population_share": 0.2337,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7803, "ryu": 0.2197 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7803,
+            "ryu": 0.2197
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p071-anglo",
           "name": "Anglo residents",
           "population_share": 0.7663,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3919, "ryu": 0.6081 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3919,
+            "ryu": 0.6081
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1946,7 +2899,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 1416,
       "initial_district_id": "d1",
       "name": "Rim (-5,1)",
@@ -1956,16 +2912,26 @@
           "name": "Latino residents",
           "population_share": 0.2316,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.8045, "ryu": 0.1955 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8045,
+            "ryu": 0.1955
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p072-anglo",
           "name": "Anglo residents",
           "population_share": 0.7684,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3839, "ryu": 0.6161 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3839,
+            "ryu": 0.6161
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -1973,7 +2939,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 1445,
       "initial_district_id": "d1",
       "name": "Rim (-4,1)",
@@ -1983,16 +2952,26 @@
           "name": "Latino residents",
           "population_share": 0.1701,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.7847, "ryu": 0.2153 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7847,
+            "ryu": 0.2153
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p073-anglo",
           "name": "Anglo residents",
           "population_share": 0.8299,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3838, "ryu": 0.6162 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3838,
+            "ryu": 0.6162
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2000,7 +2979,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 1424,
       "initial_district_id": "d2",
       "name": "Rim (-3,1)",
@@ -2010,16 +2992,26 @@
           "name": "Latino residents",
           "population_share": 0.1628,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7539, "ryu": 0.2461 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7539,
+            "ryu": 0.2461
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p074-anglo",
           "name": "Anglo residents",
           "population_share": 0.8372,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3849, "ryu": 0.6151 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3849,
+            "ryu": 0.6151
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2027,7 +3019,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 1492,
       "initial_district_id": "d2",
       "name": "Rim (-2,1)",
@@ -2036,17 +3031,27 @@
           "id": "p075-latino",
           "name": "Latino residents",
           "population_share": 0.2026,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7809, "ryu": 0.2191 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7809,
+            "ryu": 0.2191
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p075-anglo",
           "name": "Anglo residents",
           "population_share": 0.7974,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3800, "ryu": 0.6200 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.38,
+            "ryu": 0.62
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2054,7 +3059,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 1538,
       "initial_district_id": "d3",
       "name": "Rim (-1,1)",
@@ -2064,16 +3072,26 @@
           "name": "Latino residents",
           "population_share": 0.2186,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7872, "ryu": 0.2128 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7872,
+            "ryu": 0.2128
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p076-anglo",
           "name": "Anglo residents",
           "population_share": 0.7814,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3507, "ryu": 0.6493 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3507,
+            "ryu": 0.6493
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2081,7 +3099,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 1631,
       "initial_district_id": "d4",
       "name": "Rim (0,1)",
@@ -2089,18 +3110,28 @@
         {
           "id": "p077-latino",
           "name": "Latino residents",
-          "population_share": 0.1850,
+          "population_share": 0.185,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7613, "ryu": 0.2387 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7613,
+            "ryu": 0.2387
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p077-anglo",
           "name": "Anglo residents",
-          "population_share": 0.8150,
+          "population_share": 0.815,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3955, "ryu": 0.6045 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3955,
+            "ryu": 0.6045
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2108,7 +3139,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 1621,
       "initial_district_id": "d4",
       "name": "Valley (1,1)",
@@ -2118,16 +3152,26 @@
           "name": "Latino residents",
           "population_share": 0.7295,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7590, "ryu": 0.2410 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.759,
+            "ryu": 0.241
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p078-anglo",
           "name": "Anglo residents",
           "population_share": 0.2705,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3839, "ryu": 0.6161 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3839,
+            "ryu": 0.6161
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2135,7 +3179,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 1357,
       "initial_district_id": "d5",
       "name": "Valley (2,1)",
@@ -2144,17 +3191,27 @@
           "id": "p079-latino",
           "name": "Latino residents",
           "population_share": 0.6912,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7681, "ryu": 0.2319 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7681,
+            "ryu": 0.2319
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p079-anglo",
           "name": "Anglo residents",
           "population_share": 0.3088,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3877, "ryu": 0.6123 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3877,
+            "ryu": 0.6123
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2162,7 +3219,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 1366,
       "initial_district_id": "d5",
       "name": "Valley (3,1)",
@@ -2172,16 +3232,26 @@
           "name": "Latino residents",
           "population_share": 0.7036,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7773, "ryu": 0.2227 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7773,
+            "ryu": 0.2227
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p080-anglo",
           "name": "Anglo residents",
           "population_share": 0.2964,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4037, "ryu": 0.5963 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4037,
+            "ryu": 0.5963
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2189,7 +3259,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 1492,
       "initial_district_id": "d5",
       "name": "Valley (4,1)",
@@ -2199,16 +3272,26 @@
           "name": "Latino residents",
           "population_share": 0.6721,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7572, "ryu": 0.2428 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7572,
+            "ryu": 0.2428
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p081-anglo",
           "name": "Anglo residents",
           "population_share": 0.3279,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3710, "ryu": 0.6290 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.371,
+            "ryu": 0.629
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2216,7 +3299,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "valle_verde_valley",
-      "position": { "q": 5, "r": 1 },
+      "position": {
+        "q": 5,
+        "r": 1
+      },
       "total_population": 1649,
       "initial_district_id": "d5",
       "name": "Valley (5,1)",
@@ -2226,16 +3312,26 @@
           "name": "Latino residents",
           "population_share": 0.7324,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7860, "ryu": 0.2140 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.786,
+            "ryu": 0.214
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p082-anglo",
           "name": "Anglo residents",
           "population_share": 0.2676,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4003, "ryu": 0.5997 },
-          "dimensions": { "ethnicity": "anglo" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4003,
+            "ryu": 0.5997
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2243,7 +3339,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -6, "r": 2 },
+      "position": {
+        "q": -6,
+        "r": 2
+      },
       "total_population": 1558,
       "initial_district_id": "d1",
       "name": "Rim (-6,2)",
@@ -2252,17 +3351,27 @@
           "id": "p083-latino",
           "name": "Latino residents",
           "population_share": 0.1718,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7509, "ryu": 0.2491 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7509,
+            "ryu": 0.2491
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p083-anglo",
           "name": "Anglo residents",
           "population_share": 0.8282,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3798, "ryu": 0.6202 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3798,
+            "ryu": 0.6202
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2270,7 +3379,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 1523,
       "initial_district_id": "d1",
       "name": "Rim (-5,2)",
@@ -2279,17 +3391,27 @@
           "id": "p084-latino",
           "name": "Latino residents",
           "population_share": 0.1816,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.8082, "ryu": 0.1918 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.8082,
+            "ryu": 0.1918
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p084-anglo",
           "name": "Anglo residents",
           "population_share": 0.8184,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4020, "ryu": 0.5980 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.402,
+            "ryu": 0.598
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2297,7 +3419,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 1367,
       "initial_district_id": "d2",
       "name": "Rim (-4,2)",
@@ -2307,16 +3432,26 @@
           "name": "Latino residents",
           "population_share": 0.1749,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.7961, "ryu": 0.2039 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7961,
+            "ryu": 0.2039
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p085-anglo",
           "name": "Anglo residents",
           "population_share": 0.8251,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3975, "ryu": 0.6025 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3975,
+            "ryu": 0.6025
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2324,7 +3459,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 1357,
       "initial_district_id": "d2",
       "name": "Rim (-3,2)",
@@ -2333,17 +3471,27 @@
           "id": "p086-latino",
           "name": "Latino residents",
           "population_share": 0.2067,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.8023, "ryu": 0.1977 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.8023,
+            "ryu": 0.1977
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p086-anglo",
           "name": "Anglo residents",
           "population_share": 0.7933,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3897, "ryu": 0.6103 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3897,
+            "ryu": 0.6103
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2351,7 +3499,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 1595,
       "initial_district_id": "d3",
       "name": "Rim (-2,2)",
@@ -2361,16 +3512,26 @@
           "name": "Latino residents",
           "population_share": 0.2119,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.7785, "ryu": 0.2215 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7785,
+            "ryu": 0.2215
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p087-anglo",
           "name": "Anglo residents",
           "population_share": 0.7881,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3968, "ryu": 0.6032 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3968,
+            "ryu": 0.6032
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2378,7 +3539,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 1541,
       "initial_district_id": "d4",
       "name": "Rim (-1,2)",
@@ -2388,16 +3552,26 @@
           "name": "Latino residents",
           "population_share": 0.1617,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7805, "ryu": 0.2195 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7805,
+            "ryu": 0.2195
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p088-anglo",
           "name": "Anglo residents",
           "population_share": 0.8383,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3780, "ryu": 0.6220 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.378,
+            "ryu": 0.622
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2405,7 +3579,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 1579,
       "initial_district_id": "d4",
       "name": "Rim (0,2)",
@@ -2415,16 +3592,26 @@
           "name": "Latino residents",
           "population_share": 0.2392,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7885, "ryu": 0.2115 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7885,
+            "ryu": 0.2115
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p089-anglo",
           "name": "Anglo residents",
           "population_share": 0.7608,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4020, "ryu": 0.5980 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.402,
+            "ryu": 0.598
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2432,7 +3619,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 1510,
       "initial_district_id": "d5",
       "name": "Rim (1,2)",
@@ -2442,16 +3632,26 @@
           "name": "Latino residents",
           "population_share": 0.1778,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7743, "ryu": 0.2257 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7743,
+            "ryu": 0.2257
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p090-anglo",
           "name": "Anglo residents",
           "population_share": 0.8222,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3568, "ryu": 0.6432 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3568,
+            "ryu": 0.6432
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2459,7 +3659,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 1562,
       "initial_district_id": "d5",
       "name": "Rim (2,2)",
@@ -2469,16 +3672,26 @@
           "name": "Latino residents",
           "population_share": 0.1656,
           "turnout_rate": 0.54,
-          "vote_shares": { "ken": 0.8033, "ryu": 0.1967 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8033,
+            "ryu": 0.1967
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p091-anglo",
           "name": "Anglo residents",
           "population_share": 0.8344,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3671, "ryu": 0.6329 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3671,
+            "ryu": 0.6329
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2486,7 +3699,10 @@
       "id": "p092",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 1483,
       "initial_district_id": "d5",
       "name": "Rim (3,2)",
@@ -2496,16 +3712,26 @@
           "name": "Latino residents",
           "population_share": 0.2096,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7564, "ryu": 0.2436 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7564,
+            "ryu": 0.2436
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p092-anglo",
           "name": "Anglo residents",
           "population_share": 0.7904,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4012, "ryu": 0.5988 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4012,
+            "ryu": 0.5988
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2513,7 +3739,10 @@
       "id": "p093",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 4, "r": 2 },
+      "position": {
+        "q": 4,
+        "r": 2
+      },
       "total_population": 1462,
       "initial_district_id": "d5",
       "name": "Rim (4,2)",
@@ -2523,16 +3752,26 @@
           "name": "Latino residents",
           "population_share": 0.2371,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.8039, "ryu": 0.1961 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8039,
+            "ryu": 0.1961
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p093-anglo",
           "name": "Anglo residents",
           "population_share": 0.7629,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3638, "ryu": 0.6362 },
-          "dimensions": { "ethnicity": "anglo" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.3638,
+            "ryu": 0.6362
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2540,7 +3779,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -6, "r": 3 },
+      "position": {
+        "q": -6,
+        "r": 3
+      },
       "total_population": 1428,
       "initial_district_id": "d1",
       "name": "Rim (-6,3)",
@@ -2550,16 +3792,26 @@
           "name": "Latino residents",
           "population_share": 0.1637,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7596, "ryu": 0.2404 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7596,
+            "ryu": 0.2404
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p094-anglo",
           "name": "Anglo residents",
           "population_share": 0.8363,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4027, "ryu": 0.5973 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4027,
+            "ryu": 0.5973
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2567,7 +3819,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 1439,
       "initial_district_id": "d2",
       "name": "Rim (-5,3)",
@@ -2577,16 +3832,26 @@
           "name": "Latino residents",
           "population_share": 0.1666,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7599, "ryu": 0.2401 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7599,
+            "ryu": 0.2401
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p095-anglo",
           "name": "Anglo residents",
           "population_share": 0.8334,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3993, "ryu": 0.6007 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3993,
+            "ryu": 0.6007
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2594,7 +3859,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 1411,
       "initial_district_id": "d2",
       "name": "Rim (-4,3)",
@@ -2602,18 +3870,28 @@
         {
           "id": "p096-latino",
           "name": "Latino residents",
-          "population_share": 0.2070,
+          "population_share": 0.207,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.8018, "ryu": 0.1982 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8018,
+            "ryu": 0.1982
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p096-anglo",
           "name": "Anglo residents",
-          "population_share": 0.7930,
+          "population_share": 0.793,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3726, "ryu": 0.6274 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3726,
+            "ryu": 0.6274
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2621,7 +3899,10 @@
       "id": "p097",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 1508,
       "initial_district_id": "d3",
       "name": "Rim (-3,3)",
@@ -2630,17 +3911,27 @@
           "id": "p097-latino",
           "name": "Latino residents",
           "population_share": 0.1711,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7706, "ryu": 0.2294 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7706,
+            "ryu": 0.2294
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p097-anglo",
           "name": "Anglo residents",
           "population_share": 0.8289,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3716, "ryu": 0.6284 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3716,
+            "ryu": 0.6284
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2648,7 +3939,10 @@
       "id": "p098",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 1469,
       "initial_district_id": "d4",
       "name": "Rim (-2,3)",
@@ -2658,16 +3952,26 @@
           "name": "Latino residents",
           "population_share": 0.2266,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7561, "ryu": 0.2439 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7561,
+            "ryu": 0.2439
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p098-anglo",
           "name": "Anglo residents",
           "population_share": 0.7734,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4088, "ryu": 0.5912 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4088,
+            "ryu": 0.5912
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2675,7 +3979,10 @@
       "id": "p099",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 1444,
       "initial_district_id": "d4",
       "name": "Rim (-1,3)",
@@ -2685,16 +3992,26 @@
           "name": "Latino residents",
           "population_share": 0.2198,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7690, "ryu": 0.2310 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.769,
+            "ryu": 0.231
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p099-anglo",
           "name": "Anglo residents",
           "population_share": 0.7802,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3910, "ryu": 0.6090 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.391,
+            "ryu": 0.609
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2702,7 +4019,10 @@
       "id": "p100",
       "editable": true,
       "county_id": "valle_verde_central",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 1352,
       "initial_district_id": "d5",
       "name": "Rim (0,3)",
@@ -2711,17 +4031,27 @@
           "id": "p100-latino",
           "name": "Latino residents",
           "population_share": 0.2353,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7762, "ryu": 0.2238 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7762,
+            "ryu": 0.2238
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p100-anglo",
           "name": "Anglo residents",
           "population_share": 0.7647,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3770, "ryu": 0.6230 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.377,
+            "ryu": 0.623
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2729,7 +4059,10 @@
       "id": "p101",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 1397,
       "initial_district_id": "d5",
       "name": "Rim (1,3)",
@@ -2739,16 +4072,26 @@
           "name": "Latino residents",
           "population_share": 0.1901,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7913, "ryu": 0.2087 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7913,
+            "ryu": 0.2087
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p101-anglo",
           "name": "Anglo residents",
           "population_share": 0.8099,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4010, "ryu": 0.5990 },
-          "dimensions": { "ethnicity": "anglo" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.401,
+            "ryu": 0.599
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2756,7 +4099,10 @@
       "id": "p102",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 1555,
       "initial_district_id": "d5",
       "name": "Rim (2,3)",
@@ -2765,17 +4111,27 @@
           "id": "p102-latino",
           "name": "Latino residents",
           "population_share": 0.2321,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7943, "ryu": 0.2057 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7943,
+            "ryu": 0.2057
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p102-anglo",
           "name": "Anglo residents",
           "population_share": 0.7679,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4010, "ryu": 0.5990 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.401,
+            "ryu": 0.599
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2783,7 +4139,10 @@
       "id": "p103",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 3, "r": 3 },
+      "position": {
+        "q": 3,
+        "r": 3
+      },
       "total_population": 1385,
       "initial_district_id": "d5",
       "name": "Rim (3,3)",
@@ -2793,16 +4152,26 @@
           "name": "Latino residents",
           "population_share": 0.1999,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.8082, "ryu": 0.1918 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8082,
+            "ryu": 0.1918
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p103-anglo",
           "name": "Anglo residents",
           "population_share": 0.8001,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4006, "ryu": 0.5994 },
-          "dimensions": { "ethnicity": "anglo" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4006,
+            "ryu": 0.5994
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2810,7 +4179,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -6, "r": 4 },
+      "position": {
+        "q": -6,
+        "r": 4
+      },
       "total_population": 1559,
       "initial_district_id": "d2",
       "name": "Rim (-6,4)",
@@ -2820,16 +4192,26 @@
           "name": "Latino residents",
           "population_share": 0.2204,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.8035, "ryu": 0.1965 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8035,
+            "ryu": 0.1965
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p104-anglo",
           "name": "Anglo residents",
           "population_share": 0.7796,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3710, "ryu": 0.6290 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.371,
+            "ryu": 0.629
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2837,7 +4219,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 1573,
       "initial_district_id": "d2",
       "name": "Rim (-5,4)",
@@ -2847,16 +4232,26 @@
           "name": "Latino residents",
           "population_share": 0.1846,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7581, "ryu": 0.2419 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7581,
+            "ryu": 0.2419
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p105-anglo",
           "name": "Anglo residents",
           "population_share": 0.8154,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3736, "ryu": 0.6264 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3736,
+            "ryu": 0.6264
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2864,7 +4259,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 1458,
       "initial_district_id": "d3",
       "name": "Rim (-4,4)",
@@ -2874,16 +4272,26 @@
           "name": "Latino residents",
           "population_share": 0.2268,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7727, "ryu": 0.2273 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7727,
+            "ryu": 0.2273
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p106-anglo",
           "name": "Anglo residents",
           "population_share": 0.7732,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3978, "ryu": 0.6022 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3978,
+            "ryu": 0.6022
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2891,7 +4299,10 @@
       "id": "p107",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 1501,
       "initial_district_id": "d4",
       "name": "Rim (-3,4)",
@@ -2901,16 +4312,26 @@
           "name": "Latino residents",
           "population_share": 0.1994,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.8023, "ryu": 0.1977 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8023,
+            "ryu": 0.1977
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p107-anglo",
           "name": "Anglo residents",
           "population_share": 0.8006,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4014, "ryu": 0.5986 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4014,
+            "ryu": 0.5986
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2918,7 +4339,10 @@
       "id": "p108",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 1467,
       "initial_district_id": "d4",
       "name": "Rim (-2,4)",
@@ -2928,16 +4352,26 @@
           "name": "Latino residents",
           "population_share": 0.2318,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7954, "ryu": 0.2046 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7954,
+            "ryu": 0.2046
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p108-anglo",
           "name": "Anglo residents",
           "population_share": 0.7682,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3514, "ryu": 0.6486 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3514,
+            "ryu": 0.6486
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2945,7 +4379,10 @@
       "id": "p109",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 1637,
       "initial_district_id": "d5",
       "name": "Rim (-1,4)",
@@ -2955,16 +4392,26 @@
           "name": "Latino residents",
           "population_share": 0.1834,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7681, "ryu": 0.2319 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7681,
+            "ryu": 0.2319
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p109-anglo",
           "name": "Anglo residents",
           "population_share": 0.8166,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3808, "ryu": 0.6192 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3808,
+            "ryu": 0.6192
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2972,7 +4419,10 @@
       "id": "p110",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 1414,
       "initial_district_id": "d5",
       "name": "Rim (0,4)",
@@ -2982,16 +4432,26 @@
           "name": "Latino residents",
           "population_share": 0.1971,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7582, "ryu": 0.2418 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7582,
+            "ryu": 0.2418
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p110-anglo",
           "name": "Anglo residents",
           "population_share": 0.8029,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3571, "ryu": 0.6429 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3571,
+            "ryu": 0.6429
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -2999,7 +4459,10 @@
       "id": "p111",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 1631,
       "initial_district_id": "d5",
       "name": "Rim (1,4)",
@@ -3009,16 +4472,26 @@
           "name": "Latino residents",
           "population_share": 0.1643,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7594, "ryu": 0.2406 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7594,
+            "ryu": 0.2406
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p111-anglo",
           "name": "Anglo residents",
           "population_share": 0.8357,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3629, "ryu": 0.6371 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3629,
+            "ryu": 0.6371
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3026,7 +4499,10 @@
       "id": "p112",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 2, "r": 4 },
+      "position": {
+        "q": 2,
+        "r": 4
+      },
       "total_population": 1629,
       "initial_district_id": "d5",
       "name": "Rim (2,4)",
@@ -3036,16 +4512,26 @@
           "name": "Latino residents",
           "population_share": 0.1972,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7955, "ryu": 0.2045 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7955,
+            "ryu": 0.2045
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p112-anglo",
           "name": "Anglo residents",
           "population_share": 0.8028,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3722, "ryu": 0.6278 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3722,
+            "ryu": 0.6278
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3053,7 +4539,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -6, "r": 5 },
+      "position": {
+        "q": -6,
+        "r": 5
+      },
       "total_population": 1616,
       "initial_district_id": "d2",
       "name": "Rim (-6,5)",
@@ -3062,17 +4551,27 @@
           "id": "p113-latino",
           "name": "Latino residents",
           "population_share": 0.2229,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7815, "ryu": 0.2185 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7815,
+            "ryu": 0.2185
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p113-anglo",
           "name": "Anglo residents",
           "population_share": 0.7771,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3762, "ryu": 0.6238 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3762,
+            "ryu": 0.6238
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3080,7 +4579,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 1419,
       "initial_district_id": "d3",
       "name": "Rim (-5,5)",
@@ -3090,16 +4592,26 @@
           "name": "Latino residents",
           "population_share": 0.2373,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7579, "ryu": 0.2421 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7579,
+            "ryu": 0.2421
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p114-anglo",
           "name": "Anglo residents",
           "population_share": 0.7627,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3914, "ryu": 0.6086 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3914,
+            "ryu": 0.6086
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3107,7 +4619,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 1586,
       "initial_district_id": "d4",
       "name": "Rim (-4,5)",
@@ -3116,17 +4631,27 @@
           "id": "p115-latino",
           "name": "Latino residents",
           "population_share": 0.2343,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7744, "ryu": 0.2256 },
-          "dimensions": { "ethnicity": "latino" }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7744,
+            "ryu": 0.2256
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p115-anglo",
           "name": "Anglo residents",
           "population_share": 0.7657,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3733, "ryu": 0.6267 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3733,
+            "ryu": 0.6267
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3134,7 +4659,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 1609,
       "initial_district_id": "d4",
       "name": "Rim (-3,5)",
@@ -3144,16 +4672,26 @@
           "name": "Latino residents",
           "population_share": 0.2366,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7826, "ryu": 0.2174 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7826,
+            "ryu": 0.2174
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p116-anglo",
           "name": "Anglo residents",
           "population_share": 0.7634,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3889, "ryu": 0.6111 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3889,
+            "ryu": 0.6111
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3161,7 +4699,10 @@
       "id": "p117",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 1414,
       "initial_district_id": "d5",
       "name": "Rim (-2,5)",
@@ -3171,16 +4712,26 @@
           "name": "Latino residents",
           "population_share": 0.1916,
           "turnout_rate": 0.53,
-          "vote_shares": { "ken": 0.7588, "ryu": 0.2412 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7588,
+            "ryu": 0.2412
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p117-anglo",
           "name": "Anglo residents",
           "population_share": 0.8084,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4008, "ryu": 0.5992 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4008,
+            "ryu": 0.5992
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3188,7 +4739,10 @@
       "id": "p118",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 1406,
       "initial_district_id": "d5",
       "name": "Rim (-1,5)",
@@ -3198,16 +4752,26 @@
           "name": "Latino residents",
           "population_share": 0.1642,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7936, "ryu": 0.2064 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7936,
+            "ryu": 0.2064
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p118-anglo",
           "name": "Anglo residents",
           "population_share": 0.8358,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3884, "ryu": 0.6116 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3884,
+            "ryu": 0.6116
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3215,7 +4779,10 @@
       "id": "p119",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 1605,
       "initial_district_id": "d5",
       "name": "Rim (0,5)",
@@ -3225,16 +4792,26 @@
           "name": "Latino residents",
           "population_share": 0.1823,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7621, "ryu": 0.2379 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7621,
+            "ryu": 0.2379
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p119-anglo",
           "name": "Anglo residents",
           "population_share": 0.8177,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3727, "ryu": 0.6273 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3727,
+            "ryu": 0.6273
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3242,7 +4819,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 1, "r": 5 },
+      "position": {
+        "q": 1,
+        "r": 5
+      },
       "total_population": 1485,
       "initial_district_id": "d5",
       "name": "Rim (1,5)",
@@ -3252,16 +4832,26 @@
           "name": "Latino residents",
           "population_share": 0.1762,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7654, "ryu": 0.2346 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7654,
+            "ryu": 0.2346
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p120-anglo",
           "name": "Anglo residents",
           "population_share": 0.8238,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3689, "ryu": 0.6311 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3689,
+            "ryu": 0.6311
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3269,7 +4859,10 @@
       "id": "p121",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -6, "r": 6 },
+      "position": {
+        "q": -6,
+        "r": 6
+      },
       "total_population": 1414,
       "initial_district_id": "d3",
       "name": "Rim (-6,6)",
@@ -3279,16 +4872,26 @@
           "name": "Latino residents",
           "population_share": 0.2313,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7603, "ryu": 0.2397 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7603,
+            "ryu": 0.2397
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p121-anglo",
           "name": "Anglo residents",
           "population_share": 0.7687,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3590, "ryu": 0.6410 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.359,
+            "ryu": 0.641
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3296,7 +4899,10 @@
       "id": "p122",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -5, "r": 6 },
+      "position": {
+        "q": -5,
+        "r": 6
+      },
       "total_population": 1571,
       "initial_district_id": "d4",
       "name": "Rim (-5,6)",
@@ -3306,16 +4912,26 @@
           "name": "Latino residents",
           "population_share": 0.2203,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7977, "ryu": 0.2023 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7977,
+            "ryu": 0.2023
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p122-anglo",
           "name": "Anglo residents",
           "population_share": 0.7797,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4090, "ryu": 0.5910 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.409,
+            "ryu": 0.591
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3323,7 +4939,10 @@
       "id": "p123",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -4, "r": 6 },
+      "position": {
+        "q": -4,
+        "r": 6
+      },
       "total_population": 1642,
       "initial_district_id": "d4",
       "name": "Rim (-4,6)",
@@ -3333,16 +4952,26 @@
           "name": "Latino residents",
           "population_share": 0.2362,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7767, "ryu": 0.2233 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7767,
+            "ryu": 0.2233
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p123-anglo",
           "name": "Anglo residents",
           "population_share": 0.7638,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3538, "ryu": 0.6462 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3538,
+            "ryu": 0.6462
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3350,7 +4979,10 @@
       "id": "p124",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -3, "r": 6 },
+      "position": {
+        "q": -3,
+        "r": 6
+      },
       "total_population": 1627,
       "initial_district_id": "d5",
       "name": "Rim (-3,6)",
@@ -3360,16 +4992,26 @@
           "name": "Latino residents",
           "population_share": 0.2169,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7795, "ryu": 0.2205 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7795,
+            "ryu": 0.2205
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p124-anglo",
           "name": "Anglo residents",
           "population_share": 0.7831,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4063, "ryu": 0.5937 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4063,
+            "ryu": 0.5937
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3377,7 +5019,10 @@
       "id": "p125",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -2, "r": 6 },
+      "position": {
+        "q": -2,
+        "r": 6
+      },
       "total_population": 1648,
       "initial_district_id": "d5",
       "name": "Rim (-2,6)",
@@ -3387,16 +5032,26 @@
           "name": "Latino residents",
           "population_share": 0.1806,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.7577, "ryu": 0.2423 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7577,
+            "ryu": 0.2423
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p125-anglo",
           "name": "Anglo residents",
           "population_share": 0.8194,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3821, "ryu": 0.6179 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3821,
+            "ryu": 0.6179
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3404,7 +5059,10 @@
       "id": "p126",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": -1, "r": 6 },
+      "position": {
+        "q": -1,
+        "r": 6
+      },
       "total_population": 1523,
       "initial_district_id": "d5",
       "name": "Rim (-1,6)",
@@ -3414,16 +5072,26 @@
           "name": "Latino residents",
           "population_share": 0.2223,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.8095, "ryu": 0.1905 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.8095,
+            "ryu": 0.1905
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p126-anglo",
           "name": "Anglo residents",
           "population_share": 0.7777,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4081, "ryu": 0.5919 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.4081,
+            "ryu": 0.5919
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     },
@@ -3431,7 +5099,10 @@
       "id": "p127",
       "editable": true,
       "county_id": "valle_verde_rim",
-      "position": { "q": 0, "r": 6 },
+      "position": {
+        "q": 0,
+        "r": 6
+      },
       "total_population": 1374,
       "initial_district_id": "d5",
       "name": "Rim (0,6)",
@@ -3441,16 +5112,26 @@
           "name": "Latino residents",
           "population_share": 0.1905,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.7611, "ryu": 0.2389 },
-          "dimensions": { "ethnicity": "latino" }
+          "vote_shares": {
+            "ken": 0.7611,
+            "ryu": 0.2389
+          },
+          "dimensions": {
+            "ethnicity": "latino"
+          }
         },
         {
           "id": "p127-anglo",
           "name": "Anglo residents",
           "population_share": 0.8095,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3605, "ryu": 0.6395 },
-          "dimensions": { "ethnicity": "anglo" }
+          "vote_shares": {
+            "ken": 0.3605,
+            "ryu": 0.6395
+          },
+          "dimensions": {
+            "ethnicity": "anglo"
+          }
         }
       ]
     }
@@ -3465,29 +5146,36 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All five districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
       "description": "All five districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-majority-minority",
       "required": true,
-      "description": "At least one district must have a Latino population of 50% or more — giving the Valley community a fair opportunity to elect their preferred representative.",
+      "description": "At least one district must have a Latino population of 50% or more \u2014 giving the Valley community a fair opportunity to elect their preferred representative.",
       "criterion": {
         "type": "majority_minority",
-        "group_filter": { "dimension": "ethnicity", "value": "latino" },
-        "min_eligible_share": 0.50,
+        "group_filter": {
+          "dimension": "ethnicity",
+          "value": "latino"
+        },
+        "min_eligible_share": 0.5,
         "min_districts": 1
       }
     },
     {
       "id": "sc-compactness",
       "required": false,
-      "description": "All districts are reasonably compact — the Valley district hugs the Valley, not a long tendril reaching for favorable precincts (compactness ≥ 35%).",
+      "description": "All districts are reasonably compact \u2014 the Valley district hugs the Valley, not a long tendril reaching for favorable precincts (compactness \u2265 35%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
@@ -3499,12 +5187,12 @@
     "character": {
       "name": "You",
       "role": "Court-Appointed Redistricting Coordinator, Valle Verde County",
-      "motivation": "A federal court found that the current district map violates the Voting Rights Act. The Valley's Latino community has been cracked across multiple districts — diluted so thoroughly that they cannot elect their preferred candidate anywhere. You must draw a new map that complies with the law."
+      "motivation": "A federal court found that the current district map violates the Voting Rights Act. The Valley's Latino community has been cracked across multiple districts \u2014 diluted so thoroughly that they cannot elect their preferred candidate anywhere. You must draw a new map that complies with the law."
     },
     "intro_slides": [
       {
         "heading": "The Valley Grows",
-        "body": "Over the past decade, Valle Verde County's Valley has seen significant population growth. The Latino community, concentrated in this area, now makes up a meaningful share of the county's total population.\n\nBut on the current map, drawn ten years ago, the Valley is sliced across multiple districts — each one a piece of a different district, none large enough to matter."
+        "body": "Over the past decade, Valle Verde County's Valley has seen significant population growth. The Latino community, concentrated in this area, now makes up a meaningful share of the county's total population.\n\nBut on the current map, drawn ten years ago, the Valley is sliced across multiple districts \u2014 each one a piece of a different district, none large enough to matter."
       },
       {
         "heading": "The Voting Rights Act",
@@ -3512,9 +5200,9 @@
       },
       {
         "heading": "A Tradeoff You'll See",
-        "body": "Creating a majority-Latino district solves the legal problem — but notice what happens to the surrounding districts. Concentrating a cohesive voting bloc into one place can shift the balance everywhere else.\n\nThis is one of the real tensions in redistricting. Even compliance with a fairness law reshapes who wins and loses. There is no map without consequences.\n\nNote: This scenario uses simplified demographic data to illustrate VRA concepts. Real-world redistricting involves far more complex demographic analysis and legal requirements."
+        "body": "Creating a majority-Latino district solves the legal problem \u2014 but notice what happens to the surrounding districts. Concentrating a cohesive voting bloc into one place can shift the balance everywhere else.\n\nThis is one of the real tensions in redistricting. Even compliance with a fairness law reshapes who wins and loses. There is no map without consequences.\n\nNote: This scenario uses simplified demographic data to illustrate VRA concepts. Real-world redistricting involves far more complex demographic analysis and legal requirements."
       }
     ],
-    "objective": "Draw at least one majority-Latino district (≥ 50% Latino population) to give the Valley community a fair chance to elect their preferred representative."
+    "objective": "Draw at least one majority-Latino district (\u2265 50% Latino population) to give the Valley community a fair chance to elect their preferred representative."
   }
 }

--- a/game/scenarios/scenario-006.json
+++ b/game/scenarios/scenario-006.json
@@ -7,17 +7,42 @@
     "id": "brookfield_county",
     "name": "Brookfield County"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
-    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+    {
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
+    },
+    {
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" },
-    { "id": "d5", "name": "District 5" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    },
+    {
+      "id": "d4",
+      "name": "District 4"
+    },
+    {
+      "id": "d5",
+      "name": "District 5"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -25,7 +50,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": -6 },
+      "position": {
+        "q": 0,
+        "r": -6
+      },
       "total_population": 1562,
       "initial_district_id": "d1",
       "name": "West (0,-6)",
@@ -35,7 +63,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6356, "ryu": 0.3644 }
+          "vote_shares": {
+            "ken": 0.6356,
+            "ryu": 0.3644
+          }
         }
       ]
     },
@@ -43,7 +74,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": -6 },
+      "position": {
+        "q": 1,
+        "r": -6
+      },
       "total_population": 1611,
       "initial_district_id": "d1",
       "name": "East (1,-6)",
@@ -53,7 +87,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3877, "ryu": 0.6123 }
+          "vote_shares": {
+            "ken": 0.3877,
+            "ryu": 0.6123
+          }
         }
       ]
     },
@@ -61,7 +98,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": -6 },
+      "position": {
+        "q": 2,
+        "r": -6
+      },
       "total_population": 1490,
       "initial_district_id": "d2",
       "name": "East (2,-6)",
@@ -71,7 +111,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3543, "ryu": 0.6457 }
+          "vote_shares": {
+            "ken": 0.3543,
+            "ryu": 0.6457
+          }
         }
       ]
     },
@@ -79,7 +122,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": -6 },
+      "position": {
+        "q": 3,
+        "r": -6
+      },
       "total_population": 1581,
       "initial_district_id": "d2",
       "name": "East (3,-6)",
@@ -89,7 +135,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.3774, "ryu": 0.6226 }
+          "vote_shares": {
+            "ken": 0.3774,
+            "ryu": 0.6226
+          }
         }
       ]
     },
@@ -97,7 +146,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": -6 },
+      "position": {
+        "q": 4,
+        "r": -6
+      },
       "total_population": 1574,
       "initial_district_id": "d2",
       "name": "East (4,-6)",
@@ -107,7 +159,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3677, "ryu": 0.6323 }
+          "vote_shares": {
+            "ken": 0.3677,
+            "ryu": 0.6323
+          }
         }
       ]
     },
@@ -115,7 +170,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 5, "r": -6 },
+      "position": {
+        "q": 5,
+        "r": -6
+      },
       "total_population": 1480,
       "initial_district_id": "d2",
       "name": "East (5,-6)",
@@ -125,7 +183,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3947, "ryu": 0.6053 }
+          "vote_shares": {
+            "ken": 0.3947,
+            "ryu": 0.6053
+          }
         }
       ]
     },
@@ -133,7 +194,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": -6 },
+      "position": {
+        "q": 6,
+        "r": -6
+      },
       "total_population": 1548,
       "initial_district_id": "d2",
       "name": "East (6,-6)",
@@ -143,7 +207,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4130, "ryu": 0.5870 }
+          "vote_shares": {
+            "ken": 0.413,
+            "ryu": 0.587
+          }
         }
       ]
     },
@@ -151,7 +218,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": -5 },
+      "position": {
+        "q": -1,
+        "r": -5
+      },
       "total_population": 1376,
       "initial_district_id": "d1",
       "name": "West (-1,-5)",
@@ -161,7 +231,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5812, "ryu": 0.4188 }
+          "vote_shares": {
+            "ken": 0.5812,
+            "ryu": 0.4188
+          }
         }
       ]
     },
@@ -169,7 +242,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 1431,
       "initial_district_id": "d1",
       "name": "West (0,-5)",
@@ -178,8 +254,11 @@
           "id": "p009-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6148, "ryu": 0.3852 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6148,
+            "ryu": 0.3852
+          }
         }
       ]
     },
@@ -187,7 +266,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 1571,
       "initial_district_id": "d1",
       "name": "East (1,-5)",
@@ -197,7 +279,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.3960, "ryu": 0.6040 }
+          "vote_shares": {
+            "ken": 0.396,
+            "ryu": 0.604
+          }
         }
       ]
     },
@@ -205,7 +290,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 1574,
       "initial_district_id": "d2",
       "name": "East (2,-5)",
@@ -215,7 +303,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3766, "ryu": 0.6234 }
+          "vote_shares": {
+            "ken": 0.3766,
+            "ryu": 0.6234
+          }
         }
       ]
     },
@@ -223,7 +314,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 1378,
       "initial_district_id": "d2",
       "name": "East (3,-5)",
@@ -232,8 +326,11 @@
           "id": "p012-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3616, "ryu": 0.6384 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.3616,
+            "ryu": 0.6384
+          }
         }
       ]
     },
@@ -241,7 +338,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 1593,
       "initial_district_id": "d2",
       "name": "East (4,-5)",
@@ -251,7 +351,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3497, "ryu": 0.6503 }
+          "vote_shares": {
+            "ken": 0.3497,
+            "ryu": 0.6503
+          }
         }
       ]
     },
@@ -259,7 +362,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 1597,
       "initial_district_id": "d2",
       "name": "East (5,-5)",
@@ -269,7 +375,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.3423, "ryu": 0.6577 }
+          "vote_shares": {
+            "ken": 0.3423,
+            "ryu": 0.6577
+          }
         }
       ]
     },
@@ -277,7 +386,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": -5 },
+      "position": {
+        "q": 6,
+        "r": -5
+      },
       "total_population": 1456,
       "initial_district_id": "d2",
       "name": "East (6,-5)",
@@ -287,7 +399,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4057, "ryu": 0.5943 }
+          "vote_shares": {
+            "ken": 0.4057,
+            "ryu": 0.5943
+          }
         }
       ]
     },
@@ -295,7 +410,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": -4 },
+      "position": {
+        "q": -2,
+        "r": -4
+      },
       "total_population": 1511,
       "initial_district_id": "d1",
       "name": "West (-2,-4)",
@@ -305,7 +423,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6558, "ryu": 0.3442 }
+          "vote_shares": {
+            "ken": 0.6558,
+            "ryu": 0.3442
+          }
         }
       ]
     },
@@ -313,7 +434,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 1511,
       "initial_district_id": "d1",
       "name": "West (-1,-4)",
@@ -322,8 +446,11 @@
           "id": "p017-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6368, "ryu": 0.3632 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6368,
+            "ryu": 0.3632
+          }
         }
       ]
     },
@@ -331,7 +458,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 1535,
       "initial_district_id": "d1",
       "name": "West (0,-4)",
@@ -341,7 +471,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6315, "ryu": 0.3685 }
+          "vote_shares": {
+            "ken": 0.6315,
+            "ryu": 0.3685
+          }
         }
       ]
     },
@@ -349,7 +482,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 1431,
       "initial_district_id": "d2",
       "name": "East (1,-4)",
@@ -359,7 +495,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4057, "ryu": 0.5943 }
+          "vote_shares": {
+            "ken": 0.4057,
+            "ryu": 0.5943
+          }
         }
       ]
     },
@@ -367,7 +506,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 1353,
       "initial_district_id": "d2",
       "name": "East (2,-4)",
@@ -377,7 +519,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.3437, "ryu": 0.6563 }
+          "vote_shares": {
+            "ken": 0.3437,
+            "ryu": 0.6563
+          }
         }
       ]
     },
@@ -385,7 +530,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 1528,
       "initial_district_id": "d2",
       "name": "East (3,-4)",
@@ -395,7 +543,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4037, "ryu": 0.5963 }
+          "vote_shares": {
+            "ken": 0.4037,
+            "ryu": 0.5963
+          }
         }
       ]
     },
@@ -403,7 +554,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 1397,
       "initial_district_id": "d2",
       "name": "East (4,-4)",
@@ -413,7 +567,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3763, "ryu": 0.6237 }
+          "vote_shares": {
+            "ken": 0.3763,
+            "ryu": 0.6237
+          }
         }
       ]
     },
@@ -421,7 +578,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 1385,
       "initial_district_id": "d2",
       "name": "East (5,-4)",
@@ -431,7 +591,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4174, "ryu": 0.5826 }
+          "vote_shares": {
+            "ken": 0.4174,
+            "ryu": 0.5826
+          }
         }
       ]
     },
@@ -439,7 +602,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": -4 },
+      "position": {
+        "q": 6,
+        "r": -4
+      },
       "total_population": 1378,
       "initial_district_id": "d2",
       "name": "East (6,-4)",
@@ -449,7 +615,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3901, "ryu": 0.6099 }
+          "vote_shares": {
+            "ken": 0.3901,
+            "ryu": 0.6099
+          }
         }
       ]
     },
@@ -457,7 +626,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": -3 },
+      "position": {
+        "q": -3,
+        "r": -3
+      },
       "total_population": 1500,
       "initial_district_id": "d1",
       "name": "West (-3,-3)",
@@ -467,7 +639,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6267, "ryu": 0.3733 }
+          "vote_shares": {
+            "ken": 0.6267,
+            "ryu": 0.3733
+          }
         }
       ]
     },
@@ -475,7 +650,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 1501,
       "initial_district_id": "d1",
       "name": "West (-2,-3)",
@@ -485,7 +663,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5974, "ryu": 0.4026 }
+          "vote_shares": {
+            "ken": 0.5974,
+            "ryu": 0.4026
+          }
         }
       ]
     },
@@ -493,7 +674,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 1373,
       "initial_district_id": "d1",
       "name": "West (-1,-3)",
@@ -503,7 +687,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6275, "ryu": 0.3725 }
+          "vote_shares": {
+            "ken": 0.6275,
+            "ryu": 0.3725
+          }
         }
       ]
     },
@@ -511,7 +698,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 1569,
       "initial_district_id": "d1",
       "name": "West (0,-3)",
@@ -521,7 +711,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6003, "ryu": 0.3997 }
+          "vote_shares": {
+            "ken": 0.6003,
+            "ryu": 0.3997
+          }
         }
       ]
     },
@@ -529,7 +722,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 1535,
       "initial_district_id": "d2",
       "name": "East (1,-3)",
@@ -539,7 +735,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.3885, "ryu": 0.6115 }
+          "vote_shares": {
+            "ken": 0.3885,
+            "ryu": 0.6115
+          }
         }
       ]
     },
@@ -547,7 +746,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 1452,
       "initial_district_id": "d2",
       "name": "East (2,-3)",
@@ -557,7 +759,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4059, "ryu": 0.5941 }
+          "vote_shares": {
+            "ken": 0.4059,
+            "ryu": 0.5941
+          }
         }
       ]
     },
@@ -565,7 +770,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 1524,
       "initial_district_id": "d2",
       "name": "East (3,-3)",
@@ -575,7 +783,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3598, "ryu": 0.6402 }
+          "vote_shares": {
+            "ken": 0.3598,
+            "ryu": 0.6402
+          }
         }
       ]
     },
@@ -583,7 +794,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 1471,
       "initial_district_id": "d2",
       "name": "East (4,-3)",
@@ -593,7 +807,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3656, "ryu": 0.6344 }
+          "vote_shares": {
+            "ken": 0.3656,
+            "ryu": 0.6344
+          }
         }
       ]
     },
@@ -601,7 +818,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 1613,
       "initial_district_id": "d2",
       "name": "East (5,-3)",
@@ -611,7 +831,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3652, "ryu": 0.6348 }
+          "vote_shares": {
+            "ken": 0.3652,
+            "ryu": 0.6348
+          }
         }
       ]
     },
@@ -619,7 +842,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": -3 },
+      "position": {
+        "q": 6,
+        "r": -3
+      },
       "total_population": 1377,
       "initial_district_id": "d3",
       "name": "East (6,-3)",
@@ -629,7 +855,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3805, "ryu": 0.6195 }
+          "vote_shares": {
+            "ken": 0.3805,
+            "ryu": 0.6195
+          }
         }
       ]
     },
@@ -637,7 +866,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": -2 },
+      "position": {
+        "q": -4,
+        "r": -2
+      },
       "total_population": 1475,
       "initial_district_id": "d1",
       "name": "West (-4,-2)",
@@ -647,7 +879,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6005, "ryu": 0.3995 }
+          "vote_shares": {
+            "ken": 0.6005,
+            "ryu": 0.3995
+          }
         }
       ]
     },
@@ -655,7 +890,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 1519,
       "initial_district_id": "d1",
       "name": "West (-3,-2)",
@@ -665,7 +903,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6302, "ryu": 0.3698 }
+          "vote_shares": {
+            "ken": 0.6302,
+            "ryu": 0.3698
+          }
         }
       ]
     },
@@ -673,7 +914,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 1553,
       "initial_district_id": "d1",
       "name": "West (-2,-2)",
@@ -683,7 +927,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5985, "ryu": 0.4015 }
+          "vote_shares": {
+            "ken": 0.5985,
+            "ryu": 0.4015
+          }
         }
       ]
     },
@@ -691,7 +938,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 1546,
       "initial_district_id": "d1",
       "name": "West (-1,-2)",
@@ -700,8 +950,11 @@
           "id": "p038-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6496, "ryu": 0.3504 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6496,
+            "ryu": 0.3504
+          }
         }
       ]
     },
@@ -709,7 +962,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 1599,
       "initial_district_id": "d1",
       "name": "West (0,-2)",
@@ -719,7 +975,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6419, "ryu": 0.3581 }
+          "vote_shares": {
+            "ken": 0.6419,
+            "ryu": 0.3581
+          }
         }
       ]
     },
@@ -727,7 +986,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 1547,
       "initial_district_id": "d2",
       "name": "East (1,-2)",
@@ -737,7 +999,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4147, "ryu": 0.5853 }
+          "vote_shares": {
+            "ken": 0.4147,
+            "ryu": 0.5853
+          }
         }
       ]
     },
@@ -745,7 +1010,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 1567,
       "initial_district_id": "d2",
       "name": "East (2,-2)",
@@ -755,7 +1023,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3998, "ryu": 0.6002 }
+          "vote_shares": {
+            "ken": 0.3998,
+            "ryu": 0.6002
+          }
         }
       ]
     },
@@ -763,7 +1034,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 1619,
       "initial_district_id": "d2",
       "name": "East (3,-2)",
@@ -773,7 +1047,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.3865, "ryu": 0.6135 }
+          "vote_shares": {
+            "ken": 0.3865,
+            "ryu": 0.6135
+          }
         }
       ]
     },
@@ -781,7 +1058,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 1362,
       "initial_district_id": "d3",
       "name": "East (4,-2)",
@@ -791,7 +1071,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.3638, "ryu": 0.6362 }
+          "vote_shares": {
+            "ken": 0.3638,
+            "ryu": 0.6362
+          }
         }
       ]
     },
@@ -799,7 +1082,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 1374,
       "initial_district_id": "d3",
       "name": "East (5,-2)",
@@ -809,7 +1095,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4154, "ryu": 0.5846 }
+          "vote_shares": {
+            "ken": 0.4154,
+            "ryu": 0.5846
+          }
         }
       ]
     },
@@ -817,7 +1106,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": -2 },
+      "position": {
+        "q": 6,
+        "r": -2
+      },
       "total_population": 1614,
       "initial_district_id": "d3",
       "name": "East (6,-2)",
@@ -827,7 +1119,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4083, "ryu": 0.5917 }
+          "vote_shares": {
+            "ken": 0.4083,
+            "ryu": 0.5917
+          }
         }
       ]
     },
@@ -835,7 +1130,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -5, "r": -1 },
+      "position": {
+        "q": -5,
+        "r": -1
+      },
       "total_population": 1371,
       "initial_district_id": "d1",
       "name": "West (-5,-1)",
@@ -844,8 +1142,11 @@
           "id": "p046-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6530, "ryu": 0.3470 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.653,
+            "ryu": 0.347
+          }
         }
       ]
     },
@@ -853,7 +1154,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 1617,
       "initial_district_id": "d1",
       "name": "West (-4,-1)",
@@ -863,7 +1167,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6486, "ryu": 0.3514 }
+          "vote_shares": {
+            "ken": 0.6486,
+            "ryu": 0.3514
+          }
         }
       ]
     },
@@ -871,7 +1178,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 1570,
       "initial_district_id": "d1",
       "name": "West (-3,-1)",
@@ -881,7 +1191,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6144, "ryu": 0.3856 }
+          "vote_shares": {
+            "ken": 0.6144,
+            "ryu": 0.3856
+          }
         }
       ]
     },
@@ -889,7 +1202,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 1480,
       "initial_district_id": "d1",
       "name": "West (-2,-1)",
@@ -899,7 +1215,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6256, "ryu": 0.3744 }
+          "vote_shares": {
+            "ken": 0.6256,
+            "ryu": 0.3744
+          }
         }
       ]
     },
@@ -907,7 +1226,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 1533,
       "initial_district_id": "d1",
       "name": "West (-1,-1)",
@@ -917,7 +1239,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6069, "ryu": 0.3931 }
+          "vote_shares": {
+            "ken": 0.6069,
+            "ryu": 0.3931
+          }
         }
       ]
     },
@@ -925,7 +1250,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 1377,
       "initial_district_id": "d1",
       "name": "West (0,-1)",
@@ -935,7 +1263,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6014, "ryu": 0.3986 }
+          "vote_shares": {
+            "ken": 0.6014,
+            "ryu": 0.3986
+          }
         }
       ]
     },
@@ -943,7 +1274,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 1592,
       "initial_district_id": "d2",
       "name": "East (1,-1)",
@@ -952,8 +1286,11 @@
           "id": "p052-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.3494, "ryu": 0.6506 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.3494,
+            "ryu": 0.6506
+          }
         }
       ]
     },
@@ -961,7 +1298,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 1501,
       "initial_district_id": "d3",
       "name": "East (2,-1)",
@@ -971,7 +1311,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3970, "ryu": 0.6030 }
+          "vote_shares": {
+            "ken": 0.397,
+            "ryu": 0.603
+          }
         }
       ]
     },
@@ -979,7 +1322,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 1473,
       "initial_district_id": "d3",
       "name": "East (3,-1)",
@@ -989,7 +1335,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.3523, "ryu": 0.6477 }
+          "vote_shares": {
+            "ken": 0.3523,
+            "ryu": 0.6477
+          }
         }
       ]
     },
@@ -997,7 +1346,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 1381,
       "initial_district_id": "d3",
       "name": "East (4,-1)",
@@ -1007,7 +1359,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3663, "ryu": 0.6337 }
+          "vote_shares": {
+            "ken": 0.3663,
+            "ryu": 0.6337
+          }
         }
       ]
     },
@@ -1015,7 +1370,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 1359,
       "initial_district_id": "d3",
       "name": "East (5,-1)",
@@ -1025,7 +1383,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.3704, "ryu": 0.6296 }
+          "vote_shares": {
+            "ken": 0.3704,
+            "ryu": 0.6296
+          }
         }
       ]
     },
@@ -1033,7 +1394,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": -1 },
+      "position": {
+        "q": 6,
+        "r": -1
+      },
       "total_population": 1627,
       "initial_district_id": "d3",
       "name": "East (6,-1)",
@@ -1043,7 +1407,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3505, "ryu": 0.6495 }
+          "vote_shares": {
+            "ken": 0.3505,
+            "ryu": 0.6495
+          }
         }
       ]
     },
@@ -1051,7 +1418,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -6, "r": 0 },
+      "position": {
+        "q": -6,
+        "r": 0
+      },
       "total_population": 1411,
       "initial_district_id": "d5",
       "name": "West (-6,0)",
@@ -1061,7 +1431,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6477, "ryu": 0.3523 }
+          "vote_shares": {
+            "ken": 0.6477,
+            "ryu": 0.3523
+          }
         }
       ]
     },
@@ -1069,7 +1442,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 1420,
       "initial_district_id": "d5",
       "name": "West (-5,0)",
@@ -1079,7 +1455,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6009, "ryu": 0.3991 }
+          "vote_shares": {
+            "ken": 0.6009,
+            "ryu": 0.3991
+          }
         }
       ]
     },
@@ -1087,7 +1466,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 1524,
       "initial_district_id": "d5",
       "name": "West (-4,0)",
@@ -1097,7 +1479,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6193, "ryu": 0.3807 }
+          "vote_shares": {
+            "ken": 0.6193,
+            "ryu": 0.3807
+          }
         }
       ]
     },
@@ -1105,7 +1490,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 1394,
       "initial_district_id": "d5",
       "name": "West (-3,0)",
@@ -1115,7 +1503,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6283, "ryu": 0.3717 }
+          "vote_shares": {
+            "ken": 0.6283,
+            "ryu": 0.3717
+          }
         }
       ]
     },
@@ -1123,7 +1514,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 1353,
       "initial_district_id": "d5",
       "name": "West (-2,0)",
@@ -1133,7 +1527,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5971, "ryu": 0.4029 }
+          "vote_shares": {
+            "ken": 0.5971,
+            "ryu": 0.4029
+          }
         }
       ]
     },
@@ -1141,7 +1538,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 1611,
       "initial_district_id": "d5",
       "name": "West (-1,0)",
@@ -1150,8 +1550,11 @@
           "id": "p063-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6588, "ryu": 0.3412 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6588,
+            "ryu": 0.3412
+          }
         }
       ]
     },
@@ -1159,7 +1562,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 1603,
       "initial_district_id": "d3",
       "name": "West (0,0)",
@@ -1169,7 +1575,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6277, "ryu": 0.3723 }
+          "vote_shares": {
+            "ken": 0.6277,
+            "ryu": 0.3723
+          }
         }
       ]
     },
@@ -1177,7 +1586,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 1573,
       "initial_district_id": "d3",
       "name": "East (1,0)",
@@ -1187,7 +1599,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3748, "ryu": 0.6252 }
+          "vote_shares": {
+            "ken": 0.3748,
+            "ryu": 0.6252
+          }
         }
       ]
     },
@@ -1195,7 +1610,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 1625,
       "initial_district_id": "d3",
       "name": "East (2,0)",
@@ -1204,8 +1622,11 @@
           "id": "p066-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4081, "ryu": 0.5919 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4081,
+            "ryu": 0.5919
+          }
         }
       ]
     },
@@ -1213,7 +1634,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 1474,
       "initial_district_id": "d3",
       "name": "East (3,0)",
@@ -1223,7 +1647,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3447, "ryu": 0.6553 }
+          "vote_shares": {
+            "ken": 0.3447,
+            "ryu": 0.6553
+          }
         }
       ]
     },
@@ -1231,7 +1658,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 1443,
       "initial_district_id": "d3",
       "name": "East (4,0)",
@@ -1240,8 +1670,11 @@
           "id": "p068-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.3870, "ryu": 0.6130 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.387,
+            "ryu": 0.613
+          }
         }
       ]
     },
@@ -1249,7 +1682,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 1568,
       "initial_district_id": "d3",
       "name": "East (5,0)",
@@ -1259,7 +1695,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4095, "ryu": 0.5905 }
+          "vote_shares": {
+            "ken": 0.4095,
+            "ryu": 0.5905
+          }
         }
       ]
     },
@@ -1267,7 +1706,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 6, "r": 0 },
+      "position": {
+        "q": 6,
+        "r": 0
+      },
       "total_population": 1474,
       "initial_district_id": "d3",
       "name": "East (6,0)",
@@ -1277,7 +1719,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3678, "ryu": 0.6322 }
+          "vote_shares": {
+            "ken": 0.3678,
+            "ryu": 0.6322
+          }
         }
       ]
     },
@@ -1285,7 +1730,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -6, "r": 1 },
+      "position": {
+        "q": -6,
+        "r": 1
+      },
       "total_population": 1411,
       "initial_district_id": "d5",
       "name": "West (-6,1)",
@@ -1295,7 +1743,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5973, "ryu": 0.4027 }
+          "vote_shares": {
+            "ken": 0.5973,
+            "ryu": 0.4027
+          }
         }
       ]
     },
@@ -1303,7 +1754,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 1430,
       "initial_district_id": "d5",
       "name": "West (-5,1)",
@@ -1313,7 +1767,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6568, "ryu": 0.3432 }
+          "vote_shares": {
+            "ken": 0.6568,
+            "ryu": 0.3432
+          }
         }
       ]
     },
@@ -1321,7 +1778,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 1571,
       "initial_district_id": "d5",
       "name": "West (-4,1)",
@@ -1331,7 +1791,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6446, "ryu": 0.3554 }
+          "vote_shares": {
+            "ken": 0.6446,
+            "ryu": 0.3554
+          }
         }
       ]
     },
@@ -1339,7 +1802,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 1556,
       "initial_district_id": "d5",
       "name": "West (-3,1)",
@@ -1349,7 +1815,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5972, "ryu": 0.4028 }
+          "vote_shares": {
+            "ken": 0.5972,
+            "ryu": 0.4028
+          }
         }
       ]
     },
@@ -1357,7 +1826,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 1597,
       "initial_district_id": "d5",
       "name": "West (-2,1)",
@@ -1367,7 +1839,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6105, "ryu": 0.3895 }
+          "vote_shares": {
+            "ken": 0.6105,
+            "ryu": 0.3895
+          }
         }
       ]
     },
@@ -1375,7 +1850,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 1354,
       "initial_district_id": "d5",
       "name": "West (-1,1)",
@@ -1385,7 +1863,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6411, "ryu": 0.3589 }
+          "vote_shares": {
+            "ken": 0.6411,
+            "ryu": 0.3589
+          }
         }
       ]
     },
@@ -1393,7 +1874,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 1541,
       "initial_district_id": "d4",
       "name": "West (0,1)",
@@ -1403,7 +1887,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6426, "ryu": 0.3574 }
+          "vote_shares": {
+            "ken": 0.6426,
+            "ryu": 0.3574
+          }
         }
       ]
     },
@@ -1411,7 +1898,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 1607,
       "initial_district_id": "d3",
       "name": "East (1,1)",
@@ -1421,7 +1911,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3813, "ryu": 0.6187 }
+          "vote_shares": {
+            "ken": 0.3813,
+            "ryu": 0.6187
+          }
         }
       ]
     },
@@ -1429,7 +1922,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 1632,
       "initial_district_id": "d3",
       "name": "East (2,1)",
@@ -1439,7 +1935,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3770, "ryu": 0.6230 }
+          "vote_shares": {
+            "ken": 0.377,
+            "ryu": 0.623
+          }
         }
       ]
     },
@@ -1447,7 +1946,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 1495,
       "initial_district_id": "d3",
       "name": "East (3,1)",
@@ -1457,7 +1959,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4016, "ryu": 0.5984 }
+          "vote_shares": {
+            "ken": 0.4016,
+            "ryu": 0.5984
+          }
         }
       ]
     },
@@ -1465,7 +1970,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 1384,
       "initial_district_id": "d3",
       "name": "East (4,1)",
@@ -1475,7 +1983,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.3923, "ryu": 0.6077 }
+          "vote_shares": {
+            "ken": 0.3923,
+            "ryu": 0.6077
+          }
         }
       ]
     },
@@ -1483,7 +1994,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 5, "r": 1 },
+      "position": {
+        "q": 5,
+        "r": 1
+      },
       "total_population": 1400,
       "initial_district_id": "d3",
       "name": "East (5,1)",
@@ -1493,7 +2007,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3969, "ryu": 0.6031 }
+          "vote_shares": {
+            "ken": 0.3969,
+            "ryu": 0.6031
+          }
         }
       ]
     },
@@ -1501,7 +2018,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -6, "r": 2 },
+      "position": {
+        "q": -6,
+        "r": 2
+      },
       "total_population": 1389,
       "initial_district_id": "d5",
       "name": "West (-6,2)",
@@ -1510,8 +2030,11 @@
           "id": "p083-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.5879, "ryu": 0.4121 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.5879,
+            "ryu": 0.4121
+          }
         }
       ]
     },
@@ -1519,7 +2042,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 1542,
       "initial_district_id": "d5",
       "name": "West (-5,2)",
@@ -1528,8 +2054,11 @@
           "id": "p084-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.5924, "ryu": 0.4076 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.5924,
+            "ryu": 0.4076
+          }
         }
       ]
     },
@@ -1537,7 +2066,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 1650,
       "initial_district_id": "d5",
       "name": "West (-4,2)",
@@ -1547,7 +2079,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5825, "ryu": 0.4175 }
+          "vote_shares": {
+            "ken": 0.5825,
+            "ryu": 0.4175
+          }
         }
       ]
     },
@@ -1555,7 +2090,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 1430,
       "initial_district_id": "d5",
       "name": "West (-3,2)",
@@ -1565,7 +2103,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5907, "ryu": 0.4093 }
+          "vote_shares": {
+            "ken": 0.5907,
+            "ryu": 0.4093
+          }
         }
       ]
     },
@@ -1573,7 +2114,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 1357,
       "initial_district_id": "d5",
       "name": "West (-2,2)",
@@ -1583,7 +2127,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6113, "ryu": 0.3887 }
+          "vote_shares": {
+            "ken": 0.6113,
+            "ryu": 0.3887
+          }
         }
       ]
     },
@@ -1591,7 +2138,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 1437,
       "initial_district_id": "d4",
       "name": "West (-1,2)",
@@ -1600,8 +2150,11 @@
           "id": "p088-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6599, "ryu": 0.3401 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6599,
+            "ryu": 0.3401
+          }
         }
       ]
     },
@@ -1609,7 +2162,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 1589,
       "initial_district_id": "d4",
       "name": "West (0,2)",
@@ -1619,7 +2175,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6321, "ryu": 0.3679 }
+          "vote_shares": {
+            "ken": 0.6321,
+            "ryu": 0.3679
+          }
         }
       ]
     },
@@ -1627,7 +2186,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 1488,
       "initial_district_id": "d4",
       "name": "East (1,2)",
@@ -1637,7 +2199,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3820, "ryu": 0.6180 }
+          "vote_shares": {
+            "ken": 0.382,
+            "ryu": 0.618
+          }
         }
       ]
     },
@@ -1645,7 +2210,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 1581,
       "initial_district_id": "d3",
       "name": "East (2,2)",
@@ -1655,7 +2223,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.3463, "ryu": 0.6537 }
+          "vote_shares": {
+            "ken": 0.3463,
+            "ryu": 0.6537
+          }
         }
       ]
     },
@@ -1663,7 +2234,10 @@
       "id": "p092",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 1422,
       "initial_district_id": "d3",
       "name": "East (3,2)",
@@ -1673,7 +2247,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.3776, "ryu": 0.6224 }
+          "vote_shares": {
+            "ken": 0.3776,
+            "ryu": 0.6224
+          }
         }
       ]
     },
@@ -1681,7 +2258,10 @@
       "id": "p093",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 4, "r": 2 },
+      "position": {
+        "q": 4,
+        "r": 2
+      },
       "total_population": 1398,
       "initial_district_id": "d3",
       "name": "East (4,2)",
@@ -1691,7 +2271,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.3655, "ryu": 0.6345 }
+          "vote_shares": {
+            "ken": 0.3655,
+            "ryu": 0.6345
+          }
         }
       ]
     },
@@ -1699,7 +2282,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -6, "r": 3 },
+      "position": {
+        "q": -6,
+        "r": 3
+      },
       "total_population": 1560,
       "initial_district_id": "d5",
       "name": "West (-6,3)",
@@ -1709,7 +2295,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5803, "ryu": 0.4197 }
+          "vote_shares": {
+            "ken": 0.5803,
+            "ryu": 0.4197
+          }
         }
       ]
     },
@@ -1717,7 +2306,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 1618,
       "initial_district_id": "d5",
       "name": "West (-5,3)",
@@ -1727,7 +2319,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6271, "ryu": 0.3729 }
+          "vote_shares": {
+            "ken": 0.6271,
+            "ryu": 0.3729
+          }
         }
       ]
     },
@@ -1735,7 +2330,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 1536,
       "initial_district_id": "d5",
       "name": "West (-4,3)",
@@ -1745,7 +2343,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6485, "ryu": 0.3515 }
+          "vote_shares": {
+            "ken": 0.6485,
+            "ryu": 0.3515
+          }
         }
       ]
     },
@@ -1753,7 +2354,10 @@
       "id": "p097",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 1489,
       "initial_district_id": "d5",
       "name": "West (-3,3)",
@@ -1763,7 +2367,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6297, "ryu": 0.3703 }
+          "vote_shares": {
+            "ken": 0.6297,
+            "ryu": 0.3703
+          }
         }
       ]
     },
@@ -1771,7 +2378,10 @@
       "id": "p098",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 1509,
       "initial_district_id": "d4",
       "name": "West (-2,3)",
@@ -1781,7 +2391,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6530, "ryu": 0.3470 }
+          "vote_shares": {
+            "ken": 0.653,
+            "ryu": 0.347
+          }
         }
       ]
     },
@@ -1789,7 +2402,10 @@
       "id": "p099",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 1497,
       "initial_district_id": "d4",
       "name": "West (-1,3)",
@@ -1798,8 +2414,11 @@
           "id": "p099-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6359, "ryu": 0.3641 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6359,
+            "ryu": 0.3641
+          }
         }
       ]
     },
@@ -1807,7 +2426,10 @@
       "id": "p100",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 1359,
       "initial_district_id": "d4",
       "name": "West (0,3)",
@@ -1817,7 +2439,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6587, "ryu": 0.3413 }
+          "vote_shares": {
+            "ken": 0.6587,
+            "ryu": 0.3413
+          }
         }
       ]
     },
@@ -1825,7 +2450,10 @@
       "id": "p101",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 1645,
       "initial_district_id": "d4",
       "name": "East (1,3)",
@@ -1835,7 +2463,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.3607, "ryu": 0.6393 }
+          "vote_shares": {
+            "ken": 0.3607,
+            "ryu": 0.6393
+          }
         }
       ]
     },
@@ -1843,7 +2474,10 @@
       "id": "p102",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 1571,
       "initial_district_id": "d4",
       "name": "East (2,3)",
@@ -1853,7 +2487,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3781, "ryu": 0.6219 }
+          "vote_shares": {
+            "ken": 0.3781,
+            "ryu": 0.6219
+          }
         }
       ]
     },
@@ -1861,7 +2498,10 @@
       "id": "p103",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 3, "r": 3 },
+      "position": {
+        "q": 3,
+        "r": 3
+      },
       "total_population": 1482,
       "initial_district_id": "d3",
       "name": "East (3,3)",
@@ -1870,8 +2510,11 @@
           "id": "p103-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.3503, "ryu": 0.6497 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.3503,
+            "ryu": 0.6497
+          }
         }
       ]
     },
@@ -1879,7 +2522,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -6, "r": 4 },
+      "position": {
+        "q": -6,
+        "r": 4
+      },
       "total_population": 1615,
       "initial_district_id": "d5",
       "name": "West (-6,4)",
@@ -1889,7 +2535,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6429, "ryu": 0.3571 }
+          "vote_shares": {
+            "ken": 0.6429,
+            "ryu": 0.3571
+          }
         }
       ]
     },
@@ -1897,7 +2546,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 1544,
       "initial_district_id": "d5",
       "name": "West (-5,4)",
@@ -1907,7 +2559,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5937, "ryu": 0.4063 }
+          "vote_shares": {
+            "ken": 0.5937,
+            "ryu": 0.4063
+          }
         }
       ]
     },
@@ -1915,7 +2570,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 1641,
       "initial_district_id": "d5",
       "name": "West (-4,4)",
@@ -1925,7 +2583,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6596, "ryu": 0.3404 }
+          "vote_shares": {
+            "ken": 0.6596,
+            "ryu": 0.3404
+          }
         }
       ]
     },
@@ -1933,7 +2594,10 @@
       "id": "p107",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 1537,
       "initial_district_id": "d4",
       "name": "West (-3,4)",
@@ -1943,7 +2607,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6230, "ryu": 0.3770 }
+          "vote_shares": {
+            "ken": 0.623,
+            "ryu": 0.377
+          }
         }
       ]
     },
@@ -1951,7 +2618,10 @@
       "id": "p108",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 1400,
       "initial_district_id": "d4",
       "name": "West (-2,4)",
@@ -1961,7 +2631,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6529, "ryu": 0.3471 }
+          "vote_shares": {
+            "ken": 0.6529,
+            "ryu": 0.3471
+          }
         }
       ]
     },
@@ -1969,7 +2642,10 @@
       "id": "p109",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 1559,
       "initial_district_id": "d4",
       "name": "West (-1,4)",
@@ -1979,7 +2655,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5931, "ryu": 0.4069 }
+          "vote_shares": {
+            "ken": 0.5931,
+            "ryu": 0.4069
+          }
         }
       ]
     },
@@ -1987,7 +2666,10 @@
       "id": "p110",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 1423,
       "initial_district_id": "d4",
       "name": "West (0,4)",
@@ -1997,7 +2679,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6334, "ryu": 0.3666 }
+          "vote_shares": {
+            "ken": 0.6334,
+            "ryu": 0.3666
+          }
         }
       ]
     },
@@ -2005,7 +2690,10 @@
       "id": "p111",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 1572,
       "initial_district_id": "d4",
       "name": "East (1,4)",
@@ -2014,8 +2702,11 @@
           "id": "p111-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.3410, "ryu": 0.6590 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.341,
+            "ryu": 0.659
+          }
         }
       ]
     },
@@ -2023,7 +2714,10 @@
       "id": "p112",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 2, "r": 4 },
+      "position": {
+        "q": 2,
+        "r": 4
+      },
       "total_population": 1433,
       "initial_district_id": "d4",
       "name": "East (2,4)",
@@ -2033,7 +2727,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.3671, "ryu": 0.6329 }
+          "vote_shares": {
+            "ken": 0.3671,
+            "ryu": 0.6329
+          }
         }
       ]
     },
@@ -2041,7 +2738,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -6, "r": 5 },
+      "position": {
+        "q": -6,
+        "r": 5
+      },
       "total_population": 1419,
       "initial_district_id": "d5",
       "name": "West (-6,5)",
@@ -2051,7 +2751,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6520, "ryu": 0.3480 }
+          "vote_shares": {
+            "ken": 0.652,
+            "ryu": 0.348
+          }
         }
       ]
     },
@@ -2059,7 +2762,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 1402,
       "initial_district_id": "d5",
       "name": "West (-5,5)",
@@ -2069,7 +2775,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6463, "ryu": 0.3537 }
+          "vote_shares": {
+            "ken": 0.6463,
+            "ryu": 0.3537
+          }
         }
       ]
     },
@@ -2077,7 +2786,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 1615,
       "initial_district_id": "d5",
       "name": "West (-4,5)",
@@ -2087,7 +2799,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6596, "ryu": 0.3404 }
+          "vote_shares": {
+            "ken": 0.6596,
+            "ryu": 0.3404
+          }
         }
       ]
     },
@@ -2095,7 +2810,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 1586,
       "initial_district_id": "d4",
       "name": "West (-3,5)",
@@ -2105,7 +2823,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6064, "ryu": 0.3936 }
+          "vote_shares": {
+            "ken": 0.6064,
+            "ryu": 0.3936
+          }
         }
       ]
     },
@@ -2113,7 +2834,10 @@
       "id": "p117",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 1353,
       "initial_district_id": "d4",
       "name": "West (-2,5)",
@@ -2123,7 +2847,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5986, "ryu": 0.4014 }
+          "vote_shares": {
+            "ken": 0.5986,
+            "ryu": 0.4014
+          }
         }
       ]
     },
@@ -2131,7 +2858,10 @@
       "id": "p118",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 1508,
       "initial_district_id": "d4",
       "name": "West (-1,5)",
@@ -2141,7 +2871,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6066, "ryu": 0.3934 }
+          "vote_shares": {
+            "ken": 0.6066,
+            "ryu": 0.3934
+          }
         }
       ]
     },
@@ -2149,7 +2882,10 @@
       "id": "p119",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 1480,
       "initial_district_id": "d4",
       "name": "West (0,5)",
@@ -2159,7 +2895,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.6359, "ryu": 0.3641 }
+          "vote_shares": {
+            "ken": 0.6359,
+            "ryu": 0.3641
+          }
         }
       ]
     },
@@ -2167,7 +2906,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "eastbrook",
-      "position": { "q": 1, "r": 5 },
+      "position": {
+        "q": 1,
+        "r": 5
+      },
       "total_population": 1590,
       "initial_district_id": "d4",
       "name": "East (1,5)",
@@ -2177,7 +2919,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3693, "ryu": 0.6307 }
+          "vote_shares": {
+            "ken": 0.3693,
+            "ryu": 0.6307
+          }
         }
       ]
     },
@@ -2185,7 +2930,10 @@
       "id": "p121",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -6, "r": 6 },
+      "position": {
+        "q": -6,
+        "r": 6
+      },
       "total_population": 1450,
       "initial_district_id": "d5",
       "name": "West (-6,6)",
@@ -2195,7 +2943,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6448, "ryu": 0.3552 }
+          "vote_shares": {
+            "ken": 0.6448,
+            "ryu": 0.3552
+          }
         }
       ]
     },
@@ -2203,7 +2954,10 @@
       "id": "p122",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -5, "r": 6 },
+      "position": {
+        "q": -5,
+        "r": 6
+      },
       "total_population": 1610,
       "initial_district_id": "d5",
       "name": "West (-5,6)",
@@ -2213,7 +2967,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6469, "ryu": 0.3531 }
+          "vote_shares": {
+            "ken": 0.6469,
+            "ryu": 0.3531
+          }
         }
       ]
     },
@@ -2221,7 +2978,10 @@
       "id": "p123",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -4, "r": 6 },
+      "position": {
+        "q": -4,
+        "r": 6
+      },
       "total_population": 1497,
       "initial_district_id": "d4",
       "name": "West (-4,6)",
@@ -2231,7 +2991,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5982, "ryu": 0.4018 }
+          "vote_shares": {
+            "ken": 0.5982,
+            "ryu": 0.4018
+          }
         }
       ]
     },
@@ -2239,7 +3002,10 @@
       "id": "p124",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -3, "r": 6 },
+      "position": {
+        "q": -3,
+        "r": 6
+      },
       "total_population": 1470,
       "initial_district_id": "d4",
       "name": "West (-3,6)",
@@ -2249,7 +3015,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5898, "ryu": 0.4102 }
+          "vote_shares": {
+            "ken": 0.5898,
+            "ryu": 0.4102
+          }
         }
       ]
     },
@@ -2257,7 +3026,10 @@
       "id": "p125",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -2, "r": 6 },
+      "position": {
+        "q": -2,
+        "r": 6
+      },
       "total_population": 1377,
       "initial_district_id": "d4",
       "name": "West (-2,6)",
@@ -2267,7 +3039,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6372, "ryu": 0.3628 }
+          "vote_shares": {
+            "ken": 0.6372,
+            "ryu": 0.3628
+          }
         }
       ]
     },
@@ -2275,7 +3050,10 @@
       "id": "p126",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": -1, "r": 6 },
+      "position": {
+        "q": -1,
+        "r": 6
+      },
       "total_population": 1351,
       "initial_district_id": "d4",
       "name": "West (-1,6)",
@@ -2284,8 +3062,11 @@
           "id": "p126-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6524, "ryu": 0.3476 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6524,
+            "ryu": 0.3476
+          }
         }
       ]
     },
@@ -2293,7 +3074,10 @@
       "id": "p127",
       "editable": true,
       "county_id": "westbrook",
-      "position": { "q": 0, "r": 6 },
+      "position": {
+        "q": 0,
+        "r": 6
+      },
       "total_population": 1607,
       "initial_district_id": "d4",
       "name": "West (0,6)",
@@ -2303,7 +3087,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5845, "ryu": 0.4155 }
+          "vote_shares": {
+            "ken": 0.5845,
+            "ryu": 0.4155
+          }
         }
       ]
     }
@@ -2318,18 +3105,22 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All five districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
       "description": "All five districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-safe-seats-ken",
       "required": true,
-      "description": "Ken Party incumbents are protected — at least 3 districts won by a margin of 15 points or more.",
+      "description": "Ken Party incumbents are protected \u2014 at least 3 districts won by a margin of 15 points or more.",
       "criterion": {
         "type": "safe_seats",
         "party": "ken",
@@ -2340,7 +3131,7 @@
     {
       "id": "sc-safe-seats-ryu",
       "required": true,
-      "description": "Ryu Party incumbents are protected — at least 2 districts won by a margin of 15 points or more.",
+      "description": "Ryu Party incumbents are protected \u2014 at least 2 districts won by a margin of 15 points or more.",
       "criterion": {
         "type": "safe_seats",
         "party": "ryu",
@@ -2351,7 +3142,7 @@
     {
       "id": "sc-compactness",
       "required": false,
-      "description": "The map follows natural geographic lines — all districts are reasonably compact (≥ 35%).",
+      "description": "The map follows natural geographic lines \u2014 all districts are reasonably compact (\u2265 35%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
@@ -2363,7 +3154,7 @@
     "character": {
       "name": "You",
       "role": "Bipartisan Redistricting Consultant, Brookfield County",
-      "motivation": "Both parties have agreed — privately — that the current map is too competitive. Too many incumbents lost their seats last cycle. You've been hired by both sides to draw a new map where each party keeps what it has. The voters don't need to know the details."
+      "motivation": "Both parties have agreed \u2014 privately \u2014 that the current map is too competitive. Too many incumbents lost their seats last cycle. You've been hired by both sides to draw a new map where each party keeps what it has. The voters don't need to know the details."
     },
     "intro_slides": [
       {
@@ -2376,9 +3167,9 @@
       },
       {
         "heading": "What the Voters Lose",
-        "body": "A safe seat means your representative doesn't need to worry about losing. They only need to survive their own primary — which means appealing to their party's base, not to the median voter.\n\nCompetitive elections create accountability. This map is designed to eliminate them. Notice how many races are decided before anyone votes."
+        "body": "A safe seat means your representative doesn't need to worry about losing. They only need to survive their own primary \u2014 which means appealing to their party's base, not to the median voter.\n\nCompetitive elections create accountability. This map is designed to eliminate them. Notice how many races are decided before anyone votes."
       }
     ],
-    "objective": "Draw a map that protects incumbents of both parties — Ken Party wins at least 3 safe seats (margin ≥ 15 points), Ryu Party wins at least 2 safe seats (margin ≥ 15 points)."
+    "objective": "Draw a map that protects incumbents of both parties \u2014 Ken Party wins at least 3 safe seats (margin \u2265 15 points), Ryu Party wins at least 2 safe seats (margin \u2265 15 points)."
   }
 }

--- a/game/scenarios/scenario-007.json
+++ b/game/scenarios/scenario-007.json
@@ -7,17 +7,42 @@
     "id": "meridian_county",
     "name": "Meridian County"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
-    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+    {
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
+    },
+    {
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" },
-    { "id": "d5", "name": "District 5" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    },
+    {
+      "id": "d4",
+      "name": "District 4"
+    },
+    {
+      "id": "d5",
+      "name": "District 5"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -25,7 +50,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 0, "r": -6 },
+      "position": {
+        "q": 0,
+        "r": -6
+      },
       "total_population": 1428,
       "initial_district_id": "d1",
       "name": "Exurb (0,-6)",
@@ -35,7 +63,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6413, "ryu": 0.3587 }
+          "vote_shares": {
+            "ken": 0.6413,
+            "ryu": 0.3587
+          }
         }
       ]
     },
@@ -43,7 +74,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 1, "r": -6 },
+      "position": {
+        "q": 1,
+        "r": -6
+      },
       "total_population": 1496,
       "initial_district_id": "d1",
       "name": "Exurb (1,-6)",
@@ -53,7 +87,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6315, "ryu": 0.3685 }
+          "vote_shares": {
+            "ken": 0.6315,
+            "ryu": 0.3685
+          }
         }
       ]
     },
@@ -61,7 +98,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 2, "r": -6 },
+      "position": {
+        "q": 2,
+        "r": -6
+      },
       "total_population": 1543,
       "initial_district_id": "d1",
       "name": "Exurb (2,-6)",
@@ -71,7 +111,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6940, "ryu": 0.3060 }
+          "vote_shares": {
+            "ken": 0.694,
+            "ryu": 0.306
+          }
         }
       ]
     },
@@ -79,7 +122,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 3, "r": -6 },
+      "position": {
+        "q": 3,
+        "r": -6
+      },
       "total_population": 1451,
       "initial_district_id": "d1",
       "name": "Exurb (3,-6)",
@@ -89,7 +135,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6510, "ryu": 0.3490 }
+          "vote_shares": {
+            "ken": 0.651,
+            "ryu": 0.349
+          }
         }
       ]
     },
@@ -97,7 +146,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": -6 },
+      "position": {
+        "q": 4,
+        "r": -6
+      },
       "total_population": 1620,
       "initial_district_id": "d2",
       "name": "Exurb (4,-6)",
@@ -107,7 +159,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.6372, "ryu": 0.3628 }
+          "vote_shares": {
+            "ken": 0.6372,
+            "ryu": 0.3628
+          }
         }
       ]
     },
@@ -115,7 +170,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 5, "r": -6 },
+      "position": {
+        "q": 5,
+        "r": -6
+      },
       "total_population": 1493,
       "initial_district_id": "d2",
       "name": "Exurb (5,-6)",
@@ -125,7 +183,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+          "vote_shares": {
+            "ken": 0.6703,
+            "ryu": 0.3297
+          }
         }
       ]
     },
@@ -133,7 +194,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 6, "r": -6 },
+      "position": {
+        "q": 6,
+        "r": -6
+      },
       "total_population": 1387,
       "initial_district_id": "d3",
       "name": "Exurb (6,-6)",
@@ -143,7 +207,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6703, "ryu": 0.3297 }
+          "vote_shares": {
+            "ken": 0.6703,
+            "ryu": 0.3297
+          }
         }
       ]
     },
@@ -151,7 +218,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -1, "r": -5 },
+      "position": {
+        "q": -1,
+        "r": -5
+      },
       "total_population": 1511,
       "initial_district_id": "d1",
       "name": "Exurb (-1,-5)",
@@ -161,7 +231,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6472, "ryu": 0.3528 }
+          "vote_shares": {
+            "ken": 0.6472,
+            "ryu": 0.3528
+          }
         }
       ]
     },
@@ -169,7 +242,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 1492,
       "initial_district_id": "d1",
       "name": "Exurb (0,-5)",
@@ -179,7 +255,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5182, "ryu": 0.4818 }
+          "vote_shares": {
+            "ken": 0.5182,
+            "ryu": 0.4818
+          }
         }
       ]
     },
@@ -187,7 +266,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 1440,
       "initial_district_id": "d1",
       "name": "Exurb (1,-5)",
@@ -197,7 +279,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5179, "ryu": 0.4821 }
+          "vote_shares": {
+            "ken": 0.5179,
+            "ryu": 0.4821
+          }
         }
       ]
     },
@@ -205,7 +290,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 1633,
       "initial_district_id": "d1",
       "name": "Exurb (2,-5)",
@@ -215,7 +303,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5842, "ryu": 0.4158 }
+          "vote_shares": {
+            "ken": 0.5842,
+            "ryu": 0.4158
+          }
         }
       ]
     },
@@ -223,7 +314,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 1430,
       "initial_district_id": "d2",
       "name": "Exurb (3,-5)",
@@ -233,7 +327,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5256, "ryu": 0.4744 }
+          "vote_shares": {
+            "ken": 0.5256,
+            "ryu": 0.4744
+          }
         }
       ]
     },
@@ -241,7 +338,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 1623,
       "initial_district_id": "d2",
       "name": "Exurb (4,-5)",
@@ -251,7 +351,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5770, "ryu": 0.4230 }
+          "vote_shares": {
+            "ken": 0.577,
+            "ryu": 0.423
+          }
         }
       ]
     },
@@ -259,7 +362,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 1393,
       "initial_district_id": "d3",
       "name": "Exurb (5,-5)",
@@ -269,7 +375,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5349, "ryu": 0.4651 }
+          "vote_shares": {
+            "ken": 0.5349,
+            "ryu": 0.4651
+          }
         }
       ]
     },
@@ -277,7 +386,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 6, "r": -5 },
+      "position": {
+        "q": 6,
+        "r": -5
+      },
       "total_population": 1437,
       "initial_district_id": "d4",
       "name": "Exurb (6,-5)",
@@ -287,7 +399,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.7083, "ryu": 0.2917 }
+          "vote_shares": {
+            "ken": 0.7083,
+            "ryu": 0.2917
+          }
         }
       ]
     },
@@ -295,7 +410,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -2, "r": -4 },
+      "position": {
+        "q": -2,
+        "r": -4
+      },
       "total_population": 1591,
       "initial_district_id": "d1",
       "name": "Exurb (-2,-4)",
@@ -305,7 +423,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6448, "ryu": 0.3552 }
+          "vote_shares": {
+            "ken": 0.6448,
+            "ryu": 0.3552
+          }
         }
       ]
     },
@@ -313,7 +434,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 1538,
       "initial_district_id": "d1",
       "name": "Exurb (-1,-4)",
@@ -323,7 +447,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5246, "ryu": 0.4754 }
+          "vote_shares": {
+            "ken": 0.5246,
+            "ryu": 0.4754
+          }
         }
       ]
     },
@@ -331,7 +458,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 1368,
       "initial_district_id": "d1",
       "name": "Suburb (0,-4)",
@@ -340,8 +470,11 @@
           "id": "p018-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4166, "ryu": 0.5834 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4166,
+            "ryu": 0.5834
+          }
         }
       ]
     },
@@ -349,7 +482,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 1534,
       "initial_district_id": "d1",
       "name": "Suburb (1,-4)",
@@ -359,7 +495,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4805, "ryu": 0.5195 }
+          "vote_shares": {
+            "ken": 0.4805,
+            "ryu": 0.5195
+          }
         }
       ]
     },
@@ -367,7 +506,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 1415,
       "initial_district_id": "d2",
       "name": "Suburb (2,-4)",
@@ -377,7 +519,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4637, "ryu": 0.5363 }
+          "vote_shares": {
+            "ken": 0.4637,
+            "ryu": 0.5363
+          }
         }
       ]
     },
@@ -385,7 +530,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 1621,
       "initial_district_id": "d2",
       "name": "Suburb (3,-4)",
@@ -395,7 +543,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4169, "ryu": 0.5831 }
+          "vote_shares": {
+            "ken": 0.4169,
+            "ryu": 0.5831
+          }
         }
       ]
     },
@@ -403,7 +554,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 1583,
       "initial_district_id": "d3",
       "name": "Suburb (4,-4)",
@@ -413,7 +567,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4728, "ryu": 0.5272 }
+          "vote_shares": {
+            "ken": 0.4728,
+            "ryu": 0.5272
+          }
         }
       ]
     },
@@ -421,7 +578,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 1522,
       "initial_district_id": "d4",
       "name": "Exurb (5,-4)",
@@ -431,7 +591,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5213, "ryu": 0.4787 }
+          "vote_shares": {
+            "ken": 0.5213,
+            "ryu": 0.4787
+          }
         }
       ]
     },
@@ -439,7 +602,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 6, "r": -4 },
+      "position": {
+        "q": 6,
+        "r": -4
+      },
       "total_population": 1418,
       "initial_district_id": "d4",
       "name": "Exurb (6,-4)",
@@ -449,7 +615,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6399, "ryu": 0.3601 }
+          "vote_shares": {
+            "ken": 0.6399,
+            "ryu": 0.3601
+          }
         }
       ]
     },
@@ -457,7 +626,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -3, "r": -3 },
+      "position": {
+        "q": -3,
+        "r": -3
+      },
       "total_population": 1486,
       "initial_district_id": "d1",
       "name": "Exurb (-3,-3)",
@@ -467,7 +639,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6627, "ryu": 0.3373 }
+          "vote_shares": {
+            "ken": 0.6627,
+            "ryu": 0.3373
+          }
         }
       ]
     },
@@ -475,7 +650,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 1643,
       "initial_district_id": "d1",
       "name": "Exurb (-2,-3)",
@@ -485,7 +663,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5612, "ryu": 0.4388 }
+          "vote_shares": {
+            "ken": 0.5612,
+            "ryu": 0.4388
+          }
         }
       ]
     },
@@ -493,7 +674,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 1573,
       "initial_district_id": "d1",
       "name": "Suburb (-1,-3)",
@@ -502,8 +686,11 @@
           "id": "p027-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4140, "ryu": 0.5860 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.414,
+            "ryu": 0.586
+          }
         }
       ]
     },
@@ -511,7 +698,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 1607,
       "initial_district_id": "d1",
       "name": "Suburb (0,-3)",
@@ -521,7 +711,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4485, "ryu": 0.5515 }
+          "vote_shares": {
+            "ken": 0.4485,
+            "ryu": 0.5515
+          }
         }
       ]
     },
@@ -529,7 +722,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 1442,
       "initial_district_id": "d2",
       "name": "Suburb (1,-3)",
@@ -539,7 +735,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4455, "ryu": 0.5545 }
+          "vote_shares": {
+            "ken": 0.4455,
+            "ryu": 0.5545
+          }
         }
       ]
     },
@@ -547,7 +746,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 1558,
       "initial_district_id": "d2",
       "name": "Suburb (2,-3)",
@@ -557,7 +759,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4189, "ryu": 0.5811 }
+          "vote_shares": {
+            "ken": 0.4189,
+            "ryu": 0.5811
+          }
         }
       ]
     },
@@ -565,7 +770,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 1476,
       "initial_district_id": "d3",
       "name": "Suburb (3,-3)",
@@ -575,7 +783,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4115, "ryu": 0.5885 }
+          "vote_shares": {
+            "ken": 0.4115,
+            "ryu": 0.5885
+          }
         }
       ]
     },
@@ -583,7 +794,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 1626,
       "initial_district_id": "d4",
       "name": "Suburb (4,-3)",
@@ -593,7 +807,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4489, "ryu": 0.5511 }
+          "vote_shares": {
+            "ken": 0.4489,
+            "ryu": 0.5511
+          }
         }
       ]
     },
@@ -601,7 +818,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 1599,
       "initial_district_id": "d4",
       "name": "Exurb (5,-3)",
@@ -611,7 +831,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5213, "ryu": 0.4787 }
+          "vote_shares": {
+            "ken": 0.5213,
+            "ryu": 0.4787
+          }
         }
       ]
     },
@@ -619,7 +842,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 6, "r": -3 },
+      "position": {
+        "q": 6,
+        "r": -3
+      },
       "total_population": 1456,
       "initial_district_id": "d5",
       "name": "Exurb (6,-3)",
@@ -629,7 +855,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.6966, "ryu": 0.3034 }
+          "vote_shares": {
+            "ken": 0.6966,
+            "ryu": 0.3034
+          }
         }
       ]
     },
@@ -637,7 +866,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": -2 },
+      "position": {
+        "q": -4,
+        "r": -2
+      },
       "total_population": 1448,
       "initial_district_id": "d1",
       "name": "Exurb (-4,-2)",
@@ -647,7 +879,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.6786, "ryu": 0.3214 }
+          "vote_shares": {
+            "ken": 0.6786,
+            "ryu": 0.3214
+          }
         }
       ]
     },
@@ -655,7 +890,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 1560,
       "initial_district_id": "d1",
       "name": "Exurb (-3,-2)",
@@ -665,7 +903,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5697, "ryu": 0.4303 }
+          "vote_shares": {
+            "ken": 0.5697,
+            "ryu": 0.4303
+          }
         }
       ]
     },
@@ -673,7 +914,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 1437,
       "initial_district_id": "d1",
       "name": "Suburb (-2,-2)",
@@ -683,7 +927,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4418, "ryu": 0.5582 }
+          "vote_shares": {
+            "ken": 0.4418,
+            "ryu": 0.5582
+          }
         }
       ]
     },
@@ -691,7 +938,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 1517,
       "initial_district_id": "d1",
       "name": "Suburb (-1,-2)",
@@ -701,7 +951,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4544, "ryu": 0.5456 }
+          "vote_shares": {
+            "ken": 0.4544,
+            "ryu": 0.5456
+          }
         }
       ]
     },
@@ -709,7 +962,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 1564,
       "initial_district_id": "d2",
       "name": "Core (0,-2)",
@@ -719,7 +975,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.2630, "ryu": 0.7370 }
+          "vote_shares": {
+            "ken": 0.263,
+            "ryu": 0.737
+          }
         }
       ]
     },
@@ -727,7 +986,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 1374,
       "initial_district_id": "d2",
       "name": "Core (1,-2)",
@@ -737,7 +999,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.2615, "ryu": 0.7385 }
+          "vote_shares": {
+            "ken": 0.2615,
+            "ryu": 0.7385
+          }
         }
       ]
     },
@@ -745,7 +1010,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 1415,
       "initial_district_id": "d3",
       "name": "Core (2,-2)",
@@ -755,7 +1023,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.2480, "ryu": 0.7520 }
+          "vote_shares": {
+            "ken": 0.248,
+            "ryu": 0.752
+          }
         }
       ]
     },
@@ -763,7 +1034,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 1506,
       "initial_district_id": "d4",
       "name": "Suburb (3,-2)",
@@ -773,7 +1047,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4342, "ryu": 0.5658 }
+          "vote_shares": {
+            "ken": 0.4342,
+            "ryu": 0.5658
+          }
         }
       ]
     },
@@ -781,7 +1058,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 1541,
       "initial_district_id": "d4",
       "name": "Suburb (4,-2)",
@@ -791,7 +1071,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4474, "ryu": 0.5526 }
+          "vote_shares": {
+            "ken": 0.4474,
+            "ryu": 0.5526
+          }
         }
       ]
     },
@@ -799,7 +1082,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 1397,
       "initial_district_id": "d5",
       "name": "Exurb (5,-2)",
@@ -809,7 +1095,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5441, "ryu": 0.4559 }
+          "vote_shares": {
+            "ken": 0.5441,
+            "ryu": 0.4559
+          }
         }
       ]
     },
@@ -817,7 +1106,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 6, "r": -2 },
+      "position": {
+        "q": 6,
+        "r": -2
+      },
       "total_population": 1572,
       "initial_district_id": "d5",
       "name": "Exurb (6,-2)",
@@ -827,7 +1119,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6918, "ryu": 0.3082 }
+          "vote_shares": {
+            "ken": 0.6918,
+            "ryu": 0.3082
+          }
         }
       ]
     },
@@ -835,7 +1130,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -5, "r": -1 },
+      "position": {
+        "q": -5,
+        "r": -1
+      },
       "total_population": 1547,
       "initial_district_id": "d1",
       "name": "Exurb (-5,-1)",
@@ -845,7 +1143,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6724, "ryu": 0.3276 }
+          "vote_shares": {
+            "ken": 0.6724,
+            "ryu": 0.3276
+          }
         }
       ]
     },
@@ -853,7 +1154,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 1408,
       "initial_district_id": "d1",
       "name": "Exurb (-4,-1)",
@@ -863,7 +1167,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5529, "ryu": 0.4471 }
+          "vote_shares": {
+            "ken": 0.5529,
+            "ryu": 0.4471
+          }
         }
       ]
     },
@@ -871,7 +1178,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 1579,
       "initial_district_id": "d1",
       "name": "Suburb (-3,-1)",
@@ -881,7 +1191,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4140, "ryu": 0.5860 }
+          "vote_shares": {
+            "ken": 0.414,
+            "ryu": 0.586
+          }
         }
       ]
     },
@@ -889,7 +1202,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 1589,
       "initial_district_id": "d1",
       "name": "Suburb (-2,-1)",
@@ -899,7 +1215,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4418, "ryu": 0.5582 }
+          "vote_shares": {
+            "ken": 0.4418,
+            "ryu": 0.5582
+          }
         }
       ]
     },
@@ -907,7 +1226,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 1409,
       "initial_district_id": "d2",
       "name": "Core (-1,-1)",
@@ -917,7 +1239,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.2785, "ryu": 0.7215 }
+          "vote_shares": {
+            "ken": 0.2785,
+            "ryu": 0.7215
+          }
         }
       ]
     },
@@ -925,7 +1250,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 1383,
       "initial_district_id": "d2",
       "name": "Core (0,-1)",
@@ -934,8 +1262,11 @@
           "id": "p051-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2375, "ryu": 0.7625 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.2375,
+            "ryu": 0.7625
+          }
         }
       ]
     },
@@ -943,7 +1274,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 1501,
       "initial_district_id": "d3",
       "name": "Core (1,-1)",
@@ -953,7 +1287,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.2605, "ryu": 0.7395 }
+          "vote_shares": {
+            "ken": 0.2605,
+            "ryu": 0.7395
+          }
         }
       ]
     },
@@ -961,7 +1298,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 1446,
       "initial_district_id": "d4",
       "name": "Core (2,-1)",
@@ -971,7 +1311,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.2224, "ryu": 0.7776 }
+          "vote_shares": {
+            "ken": 0.2224,
+            "ryu": 0.7776
+          }
         }
       ]
     },
@@ -979,7 +1322,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 1378,
       "initial_district_id": "d4",
       "name": "Suburb (3,-1)",
@@ -988,8 +1334,11 @@
           "id": "p054-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4886, "ryu": 0.5114 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4886,
+            "ryu": 0.5114
+          }
         }
       ]
     },
@@ -997,7 +1346,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 1593,
       "initial_district_id": "d5",
       "name": "Suburb (4,-1)",
@@ -1007,7 +1359,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4708, "ryu": 0.5292 }
+          "vote_shares": {
+            "ken": 0.4708,
+            "ryu": 0.5292
+          }
         }
       ]
     },
@@ -1015,7 +1370,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 1532,
       "initial_district_id": "d5",
       "name": "Exurb (5,-1)",
@@ -1024,8 +1382,11 @@
           "id": "p056-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5800, "ryu": 0.4200 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.58,
+            "ryu": 0.42
+          }
         }
       ]
     },
@@ -1033,7 +1394,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 6, "r": -1 },
+      "position": {
+        "q": 6,
+        "r": -1
+      },
       "total_population": 1544,
       "initial_district_id": "d5",
       "name": "Exurb (6,-1)",
@@ -1043,7 +1407,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6719, "ryu": 0.3281 }
+          "vote_shares": {
+            "ken": 0.6719,
+            "ryu": 0.3281
+          }
         }
       ]
     },
@@ -1051,7 +1418,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -6, "r": 0 },
+      "position": {
+        "q": -6,
+        "r": 0
+      },
       "total_population": 1561,
       "initial_district_id": "d1",
       "name": "Exurb (-6,0)",
@@ -1061,7 +1431,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6956, "ryu": 0.3044 }
+          "vote_shares": {
+            "ken": 0.6956,
+            "ryu": 0.3044
+          }
         }
       ]
     },
@@ -1069,7 +1442,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 1428,
       "initial_district_id": "d1",
       "name": "Exurb (-5,0)",
@@ -1079,7 +1455,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5171, "ryu": 0.4829 }
+          "vote_shares": {
+            "ken": 0.5171,
+            "ryu": 0.4829
+          }
         }
       ]
     },
@@ -1087,7 +1466,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 1608,
       "initial_district_id": "d1",
       "name": "Suburb (-4,0)",
@@ -1097,7 +1479,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4206, "ryu": 0.5794 }
+          "vote_shares": {
+            "ken": 0.4206,
+            "ryu": 0.5794
+          }
         }
       ]
     },
@@ -1105,7 +1490,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 1378,
       "initial_district_id": "d1",
       "name": "Suburb (-3,0)",
@@ -1115,7 +1503,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4563, "ryu": 0.5437 }
+          "vote_shares": {
+            "ken": 0.4563,
+            "ryu": 0.5437
+          }
         }
       ]
     },
@@ -1123,7 +1514,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 1426,
       "initial_district_id": "d2",
       "name": "Core (-2,0)",
@@ -1133,7 +1527,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.2216, "ryu": 0.7784 }
+          "vote_shares": {
+            "ken": 0.2216,
+            "ryu": 0.7784
+          }
         }
       ]
     },
@@ -1141,7 +1538,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 1444,
       "initial_district_id": "d2",
       "name": "Core (-1,0)",
@@ -1151,7 +1551,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.2410, "ryu": 0.7590 }
+          "vote_shares": {
+            "ken": 0.241,
+            "ryu": 0.759
+          }
         }
       ]
     },
@@ -1159,7 +1562,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 1466,
       "initial_district_id": "d3",
       "name": "Core (0,0)",
@@ -1169,7 +1575,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.2184, "ryu": 0.7816 }
+          "vote_shares": {
+            "ken": 0.2184,
+            "ryu": 0.7816
+          }
         }
       ]
     },
@@ -1177,7 +1586,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 1529,
       "initial_district_id": "d4",
       "name": "Core (1,0)",
@@ -1187,7 +1599,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.2731, "ryu": 0.7269 }
+          "vote_shares": {
+            "ken": 0.2731,
+            "ryu": 0.7269
+          }
         }
       ]
     },
@@ -1195,7 +1610,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 1616,
       "initial_district_id": "d4",
       "name": "Core (2,0)",
@@ -1204,8 +1622,11 @@
           "id": "p066-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2847, "ryu": 0.7153 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.2847,
+            "ryu": 0.7153
+          }
         }
       ]
     },
@@ -1213,7 +1634,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 1392,
       "initial_district_id": "d5",
       "name": "Suburb (3,0)",
@@ -1223,7 +1647,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4707, "ryu": 0.5293 }
+          "vote_shares": {
+            "ken": 0.4707,
+            "ryu": 0.5293
+          }
         }
       ]
     },
@@ -1231,7 +1658,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 1496,
       "initial_district_id": "d5",
       "name": "Suburb (4,0)",
@@ -1241,7 +1671,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4518, "ryu": 0.5482 }
+          "vote_shares": {
+            "ken": 0.4518,
+            "ryu": 0.5482
+          }
         }
       ]
     },
@@ -1249,7 +1682,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 1365,
       "initial_district_id": "d5",
       "name": "Exurb (5,0)",
@@ -1259,7 +1695,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5351, "ryu": 0.4649 }
+          "vote_shares": {
+            "ken": 0.5351,
+            "ryu": 0.4649
+          }
         }
       ]
     },
@@ -1267,7 +1706,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 6, "r": 0 },
+      "position": {
+        "q": 6,
+        "r": 0
+      },
       "total_population": 1636,
       "initial_district_id": "d5",
       "name": "Exurb (6,0)",
@@ -1277,7 +1719,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6887, "ryu": 0.3113 }
+          "vote_shares": {
+            "ken": 0.6887,
+            "ryu": 0.3113
+          }
         }
       ]
     },
@@ -1285,7 +1730,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -6, "r": 1 },
+      "position": {
+        "q": -6,
+        "r": 1
+      },
       "total_population": 1511,
       "initial_district_id": "d1",
       "name": "Exurb (-6,1)",
@@ -1295,7 +1743,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6543, "ryu": 0.3457 }
+          "vote_shares": {
+            "ken": 0.6543,
+            "ryu": 0.3457
+          }
         }
       ]
     },
@@ -1303,7 +1754,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 1493,
       "initial_district_id": "d1",
       "name": "Exurb (-5,1)",
@@ -1313,7 +1767,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5762, "ryu": 0.4238 }
+          "vote_shares": {
+            "ken": 0.5762,
+            "ryu": 0.4238
+          }
         }
       ]
     },
@@ -1321,7 +1778,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 1451,
       "initial_district_id": "d1",
       "name": "Suburb (-4,1)",
@@ -1330,8 +1790,11 @@
           "id": "p073-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4611, "ryu": 0.5389 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.4611,
+            "ryu": 0.5389
+          }
         }
       ]
     },
@@ -1339,7 +1802,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 1489,
       "initial_district_id": "d2",
       "name": "Suburb (-3,1)",
@@ -1349,7 +1815,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4537, "ryu": 0.5463 }
+          "vote_shares": {
+            "ken": 0.4537,
+            "ryu": 0.5463
+          }
         }
       ]
     },
@@ -1357,7 +1826,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 1426,
       "initial_district_id": "d2",
       "name": "Core (-2,1)",
@@ -1367,7 +1839,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.2270, "ryu": 0.7730 }
+          "vote_shares": {
+            "ken": 0.227,
+            "ryu": 0.773
+          }
         }
       ]
     },
@@ -1375,7 +1850,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 1453,
       "initial_district_id": "d3",
       "name": "Core (-1,1)",
@@ -1385,7 +1863,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.2533, "ryu": 0.7467 }
+          "vote_shares": {
+            "ken": 0.2533,
+            "ryu": 0.7467
+          }
         }
       ]
     },
@@ -1393,7 +1874,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 1436,
       "initial_district_id": "d4",
       "name": "Core (0,1)",
@@ -1403,7 +1887,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.2758, "ryu": 0.7242 }
+          "vote_shares": {
+            "ken": 0.2758,
+            "ryu": 0.7242
+          }
         }
       ]
     },
@@ -1411,7 +1898,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 1642,
       "initial_district_id": "d4",
       "name": "Core (1,1)",
@@ -1421,7 +1911,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.2654, "ryu": 0.7346 }
+          "vote_shares": {
+            "ken": 0.2654,
+            "ryu": 0.7346
+          }
         }
       ]
     },
@@ -1429,7 +1922,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 1461,
       "initial_district_id": "d5",
       "name": "Suburb (2,1)",
@@ -1439,7 +1935,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4502, "ryu": 0.5498 }
+          "vote_shares": {
+            "ken": 0.4502,
+            "ryu": 0.5498
+          }
         }
       ]
     },
@@ -1447,7 +1946,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 1533,
       "initial_district_id": "d5",
       "name": "Suburb (3,1)",
@@ -1457,7 +1959,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4200, "ryu": 0.5800 }
+          "vote_shares": {
+            "ken": 0.42,
+            "ryu": 0.58
+          }
         }
       ]
     },
@@ -1465,7 +1970,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 1587,
       "initial_district_id": "d5",
       "name": "Exurb (4,1)",
@@ -1475,7 +1983,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5158, "ryu": 0.4842 }
+          "vote_shares": {
+            "ken": 0.5158,
+            "ryu": 0.4842
+          }
         }
       ]
     },
@@ -1483,7 +1994,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 5, "r": 1 },
+      "position": {
+        "q": 5,
+        "r": 1
+      },
       "total_population": 1628,
       "initial_district_id": "d5",
       "name": "Exurb (5,1)",
@@ -1493,7 +2007,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6917, "ryu": 0.3083 }
+          "vote_shares": {
+            "ken": 0.6917,
+            "ryu": 0.3083
+          }
         }
       ]
     },
@@ -1501,7 +2018,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -6, "r": 2 },
+      "position": {
+        "q": -6,
+        "r": 2
+      },
       "total_population": 1550,
       "initial_district_id": "d1",
       "name": "Exurb (-6,2)",
@@ -1511,7 +2031,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6485, "ryu": 0.3515 }
+          "vote_shares": {
+            "ken": 0.6485,
+            "ryu": 0.3515
+          }
         }
       ]
     },
@@ -1519,7 +2042,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 1406,
       "initial_district_id": "d1",
       "name": "Exurb (-5,2)",
@@ -1529,7 +2055,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5500, "ryu": 0.4500 }
+          "vote_shares": {
+            "ken": 0.55,
+            "ryu": 0.45
+          }
         }
       ]
     },
@@ -1537,7 +2066,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 1416,
       "initial_district_id": "d2",
       "name": "Suburb (-4,2)",
@@ -1547,7 +2079,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4799, "ryu": 0.5201 }
+          "vote_shares": {
+            "ken": 0.4799,
+            "ryu": 0.5201
+          }
         }
       ]
     },
@@ -1555,7 +2090,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 1541,
       "initial_district_id": "d2",
       "name": "Suburb (-3,2)",
@@ -1565,7 +2103,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4355, "ryu": 0.5645 }
+          "vote_shares": {
+            "ken": 0.4355,
+            "ryu": 0.5645
+          }
         }
       ]
     },
@@ -1573,7 +2114,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 1355,
       "initial_district_id": "d3",
       "name": "Core (-2,2)",
@@ -1583,7 +2127,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.2850, "ryu": 0.7150 }
+          "vote_shares": {
+            "ken": 0.285,
+            "ryu": 0.715
+          }
         }
       ]
     },
@@ -1591,7 +2138,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 1362,
       "initial_district_id": "d4",
       "name": "Core (-1,2)",
@@ -1601,7 +2151,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.2824, "ryu": 0.7176 }
+          "vote_shares": {
+            "ken": 0.2824,
+            "ryu": 0.7176
+          }
         }
       ]
     },
@@ -1609,7 +2162,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 1460,
       "initial_district_id": "d4",
       "name": "Core (0,2)",
@@ -1619,7 +2175,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.2727, "ryu": 0.7273 }
+          "vote_shares": {
+            "ken": 0.2727,
+            "ryu": 0.7273
+          }
         }
       ]
     },
@@ -1627,7 +2186,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 1365,
       "initial_district_id": "d5",
       "name": "Suburb (1,2)",
@@ -1637,7 +2199,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4257, "ryu": 0.5743 }
+          "vote_shares": {
+            "ken": 0.4257,
+            "ryu": 0.5743
+          }
         }
       ]
     },
@@ -1645,7 +2210,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 1552,
       "initial_district_id": "d5",
       "name": "Suburb (2,2)",
@@ -1655,7 +2223,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4491, "ryu": 0.5509 }
+          "vote_shares": {
+            "ken": 0.4491,
+            "ryu": 0.5509
+          }
         }
       ]
     },
@@ -1663,7 +2234,10 @@
       "id": "p092",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 1502,
       "initial_district_id": "d5",
       "name": "Exurb (3,2)",
@@ -1673,7 +2247,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5146, "ryu": 0.4854 }
+          "vote_shares": {
+            "ken": 0.5146,
+            "ryu": 0.4854
+          }
         }
       ]
     },
@@ -1681,7 +2258,10 @@
       "id": "p093",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 4, "r": 2 },
+      "position": {
+        "q": 4,
+        "r": 2
+      },
       "total_population": 1539,
       "initial_district_id": "d5",
       "name": "Exurb (4,2)",
@@ -1691,7 +2271,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6522, "ryu": 0.3478 }
+          "vote_shares": {
+            "ken": 0.6522,
+            "ryu": 0.3478
+          }
         }
       ]
     },
@@ -1699,7 +2282,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -6, "r": 3 },
+      "position": {
+        "q": -6,
+        "r": 3
+      },
       "total_population": 1502,
       "initial_district_id": "d1",
       "name": "Exurb (-6,3)",
@@ -1708,8 +2294,11 @@
           "id": "p094-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.6435, "ryu": 0.3565 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.6435,
+            "ryu": 0.3565
+          }
         }
       ]
     },
@@ -1717,7 +2306,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 1419,
       "initial_district_id": "d2",
       "name": "Exurb (-5,3)",
@@ -1727,7 +2319,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5717, "ryu": 0.4283 }
+          "vote_shares": {
+            "ken": 0.5717,
+            "ryu": 0.4283
+          }
         }
       ]
     },
@@ -1735,7 +2330,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 1647,
       "initial_district_id": "d2",
       "name": "Suburb (-4,3)",
@@ -1745,7 +2343,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4819, "ryu": 0.5181 }
+          "vote_shares": {
+            "ken": 0.4819,
+            "ryu": 0.5181
+          }
         }
       ]
     },
@@ -1753,7 +2354,10 @@
       "id": "p097",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 1360,
       "initial_district_id": "d3",
       "name": "Suburb (-3,3)",
@@ -1763,7 +2367,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4761, "ryu": 0.5239 }
+          "vote_shares": {
+            "ken": 0.4761,
+            "ryu": 0.5239
+          }
         }
       ]
     },
@@ -1771,7 +2378,10 @@
       "id": "p098",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 1594,
       "initial_district_id": "d4",
       "name": "Suburb (-2,3)",
@@ -1781,7 +2391,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4149, "ryu": 0.5851 }
+          "vote_shares": {
+            "ken": 0.4149,
+            "ryu": 0.5851
+          }
         }
       ]
     },
@@ -1789,7 +2402,10 @@
       "id": "p099",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 1473,
       "initial_district_id": "d4",
       "name": "Suburb (-1,3)",
@@ -1799,7 +2415,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4101, "ryu": 0.5899 }
+          "vote_shares": {
+            "ken": 0.4101,
+            "ryu": 0.5899
+          }
         }
       ]
     },
@@ -1807,7 +2426,10 @@
       "id": "p100",
       "editable": true,
       "county_id": "reform_central",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 1373,
       "initial_district_id": "d5",
       "name": "Suburb (0,3)",
@@ -1817,7 +2439,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4273, "ryu": 0.5727 }
+          "vote_shares": {
+            "ken": 0.4273,
+            "ryu": 0.5727
+          }
         }
       ]
     },
@@ -1825,7 +2450,10 @@
       "id": "p101",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 1364,
       "initial_district_id": "d5",
       "name": "Suburb (1,3)",
@@ -1835,7 +2463,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4709, "ryu": 0.5291 }
+          "vote_shares": {
+            "ken": 0.4709,
+            "ryu": 0.5291
+          }
         }
       ]
     },
@@ -1843,7 +2474,10 @@
       "id": "p102",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 1637,
       "initial_district_id": "d5",
       "name": "Exurb (2,3)",
@@ -1853,7 +2487,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5299, "ryu": 0.4701 }
+          "vote_shares": {
+            "ken": 0.5299,
+            "ryu": 0.4701
+          }
         }
       ]
     },
@@ -1861,7 +2498,10 @@
       "id": "p103",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 3, "r": 3 },
+      "position": {
+        "q": 3,
+        "r": 3
+      },
       "total_population": 1517,
       "initial_district_id": "d5",
       "name": "Exurb (3,3)",
@@ -1871,7 +2511,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6605, "ryu": 0.3395 }
+          "vote_shares": {
+            "ken": 0.6605,
+            "ryu": 0.3395
+          }
         }
       ]
     },
@@ -1879,7 +2522,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -6, "r": 4 },
+      "position": {
+        "q": -6,
+        "r": 4
+      },
       "total_population": 1548,
       "initial_district_id": "d2",
       "name": "Exurb (-6,4)",
@@ -1889,7 +2535,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.6932, "ryu": 0.3068 }
+          "vote_shares": {
+            "ken": 0.6932,
+            "ryu": 0.3068
+          }
         }
       ]
     },
@@ -1897,7 +2546,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 1619,
       "initial_district_id": "d2",
       "name": "Exurb (-5,4)",
@@ -1907,7 +2559,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5864, "ryu": 0.4136 }
+          "vote_shares": {
+            "ken": 0.5864,
+            "ryu": 0.4136
+          }
         }
       ]
     },
@@ -1915,7 +2570,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 1566,
       "initial_district_id": "d3",
       "name": "Suburb (-4,4)",
@@ -1925,7 +2583,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4117, "ryu": 0.5883 }
+          "vote_shares": {
+            "ken": 0.4117,
+            "ryu": 0.5883
+          }
         }
       ]
     },
@@ -1933,7 +2594,10 @@
       "id": "p107",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 1398,
       "initial_district_id": "d4",
       "name": "Suburb (-3,4)",
@@ -1943,7 +2607,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4610, "ryu": 0.5390 }
+          "vote_shares": {
+            "ken": 0.461,
+            "ryu": 0.539
+          }
         }
       ]
     },
@@ -1951,7 +2618,10 @@
       "id": "p108",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 1612,
       "initial_district_id": "d4",
       "name": "Suburb (-2,4)",
@@ -1961,7 +2631,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4704, "ryu": 0.5296 }
+          "vote_shares": {
+            "ken": 0.4704,
+            "ryu": 0.5296
+          }
         }
       ]
     },
@@ -1969,7 +2642,10 @@
       "id": "p109",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 1440,
       "initial_district_id": "d5",
       "name": "Suburb (-1,4)",
@@ -1979,7 +2655,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4643, "ryu": 0.5357 }
+          "vote_shares": {
+            "ken": 0.4643,
+            "ryu": 0.5357
+          }
         }
       ]
     },
@@ -1987,7 +2666,10 @@
       "id": "p110",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 1557,
       "initial_district_id": "d5",
       "name": "Suburb (0,4)",
@@ -1997,7 +2679,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4390, "ryu": 0.5610 }
+          "vote_shares": {
+            "ken": 0.439,
+            "ryu": 0.561
+          }
         }
       ]
     },
@@ -2005,7 +2690,10 @@
       "id": "p111",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 1515,
       "initial_district_id": "d5",
       "name": "Exurb (1,4)",
@@ -2015,7 +2703,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5146, "ryu": 0.4854 }
+          "vote_shares": {
+            "ken": 0.5146,
+            "ryu": 0.4854
+          }
         }
       ]
     },
@@ -2023,7 +2714,10 @@
       "id": "p112",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 2, "r": 4 },
+      "position": {
+        "q": 2,
+        "r": 4
+      },
       "total_population": 1432,
       "initial_district_id": "d5",
       "name": "Exurb (2,4)",
@@ -2033,7 +2727,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.6739, "ryu": 0.3261 }
+          "vote_shares": {
+            "ken": 0.6739,
+            "ryu": 0.3261
+          }
         }
       ]
     },
@@ -2041,7 +2738,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -6, "r": 5 },
+      "position": {
+        "q": -6,
+        "r": 5
+      },
       "total_population": 1362,
       "initial_district_id": "d2",
       "name": "Exurb (-6,5)",
@@ -2051,7 +2751,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7039, "ryu": 0.2961 }
+          "vote_shares": {
+            "ken": 0.7039,
+            "ryu": 0.2961
+          }
         }
       ]
     },
@@ -2059,7 +2762,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 1354,
       "initial_district_id": "d3",
       "name": "Exurb (-5,5)",
@@ -2069,7 +2775,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5881, "ryu": 0.4119 }
+          "vote_shares": {
+            "ken": 0.5881,
+            "ryu": 0.4119
+          }
         }
       ]
     },
@@ -2077,7 +2786,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 1556,
       "initial_district_id": "d4",
       "name": "Exurb (-4,5)",
@@ -2087,7 +2799,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5716, "ryu": 0.4284 }
+          "vote_shares": {
+            "ken": 0.5716,
+            "ryu": 0.4284
+          }
         }
       ]
     },
@@ -2095,7 +2810,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 1381,
       "initial_district_id": "d4",
       "name": "Exurb (-3,5)",
@@ -2105,7 +2823,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5145, "ryu": 0.4855 }
+          "vote_shares": {
+            "ken": 0.5145,
+            "ryu": 0.4855
+          }
         }
       ]
     },
@@ -2113,7 +2834,10 @@
       "id": "p117",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 1467,
       "initial_district_id": "d5",
       "name": "Exurb (-2,5)",
@@ -2123,7 +2847,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5509, "ryu": 0.4491 }
+          "vote_shares": {
+            "ken": 0.5509,
+            "ryu": 0.4491
+          }
         }
       ]
     },
@@ -2131,7 +2858,10 @@
       "id": "p118",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 1434,
       "initial_district_id": "d5",
       "name": "Exurb (-1,5)",
@@ -2141,7 +2871,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5403, "ryu": 0.4597 }
+          "vote_shares": {
+            "ken": 0.5403,
+            "ryu": 0.4597
+          }
         }
       ]
     },
@@ -2149,7 +2882,10 @@
       "id": "p119",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 1533,
       "initial_district_id": "d5",
       "name": "Exurb (0,5)",
@@ -2159,7 +2895,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5178, "ryu": 0.4822 }
+          "vote_shares": {
+            "ken": 0.5178,
+            "ryu": 0.4822
+          }
         }
       ]
     },
@@ -2167,7 +2906,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 1, "r": 5 },
+      "position": {
+        "q": 1,
+        "r": 5
+      },
       "total_population": 1370,
       "initial_district_id": "d5",
       "name": "Exurb (1,5)",
@@ -2177,7 +2919,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.6415, "ryu": 0.3585 }
+          "vote_shares": {
+            "ken": 0.6415,
+            "ryu": 0.3585
+          }
         }
       ]
     },
@@ -2185,7 +2930,10 @@
       "id": "p121",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -6, "r": 6 },
+      "position": {
+        "q": -6,
+        "r": 6
+      },
       "total_population": 1418,
       "initial_district_id": "d3",
       "name": "Exurb (-6,6)",
@@ -2194,8 +2942,11 @@
           "id": "p121-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7040, "ryu": 0.2960 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.704,
+            "ryu": 0.296
+          }
         }
       ]
     },
@@ -2203,7 +2954,10 @@
       "id": "p122",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -5, "r": 6 },
+      "position": {
+        "q": -5,
+        "r": 6
+      },
       "total_population": 1446,
       "initial_district_id": "d4",
       "name": "Exurb (-5,6)",
@@ -2213,7 +2967,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6584, "ryu": 0.3416 }
+          "vote_shares": {
+            "ken": 0.6584,
+            "ryu": 0.3416
+          }
         }
       ]
     },
@@ -2221,7 +2978,10 @@
       "id": "p123",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -4, "r": 6 },
+      "position": {
+        "q": -4,
+        "r": 6
+      },
       "total_population": 1644,
       "initial_district_id": "d4",
       "name": "Exurb (-4,6)",
@@ -2231,7 +2991,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.6817, "ryu": 0.3183 }
+          "vote_shares": {
+            "ken": 0.6817,
+            "ryu": 0.3183
+          }
         }
       ]
     },
@@ -2239,7 +3002,10 @@
       "id": "p124",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -3, "r": 6 },
+      "position": {
+        "q": -3,
+        "r": 6
+      },
       "total_population": 1360,
       "initial_district_id": "d5",
       "name": "Exurb (-3,6)",
@@ -2249,7 +3015,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.6735, "ryu": 0.3265 }
+          "vote_shares": {
+            "ken": 0.6735,
+            "ryu": 0.3265
+          }
         }
       ]
     },
@@ -2257,7 +3026,10 @@
       "id": "p125",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -2, "r": 6 },
+      "position": {
+        "q": -2,
+        "r": 6
+      },
       "total_population": 1392,
       "initial_district_id": "d5",
       "name": "Exurb (-2,6)",
@@ -2267,7 +3039,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.6463, "ryu": 0.3537 }
+          "vote_shares": {
+            "ken": 0.6463,
+            "ryu": 0.3537
+          }
         }
       ]
     },
@@ -2275,7 +3050,10 @@
       "id": "p126",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": -1, "r": 6 },
+      "position": {
+        "q": -1,
+        "r": 6
+      },
       "total_population": 1648,
       "initial_district_id": "d5",
       "name": "Exurb (-1,6)",
@@ -2285,7 +3063,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.6408, "ryu": 0.3592 }
+          "vote_shares": {
+            "ken": 0.6408,
+            "ryu": 0.3592
+          }
         }
       ]
     },
@@ -2293,7 +3074,10 @@
       "id": "p127",
       "editable": true,
       "county_id": "reform_outer",
-      "position": { "q": 0, "r": 6 },
+      "position": {
+        "q": 0,
+        "r": 6
+      },
       "total_population": 1360,
       "initial_district_id": "d5",
       "name": "Exurb (0,6)",
@@ -2303,14 +3087,17 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6656, "ryu": 0.3344 }
+          "vote_shares": {
+            "ken": 0.6656,
+            "ryu": 0.3344
+          }
         }
       ]
     }
   ],
   "events": [],
   "rules": {
-    "population_tolerance": 0.10,
+    "population_tolerance": 0.05,
     "contiguity": "required"
   },
   "success_criteria": [
@@ -2318,28 +3105,32 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All five districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
-      "description": "All five districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "description": "All five districts have roughly equal population (within 5%).",
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-compactness",
       "required": true,
-      "description": "All districts must be reasonably compact — no long tentacles or thin strips (compactness ≥ 40%).",
+      "description": "All districts must be reasonably compact \u2014 no long tentacles or thin strips (compactness \u2265 50%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
-        "threshold": 0.40
+        "threshold": 0.5
       }
     },
     {
       "id": "sc-efficiency-gap",
       "required": false,
-      "description": "Even a geometrically neutral map has an efficiency gap — see how close to zero you can get (≤ 15%).",
+      "description": "Even a geometrically neutral map has an efficiency gap \u2014 see how close to zero you can get (\u2264 15%).",
       "criterion": {
         "type": "efficiency_gap",
         "operator": "lte",
@@ -2351,22 +3142,22 @@
     "character": {
       "name": "You",
       "role": "Independent Reform Commissioner, Meridian County",
-      "motivation": "The legislature has deadlocked. A court has ordered an independent commission to draw a new map using only neutral criteria — equal population, geographic compactness, and contiguity. No partisan data allowed. Draw the fairest map you can."
+      "motivation": "The legislature has deadlocked. A court has ordered an independent commission to draw a new map using only neutral criteria \u2014 equal population, geographic compactness, and contiguity. No partisan data allowed. Draw the fairest map you can."
     },
     "intro_slides": [
       {
         "heading": "The Promise of Neutral Rules",
-        "body": "Reformers have long argued that if we just take politics out of redistricting — use an independent commission, apply mechanical criteria, ignore partisan data — the maps will be fair.\n\nMeridian County is your test case. Draw a map using only geometric rules: compact districts, equal population, no disconnected pieces. No partisan data. Just shapes."
+        "body": "Reformers have long argued that if we just take politics out of redistricting \u2014 use an independent commission, apply mechanical criteria, ignore partisan data \u2014 the maps will be fair.\n\nMeridian County is your test case. Draw a map using only geometric rules: compact districts, equal population, no disconnected pieces. No partisan data. Just shapes."
       },
       {
         "heading": "The Geography Problem",
-        "body": "Here's what nobody tells you: voters aren't distributed randomly. In Meridian County — as in most American counties — different communities cluster together. Urban neighborhoods vote differently from suburbs, which vote differently from exurbs.\n\nA perfectly geometric map doesn't erase that. It just captures it differently."
+        "body": "Here's what nobody tells you: voters aren't distributed randomly. In Meridian County \u2014 as in most American counties \u2014 different communities cluster together. Urban neighborhoods vote differently from suburbs, which vote differently from exurbs.\n\nA perfectly geometric map doesn't erase that. It just captures it differently."
       },
       {
         "heading": "What the Map Will Show You",
-        "body": "When you're done, submit your map and look at the results. You drew it without looking at party data. But the outcome won't be perfectly proportional.\n\nThis is called the geography problem. It's not a bug in your map — it's a feature of where people live. Neutral rules don't produce neutral outcomes. They produce different outcomes."
+        "body": "When you're done, submit your map and look at the results. You drew it without looking at party data. But the outcome won't be perfectly proportional.\n\nThis is called the geography problem. It's not a bug in your map \u2014 it's a feature of where people live. Neutral rules don't produce neutral outcomes. They produce different outcomes."
       }
     ],
-    "objective": "Draw a compact, population-balanced map using only geometric criteria. No partisan data required — or allowed."
+    "objective": "Draw a compact, population-balanced map using only geometric criteria. No partisan data required \u2014 or allowed."
   }
 }

--- a/game/scenarios/scenario-008.json
+++ b/game/scenarios/scenario-008.json
@@ -7,17 +7,42 @@
     "id": "accord_county",
     "name": "Accord County"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
-    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+    {
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
+    },
+    {
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" },
-    { "id": "d5", "name": "District 5" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    },
+    {
+      "id": "d4",
+      "name": "District 4"
+    },
+    {
+      "id": "d5",
+      "name": "District 5"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -25,7 +50,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 0, "r": -6 },
+      "position": {
+        "q": 0,
+        "r": -6
+      },
       "total_population": 1463,
       "initial_district_id": "d1",
       "name": "Exurb (0,-6)",
@@ -35,7 +63,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.8064, "ryu": 0.1936 }
+          "vote_shares": {
+            "ken": 0.8064,
+            "ryu": 0.1936
+          }
         }
       ]
     },
@@ -43,7 +74,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 1, "r": -6 },
+      "position": {
+        "q": 1,
+        "r": -6
+      },
       "total_population": 1612,
       "initial_district_id": "d1",
       "name": "Exurb (1,-6)",
@@ -53,7 +87,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.8376, "ryu": 0.1624 }
+          "vote_shares": {
+            "ken": 0.8376,
+            "ryu": 0.1624
+          }
         }
       ]
     },
@@ -61,7 +98,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 2, "r": -6 },
+      "position": {
+        "q": 2,
+        "r": -6
+      },
       "total_population": 1542,
       "initial_district_id": "d2",
       "name": "Exurb (2,-6)",
@@ -71,7 +111,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.7942, "ryu": 0.2058 }
+          "vote_shares": {
+            "ken": 0.7942,
+            "ryu": 0.2058
+          }
         }
       ]
     },
@@ -79,7 +122,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 3, "r": -6 },
+      "position": {
+        "q": 3,
+        "r": -6
+      },
       "total_population": 1367,
       "initial_district_id": "d2",
       "name": "Exurb (3,-6)",
@@ -89,7 +135,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7829, "ryu": 0.2171 }
+          "vote_shares": {
+            "ken": 0.7829,
+            "ryu": 0.2171
+          }
         }
       ]
     },
@@ -97,7 +146,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": -6 },
+      "position": {
+        "q": 4,
+        "r": -6
+      },
       "total_population": 1385,
       "initial_district_id": "d2",
       "name": "Exurb (4,-6)",
@@ -107,7 +159,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.8037, "ryu": 0.1963 }
+          "vote_shares": {
+            "ken": 0.8037,
+            "ryu": 0.1963
+          }
         }
       ]
     },
@@ -115,7 +170,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 5, "r": -6 },
+      "position": {
+        "q": 5,
+        "r": -6
+      },
       "total_population": 1378,
       "initial_district_id": "d2",
       "name": "Exurb (5,-6)",
@@ -125,7 +183,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.7616, "ryu": 0.2384 }
+          "vote_shares": {
+            "ken": 0.7616,
+            "ryu": 0.2384
+          }
         }
       ]
     },
@@ -133,7 +194,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 6, "r": -6 },
+      "position": {
+        "q": 6,
+        "r": -6
+      },
       "total_population": 1403,
       "initial_district_id": "d2",
       "name": "Exurb (6,-6)",
@@ -143,7 +207,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.8125, "ryu": 0.1875 }
+          "vote_shares": {
+            "ken": 0.8125,
+            "ryu": 0.1875
+          }
         }
       ]
     },
@@ -151,7 +218,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -1, "r": -5 },
+      "position": {
+        "q": -1,
+        "r": -5
+      },
       "total_population": 1420,
       "initial_district_id": "d1",
       "name": "Exurb (-1,-5)",
@@ -161,7 +231,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.8080, "ryu": 0.1920 }
+          "vote_shares": {
+            "ken": 0.808,
+            "ryu": 0.192
+          }
         }
       ]
     },
@@ -169,7 +242,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 1466,
       "initial_district_id": "d1",
       "name": "Exurb (0,-5)",
@@ -179,7 +255,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.7732, "ryu": 0.2268 }
+          "vote_shares": {
+            "ken": 0.7732,
+            "ryu": 0.2268
+          }
         }
       ]
     },
@@ -187,7 +266,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 1614,
       "initial_district_id": "d1",
       "name": "Exurb (1,-5)",
@@ -196,8 +278,11 @@
           "id": "p010-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.8320, "ryu": 0.1680 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.832,
+            "ryu": 0.168
+          }
         }
       ]
     },
@@ -205,7 +290,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 1584,
       "initial_district_id": "d2",
       "name": "Exurb (2,-5)",
@@ -215,7 +303,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7924, "ryu": 0.2076 }
+          "vote_shares": {
+            "ken": 0.7924,
+            "ryu": 0.2076
+          }
         }
       ]
     },
@@ -223,7 +314,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 1593,
       "initial_district_id": "d2",
       "name": "Exurb (3,-5)",
@@ -233,7 +327,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.8240, "ryu": 0.1760 }
+          "vote_shares": {
+            "ken": 0.824,
+            "ryu": 0.176
+          }
         }
       ]
     },
@@ -241,7 +338,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 1608,
       "initial_district_id": "d2",
       "name": "Exurb (4,-5)",
@@ -251,7 +351,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.8287, "ryu": 0.1713 }
+          "vote_shares": {
+            "ken": 0.8287,
+            "ryu": 0.1713
+          }
         }
       ]
     },
@@ -259,7 +362,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 1406,
       "initial_district_id": "d2",
       "name": "Exurb (5,-5)",
@@ -269,7 +375,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.7852, "ryu": 0.2148 }
+          "vote_shares": {
+            "ken": 0.7852,
+            "ryu": 0.2148
+          }
         }
       ]
     },
@@ -277,7 +386,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 6, "r": -5 },
+      "position": {
+        "q": 6,
+        "r": -5
+      },
       "total_population": 1511,
       "initial_district_id": "d2",
       "name": "Exurb (6,-5)",
@@ -287,7 +399,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.8252, "ryu": 0.1748 }
+          "vote_shares": {
+            "ken": 0.8252,
+            "ryu": 0.1748
+          }
         }
       ]
     },
@@ -295,7 +410,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -2, "r": -4 },
+      "position": {
+        "q": -2,
+        "r": -4
+      },
       "total_population": 1596,
       "initial_district_id": "d1",
       "name": "Exurb (-2,-4)",
@@ -305,7 +423,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.7990, "ryu": 0.2010 }
+          "vote_shares": {
+            "ken": 0.799,
+            "ryu": 0.201
+          }
         }
       ]
     },
@@ -313,7 +434,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 1379,
       "initial_district_id": "d1",
       "name": "Exurb (-1,-4)",
@@ -323,7 +447,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.8235, "ryu": 0.1765 }
+          "vote_shares": {
+            "ken": 0.8235,
+            "ryu": 0.1765
+          }
         }
       ]
     },
@@ -331,7 +458,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 1397,
       "initial_district_id": "d1",
       "name": "Suburb (0,-4)",
@@ -341,7 +471,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4926, "ryu": 0.5074 }
+          "vote_shares": {
+            "ken": 0.4926,
+            "ryu": 0.5074
+          }
         }
       ]
     },
@@ -349,7 +482,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 1584,
       "initial_district_id": "d2",
       "name": "Suburb (1,-4)",
@@ -359,7 +495,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4682, "ryu": 0.5318 }
+          "vote_shares": {
+            "ken": 0.4682,
+            "ryu": 0.5318
+          }
         }
       ]
     },
@@ -367,7 +506,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 1566,
       "initial_district_id": "d2",
       "name": "Suburb (2,-4)",
@@ -377,7 +519,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5300, "ryu": 0.4700 }
+          "vote_shares": {
+            "ken": 0.53,
+            "ryu": 0.47
+          }
         }
       ]
     },
@@ -385,7 +530,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 1629,
       "initial_district_id": "d2",
       "name": "Suburb (3,-4)",
@@ -395,7 +543,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5226, "ryu": 0.4774 }
+          "vote_shares": {
+            "ken": 0.5226,
+            "ryu": 0.4774
+          }
         }
       ]
     },
@@ -403,7 +554,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 1538,
       "initial_district_id": "d2",
       "name": "Suburb (4,-4)",
@@ -413,7 +567,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5241, "ryu": 0.4759 }
+          "vote_shares": {
+            "ken": 0.5241,
+            "ryu": 0.4759
+          }
         }
       ]
     },
@@ -421,7 +578,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 1491,
       "initial_district_id": "d2",
       "name": "Exurb (5,-4)",
@@ -431,7 +591,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.8322, "ryu": 0.1678 }
+          "vote_shares": {
+            "ken": 0.8322,
+            "ryu": 0.1678
+          }
         }
       ]
     },
@@ -439,7 +602,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 6, "r": -4 },
+      "position": {
+        "q": 6,
+        "r": -4
+      },
       "total_population": 1645,
       "initial_district_id": "d2",
       "name": "Exurb (6,-4)",
@@ -449,7 +615,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.7650, "ryu": 0.2350 }
+          "vote_shares": {
+            "ken": 0.765,
+            "ryu": 0.235
+          }
         }
       ]
     },
@@ -457,7 +626,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -3, "r": -3 },
+      "position": {
+        "q": -3,
+        "r": -3
+      },
       "total_population": 1623,
       "initial_district_id": "d1",
       "name": "Exurb (-3,-3)",
@@ -467,7 +639,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7881, "ryu": 0.2119 }
+          "vote_shares": {
+            "ken": 0.7881,
+            "ryu": 0.2119
+          }
         }
       ]
     },
@@ -475,7 +650,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 1578,
       "initial_district_id": "d1",
       "name": "Exurb (-2,-3)",
@@ -485,7 +663,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.7953, "ryu": 0.2047 }
+          "vote_shares": {
+            "ken": 0.7953,
+            "ryu": 0.2047
+          }
         }
       ]
     },
@@ -493,7 +674,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 1611,
       "initial_district_id": "d1",
       "name": "Suburb (-1,-3)",
@@ -503,7 +687,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4869, "ryu": 0.5131 }
+          "vote_shares": {
+            "ken": 0.4869,
+            "ryu": 0.5131
+          }
         }
       ]
     },
@@ -511,7 +698,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 1462,
       "initial_district_id": "d1",
       "name": "Suburb (0,-3)",
@@ -521,7 +711,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4713, "ryu": 0.5287 }
+          "vote_shares": {
+            "ken": 0.4713,
+            "ryu": 0.5287
+          }
         }
       ]
     },
@@ -529,7 +722,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 1548,
       "initial_district_id": "d2",
       "name": "Suburb (1,-3)",
@@ -539,7 +735,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5174, "ryu": 0.4826 }
+          "vote_shares": {
+            "ken": 0.5174,
+            "ryu": 0.4826
+          }
         }
       ]
     },
@@ -547,7 +746,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 1389,
       "initial_district_id": "d2",
       "name": "Suburb (2,-3)",
@@ -557,7 +759,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4906, "ryu": 0.5094 }
+          "vote_shares": {
+            "ken": 0.4906,
+            "ryu": 0.5094
+          }
         }
       ]
     },
@@ -565,7 +770,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 1632,
       "initial_district_id": "d2",
       "name": "Suburb (3,-3)",
@@ -575,7 +783,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4627, "ryu": 0.5373 }
+          "vote_shares": {
+            "ken": 0.4627,
+            "ryu": 0.5373
+          }
         }
       ]
     },
@@ -583,7 +794,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 1490,
       "initial_district_id": "d2",
       "name": "Suburb (4,-3)",
@@ -593,7 +807,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5286, "ryu": 0.4714 }
+          "vote_shares": {
+            "ken": 0.5286,
+            "ryu": 0.4714
+          }
         }
       ]
     },
@@ -601,7 +818,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 1528,
       "initial_district_id": "d2",
       "name": "Exurb (5,-3)",
@@ -610,8 +830,11 @@
           "id": "p033-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.8332, "ryu": 0.1668 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.8332,
+            "ryu": 0.1668
+          }
         }
       ]
     },
@@ -619,7 +842,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 6, "r": -3 },
+      "position": {
+        "q": 6,
+        "r": -3
+      },
       "total_population": 1426,
       "initial_district_id": "d3",
       "name": "Exurb (6,-3)",
@@ -629,7 +855,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.7668, "ryu": 0.2332 }
+          "vote_shares": {
+            "ken": 0.7668,
+            "ryu": 0.2332
+          }
         }
       ]
     },
@@ -637,7 +866,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": -2 },
+      "position": {
+        "q": -4,
+        "r": -2
+      },
       "total_population": 1584,
       "initial_district_id": "d1",
       "name": "Exurb (-4,-2)",
@@ -647,7 +879,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.7631, "ryu": 0.2369 }
+          "vote_shares": {
+            "ken": 0.7631,
+            "ryu": 0.2369
+          }
         }
       ]
     },
@@ -655,7 +890,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 1517,
       "initial_district_id": "d1",
       "name": "Exurb (-3,-2)",
@@ -664,8 +902,11 @@
           "id": "p036-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.8218, "ryu": 0.1782 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.8218,
+            "ryu": 0.1782
+          }
         }
       ]
     },
@@ -673,7 +914,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 1372,
       "initial_district_id": "d1",
       "name": "Suburb (-2,-2)",
@@ -683,7 +927,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5282, "ryu": 0.4718 }
+          "vote_shares": {
+            "ken": 0.5282,
+            "ryu": 0.4718
+          }
         }
       ]
     },
@@ -691,7 +938,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 1572,
       "initial_district_id": "d1",
       "name": "Suburb (-1,-2)",
@@ -701,7 +951,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5160, "ryu": 0.4840 }
+          "vote_shares": {
+            "ken": 0.516,
+            "ryu": 0.484
+          }
         }
       ]
     },
@@ -709,7 +962,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 1598,
       "initial_district_id": "d1",
       "name": "Core (0,-2)",
@@ -719,7 +975,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1707, "ryu": 0.8293 }
+          "vote_shares": {
+            "ken": 0.1707,
+            "ryu": 0.8293
+          }
         }
       ]
     },
@@ -727,7 +986,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 1353,
       "initial_district_id": "d2",
       "name": "Core (1,-2)",
@@ -736,8 +998,11 @@
           "id": "p040-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2341, "ryu": 0.7659 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.2341,
+            "ryu": 0.7659
+          }
         }
       ]
     },
@@ -745,7 +1010,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 1382,
       "initial_district_id": "d2",
       "name": "Core (2,-2)",
@@ -754,8 +1022,11 @@
           "id": "p041-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2236, "ryu": 0.7764 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.2236,
+            "ryu": 0.7764
+          }
         }
       ]
     },
@@ -763,7 +1034,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 1422,
       "initial_district_id": "d2",
       "name": "Suburb (3,-2)",
@@ -773,7 +1047,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4769, "ryu": 0.5231 }
+          "vote_shares": {
+            "ken": 0.4769,
+            "ryu": 0.5231
+          }
         }
       ]
     },
@@ -781,7 +1058,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 1559,
       "initial_district_id": "d3",
       "name": "Suburb (4,-2)",
@@ -791,7 +1071,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4931, "ryu": 0.5069 }
+          "vote_shares": {
+            "ken": 0.4931,
+            "ryu": 0.5069
+          }
         }
       ]
     },
@@ -799,7 +1082,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 1393,
       "initial_district_id": "d3",
       "name": "Exurb (5,-2)",
@@ -809,7 +1095,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7875, "ryu": 0.2125 }
+          "vote_shares": {
+            "ken": 0.7875,
+            "ryu": 0.2125
+          }
         }
       ]
     },
@@ -817,7 +1106,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 6, "r": -2 },
+      "position": {
+        "q": 6,
+        "r": -2
+      },
       "total_population": 1477,
       "initial_district_id": "d3",
       "name": "Exurb (6,-2)",
@@ -827,7 +1119,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.7984, "ryu": 0.2016 }
+          "vote_shares": {
+            "ken": 0.7984,
+            "ryu": 0.2016
+          }
         }
       ]
     },
@@ -835,7 +1130,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -5, "r": -1 },
+      "position": {
+        "q": -5,
+        "r": -1
+      },
       "total_population": 1621,
       "initial_district_id": "d1",
       "name": "Exurb (-5,-1)",
@@ -845,7 +1143,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.7764, "ryu": 0.2236 }
+          "vote_shares": {
+            "ken": 0.7764,
+            "ryu": 0.2236
+          }
         }
       ]
     },
@@ -853,7 +1154,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 1539,
       "initial_district_id": "d1",
       "name": "Exurb (-4,-1)",
@@ -863,7 +1167,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.8395, "ryu": 0.1605 }
+          "vote_shares": {
+            "ken": 0.8395,
+            "ryu": 0.1605
+          }
         }
       ]
     },
@@ -871,7 +1178,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 1587,
       "initial_district_id": "d1",
       "name": "Suburb (-3,-1)",
@@ -881,7 +1191,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4876, "ryu": 0.5124 }
+          "vote_shares": {
+            "ken": 0.4876,
+            "ryu": 0.5124
+          }
         }
       ]
     },
@@ -889,7 +1202,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 1507,
       "initial_district_id": "d1",
       "name": "Suburb (-2,-1)",
@@ -899,7 +1215,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4822, "ryu": 0.5178 }
+          "vote_shares": {
+            "ken": 0.4822,
+            "ryu": 0.5178
+          }
         }
       ]
     },
@@ -907,7 +1226,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 1541,
       "initial_district_id": "d1",
       "name": "Core (-1,-1)",
@@ -917,7 +1239,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1920, "ryu": 0.8080 }
+          "vote_shares": {
+            "ken": 0.192,
+            "ryu": 0.808
+          }
         }
       ]
     },
@@ -925,7 +1250,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 1600,
       "initial_district_id": "d1",
       "name": "Core (0,-1)",
@@ -935,7 +1263,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.2398, "ryu": 0.7602 }
+          "vote_shares": {
+            "ken": 0.2398,
+            "ryu": 0.7602
+          }
         }
       ]
     },
@@ -943,7 +1274,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 1503,
       "initial_district_id": "d2",
       "name": "Core (1,-1)",
@@ -953,7 +1287,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.1668, "ryu": 0.8332 }
+          "vote_shares": {
+            "ken": 0.1668,
+            "ryu": 0.8332
+          }
         }
       ]
     },
@@ -961,7 +1298,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 1535,
       "initial_district_id": "d3",
       "name": "Core (2,-1)",
@@ -971,7 +1311,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.2151, "ryu": 0.7849 }
+          "vote_shares": {
+            "ken": 0.2151,
+            "ryu": 0.7849
+          }
         }
       ]
     },
@@ -979,7 +1322,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 1371,
       "initial_district_id": "d3",
       "name": "Suburb (3,-1)",
@@ -989,7 +1335,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4848, "ryu": 0.5152 }
+          "vote_shares": {
+            "ken": 0.4848,
+            "ryu": 0.5152
+          }
         }
       ]
     },
@@ -997,7 +1346,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 1513,
       "initial_district_id": "d3",
       "name": "Suburb (4,-1)",
@@ -1007,7 +1359,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4899, "ryu": 0.5101 }
+          "vote_shares": {
+            "ken": 0.4899,
+            "ryu": 0.5101
+          }
         }
       ]
     },
@@ -1015,7 +1370,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 1394,
       "initial_district_id": "d3",
       "name": "Exurb (5,-1)",
@@ -1025,7 +1383,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.8039, "ryu": 0.1961 }
+          "vote_shares": {
+            "ken": 0.8039,
+            "ryu": 0.1961
+          }
         }
       ]
     },
@@ -1033,7 +1394,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 6, "r": -1 },
+      "position": {
+        "q": 6,
+        "r": -1
+      },
       "total_population": 1376,
       "initial_district_id": "d3",
       "name": "Exurb (6,-1)",
@@ -1043,7 +1407,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.7962, "ryu": 0.2038 }
+          "vote_shares": {
+            "ken": 0.7962,
+            "ryu": 0.2038
+          }
         }
       ]
     },
@@ -1051,7 +1418,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -6, "r": 0 },
+      "position": {
+        "q": -6,
+        "r": 0
+      },
       "total_population": 1519,
       "initial_district_id": "d5",
       "name": "Exurb (-6,0)",
@@ -1061,7 +1431,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.8071, "ryu": 0.1929 }
+          "vote_shares": {
+            "ken": 0.8071,
+            "ryu": 0.1929
+          }
         }
       ]
     },
@@ -1069,7 +1442,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 1465,
       "initial_district_id": "d5",
       "name": "Exurb (-5,0)",
@@ -1079,7 +1455,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.8237, "ryu": 0.1763 }
+          "vote_shares": {
+            "ken": 0.8237,
+            "ryu": 0.1763
+          }
         }
       ]
     },
@@ -1087,7 +1466,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 1457,
       "initial_district_id": "d5",
       "name": "Suburb (-4,0)",
@@ -1097,7 +1479,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4601, "ryu": 0.5399 }
+          "vote_shares": {
+            "ken": 0.4601,
+            "ryu": 0.5399
+          }
         }
       ]
     },
@@ -1105,7 +1490,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 1525,
       "initial_district_id": "d5",
       "name": "Suburb (-3,0)",
@@ -1115,7 +1503,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4871, "ryu": 0.5129 }
+          "vote_shares": {
+            "ken": 0.4871,
+            "ryu": 0.5129
+          }
         }
       ]
     },
@@ -1123,7 +1514,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 1596,
       "initial_district_id": "d5",
       "name": "Core (-2,0)",
@@ -1133,7 +1527,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.2160, "ryu": 0.7840 }
+          "vote_shares": {
+            "ken": 0.216,
+            "ryu": 0.784
+          }
         }
       ]
     },
@@ -1141,7 +1538,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 1411,
       "initial_district_id": "d5",
       "name": "Core (-1,0)",
@@ -1150,8 +1550,11 @@
           "id": "p063-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.2033, "ryu": 0.7967 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.2033,
+            "ryu": 0.7967
+          }
         }
       ]
     },
@@ -1159,7 +1562,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 1401,
       "initial_district_id": "d3",
       "name": "Core (0,0)",
@@ -1169,7 +1575,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1659, "ryu": 0.8341 }
+          "vote_shares": {
+            "ken": 0.1659,
+            "ryu": 0.8341
+          }
         }
       ]
     },
@@ -1177,7 +1586,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 1640,
       "initial_district_id": "d3",
       "name": "Core (1,0)",
@@ -1187,7 +1599,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.1736, "ryu": 0.8264 }
+          "vote_shares": {
+            "ken": 0.1736,
+            "ryu": 0.8264
+          }
         }
       ]
     },
@@ -1195,7 +1610,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 1585,
       "initial_district_id": "d3",
       "name": "Core (2,0)",
@@ -1205,7 +1623,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1687, "ryu": 0.8313 }
+          "vote_shares": {
+            "ken": 0.1687,
+            "ryu": 0.8313
+          }
         }
       ]
     },
@@ -1213,7 +1634,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 1535,
       "initial_district_id": "d3",
       "name": "Suburb (3,0)",
@@ -1223,7 +1647,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4793, "ryu": 0.5207 }
+          "vote_shares": {
+            "ken": 0.4793,
+            "ryu": 0.5207
+          }
         }
       ]
     },
@@ -1231,7 +1658,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 1405,
       "initial_district_id": "d3",
       "name": "Suburb (4,0)",
@@ -1241,7 +1671,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5145, "ryu": 0.4855 }
+          "vote_shares": {
+            "ken": 0.5145,
+            "ryu": 0.4855
+          }
         }
       ]
     },
@@ -1249,7 +1682,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 1519,
       "initial_district_id": "d3",
       "name": "Exurb (5,0)",
@@ -1259,7 +1695,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7859, "ryu": 0.2141 }
+          "vote_shares": {
+            "ken": 0.7859,
+            "ryu": 0.2141
+          }
         }
       ]
     },
@@ -1267,7 +1706,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 6, "r": 0 },
+      "position": {
+        "q": 6,
+        "r": 0
+      },
       "total_population": 1457,
       "initial_district_id": "d3",
       "name": "Exurb (6,0)",
@@ -1277,7 +1719,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.8210, "ryu": 0.1790 }
+          "vote_shares": {
+            "ken": 0.821,
+            "ryu": 0.179
+          }
         }
       ]
     },
@@ -1285,7 +1730,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -6, "r": 1 },
+      "position": {
+        "q": -6,
+        "r": 1
+      },
       "total_population": 1405,
       "initial_district_id": "d5",
       "name": "Exurb (-6,1)",
@@ -1295,7 +1743,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.8396, "ryu": 0.1604 }
+          "vote_shares": {
+            "ken": 0.8396,
+            "ryu": 0.1604
+          }
         }
       ]
     },
@@ -1303,7 +1754,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 1354,
       "initial_district_id": "d5",
       "name": "Exurb (-5,1)",
@@ -1313,7 +1767,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7726, "ryu": 0.2274 }
+          "vote_shares": {
+            "ken": 0.7726,
+            "ryu": 0.2274
+          }
         }
       ]
     },
@@ -1321,7 +1778,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 1551,
       "initial_district_id": "d5",
       "name": "Suburb (-4,1)",
@@ -1331,7 +1791,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4660, "ryu": 0.5340 }
+          "vote_shares": {
+            "ken": 0.466,
+            "ryu": 0.534
+          }
         }
       ]
     },
@@ -1339,7 +1802,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 1372,
       "initial_district_id": "d5",
       "name": "Suburb (-3,1)",
@@ -1349,7 +1815,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5323, "ryu": 0.4677 }
+          "vote_shares": {
+            "ken": 0.5323,
+            "ryu": 0.4677
+          }
         }
       ]
     },
@@ -1357,7 +1826,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 1646,
       "initial_district_id": "d5",
       "name": "Core (-2,1)",
@@ -1367,7 +1839,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.1772, "ryu": 0.8228 }
+          "vote_shares": {
+            "ken": 0.1772,
+            "ryu": 0.8228
+          }
         }
       ]
     },
@@ -1375,7 +1850,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 1603,
       "initial_district_id": "d5",
       "name": "Core (-1,1)",
@@ -1385,7 +1863,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.2061, "ryu": 0.7939 }
+          "vote_shares": {
+            "ken": 0.2061,
+            "ryu": 0.7939
+          }
         }
       ]
     },
@@ -1393,7 +1874,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 1501,
       "initial_district_id": "d4",
       "name": "Core (0,1)",
@@ -1403,7 +1887,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1682, "ryu": 0.8318 }
+          "vote_shares": {
+            "ken": 0.1682,
+            "ryu": 0.8318
+          }
         }
       ]
     },
@@ -1411,7 +1898,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 1547,
       "initial_district_id": "d3",
       "name": "Core (1,1)",
@@ -1421,7 +1911,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.2205, "ryu": 0.7795 }
+          "vote_shares": {
+            "ken": 0.2205,
+            "ryu": 0.7795
+          }
         }
       ]
     },
@@ -1429,7 +1922,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 1647,
       "initial_district_id": "d3",
       "name": "Suburb (2,1)",
@@ -1439,7 +1935,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4935, "ryu": 0.5065 }
+          "vote_shares": {
+            "ken": 0.4935,
+            "ryu": 0.5065
+          }
         }
       ]
     },
@@ -1447,7 +1946,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 1650,
       "initial_district_id": "d3",
       "name": "Suburb (3,1)",
@@ -1457,7 +1959,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5006, "ryu": 0.4994 }
+          "vote_shares": {
+            "ken": 0.5006,
+            "ryu": 0.4994
+          }
         }
       ]
     },
@@ -1465,7 +1970,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 1613,
       "initial_district_id": "d3",
       "name": "Exurb (4,1)",
@@ -1474,8 +1982,11 @@
           "id": "p081-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.7872, "ryu": 0.2128 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.7872,
+            "ryu": 0.2128
+          }
         }
       ]
     },
@@ -1483,7 +1994,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 5, "r": 1 },
+      "position": {
+        "q": 5,
+        "r": 1
+      },
       "total_population": 1521,
       "initial_district_id": "d3",
       "name": "Exurb (5,1)",
@@ -1493,7 +2007,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.7693, "ryu": 0.2307 }
+          "vote_shares": {
+            "ken": 0.7693,
+            "ryu": 0.2307
+          }
         }
       ]
     },
@@ -1501,7 +2018,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -6, "r": 2 },
+      "position": {
+        "q": -6,
+        "r": 2
+      },
       "total_population": 1362,
       "initial_district_id": "d5",
       "name": "Exurb (-6,2)",
@@ -1510,8 +2030,11 @@
           "id": "p083-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.7696, "ryu": 0.2304 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.7696,
+            "ryu": 0.2304
+          }
         }
       ]
     },
@@ -1519,7 +2042,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 1576,
       "initial_district_id": "d5",
       "name": "Exurb (-5,2)",
@@ -1529,7 +2055,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.8320, "ryu": 0.1680 }
+          "vote_shares": {
+            "ken": 0.832,
+            "ryu": 0.168
+          }
         }
       ]
     },
@@ -1537,7 +2066,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 1650,
       "initial_district_id": "d5",
       "name": "Suburb (-4,2)",
@@ -1547,7 +2079,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4965, "ryu": 0.5035 }
+          "vote_shares": {
+            "ken": 0.4965,
+            "ryu": 0.5035
+          }
         }
       ]
     },
@@ -1555,7 +2090,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 1583,
       "initial_district_id": "d5",
       "name": "Suburb (-3,2)",
@@ -1565,7 +2103,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4893, "ryu": 0.5107 }
+          "vote_shares": {
+            "ken": 0.4893,
+            "ryu": 0.5107
+          }
         }
       ]
     },
@@ -1573,7 +2114,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 1561,
       "initial_district_id": "d5",
       "name": "Core (-2,2)",
@@ -1583,7 +2127,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.1892, "ryu": 0.8108 }
+          "vote_shares": {
+            "ken": 0.1892,
+            "ryu": 0.8108
+          }
         }
       ]
     },
@@ -1591,7 +2138,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 1350,
       "initial_district_id": "d4",
       "name": "Core (-1,2)",
@@ -1601,7 +2151,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.2301, "ryu": 0.7699 }
+          "vote_shares": {
+            "ken": 0.2301,
+            "ryu": 0.7699
+          }
         }
       ]
     },
@@ -1609,7 +2162,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 1619,
       "initial_district_id": "d4",
       "name": "Core (0,2)",
@@ -1619,7 +2175,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.1622, "ryu": 0.8378 }
+          "vote_shares": {
+            "ken": 0.1622,
+            "ryu": 0.8378
+          }
         }
       ]
     },
@@ -1627,7 +2186,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 1559,
       "initial_district_id": "d4",
       "name": "Suburb (1,2)",
@@ -1636,8 +2198,11 @@
           "id": "p090-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5188, "ryu": 0.4812 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.5188,
+            "ryu": 0.4812
+          }
         }
       ]
     },
@@ -1645,7 +2210,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 1430,
       "initial_district_id": "d3",
       "name": "Suburb (2,2)",
@@ -1655,7 +2223,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4686, "ryu": 0.5314 }
+          "vote_shares": {
+            "ken": 0.4686,
+            "ryu": 0.5314
+          }
         }
       ]
     },
@@ -1663,7 +2234,10 @@
       "id": "p092",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 1591,
       "initial_district_id": "d3",
       "name": "Exurb (3,2)",
@@ -1673,7 +2247,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.8334, "ryu": 0.1666 }
+          "vote_shares": {
+            "ken": 0.8334,
+            "ryu": 0.1666
+          }
         }
       ]
     },
@@ -1681,7 +2258,10 @@
       "id": "p093",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 4, "r": 2 },
+      "position": {
+        "q": 4,
+        "r": 2
+      },
       "total_population": 1434,
       "initial_district_id": "d3",
       "name": "Exurb (4,2)",
@@ -1691,7 +2271,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.8335, "ryu": 0.1665 }
+          "vote_shares": {
+            "ken": 0.8335,
+            "ryu": 0.1665
+          }
         }
       ]
     },
@@ -1699,7 +2282,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -6, "r": 3 },
+      "position": {
+        "q": -6,
+        "r": 3
+      },
       "total_population": 1443,
       "initial_district_id": "d5",
       "name": "Exurb (-6,3)",
@@ -1708,8 +2294,11 @@
           "id": "p094-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.8006, "ryu": 0.1994 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.8006,
+            "ryu": 0.1994
+          }
         }
       ]
     },
@@ -1717,7 +2306,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 1456,
       "initial_district_id": "d5",
       "name": "Exurb (-5,3)",
@@ -1727,7 +2319,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7824, "ryu": 0.2176 }
+          "vote_shares": {
+            "ken": 0.7824,
+            "ryu": 0.2176
+          }
         }
       ]
     },
@@ -1735,7 +2330,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 1357,
       "initial_district_id": "d5",
       "name": "Suburb (-4,3)",
@@ -1745,7 +2343,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4863, "ryu": 0.5137 }
+          "vote_shares": {
+            "ken": 0.4863,
+            "ryu": 0.5137
+          }
         }
       ]
     },
@@ -1753,7 +2354,10 @@
       "id": "p097",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 1437,
       "initial_district_id": "d5",
       "name": "Suburb (-3,3)",
@@ -1763,7 +2367,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5243, "ryu": 0.4757 }
+          "vote_shares": {
+            "ken": 0.5243,
+            "ryu": 0.4757
+          }
         }
       ]
     },
@@ -1771,7 +2378,10 @@
       "id": "p098",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 1500,
       "initial_district_id": "d4",
       "name": "Suburb (-2,3)",
@@ -1781,7 +2391,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4737, "ryu": 0.5263 }
+          "vote_shares": {
+            "ken": 0.4737,
+            "ryu": 0.5263
+          }
         }
       ]
     },
@@ -1789,7 +2402,10 @@
       "id": "p099",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 1565,
       "initial_district_id": "d4",
       "name": "Suburb (-1,3)",
@@ -1799,7 +2415,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5177, "ryu": 0.4823 }
+          "vote_shares": {
+            "ken": 0.5177,
+            "ryu": 0.4823
+          }
         }
       ]
     },
@@ -1807,7 +2426,10 @@
       "id": "p100",
       "editable": true,
       "county_id": "accord_central",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 1542,
       "initial_district_id": "d4",
       "name": "Suburb (0,3)",
@@ -1817,7 +2439,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4661, "ryu": 0.5339 }
+          "vote_shares": {
+            "ken": 0.4661,
+            "ryu": 0.5339
+          }
         }
       ]
     },
@@ -1825,7 +2450,10 @@
       "id": "p101",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 1609,
       "initial_district_id": "d4",
       "name": "Suburb (1,3)",
@@ -1835,7 +2463,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5360, "ryu": 0.4640 }
+          "vote_shares": {
+            "ken": 0.536,
+            "ryu": 0.464
+          }
         }
       ]
     },
@@ -1843,7 +2474,10 @@
       "id": "p102",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 1554,
       "initial_district_id": "d4",
       "name": "Exurb (2,3)",
@@ -1853,7 +2487,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.8137, "ryu": 0.1863 }
+          "vote_shares": {
+            "ken": 0.8137,
+            "ryu": 0.1863
+          }
         }
       ]
     },
@@ -1861,7 +2498,10 @@
       "id": "p103",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 3, "r": 3 },
+      "position": {
+        "q": 3,
+        "r": 3
+      },
       "total_population": 1491,
       "initial_district_id": "d3",
       "name": "Exurb (3,3)",
@@ -1871,7 +2511,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.8131, "ryu": 0.1869 }
+          "vote_shares": {
+            "ken": 0.8131,
+            "ryu": 0.1869
+          }
         }
       ]
     },
@@ -1879,7 +2522,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -6, "r": 4 },
+      "position": {
+        "q": -6,
+        "r": 4
+      },
       "total_population": 1392,
       "initial_district_id": "d5",
       "name": "Exurb (-6,4)",
@@ -1889,7 +2535,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.8246, "ryu": 0.1754 }
+          "vote_shares": {
+            "ken": 0.8246,
+            "ryu": 0.1754
+          }
         }
       ]
     },
@@ -1897,7 +2546,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 1384,
       "initial_district_id": "d5",
       "name": "Exurb (-5,4)",
@@ -1907,7 +2559,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.8052, "ryu": 0.1948 }
+          "vote_shares": {
+            "ken": 0.8052,
+            "ryu": 0.1948
+          }
         }
       ]
     },
@@ -1915,7 +2570,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 1467,
       "initial_district_id": "d5",
       "name": "Suburb (-4,4)",
@@ -1925,7 +2583,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5380, "ryu": 0.4620 }
+          "vote_shares": {
+            "ken": 0.538,
+            "ryu": 0.462
+          }
         }
       ]
     },
@@ -1933,7 +2594,10 @@
       "id": "p107",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 1480,
       "initial_district_id": "d4",
       "name": "Suburb (-3,4)",
@@ -1943,7 +2607,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4609, "ryu": 0.5391 }
+          "vote_shares": {
+            "ken": 0.4609,
+            "ryu": 0.5391
+          }
         }
       ]
     },
@@ -1951,7 +2618,10 @@
       "id": "p108",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 1350,
       "initial_district_id": "d4",
       "name": "Suburb (-2,4)",
@@ -1961,7 +2631,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4792, "ryu": 0.5208 }
+          "vote_shares": {
+            "ken": 0.4792,
+            "ryu": 0.5208
+          }
         }
       ]
     },
@@ -1969,7 +2642,10 @@
       "id": "p109",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 1456,
       "initial_district_id": "d4",
       "name": "Suburb (-1,4)",
@@ -1979,7 +2655,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4838, "ryu": 0.5162 }
+          "vote_shares": {
+            "ken": 0.4838,
+            "ryu": 0.5162
+          }
         }
       ]
     },
@@ -1987,7 +2666,10 @@
       "id": "p110",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 1559,
       "initial_district_id": "d4",
       "name": "Suburb (0,4)",
@@ -1997,7 +2679,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4795, "ryu": 0.5205 }
+          "vote_shares": {
+            "ken": 0.4795,
+            "ryu": 0.5205
+          }
         }
       ]
     },
@@ -2005,7 +2690,10 @@
       "id": "p111",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 1501,
       "initial_district_id": "d4",
       "name": "Exurb (1,4)",
@@ -2015,7 +2703,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.7607, "ryu": 0.2393 }
+          "vote_shares": {
+            "ken": 0.7607,
+            "ryu": 0.2393
+          }
         }
       ]
     },
@@ -2023,7 +2714,10 @@
       "id": "p112",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 2, "r": 4 },
+      "position": {
+        "q": 2,
+        "r": 4
+      },
       "total_population": 1490,
       "initial_district_id": "d4",
       "name": "Exurb (2,4)",
@@ -2033,7 +2727,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.7992, "ryu": 0.2008 }
+          "vote_shares": {
+            "ken": 0.7992,
+            "ryu": 0.2008
+          }
         }
       ]
     },
@@ -2041,7 +2738,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -6, "r": 5 },
+      "position": {
+        "q": -6,
+        "r": 5
+      },
       "total_population": 1544,
       "initial_district_id": "d5",
       "name": "Exurb (-6,5)",
@@ -2051,7 +2751,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.8268, "ryu": 0.1732 }
+          "vote_shares": {
+            "ken": 0.8268,
+            "ryu": 0.1732
+          }
         }
       ]
     },
@@ -2059,7 +2762,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 1602,
       "initial_district_id": "d5",
       "name": "Exurb (-5,5)",
@@ -2069,7 +2775,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.8331, "ryu": 0.1669 }
+          "vote_shares": {
+            "ken": 0.8331,
+            "ryu": 0.1669
+          }
         }
       ]
     },
@@ -2077,7 +2786,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 1612,
       "initial_district_id": "d5",
       "name": "Exurb (-4,5)",
@@ -2087,7 +2799,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7630, "ryu": 0.2370 }
+          "vote_shares": {
+            "ken": 0.763,
+            "ryu": 0.237
+          }
         }
       ]
     },
@@ -2095,7 +2810,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 1482,
       "initial_district_id": "d4",
       "name": "Exurb (-3,5)",
@@ -2104,8 +2822,11 @@
           "id": "p116-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.7740, "ryu": 0.2260 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.774,
+            "ryu": 0.226
+          }
         }
       ]
     },
@@ -2113,7 +2834,10 @@
       "id": "p117",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 1535,
       "initial_district_id": "d4",
       "name": "Exurb (-2,5)",
@@ -2123,7 +2847,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.8105, "ryu": 0.1895 }
+          "vote_shares": {
+            "ken": 0.8105,
+            "ryu": 0.1895
+          }
         }
       ]
     },
@@ -2131,7 +2858,10 @@
       "id": "p118",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 1471,
       "initial_district_id": "d4",
       "name": "Exurb (-1,5)",
@@ -2141,7 +2871,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.7782, "ryu": 0.2218 }
+          "vote_shares": {
+            "ken": 0.7782,
+            "ryu": 0.2218
+          }
         }
       ]
     },
@@ -2149,7 +2882,10 @@
       "id": "p119",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 1416,
       "initial_district_id": "d4",
       "name": "Exurb (0,5)",
@@ -2159,7 +2895,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.8302, "ryu": 0.1698 }
+          "vote_shares": {
+            "ken": 0.8302,
+            "ryu": 0.1698
+          }
         }
       ]
     },
@@ -2167,7 +2906,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 1, "r": 5 },
+      "position": {
+        "q": 1,
+        "r": 5
+      },
       "total_population": 1416,
       "initial_district_id": "d4",
       "name": "Exurb (1,5)",
@@ -2177,7 +2919,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.8360, "ryu": 0.1640 }
+          "vote_shares": {
+            "ken": 0.836,
+            "ryu": 0.164
+          }
         }
       ]
     },
@@ -2185,7 +2930,10 @@
       "id": "p121",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -6, "r": 6 },
+      "position": {
+        "q": -6,
+        "r": 6
+      },
       "total_population": 1454,
       "initial_district_id": "d5",
       "name": "Exurb (-6,6)",
@@ -2195,7 +2943,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.7811, "ryu": 0.2189 }
+          "vote_shares": {
+            "ken": 0.7811,
+            "ryu": 0.2189
+          }
         }
       ]
     },
@@ -2203,7 +2954,10 @@
       "id": "p122",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -5, "r": 6 },
+      "position": {
+        "q": -5,
+        "r": 6
+      },
       "total_population": 1508,
       "initial_district_id": "d5",
       "name": "Exurb (-5,6)",
@@ -2213,7 +2967,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.8059, "ryu": 0.1941 }
+          "vote_shares": {
+            "ken": 0.8059,
+            "ryu": 0.1941
+          }
         }
       ]
     },
@@ -2221,7 +2978,10 @@
       "id": "p123",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -4, "r": 6 },
+      "position": {
+        "q": -4,
+        "r": 6
+      },
       "total_population": 1452,
       "initial_district_id": "d4",
       "name": "Exurb (-4,6)",
@@ -2231,7 +2991,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.8352, "ryu": 0.1648 }
+          "vote_shares": {
+            "ken": 0.8352,
+            "ryu": 0.1648
+          }
         }
       ]
     },
@@ -2239,7 +3002,10 @@
       "id": "p124",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -3, "r": 6 },
+      "position": {
+        "q": -3,
+        "r": 6
+      },
       "total_population": 1436,
       "initial_district_id": "d4",
       "name": "Exurb (-3,6)",
@@ -2249,7 +3015,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.7609, "ryu": 0.2391 }
+          "vote_shares": {
+            "ken": 0.7609,
+            "ryu": 0.2391
+          }
         }
       ]
     },
@@ -2257,7 +3026,10 @@
       "id": "p125",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -2, "r": 6 },
+      "position": {
+        "q": -2,
+        "r": 6
+      },
       "total_population": 1541,
       "initial_district_id": "d4",
       "name": "Exurb (-2,6)",
@@ -2267,7 +3039,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.8389, "ryu": 0.1611 }
+          "vote_shares": {
+            "ken": 0.8389,
+            "ryu": 0.1611
+          }
         }
       ]
     },
@@ -2275,7 +3050,10 @@
       "id": "p126",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": -1, "r": 6 },
+      "position": {
+        "q": -1,
+        "r": 6
+      },
       "total_population": 1487,
       "initial_district_id": "d4",
       "name": "Exurb (-1,6)",
@@ -2285,7 +3063,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.7753, "ryu": 0.2247 }
+          "vote_shares": {
+            "ken": 0.7753,
+            "ryu": 0.2247
+          }
         }
       ]
     },
@@ -2293,7 +3074,10 @@
       "id": "p127",
       "editable": true,
       "county_id": "accord_outer",
-      "position": { "q": 0, "r": 6 },
+      "position": {
+        "q": 0,
+        "r": 6
+      },
       "total_population": 1431,
       "initial_district_id": "d4",
       "name": "Exurb (0,6)",
@@ -2303,14 +3087,17 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.8263, "ryu": 0.1737 }
+          "vote_shares": {
+            "ken": 0.8263,
+            "ryu": 0.1737
+          }
         }
       ]
     }
   ],
   "events": [],
   "rules": {
-    "population_tolerance": 0.10,
+    "population_tolerance": 0.05,
     "contiguity": "required"
   },
   "success_criteria": [
@@ -2318,32 +3105,36 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All five districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
-      "description": "All five districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "description": "All five districts have roughly equal population (within 5%).",
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-compactness",
       "required": true,
-      "description": "All districts must be reasonably compact — no long tentacles or thin strips (compactness ≥ 40%).",
+      "description": "All districts must be reasonably compact \u2014 no long tentacles or thin strips (compactness \u2265 40%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
-        "threshold": 0.40
+        "threshold": 0.4
       }
     },
     {
       "id": "sc-efficiency-gap",
       "required": false,
-      "description": "How close to zero can you get the efficiency gap on a purely neutral map? (≤ 10%).",
+      "description": "How close to zero can you get the efficiency gap on a purely neutral map? (\u2264 10%).",
       "criterion": {
         "type": "efficiency_gap",
         "operator": "lte",
-        "threshold": 0.10
+        "threshold": 0.1
       }
     }
   ],
@@ -2351,7 +3142,7 @@
     "character": {
       "name": "You",
       "role": "Independent Commissioner, Accord County Redistricting Commission",
-      "motivation": "After years of partisan warfare over district lines, both parties agreed to something remarkable: an independent commission with binding authority. The rules are strict — equal population, geographic compactness, contiguous districts. No partisan data allowed. Both sides signed off on the criteria. Now you draw the map."
+      "motivation": "After years of partisan warfare over district lines, both parties agreed to something remarkable: an independent commission with binding authority. The rules are strict \u2014 equal population, geographic compactness, contiguous districts. No partisan data allowed. Both sides signed off on the criteria. Now you draw the map."
     },
     "intro_slides": [
       {
@@ -2360,7 +3151,7 @@
       },
       {
         "heading": "The Problem with Perfect Neutrality",
-        "body": "Here's what both parties understood privately, even as they signed: neutral rules don't produce neutral outcomes. They produce outcomes driven by geography.\n\nIn Accord County, geography has a lean. Ryu voters cluster tightly in the urban core. Ken voters spread across the suburbs and exurbs. Any compact map will reflect that geography — not because anyone drew it that way, but because that's where people live."
+        "body": "Here's what both parties understood privately, even as they signed: neutral rules don't produce neutral outcomes. They produce outcomes driven by geography.\n\nIn Accord County, geography has a lean. Ryu voters cluster tightly in the urban core. Ken voters spread across the suburbs and exurbs. Any compact map will reflect that geography \u2014 not because anyone drew it that way, but because that's where people live."
       },
       {
         "heading": "A Fair Process, An Unfair Outcome?",

--- a/game/scenarios/scenario-009.json
+++ b/game/scenarios/scenario-009.json
@@ -7,17 +7,42 @@
     "id": "pawprint_county",
     "name": "Pawprint County"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "cat", "name": "Cat Party", "abbreviation": "CAT" },
-    { "id": "dog", "name": "Dog Party", "abbreviation": "DOG" }
+    {
+      "id": "cat",
+      "name": "Cat Party",
+      "abbreviation": "CAT"
+    },
+    {
+      "id": "dog",
+      "name": "Dog Party",
+      "abbreviation": "DOG"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" },
-    { "id": "d5", "name": "District 5" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    },
+    {
+      "id": "d4",
+      "name": "District 4"
+    },
+    {
+      "id": "d5",
+      "name": "District 5"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -25,7 +50,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 0, "r": -6 },
+      "position": {
+        "q": 0,
+        "r": -6
+      },
       "total_population": 1644,
       "initial_district_id": "d5",
       "name": "Dogdale (0,-6)",
@@ -35,7 +63,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.4103, "dog": 0.5897 }
+          "vote_shares": {
+            "cat": 0.4103,
+            "dog": 0.5897
+          }
         }
       ]
     },
@@ -43,7 +74,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 1, "r": -6 },
+      "position": {
+        "q": 1,
+        "r": -6
+      },
       "total_population": 1593,
       "initial_district_id": "d5",
       "name": "Dogdale (1,-6)",
@@ -53,7 +87,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "cat": 0.4495, "dog": 0.5505 }
+          "vote_shares": {
+            "cat": 0.4495,
+            "dog": 0.5505
+          }
         }
       ]
     },
@@ -61,7 +98,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 2, "r": -6 },
+      "position": {
+        "q": 2,
+        "r": -6
+      },
       "total_population": 1580,
       "initial_district_id": "d5",
       "name": "Dogdale (2,-6)",
@@ -71,7 +111,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "cat": 0.4298, "dog": 0.5702 }
+          "vote_shares": {
+            "cat": 0.4298,
+            "dog": 0.5702
+          }
         }
       ]
     },
@@ -79,7 +122,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 3, "r": -6 },
+      "position": {
+        "q": 3,
+        "r": -6
+      },
       "total_population": 1556,
       "initial_district_id": "d5",
       "name": "Dogdale (3,-6)",
@@ -89,7 +135,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.4472, "dog": 0.5528 }
+          "vote_shares": {
+            "cat": 0.4472,
+            "dog": 0.5528
+          }
         }
       ]
     },
@@ -97,7 +146,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": -6 },
+      "position": {
+        "q": 4,
+        "r": -6
+      },
       "total_population": 1591,
       "initial_district_id": "d5",
       "name": "Dogdale (4,-6)",
@@ -107,7 +159,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "cat": 0.4211, "dog": 0.5789 }
+          "vote_shares": {
+            "cat": 0.4211,
+            "dog": 0.5789
+          }
         }
       ]
     },
@@ -115,7 +170,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 5, "r": -6 },
+      "position": {
+        "q": 5,
+        "r": -6
+      },
       "total_population": 1589,
       "initial_district_id": "d5",
       "name": "Dogdale (5,-6)",
@@ -125,7 +183,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.4526, "dog": 0.5474 }
+          "vote_shares": {
+            "cat": 0.4526,
+            "dog": 0.5474
+          }
         }
       ]
     },
@@ -133,7 +194,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 6, "r": -6 },
+      "position": {
+        "q": 6,
+        "r": -6
+      },
       "total_population": 1590,
       "initial_district_id": "d5",
       "name": "Dogdale (6,-6)",
@@ -143,7 +207,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.3991, "dog": 0.6009 }
+          "vote_shares": {
+            "cat": 0.3991,
+            "dog": 0.6009
+          }
         }
       ]
     },
@@ -151,7 +218,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -1, "r": -5 },
+      "position": {
+        "q": -1,
+        "r": -5
+      },
       "total_population": 1455,
       "initial_district_id": "d5",
       "name": "Dogdale (-1,-5)",
@@ -161,7 +231,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "cat": 0.4331, "dog": 0.5669 }
+          "vote_shares": {
+            "cat": 0.4331,
+            "dog": 0.5669
+          }
         }
       ]
     },
@@ -169,7 +242,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 1567,
       "initial_district_id": "d5",
       "name": "Dogdale (0,-5)",
@@ -179,7 +255,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "cat": 0.4492, "dog": 0.5508 }
+          "vote_shares": {
+            "cat": 0.4492,
+            "dog": 0.5508
+          }
         }
       ]
     },
@@ -187,7 +266,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 1465,
       "initial_district_id": "d5",
       "name": "Dogdale (1,-5)",
@@ -197,7 +279,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.4582, "dog": 0.5418 }
+          "vote_shares": {
+            "cat": 0.4582,
+            "dog": 0.5418
+          }
         }
       ]
     },
@@ -205,7 +290,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 1649,
       "initial_district_id": "d5",
       "name": "Dogdale (2,-5)",
@@ -215,7 +303,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.4166, "dog": 0.5834 }
+          "vote_shares": {
+            "cat": 0.4166,
+            "dog": 0.5834
+          }
         }
       ]
     },
@@ -223,7 +314,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 1358,
       "initial_district_id": "d5",
       "name": "Dogdale (3,-5)",
@@ -233,7 +327,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.3894, "dog": 0.6106 }
+          "vote_shares": {
+            "cat": 0.3894,
+            "dog": 0.6106
+          }
         }
       ]
     },
@@ -241,7 +338,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 1408,
       "initial_district_id": "d5",
       "name": "Dogdale (4,-5)",
@@ -250,8 +350,11 @@
           "id": "p013-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "cat": 0.4240, "dog": 0.5760 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "cat": 0.424,
+            "dog": 0.576
+          }
         }
       ]
     },
@@ -259,7 +362,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 1611,
       "initial_district_id": "d5",
       "name": "Dogdale (5,-5)",
@@ -269,7 +375,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.4310, "dog": 0.5690 }
+          "vote_shares": {
+            "cat": 0.431,
+            "dog": 0.569
+          }
         }
       ]
     },
@@ -277,7 +386,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 6, "r": -5 },
+      "position": {
+        "q": 6,
+        "r": -5
+      },
       "total_population": 1618,
       "initial_district_id": "d5",
       "name": "Dogdale (6,-5)",
@@ -287,7 +399,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "cat": 0.3900, "dog": 0.6100 }
+          "vote_shares": {
+            "cat": 0.39,
+            "dog": 0.61
+          }
         }
       ]
     },
@@ -295,7 +410,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -2, "r": -4 },
+      "position": {
+        "q": -2,
+        "r": -4
+      },
       "total_population": 1562,
       "initial_district_id": "d5",
       "name": "Dogdale (-2,-4)",
@@ -305,7 +423,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.3937, "dog": 0.6063 }
+          "vote_shares": {
+            "cat": 0.3937,
+            "dog": 0.6063
+          }
         }
       ]
     },
@@ -313,7 +434,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 1529,
       "initial_district_id": "d5",
       "name": "Dogdale (-1,-4)",
@@ -323,7 +447,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "cat": 0.4510, "dog": 0.5490 }
+          "vote_shares": {
+            "cat": 0.451,
+            "dog": 0.549
+          }
         }
       ]
     },
@@ -331,7 +458,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 1625,
       "initial_district_id": "d5",
       "name": "Midtown (0,-4)",
@@ -341,7 +471,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.7402, "dog": 0.2598 }
+          "vote_shares": {
+            "cat": 0.7402,
+            "dog": 0.2598
+          }
         }
       ]
     },
@@ -349,7 +482,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 1409,
       "initial_district_id": "d5",
       "name": "Midtown (1,-4)",
@@ -359,7 +495,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.7114, "dog": 0.2886 }
+          "vote_shares": {
+            "cat": 0.7114,
+            "dog": 0.2886
+          }
         }
       ]
     },
@@ -367,7 +506,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 1463,
       "initial_district_id": "d5",
       "name": "Midtown (2,-4)",
@@ -377,7 +519,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "cat": 0.7080, "dog": 0.2920 }
+          "vote_shares": {
+            "cat": 0.708,
+            "dog": 0.292
+          }
         }
       ]
     },
@@ -385,7 +530,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 1631,
       "initial_district_id": "d5",
       "name": "Midtown (3,-4)",
@@ -395,7 +543,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.6944, "dog": 0.3056 }
+          "vote_shares": {
+            "cat": 0.6944,
+            "dog": 0.3056
+          }
         }
       ]
     },
@@ -403,7 +554,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 1474,
       "initial_district_id": "d5",
       "name": "Midtown (4,-4)",
@@ -413,7 +567,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "cat": 0.7167, "dog": 0.2833 }
+          "vote_shares": {
+            "cat": 0.7167,
+            "dog": 0.2833
+          }
         }
       ]
     },
@@ -421,7 +578,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 1376,
       "initial_district_id": "d5",
       "name": "Dogdale (5,-4)",
@@ -431,7 +591,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.4283, "dog": 0.5717 }
+          "vote_shares": {
+            "cat": 0.4283,
+            "dog": 0.5717
+          }
         }
       ]
     },
@@ -439,7 +602,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 6, "r": -4 },
+      "position": {
+        "q": 6,
+        "r": -4
+      },
       "total_population": 1471,
       "initial_district_id": "d5",
       "name": "Dogdale (6,-4)",
@@ -449,7 +615,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "cat": 0.4109, "dog": 0.5891 }
+          "vote_shares": {
+            "cat": 0.4109,
+            "dog": 0.5891
+          }
         }
       ]
     },
@@ -457,7 +626,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -3, "r": -3 },
+      "position": {
+        "q": -3,
+        "r": -3
+      },
       "total_population": 1421,
       "initial_district_id": "d5",
       "name": "Dogdale (-3,-3)",
@@ -467,7 +639,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "cat": 0.4101, "dog": 0.5899 }
+          "vote_shares": {
+            "cat": 0.4101,
+            "dog": 0.5899
+          }
         }
       ]
     },
@@ -475,7 +650,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 1548,
       "initial_district_id": "d5",
       "name": "Dogdale (-2,-3)",
@@ -485,7 +663,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.4232, "dog": 0.5768 }
+          "vote_shares": {
+            "cat": 0.4232,
+            "dog": 0.5768
+          }
         }
       ]
     },
@@ -493,7 +674,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 1360,
       "initial_district_id": "d5",
       "name": "Midtown (-1,-3)",
@@ -503,7 +687,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.7388, "dog": 0.2612 }
+          "vote_shares": {
+            "cat": 0.7388,
+            "dog": 0.2612
+          }
         }
       ]
     },
@@ -511,7 +698,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 1549,
       "initial_district_id": "d5",
       "name": "Midtown (0,-3)",
@@ -521,7 +711,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.6884, "dog": 0.3116 }
+          "vote_shares": {
+            "cat": 0.6884,
+            "dog": 0.3116
+          }
         }
       ]
     },
@@ -529,7 +722,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 1466,
       "initial_district_id": "d5",
       "name": "Midtown (1,-3)",
@@ -539,7 +735,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "cat": 0.7259, "dog": 0.2741 }
+          "vote_shares": {
+            "cat": 0.7259,
+            "dog": 0.2741
+          }
         }
       ]
     },
@@ -547,7 +746,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 1644,
       "initial_district_id": "d5",
       "name": "Midtown (2,-3)",
@@ -557,7 +759,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.7409, "dog": 0.2591 }
+          "vote_shares": {
+            "cat": 0.7409,
+            "dog": 0.2591
+          }
         }
       ]
     },
@@ -565,7 +770,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 1643,
       "initial_district_id": "d5",
       "name": "Midtown (3,-3)",
@@ -575,7 +783,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "cat": 0.7198, "dog": 0.2802 }
+          "vote_shares": {
+            "cat": 0.7198,
+            "dog": 0.2802
+          }
         }
       ]
     },
@@ -583,7 +794,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 1535,
       "initial_district_id": "d5",
       "name": "Midtown (4,-3)",
@@ -593,7 +807,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "cat": 0.7575, "dog": 0.2425 }
+          "vote_shares": {
+            "cat": 0.7575,
+            "dog": 0.2425
+          }
         }
       ]
     },
@@ -601,7 +818,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 1361,
       "initial_district_id": "d5",
       "name": "Dogdale (5,-3)",
@@ -611,7 +831,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.4359, "dog": 0.5641 }
+          "vote_shares": {
+            "cat": 0.4359,
+            "dog": 0.5641
+          }
         }
       ]
     },
@@ -619,7 +842,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 6, "r": -3 },
+      "position": {
+        "q": 6,
+        "r": -3
+      },
       "total_population": 1503,
       "initial_district_id": "d5",
       "name": "Dogdale (6,-3)",
@@ -629,7 +855,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.4408, "dog": 0.5592 }
+          "vote_shares": {
+            "cat": 0.4408,
+            "dog": 0.5592
+          }
         }
       ]
     },
@@ -637,7 +866,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": -2 },
+      "position": {
+        "q": -4,
+        "r": -2
+      },
       "total_population": 1551,
       "initial_district_id": "d4",
       "name": "Dogdale (-4,-2)",
@@ -647,7 +879,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "cat": 0.4240, "dog": 0.5760 }
+          "vote_shares": {
+            "cat": 0.424,
+            "dog": 0.576
+          }
         }
       ]
     },
@@ -655,7 +890,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 1584,
       "initial_district_id": "d4",
       "name": "Dogdale (-3,-2)",
@@ -665,7 +903,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.4072, "dog": 0.5928 }
+          "vote_shares": {
+            "cat": 0.4072,
+            "dog": 0.5928
+          }
         }
       ]
     },
@@ -673,7 +914,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 1600,
       "initial_district_id": "d4",
       "name": "Midtown (-2,-2)",
@@ -683,7 +927,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "cat": 0.7146, "dog": 0.2854 }
+          "vote_shares": {
+            "cat": 0.7146,
+            "dog": 0.2854
+          }
         }
       ]
     },
@@ -691,7 +938,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 1382,
       "initial_district_id": "d4",
       "name": "Midtown (-1,-2)",
@@ -701,7 +951,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "cat": 0.7443, "dog": 0.2557 }
+          "vote_shares": {
+            "cat": 0.7443,
+            "dog": 0.2557
+          }
         }
       ]
     },
@@ -709,7 +962,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 1509,
       "initial_district_id": "d4",
       "name": "Catville (0,-2)",
@@ -719,7 +975,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.8261, "dog": 0.1739 }
+          "vote_shares": {
+            "cat": 0.8261,
+            "dog": 0.1739
+          }
         }
       ]
     },
@@ -727,7 +986,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 1489,
       "initial_district_id": "d4",
       "name": "Catville (1,-2)",
@@ -737,7 +999,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.8174, "dog": 0.1826 }
+          "vote_shares": {
+            "cat": 0.8174,
+            "dog": 0.1826
+          }
         }
       ]
     },
@@ -745,7 +1010,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 1598,
       "initial_district_id": "d4",
       "name": "Catville (2,-2)",
@@ -755,7 +1023,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.8159, "dog": 0.1841 }
+          "vote_shares": {
+            "cat": 0.8159,
+            "dog": 0.1841
+          }
         }
       ]
     },
@@ -763,7 +1034,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 1385,
       "initial_district_id": "d4",
       "name": "Midtown (3,-2)",
@@ -773,7 +1047,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.7162, "dog": 0.2838 }
+          "vote_shares": {
+            "cat": 0.7162,
+            "dog": 0.2838
+          }
         }
       ]
     },
@@ -781,7 +1058,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 1350,
       "initial_district_id": "d4",
       "name": "Midtown (4,-2)",
@@ -791,7 +1071,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.7432, "dog": 0.2568 }
+          "vote_shares": {
+            "cat": 0.7432,
+            "dog": 0.2568
+          }
         }
       ]
     },
@@ -799,7 +1082,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 1371,
       "initial_district_id": "d4",
       "name": "Dogdale (5,-2)",
@@ -809,7 +1095,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "cat": 0.4213, "dog": 0.5787 }
+          "vote_shares": {
+            "cat": 0.4213,
+            "dog": 0.5787
+          }
         }
       ]
     },
@@ -817,7 +1106,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 6, "r": -2 },
+      "position": {
+        "q": 6,
+        "r": -2
+      },
       "total_population": 1379,
       "initial_district_id": "d4",
       "name": "Dogdale (6,-2)",
@@ -827,7 +1119,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.4561, "dog": 0.5439 }
+          "vote_shares": {
+            "cat": 0.4561,
+            "dog": 0.5439
+          }
         }
       ]
     },
@@ -835,7 +1130,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -5, "r": -1 },
+      "position": {
+        "q": -5,
+        "r": -1
+      },
       "total_population": 1358,
       "initial_district_id": "d4",
       "name": "Dogdale (-5,-1)",
@@ -845,7 +1143,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.3911, "dog": 0.6089 }
+          "vote_shares": {
+            "cat": 0.3911,
+            "dog": 0.6089
+          }
         }
       ]
     },
@@ -853,7 +1154,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 1550,
       "initial_district_id": "d4",
       "name": "Dogdale (-4,-1)",
@@ -863,7 +1167,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "cat": 0.4011, "dog": 0.5989 }
+          "vote_shares": {
+            "cat": 0.4011,
+            "dog": 0.5989
+          }
         }
       ]
     },
@@ -871,7 +1178,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 1421,
       "initial_district_id": "d4",
       "name": "Midtown (-3,-1)",
@@ -881,7 +1191,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.6999, "dog": 0.3001 }
+          "vote_shares": {
+            "cat": 0.6999,
+            "dog": 0.3001
+          }
         }
       ]
     },
@@ -889,7 +1202,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 1569,
       "initial_district_id": "d4",
       "name": "Midtown (-2,-1)",
@@ -899,7 +1215,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "cat": 0.6894, "dog": 0.3106 }
+          "vote_shares": {
+            "cat": 0.6894,
+            "dog": 0.3106
+          }
         }
       ]
     },
@@ -907,7 +1226,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 1590,
       "initial_district_id": "d4",
       "name": "Catville (-1,-1)",
@@ -917,7 +1239,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "cat": 0.8496, "dog": 0.1504 }
+          "vote_shares": {
+            "cat": 0.8496,
+            "dog": 0.1504
+          }
         }
       ]
     },
@@ -925,7 +1250,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 1456,
       "initial_district_id": "d4",
       "name": "Catville (0,-1)",
@@ -935,7 +1263,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.8542, "dog": 0.1458 }
+          "vote_shares": {
+            "cat": 0.8542,
+            "dog": 0.1458
+          }
         }
       ]
     },
@@ -943,7 +1274,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 1387,
       "initial_district_id": "d4",
       "name": "Catville (1,-1)",
@@ -953,7 +1287,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.8411, "dog": 0.1589 }
+          "vote_shares": {
+            "cat": 0.8411,
+            "dog": 0.1589
+          }
         }
       ]
     },
@@ -961,7 +1298,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 1427,
       "initial_district_id": "d4",
       "name": "Catville (2,-1)",
@@ -971,7 +1311,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.7836, "dog": 0.2164 }
+          "vote_shares": {
+            "cat": 0.7836,
+            "dog": 0.2164
+          }
         }
       ]
     },
@@ -979,7 +1322,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 1526,
       "initial_district_id": "d4",
       "name": "Midtown (3,-1)",
@@ -989,7 +1335,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.6801, "dog": 0.3199 }
+          "vote_shares": {
+            "cat": 0.6801,
+            "dog": 0.3199
+          }
         }
       ]
     },
@@ -997,7 +1346,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 1368,
       "initial_district_id": "d4",
       "name": "Midtown (4,-1)",
@@ -1007,7 +1359,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "cat": 0.7413, "dog": 0.2587 }
+          "vote_shares": {
+            "cat": 0.7413,
+            "dog": 0.2587
+          }
         }
       ]
     },
@@ -1015,7 +1370,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 1626,
       "initial_district_id": "d4",
       "name": "Dogdale (5,-1)",
@@ -1025,7 +1383,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "cat": 0.4595, "dog": 0.5405 }
+          "vote_shares": {
+            "cat": 0.4595,
+            "dog": 0.5405
+          }
         }
       ]
     },
@@ -1033,7 +1394,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 6, "r": -1 },
+      "position": {
+        "q": 6,
+        "r": -1
+      },
       "total_population": 1469,
       "initial_district_id": "d4",
       "name": "Dogdale (6,-1)",
@@ -1043,7 +1407,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.3958, "dog": 0.6042 }
+          "vote_shares": {
+            "cat": 0.3958,
+            "dog": 0.6042
+          }
         }
       ]
     },
@@ -1051,7 +1418,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -6, "r": 0 },
+      "position": {
+        "q": -6,
+        "r": 0
+      },
       "total_population": 1645,
       "initial_district_id": "d3",
       "name": "Dogdale (-6,0)",
@@ -1061,7 +1431,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.4465, "dog": 0.5535 }
+          "vote_shares": {
+            "cat": 0.4465,
+            "dog": 0.5535
+          }
         }
       ]
     },
@@ -1069,7 +1442,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 1376,
       "initial_district_id": "d3",
       "name": "Dogdale (-5,0)",
@@ -1079,7 +1455,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.3853, "dog": 0.6147 }
+          "vote_shares": {
+            "cat": 0.3853,
+            "dog": 0.6147
+          }
         }
       ]
     },
@@ -1087,7 +1466,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 1398,
       "initial_district_id": "d3",
       "name": "Midtown (-4,0)",
@@ -1097,7 +1479,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "cat": 0.7413, "dog": 0.2587 }
+          "vote_shares": {
+            "cat": 0.7413,
+            "dog": 0.2587
+          }
         }
       ]
     },
@@ -1105,7 +1490,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 1625,
       "initial_district_id": "d3",
       "name": "Midtown (-3,0)",
@@ -1115,7 +1503,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.7555, "dog": 0.2445 }
+          "vote_shares": {
+            "cat": 0.7555,
+            "dog": 0.2445
+          }
         }
       ]
     },
@@ -1123,7 +1514,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 1438,
       "initial_district_id": "d3",
       "name": "Catville (-2,0)",
@@ -1133,7 +1527,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.8476, "dog": 0.1524 }
+          "vote_shares": {
+            "cat": 0.8476,
+            "dog": 0.1524
+          }
         }
       ]
     },
@@ -1141,7 +1538,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 1450,
       "initial_district_id": "d3",
       "name": "Catville (-1,0)",
@@ -1151,7 +1551,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "cat": 0.8053, "dog": 0.1947 }
+          "vote_shares": {
+            "cat": 0.8053,
+            "dog": 0.1947
+          }
         }
       ]
     },
@@ -1159,7 +1562,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 1586,
       "initial_district_id": "d3",
       "name": "Catville (0,0)",
@@ -1169,7 +1575,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.8304, "dog": 0.1696 }
+          "vote_shares": {
+            "cat": 0.8304,
+            "dog": 0.1696
+          }
         }
       ]
     },
@@ -1177,7 +1586,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 1384,
       "initial_district_id": "d3",
       "name": "Catville (1,0)",
@@ -1187,7 +1599,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.7926, "dog": 0.2074 }
+          "vote_shares": {
+            "cat": 0.7926,
+            "dog": 0.2074
+          }
         }
       ]
     },
@@ -1195,7 +1610,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 1541,
       "initial_district_id": "d3",
       "name": "Catville (2,0)",
@@ -1205,7 +1623,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.8196, "dog": 0.1804 }
+          "vote_shares": {
+            "cat": 0.8196,
+            "dog": 0.1804
+          }
         }
       ]
     },
@@ -1213,7 +1634,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 1434,
       "initial_district_id": "d3",
       "name": "Midtown (3,0)",
@@ -1223,7 +1647,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.6923, "dog": 0.3077 }
+          "vote_shares": {
+            "cat": 0.6923,
+            "dog": 0.3077
+          }
         }
       ]
     },
@@ -1231,7 +1658,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 1503,
       "initial_district_id": "d3",
       "name": "Midtown (4,0)",
@@ -1241,7 +1671,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.7418, "dog": 0.2582 }
+          "vote_shares": {
+            "cat": 0.7418,
+            "dog": 0.2582
+          }
         }
       ]
     },
@@ -1249,7 +1682,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 1434,
       "initial_district_id": "d3",
       "name": "Dogdale (5,0)",
@@ -1259,7 +1695,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.4003, "dog": 0.5997 }
+          "vote_shares": {
+            "cat": 0.4003,
+            "dog": 0.5997
+          }
         }
       ]
     },
@@ -1267,7 +1706,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 6, "r": 0 },
+      "position": {
+        "q": 6,
+        "r": 0
+      },
       "total_population": 1410,
       "initial_district_id": "d3",
       "name": "Dogdale (6,0)",
@@ -1277,7 +1719,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.4212, "dog": 0.5788 }
+          "vote_shares": {
+            "cat": 0.4212,
+            "dog": 0.5788
+          }
         }
       ]
     },
@@ -1285,7 +1730,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -6, "r": 1 },
+      "position": {
+        "q": -6,
+        "r": 1
+      },
       "total_population": 1597,
       "initial_district_id": "d2",
       "name": "Dogdale (-6,1)",
@@ -1295,7 +1743,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "cat": 0.4008, "dog": 0.5992 }
+          "vote_shares": {
+            "cat": 0.4008,
+            "dog": 0.5992
+          }
         }
       ]
     },
@@ -1303,7 +1754,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 1375,
       "initial_district_id": "d2",
       "name": "Dogdale (-5,1)",
@@ -1313,7 +1767,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.4545, "dog": 0.5455 }
+          "vote_shares": {
+            "cat": 0.4545,
+            "dog": 0.5455
+          }
         }
       ]
     },
@@ -1321,7 +1778,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 1604,
       "initial_district_id": "d2",
       "name": "Midtown (-4,1)",
@@ -1331,7 +1791,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.6933, "dog": 0.3067 }
+          "vote_shares": {
+            "cat": 0.6933,
+            "dog": 0.3067
+          }
         }
       ]
     },
@@ -1339,7 +1802,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 1466,
       "initial_district_id": "d2",
       "name": "Midtown (-3,1)",
@@ -1349,7 +1815,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.7340, "dog": 0.2660 }
+          "vote_shares": {
+            "cat": 0.734,
+            "dog": 0.266
+          }
         }
       ]
     },
@@ -1357,7 +1826,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 1546,
       "initial_district_id": "d2",
       "name": "Catville (-2,1)",
@@ -1367,7 +1839,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "cat": 0.8314, "dog": 0.1686 }
+          "vote_shares": {
+            "cat": 0.8314,
+            "dog": 0.1686
+          }
         }
       ]
     },
@@ -1375,7 +1850,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 1374,
       "initial_district_id": "d2",
       "name": "Catville (-1,1)",
@@ -1385,7 +1863,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "cat": 0.7821, "dog": 0.2179 }
+          "vote_shares": {
+            "cat": 0.7821,
+            "dog": 0.2179
+          }
         }
       ]
     },
@@ -1393,7 +1874,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 1649,
       "initial_district_id": "d2",
       "name": "Catville (0,1)",
@@ -1403,7 +1887,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.7951, "dog": 0.2049 }
+          "vote_shares": {
+            "cat": 0.7951,
+            "dog": 0.2049
+          }
         }
       ]
     },
@@ -1411,7 +1898,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 1357,
       "initial_district_id": "d2",
       "name": "Catville (1,1)",
@@ -1421,7 +1911,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.8493, "dog": 0.1507 }
+          "vote_shares": {
+            "cat": 0.8493,
+            "dog": 0.1507
+          }
         }
       ]
     },
@@ -1429,7 +1922,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 1577,
       "initial_district_id": "d2",
       "name": "Midtown (2,1)",
@@ -1439,7 +1935,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "cat": 0.7038, "dog": 0.2962 }
+          "vote_shares": {
+            "cat": 0.7038,
+            "dog": 0.2962
+          }
         }
       ]
     },
@@ -1447,7 +1946,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 1552,
       "initial_district_id": "d2",
       "name": "Midtown (3,1)",
@@ -1457,7 +1959,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.7483, "dog": 0.2517 }
+          "vote_shares": {
+            "cat": 0.7483,
+            "dog": 0.2517
+          }
         }
       ]
     },
@@ -1465,7 +1970,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 1552,
       "initial_district_id": "d2",
       "name": "Dogdale (4,1)",
@@ -1475,7 +1983,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.4513, "dog": 0.5487 }
+          "vote_shares": {
+            "cat": 0.4513,
+            "dog": 0.5487
+          }
         }
       ]
     },
@@ -1483,7 +1994,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 5, "r": 1 },
+      "position": {
+        "q": 5,
+        "r": 1
+      },
       "total_population": 1497,
       "initial_district_id": "d2",
       "name": "Dogdale (5,1)",
@@ -1493,7 +2007,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.4341, "dog": 0.5659 }
+          "vote_shares": {
+            "cat": 0.4341,
+            "dog": 0.5659
+          }
         }
       ]
     },
@@ -1501,7 +2018,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -6, "r": 2 },
+      "position": {
+        "q": -6,
+        "r": 2
+      },
       "total_population": 1496,
       "initial_district_id": "d2",
       "name": "Dogdale (-6,2)",
@@ -1511,7 +2031,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "cat": 0.3831, "dog": 0.6169 }
+          "vote_shares": {
+            "cat": 0.3831,
+            "dog": 0.6169
+          }
         }
       ]
     },
@@ -1519,7 +2042,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 1540,
       "initial_district_id": "d2",
       "name": "Dogdale (-5,2)",
@@ -1529,7 +2055,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.4485, "dog": 0.5515 }
+          "vote_shares": {
+            "cat": 0.4485,
+            "dog": 0.5515
+          }
         }
       ]
     },
@@ -1537,7 +2066,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 1371,
       "initial_district_id": "d2",
       "name": "Midtown (-4,2)",
@@ -1547,7 +2079,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.6988, "dog": 0.3012 }
+          "vote_shares": {
+            "cat": 0.6988,
+            "dog": 0.3012
+          }
         }
       ]
     },
@@ -1555,7 +2090,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 1638,
       "initial_district_id": "d2",
       "name": "Midtown (-3,2)",
@@ -1565,7 +2103,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.6847, "dog": 0.3153 }
+          "vote_shares": {
+            "cat": 0.6847,
+            "dog": 0.3153
+          }
         }
       ]
     },
@@ -1573,7 +2114,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 1451,
       "initial_district_id": "d2",
       "name": "Catville (-2,2)",
@@ -1582,8 +2126,11 @@
           "id": "p087-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "cat": 0.8403, "dog": 0.1597 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "cat": 0.8403,
+            "dog": 0.1597
+          }
         }
       ]
     },
@@ -1591,7 +2138,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 1522,
       "initial_district_id": "d2",
       "name": "Catville (-1,2)",
@@ -1601,7 +2151,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.7935, "dog": 0.2065 }
+          "vote_shares": {
+            "cat": 0.7935,
+            "dog": 0.2065
+          }
         }
       ]
     },
@@ -1609,7 +2162,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 1561,
       "initial_district_id": "d2",
       "name": "Catville (0,2)",
@@ -1618,8 +2174,11 @@
           "id": "p089-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "cat": 0.7935, "dog": 0.2065 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "cat": 0.7935,
+            "dog": 0.2065
+          }
         }
       ]
     },
@@ -1627,7 +2186,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 1446,
       "initial_district_id": "d2",
       "name": "Midtown (1,2)",
@@ -1637,7 +2199,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "cat": 0.7424, "dog": 0.2576 }
+          "vote_shares": {
+            "cat": 0.7424,
+            "dog": 0.2576
+          }
         }
       ]
     },
@@ -1645,7 +2210,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 1433,
       "initial_district_id": "d2",
       "name": "Midtown (2,2)",
@@ -1655,7 +2223,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.7109, "dog": 0.2891 }
+          "vote_shares": {
+            "cat": 0.7109,
+            "dog": 0.2891
+          }
         }
       ]
     },
@@ -1663,7 +2234,10 @@
       "id": "p092",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 1621,
       "initial_district_id": "d2",
       "name": "Dogdale (3,2)",
@@ -1673,7 +2247,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "cat": 0.3896, "dog": 0.6104 }
+          "vote_shares": {
+            "cat": 0.3896,
+            "dog": 0.6104
+          }
         }
       ]
     },
@@ -1681,7 +2258,10 @@
       "id": "p093",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 4, "r": 2 },
+      "position": {
+        "q": 4,
+        "r": 2
+      },
       "total_population": 1582,
       "initial_district_id": "d2",
       "name": "Dogdale (4,2)",
@@ -1691,7 +2271,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "cat": 0.3854, "dog": 0.6146 }
+          "vote_shares": {
+            "cat": 0.3854,
+            "dog": 0.6146
+          }
         }
       ]
     },
@@ -1699,7 +2282,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -6, "r": 3 },
+      "position": {
+        "q": -6,
+        "r": 3
+      },
       "total_population": 1646,
       "initial_district_id": "d1",
       "name": "Dogdale (-6,3)",
@@ -1709,7 +2295,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "cat": 0.4549, "dog": 0.5451 }
+          "vote_shares": {
+            "cat": 0.4549,
+            "dog": 0.5451
+          }
         }
       ]
     },
@@ -1717,7 +2306,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 1554,
       "initial_district_id": "d1",
       "name": "Dogdale (-5,3)",
@@ -1727,7 +2319,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.4483, "dog": 0.5517 }
+          "vote_shares": {
+            "cat": 0.4483,
+            "dog": 0.5517
+          }
         }
       ]
     },
@@ -1735,7 +2330,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 1529,
       "initial_district_id": "d1",
       "name": "Midtown (-4,3)",
@@ -1745,7 +2343,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.7204, "dog": 0.2796 }
+          "vote_shares": {
+            "cat": 0.7204,
+            "dog": 0.2796
+          }
         }
       ]
     },
@@ -1753,7 +2354,10 @@
       "id": "p097",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 1548,
       "initial_district_id": "d1",
       "name": "Midtown (-3,3)",
@@ -1763,7 +2367,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.7177, "dog": 0.2823 }
+          "vote_shares": {
+            "cat": 0.7177,
+            "dog": 0.2823
+          }
         }
       ]
     },
@@ -1771,7 +2378,10 @@
       "id": "p098",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 1537,
       "initial_district_id": "d1",
       "name": "Midtown (-2,3)",
@@ -1781,7 +2391,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "cat": 0.7094, "dog": 0.2906 }
+          "vote_shares": {
+            "cat": 0.7094,
+            "dog": 0.2906
+          }
         }
       ]
     },
@@ -1789,7 +2402,10 @@
       "id": "p099",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 1400,
       "initial_district_id": "d1",
       "name": "Midtown (-1,3)",
@@ -1798,8 +2414,11 @@
           "id": "p099-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "cat": 0.7119, "dog": 0.2881 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "cat": 0.7119,
+            "dog": 0.2881
+          }
         }
       ]
     },
@@ -1807,7 +2426,10 @@
       "id": "p100",
       "editable": true,
       "county_id": "catville",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 1534,
       "initial_district_id": "d1",
       "name": "Midtown (0,3)",
@@ -1817,7 +2439,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.7359, "dog": 0.2641 }
+          "vote_shares": {
+            "cat": 0.7359,
+            "dog": 0.2641
+          }
         }
       ]
     },
@@ -1825,7 +2450,10 @@
       "id": "p101",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 1393,
       "initial_district_id": "d1",
       "name": "Midtown (1,3)",
@@ -1835,7 +2463,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.6982, "dog": 0.3018 }
+          "vote_shares": {
+            "cat": 0.6982,
+            "dog": 0.3018
+          }
         }
       ]
     },
@@ -1843,7 +2474,10 @@
       "id": "p102",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 1423,
       "initial_district_id": "d1",
       "name": "Dogdale (2,3)",
@@ -1853,7 +2487,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.4050, "dog": 0.5950 }
+          "vote_shares": {
+            "cat": 0.405,
+            "dog": 0.595
+          }
         }
       ]
     },
@@ -1861,7 +2498,10 @@
       "id": "p103",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 3, "r": 3 },
+      "position": {
+        "q": 3,
+        "r": 3
+      },
       "total_population": 1374,
       "initial_district_id": "d1",
       "name": "Dogdale (3,3)",
@@ -1871,7 +2511,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.4138, "dog": 0.5862 }
+          "vote_shares": {
+            "cat": 0.4138,
+            "dog": 0.5862
+          }
         }
       ]
     },
@@ -1879,7 +2522,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -6, "r": 4 },
+      "position": {
+        "q": -6,
+        "r": 4
+      },
       "total_population": 1368,
       "initial_district_id": "d1",
       "name": "Dogdale (-6,4)",
@@ -1889,7 +2535,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.3816, "dog": 0.6184 }
+          "vote_shares": {
+            "cat": 0.3816,
+            "dog": 0.6184
+          }
         }
       ]
     },
@@ -1897,7 +2546,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 1407,
       "initial_district_id": "d1",
       "name": "Dogdale (-5,4)",
@@ -1907,7 +2559,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "cat": 0.4039, "dog": 0.5961 }
+          "vote_shares": {
+            "cat": 0.4039,
+            "dog": 0.5961
+          }
         }
       ]
     },
@@ -1915,7 +2570,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 1536,
       "initial_district_id": "d1",
       "name": "Midtown (-4,4)",
@@ -1925,7 +2583,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.6912, "dog": 0.3088 }
+          "vote_shares": {
+            "cat": 0.6912,
+            "dog": 0.3088
+          }
         }
       ]
     },
@@ -1933,7 +2594,10 @@
       "id": "p107",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 1612,
       "initial_district_id": "d1",
       "name": "Midtown (-3,4)",
@@ -1943,7 +2607,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.7022, "dog": 0.2978 }
+          "vote_shares": {
+            "cat": 0.7022,
+            "dog": 0.2978
+          }
         }
       ]
     },
@@ -1951,7 +2618,10 @@
       "id": "p108",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 1585,
       "initial_district_id": "d1",
       "name": "Midtown (-2,4)",
@@ -1961,7 +2631,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.7191, "dog": 0.2809 }
+          "vote_shares": {
+            "cat": 0.7191,
+            "dog": 0.2809
+          }
         }
       ]
     },
@@ -1969,7 +2642,10 @@
       "id": "p109",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 1479,
       "initial_district_id": "d1",
       "name": "Midtown (-1,4)",
@@ -1979,7 +2655,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "cat": 0.6883, "dog": 0.3117 }
+          "vote_shares": {
+            "cat": 0.6883,
+            "dog": 0.3117
+          }
         }
       ]
     },
@@ -1987,7 +2666,10 @@
       "id": "p110",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 1405,
       "initial_district_id": "d1",
       "name": "Midtown (0,4)",
@@ -1996,8 +2678,11 @@
           "id": "p110-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "cat": 0.7302, "dog": 0.2698 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "cat": 0.7302,
+            "dog": 0.2698
+          }
         }
       ]
     },
@@ -2005,7 +2690,10 @@
       "id": "p111",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 1400,
       "initial_district_id": "d1",
       "name": "Dogdale (1,4)",
@@ -2015,7 +2703,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "cat": 0.4177, "dog": 0.5823 }
+          "vote_shares": {
+            "cat": 0.4177,
+            "dog": 0.5823
+          }
         }
       ]
     },
@@ -2023,7 +2714,10 @@
       "id": "p112",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 2, "r": 4 },
+      "position": {
+        "q": 2,
+        "r": 4
+      },
       "total_population": 1635,
       "initial_district_id": "d1",
       "name": "Dogdale (2,4)",
@@ -2033,7 +2727,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.4576, "dog": 0.5424 }
+          "vote_shares": {
+            "cat": 0.4576,
+            "dog": 0.5424
+          }
         }
       ]
     },
@@ -2041,7 +2738,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -6, "r": 5 },
+      "position": {
+        "q": -6,
+        "r": 5
+      },
       "total_population": 1435,
       "initial_district_id": "d1",
       "name": "Dogdale (-6,5)",
@@ -2050,8 +2750,11 @@
           "id": "p113-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "cat": 0.4473, "dog": 0.5527 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "cat": 0.4473,
+            "dog": 0.5527
+          }
         }
       ]
     },
@@ -2059,7 +2762,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 1510,
       "initial_district_id": "d1",
       "name": "Dogdale (-5,5)",
@@ -2069,7 +2775,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "cat": 0.4518, "dog": 0.5482 }
+          "vote_shares": {
+            "cat": 0.4518,
+            "dog": 0.5482
+          }
         }
       ]
     },
@@ -2077,7 +2786,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 1409,
       "initial_district_id": "d1",
       "name": "Dogdale (-4,5)",
@@ -2087,7 +2799,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.4437, "dog": 0.5563 }
+          "vote_shares": {
+            "cat": 0.4437,
+            "dog": 0.5563
+          }
         }
       ]
     },
@@ -2095,7 +2810,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 1570,
       "initial_district_id": "d1",
       "name": "Dogdale (-3,5)",
@@ -2105,7 +2823,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "cat": 0.4152, "dog": 0.5848 }
+          "vote_shares": {
+            "cat": 0.4152,
+            "dog": 0.5848
+          }
         }
       ]
     },
@@ -2113,7 +2834,10 @@
       "id": "p117",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 1617,
       "initial_district_id": "d1",
       "name": "Dogdale (-2,5)",
@@ -2123,7 +2847,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "cat": 0.4470, "dog": 0.5530 }
+          "vote_shares": {
+            "cat": 0.447,
+            "dog": 0.553
+          }
         }
       ]
     },
@@ -2131,7 +2858,10 @@
       "id": "p118",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 1534,
       "initial_district_id": "d1",
       "name": "Dogdale (-1,5)",
@@ -2141,7 +2871,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "cat": 0.3920, "dog": 0.6080 }
+          "vote_shares": {
+            "cat": 0.392,
+            "dog": 0.608
+          }
         }
       ]
     },
@@ -2149,7 +2882,10 @@
       "id": "p119",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 1408,
       "initial_district_id": "d1",
       "name": "Dogdale (0,5)",
@@ -2159,7 +2895,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.4032, "dog": 0.5968 }
+          "vote_shares": {
+            "cat": 0.4032,
+            "dog": 0.5968
+          }
         }
       ]
     },
@@ -2167,7 +2906,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 1, "r": 5 },
+      "position": {
+        "q": 1,
+        "r": 5
+      },
       "total_population": 1546,
       "initial_district_id": "d1",
       "name": "Dogdale (1,5)",
@@ -2177,7 +2919,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.4409, "dog": 0.5591 }
+          "vote_shares": {
+            "cat": 0.4409,
+            "dog": 0.5591
+          }
         }
       ]
     },
@@ -2185,7 +2930,10 @@
       "id": "p121",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -6, "r": 6 },
+      "position": {
+        "q": -6,
+        "r": 6
+      },
       "total_population": 1541,
       "initial_district_id": "d1",
       "name": "Dogdale (-6,6)",
@@ -2195,7 +2943,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "cat": 0.3943, "dog": 0.6057 }
+          "vote_shares": {
+            "cat": 0.3943,
+            "dog": 0.6057
+          }
         }
       ]
     },
@@ -2203,7 +2954,10 @@
       "id": "p122",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -5, "r": 6 },
+      "position": {
+        "q": -5,
+        "r": 6
+      },
       "total_population": 1607,
       "initial_district_id": "d1",
       "name": "Dogdale (-5,6)",
@@ -2213,7 +2967,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.3944, "dog": 0.6056 }
+          "vote_shares": {
+            "cat": 0.3944,
+            "dog": 0.6056
+          }
         }
       ]
     },
@@ -2221,7 +2978,10 @@
       "id": "p123",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -4, "r": 6 },
+      "position": {
+        "q": -4,
+        "r": 6
+      },
       "total_population": 1553,
       "initial_district_id": "d1",
       "name": "Dogdale (-4,6)",
@@ -2231,7 +2991,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "cat": 0.4460, "dog": 0.5540 }
+          "vote_shares": {
+            "cat": 0.446,
+            "dog": 0.554
+          }
         }
       ]
     },
@@ -2239,7 +3002,10 @@
       "id": "p124",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -3, "r": 6 },
+      "position": {
+        "q": -3,
+        "r": 6
+      },
       "total_population": 1399,
       "initial_district_id": "d1",
       "name": "Dogdale (-3,6)",
@@ -2249,7 +3015,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "cat": 0.3854, "dog": 0.6146 }
+          "vote_shares": {
+            "cat": 0.3854,
+            "dog": 0.6146
+          }
         }
       ]
     },
@@ -2257,7 +3026,10 @@
       "id": "p125",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -2, "r": 6 },
+      "position": {
+        "q": -2,
+        "r": 6
+      },
       "total_population": 1390,
       "initial_district_id": "d1",
       "name": "Dogdale (-2,6)",
@@ -2267,7 +3039,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "cat": 0.4053, "dog": 0.5947 }
+          "vote_shares": {
+            "cat": 0.4053,
+            "dog": 0.5947
+          }
         }
       ]
     },
@@ -2275,7 +3050,10 @@
       "id": "p126",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": -1, "r": 6 },
+      "position": {
+        "q": -1,
+        "r": 6
+      },
       "total_population": 1596,
       "initial_district_id": "d1",
       "name": "Dogdale (-1,6)",
@@ -2285,7 +3063,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "cat": 0.4066, "dog": 0.5934 }
+          "vote_shares": {
+            "cat": 0.4066,
+            "dog": 0.5934
+          }
         }
       ]
     },
@@ -2293,7 +3074,10 @@
       "id": "p127",
       "editable": true,
       "county_id": "dogdale",
-      "position": { "q": 0, "r": 6 },
+      "position": {
+        "q": 0,
+        "r": 6
+      },
       "total_population": 1446,
       "initial_district_id": "d1",
       "name": "Dogdale (0,6)",
@@ -2303,7 +3087,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "cat": 0.4523, "dog": 0.5477 }
+          "vote_shares": {
+            "cat": 0.4523,
+            "dog": 0.5477
+          }
         }
       ]
     }
@@ -2318,28 +3105,32 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All five districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
       "description": "All five districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-compactness",
       "required": true,
-      "description": "Districts must be geographically compact — no sprawling fur-balls (compactness ≥ 40%).",
+      "description": "Districts must be geographically compact \u2014 no sprawling fur-balls (compactness \u2265 40%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
-        "threshold": 0.40
+        "threshold": 0.4
       }
     },
     {
       "id": "sc-safe-seats-cat",
       "required": true,
-      "description": "The Cat Party must lock in at least 3 safe districts (winning margin ≥ 15 points).",
+      "description": "The Cat Party must lock in at least 3 safe districts (winning margin \u2265 15 points).",
       "criterion": {
         "type": "safe_seats",
         "party": "cat",
@@ -2350,7 +3141,7 @@
     {
       "id": "sc-safe-seats-dog",
       "required": false,
-      "description": "Even dogs deserve one safe seat — can you give the Dog Party at least 1 district won by 15+ points?",
+      "description": "Even dogs deserve one safe seat \u2014 can you give the Dog Party at least 1 district won by 15+ points?",
       "criterion": {
         "type": "safe_seats",
         "party": "dog",
@@ -2372,13 +3163,13 @@
       },
       {
         "heading": "The Math",
-        "body": "Cats make up about 60% of Pawprint County's voters — a comfortable majority in the urban core, but the outer precincts are more competitive.\n\nLeft to chance, those outer districts could swing either way. Your job is to take chance out of the equation. Draw lines that turn a majority into a durable map."
+        "body": "Cats make up about 60% of Pawprint County's voters \u2014 a comfortable majority in the urban core, but the outer precincts are more competitive.\n\nLeft to chance, those outer districts could swing either way. Your job is to take chance out of the equation. Draw lines that turn a majority into a durable map."
       },
       {
         "heading": "Same Game, Different Fur",
-        "body": "You've seen this before — packing, cracking, population balance, compactness. The tools are the same whether you're drawing for Cats, Dogs, Ken, Ryu, or anyone else.\n\nThe rules of redistricting don't care about the players. Only the lines matter."
+        "body": "You've seen this before \u2014 packing, cracking, population balance, compactness. The tools are the same whether you're drawing for Cats, Dogs, Ken, Ryu, or anyone else.\n\nThe rules of redistricting don't care about the players. Only the lines matter."
       }
     ],
-    "objective": "Draw a compact, population-balanced map that locks in at least 3 safe Cat Party districts (winning margin ≥ 15 points). Bonus: leave the dogs one safe seat to chew on."
+    "objective": "Draw a compact, population-balanced map that locks in at least 3 safe Cat Party districts (winning margin \u2265 15 points). Bonus: leave the dogs one safe seat to chew on."
   }
 }

--- a/game/scenarios/tutorial-002.json
+++ b/game/scenarios/tutorial-002.json
@@ -7,15 +7,34 @@
     "id": "millbrook_county",
     "name": "Millbrook County"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "ken", "name": "Ken Party", "abbreviation": "KEN" },
-    { "id": "ryu", "name": "Ryu Party", "abbreviation": "RYU" }
+    {
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
+    },
+    {
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
+    }
   ],
   "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" }
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    }
   ],
   "default_district_id": "d1",
   "precincts": [
@@ -23,7 +42,10 @@
       "id": "p001",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 0, "r": -8 },
+      "position": {
+        "q": 0,
+        "r": -8
+      },
       "total_population": 2731,
       "initial_district_id": "d1",
       "name": "North (0,-8)",
@@ -33,7 +55,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5323, "ryu": 0.4677 }
+          "vote_shares": {
+            "ken": 0.5323,
+            "ryu": 0.4677
+          }
         }
       ]
     },
@@ -41,7 +66,10 @@
       "id": "p002",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 1, "r": -8 },
+      "position": {
+        "q": 1,
+        "r": -8
+      },
       "total_population": 3118,
       "initial_district_id": "d1",
       "name": "North (1,-8)",
@@ -51,7 +79,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5917, "ryu": 0.4083 }
+          "vote_shares": {
+            "ken": 0.5917,
+            "ryu": 0.4083
+          }
         }
       ]
     },
@@ -59,7 +90,10 @@
       "id": "p003",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -1, "r": -7 },
+      "position": {
+        "q": -1,
+        "r": -7
+      },
       "total_population": 2860,
       "initial_district_id": "d1",
       "name": "North (-1,-7)",
@@ -69,7 +103,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5739, "ryu": 0.4261 }
+          "vote_shares": {
+            "ken": 0.5739,
+            "ryu": 0.4261
+          }
         }
       ]
     },
@@ -77,7 +114,10 @@
       "id": "p004",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 0, "r": -7 },
+      "position": {
+        "q": 0,
+        "r": -7
+      },
       "total_population": 2724,
       "initial_district_id": "d1",
       "name": "North (0,-7)",
@@ -87,7 +127,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5671, "ryu": 0.4329 }
+          "vote_shares": {
+            "ken": 0.5671,
+            "ryu": 0.4329
+          }
         }
       ]
     },
@@ -95,7 +138,10 @@
       "id": "p005",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 1, "r": -7 },
+      "position": {
+        "q": 1,
+        "r": -7
+      },
       "total_population": 2897,
       "initial_district_id": "d1",
       "name": "North (1,-7)",
@@ -105,7 +151,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5247, "ryu": 0.4753 }
+          "vote_shares": {
+            "ken": 0.5247,
+            "ryu": 0.4753
+          }
         }
       ]
     },
@@ -113,7 +162,10 @@
       "id": "p006",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 2, "r": -7 },
+      "position": {
+        "q": 2,
+        "r": -7
+      },
       "total_population": 2727,
       "initial_district_id": "d1",
       "name": "North (2,-7)",
@@ -122,8 +174,11 @@
           "id": "p006-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5113, "ryu": 0.4887 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.5113,
+            "ryu": 0.4887
+          }
         }
       ]
     },
@@ -131,7 +186,10 @@
       "id": "p007",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 3, "r": -7 },
+      "position": {
+        "q": 3,
+        "r": -7
+      },
       "total_population": 2738,
       "initial_district_id": "d1",
       "name": "North (3,-7)",
@@ -141,7 +199,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5795, "ryu": 0.4205 }
+          "vote_shares": {
+            "ken": 0.5795,
+            "ryu": 0.4205
+          }
         }
       ]
     },
@@ -149,7 +210,10 @@
       "id": "p008",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 4, "r": -7 },
+      "position": {
+        "q": 4,
+        "r": -7
+      },
       "total_population": 3228,
       "initial_district_id": "d1",
       "name": "North (4,-7)",
@@ -159,7 +223,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5467, "ryu": 0.4533 }
+          "vote_shares": {
+            "ken": 0.5467,
+            "ryu": 0.4533
+          }
         }
       ]
     },
@@ -167,7 +234,10 @@
       "id": "p009",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 5, "r": -7 },
+      "position": {
+        "q": 5,
+        "r": -7
+      },
       "total_population": 2716,
       "initial_district_id": "d1",
       "name": "North (5,-7)",
@@ -177,7 +247,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5895, "ryu": 0.4105 }
+          "vote_shares": {
+            "ken": 0.5895,
+            "ryu": 0.4105
+          }
         }
       ]
     },
@@ -185,7 +258,10 @@
       "id": "p010",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 6, "r": -7 },
+      "position": {
+        "q": 6,
+        "r": -7
+      },
       "total_population": 3230,
       "initial_district_id": "d1",
       "name": "North (6,-7)",
@@ -194,8 +270,11 @@
           "id": "p010-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4937, "ryu": 0.5063 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.4937,
+            "ryu": 0.5063
+          }
         }
       ]
     },
@@ -203,7 +282,10 @@
       "id": "p011",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 7, "r": -7 },
+      "position": {
+        "q": 7,
+        "r": -7
+      },
       "total_population": 2736,
       "initial_district_id": "d1",
       "name": "North (7,-7)",
@@ -213,7 +295,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5602, "ryu": 0.4398 }
+          "vote_shares": {
+            "ken": 0.5602,
+            "ryu": 0.4398
+          }
         }
       ]
     },
@@ -221,7 +306,10 @@
       "id": "p012",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -2, "r": -6 },
+      "position": {
+        "q": -2,
+        "r": -6
+      },
       "total_population": 2953,
       "initial_district_id": "d1",
       "name": "North (-2,-6)",
@@ -231,7 +319,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6006, "ryu": 0.3994 }
+          "vote_shares": {
+            "ken": 0.6006,
+            "ryu": 0.3994
+          }
         }
       ]
     },
@@ -239,7 +330,10 @@
       "id": "p013",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -1, "r": -6 },
+      "position": {
+        "q": -1,
+        "r": -6
+      },
       "total_population": 3127,
       "initial_district_id": "d1",
       "name": "North (-1,-6)",
@@ -249,7 +343,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5678, "ryu": 0.4322 }
+          "vote_shares": {
+            "ken": 0.5678,
+            "ryu": 0.4322
+          }
         }
       ]
     },
@@ -257,7 +354,10 @@
       "id": "p014",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 0, "r": -6 },
+      "position": {
+        "q": 0,
+        "r": -6
+      },
       "total_population": 2958,
       "initial_district_id": "d1",
       "name": "North (0,-6)",
@@ -267,7 +367,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5795, "ryu": 0.4205 }
+          "vote_shares": {
+            "ken": 0.5795,
+            "ryu": 0.4205
+          }
         }
       ]
     },
@@ -275,7 +378,10 @@
       "id": "p015",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 1, "r": -6 },
+      "position": {
+        "q": 1,
+        "r": -6
+      },
       "total_population": 2819,
       "initial_district_id": "d1",
       "name": "North (1,-6)",
@@ -285,7 +391,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5372, "ryu": 0.4628 }
+          "vote_shares": {
+            "ken": 0.5372,
+            "ryu": 0.4628
+          }
         }
       ]
     },
@@ -293,7 +402,10 @@
       "id": "p016",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 2, "r": -6 },
+      "position": {
+        "q": 2,
+        "r": -6
+      },
       "total_population": 3180,
       "initial_district_id": "d1",
       "name": "North (2,-6)",
@@ -303,7 +415,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5709, "ryu": 0.4291 }
+          "vote_shares": {
+            "ken": 0.5709,
+            "ryu": 0.4291
+          }
         }
       ]
     },
@@ -311,7 +426,10 @@
       "id": "p017",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 3, "r": -6 },
+      "position": {
+        "q": 3,
+        "r": -6
+      },
       "total_population": 2932,
       "initial_district_id": "d1",
       "name": "North (3,-6)",
@@ -321,7 +439,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5192, "ryu": 0.4808 }
+          "vote_shares": {
+            "ken": 0.5192,
+            "ryu": 0.4808
+          }
         }
       ]
     },
@@ -329,7 +450,10 @@
       "id": "p018",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 4, "r": -6 },
+      "position": {
+        "q": 4,
+        "r": -6
+      },
       "total_population": 2962,
       "initial_district_id": "d1",
       "name": "North (4,-6)",
@@ -339,7 +463,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5326, "ryu": 0.4674 }
+          "vote_shares": {
+            "ken": 0.5326,
+            "ryu": 0.4674
+          }
         }
       ]
     },
@@ -347,7 +474,10 @@
       "id": "p019",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 5, "r": -6 },
+      "position": {
+        "q": 5,
+        "r": -6
+      },
       "total_population": 3152,
       "initial_district_id": "d1",
       "name": "North (5,-6)",
@@ -357,7 +487,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5127, "ryu": 0.4873 }
+          "vote_shares": {
+            "ken": 0.5127,
+            "ryu": 0.4873
+          }
         }
       ]
     },
@@ -365,7 +498,10 @@
       "id": "p020",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 6, "r": -6 },
+      "position": {
+        "q": 6,
+        "r": -6
+      },
       "total_population": 2831,
       "initial_district_id": "d1",
       "name": "North (6,-6)",
@@ -375,7 +511,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5590, "ryu": 0.4410 }
+          "vote_shares": {
+            "ken": 0.559,
+            "ryu": 0.441
+          }
         }
       ]
     },
@@ -383,7 +522,10 @@
       "id": "p021",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 7, "r": -6 },
+      "position": {
+        "q": 7,
+        "r": -6
+      },
       "total_population": 3274,
       "initial_district_id": "d1",
       "name": "North (7,-6)",
@@ -393,7 +535,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6059, "ryu": 0.3941 }
+          "vote_shares": {
+            "ken": 0.6059,
+            "ryu": 0.3941
+          }
         }
       ]
     },
@@ -401,7 +546,10 @@
       "id": "p022",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -3, "r": -5 },
+      "position": {
+        "q": -3,
+        "r": -5
+      },
       "total_population": 3120,
       "initial_district_id": "d1",
       "name": "North (-3,-5)",
@@ -411,7 +559,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5305, "ryu": 0.4695 }
+          "vote_shares": {
+            "ken": 0.5305,
+            "ryu": 0.4695
+          }
         }
       ]
     },
@@ -419,7 +570,10 @@
       "id": "p023",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -2, "r": -5 },
+      "position": {
+        "q": -2,
+        "r": -5
+      },
       "total_population": 3103,
       "initial_district_id": "d1",
       "name": "North (-2,-5)",
@@ -429,7 +583,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5955, "ryu": 0.4045 }
+          "vote_shares": {
+            "ken": 0.5955,
+            "ryu": 0.4045
+          }
         }
       ]
     },
@@ -437,7 +594,10 @@
       "id": "p024",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -1, "r": -5 },
+      "position": {
+        "q": -1,
+        "r": -5
+      },
       "total_population": 3046,
       "initial_district_id": "d1",
       "name": "North (-1,-5)",
@@ -447,7 +607,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5841, "ryu": 0.4159 }
+          "vote_shares": {
+            "ken": 0.5841,
+            "ryu": 0.4159
+          }
         }
       ]
     },
@@ -455,7 +618,10 @@
       "id": "p025",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 0, "r": -5 },
+      "position": {
+        "q": 0,
+        "r": -5
+      },
       "total_population": 2718,
       "initial_district_id": "d1",
       "name": "North (0,-5)",
@@ -465,7 +631,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5699, "ryu": 0.4301 }
+          "vote_shares": {
+            "ken": 0.5699,
+            "ryu": 0.4301
+          }
         }
       ]
     },
@@ -473,7 +642,10 @@
       "id": "p026",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 1, "r": -5 },
+      "position": {
+        "q": 1,
+        "r": -5
+      },
       "total_population": 2855,
       "initial_district_id": "d1",
       "name": "North (1,-5)",
@@ -483,7 +655,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5287, "ryu": 0.4713 }
+          "vote_shares": {
+            "ken": 0.5287,
+            "ryu": 0.4713
+          }
         }
       ]
     },
@@ -491,7 +666,10 @@
       "id": "p027",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 2, "r": -5 },
+      "position": {
+        "q": 2,
+        "r": -5
+      },
       "total_population": 3058,
       "initial_district_id": "d1",
       "name": "North (2,-5)",
@@ -501,7 +679,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5458, "ryu": 0.4542 }
+          "vote_shares": {
+            "ken": 0.5458,
+            "ryu": 0.4542
+          }
         }
       ]
     },
@@ -509,7 +690,10 @@
       "id": "p028",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 3, "r": -5 },
+      "position": {
+        "q": 3,
+        "r": -5
+      },
       "total_population": 3098,
       "initial_district_id": "d1",
       "name": "North (3,-5)",
@@ -519,7 +703,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5642, "ryu": 0.4358 }
+          "vote_shares": {
+            "ken": 0.5642,
+            "ryu": 0.4358
+          }
         }
       ]
     },
@@ -527,7 +714,10 @@
       "id": "p029",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 4, "r": -5 },
+      "position": {
+        "q": 4,
+        "r": -5
+      },
       "total_population": 3210,
       "initial_district_id": "d1",
       "name": "North (4,-5)",
@@ -537,7 +727,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5195, "ryu": 0.4805 }
+          "vote_shares": {
+            "ken": 0.5195,
+            "ryu": 0.4805
+          }
         }
       ]
     },
@@ -545,7 +738,10 @@
       "id": "p030",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 5, "r": -5 },
+      "position": {
+        "q": 5,
+        "r": -5
+      },
       "total_population": 2841,
       "initial_district_id": "d1",
       "name": "North (5,-5)",
@@ -555,7 +751,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5731, "ryu": 0.4269 }
+          "vote_shares": {
+            "ken": 0.5731,
+            "ryu": 0.4269
+          }
         }
       ]
     },
@@ -563,7 +762,10 @@
       "id": "p031",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 6, "r": -5 },
+      "position": {
+        "q": 6,
+        "r": -5
+      },
       "total_population": 2750,
       "initial_district_id": "d1",
       "name": "North (6,-5)",
@@ -573,7 +775,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5576, "ryu": 0.4424 }
+          "vote_shares": {
+            "ken": 0.5576,
+            "ryu": 0.4424
+          }
         }
       ]
     },
@@ -581,7 +786,10 @@
       "id": "p032",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 7, "r": -5 },
+      "position": {
+        "q": 7,
+        "r": -5
+      },
       "total_population": 2735,
       "initial_district_id": "d1",
       "name": "North (7,-5)",
@@ -591,7 +799,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5566, "ryu": 0.4434 }
+          "vote_shares": {
+            "ken": 0.5566,
+            "ryu": 0.4434
+          }
         }
       ]
     },
@@ -599,7 +810,10 @@
       "id": "p033",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -4, "r": -4 },
+      "position": {
+        "q": -4,
+        "r": -4
+      },
       "total_population": 3272,
       "initial_district_id": "d1",
       "name": "North (-4,-4)",
@@ -609,7 +823,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.6044, "ryu": 0.3956 }
+          "vote_shares": {
+            "ken": 0.6044,
+            "ryu": 0.3956
+          }
         }
       ]
     },
@@ -617,7 +834,10 @@
       "id": "p034",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -3, "r": -4 },
+      "position": {
+        "q": -3,
+        "r": -4
+      },
       "total_population": 3131,
       "initial_district_id": "d1",
       "name": "North (-3,-4)",
@@ -627,7 +847,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5043, "ryu": 0.4957 }
+          "vote_shares": {
+            "ken": 0.5043,
+            "ryu": 0.4957
+          }
         }
       ]
     },
@@ -635,7 +858,10 @@
       "id": "p035",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -2, "r": -4 },
+      "position": {
+        "q": -2,
+        "r": -4
+      },
       "total_population": 2769,
       "initial_district_id": "d1",
       "name": "North (-2,-4)",
@@ -645,7 +871,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.5950, "ryu": 0.4050 }
+          "vote_shares": {
+            "ken": 0.595,
+            "ryu": 0.405
+          }
         }
       ]
     },
@@ -653,7 +882,10 @@
       "id": "p036",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -1, "r": -4 },
+      "position": {
+        "q": -1,
+        "r": -4
+      },
       "total_population": 3261,
       "initial_district_id": "d1",
       "name": "North (-1,-4)",
@@ -663,7 +895,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5395, "ryu": 0.4605 }
+          "vote_shares": {
+            "ken": 0.5395,
+            "ryu": 0.4605
+          }
         }
       ]
     },
@@ -671,7 +906,10 @@
       "id": "p037",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 0, "r": -4 },
+      "position": {
+        "q": 0,
+        "r": -4
+      },
       "total_population": 3004,
       "initial_district_id": "d1",
       "name": "North (0,-4)",
@@ -681,7 +919,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5554, "ryu": 0.4446 }
+          "vote_shares": {
+            "ken": 0.5554,
+            "ryu": 0.4446
+          }
         }
       ]
     },
@@ -689,7 +930,10 @@
       "id": "p038",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 1, "r": -4 },
+      "position": {
+        "q": 1,
+        "r": -4
+      },
       "total_population": 3288,
       "initial_district_id": "d1",
       "name": "North (1,-4)",
@@ -699,7 +943,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5534, "ryu": 0.4466 }
+          "vote_shares": {
+            "ken": 0.5534,
+            "ryu": 0.4466
+          }
         }
       ]
     },
@@ -707,7 +954,10 @@
       "id": "p039",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 2, "r": -4 },
+      "position": {
+        "q": 2,
+        "r": -4
+      },
       "total_population": 2905,
       "initial_district_id": "d1",
       "name": "North (2,-4)",
@@ -717,7 +967,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5604, "ryu": 0.4396 }
+          "vote_shares": {
+            "ken": 0.5604,
+            "ryu": 0.4396
+          }
         }
       ]
     },
@@ -725,7 +978,10 @@
       "id": "p040",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 3, "r": -4 },
+      "position": {
+        "q": 3,
+        "r": -4
+      },
       "total_population": 3091,
       "initial_district_id": "d1",
       "name": "North (3,-4)",
@@ -735,7 +991,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5248, "ryu": 0.4752 }
+          "vote_shares": {
+            "ken": 0.5248,
+            "ryu": 0.4752
+          }
         }
       ]
     },
@@ -743,7 +1002,10 @@
       "id": "p041",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 4, "r": -4 },
+      "position": {
+        "q": 4,
+        "r": -4
+      },
       "total_population": 2907,
       "initial_district_id": "d1",
       "name": "North (4,-4)",
@@ -752,8 +1014,11 @@
           "id": "p041-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5024, "ryu": 0.4976 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.5024,
+            "ryu": 0.4976
+          }
         }
       ]
     },
@@ -761,7 +1026,10 @@
       "id": "p042",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 5, "r": -4 },
+      "position": {
+        "q": 5,
+        "r": -4
+      },
       "total_population": 2838,
       "initial_district_id": "d1",
       "name": "North (5,-4)",
@@ -770,8 +1038,11 @@
           "id": "p042-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.6088, "ryu": 0.3912 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.6088,
+            "ryu": 0.3912
+          }
         }
       ]
     },
@@ -779,7 +1050,10 @@
       "id": "p043",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 6, "r": -4 },
+      "position": {
+        "q": 6,
+        "r": -4
+      },
       "total_population": 2862,
       "initial_district_id": "d1",
       "name": "North (6,-4)",
@@ -789,7 +1063,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5569, "ryu": 0.4431 }
+          "vote_shares": {
+            "ken": 0.5569,
+            "ryu": 0.4431
+          }
         }
       ]
     },
@@ -797,7 +1074,10 @@
       "id": "p044",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 7, "r": -4 },
+      "position": {
+        "q": 7,
+        "r": -4
+      },
       "total_population": 2942,
       "initial_district_id": "d1",
       "name": "North (7,-4)",
@@ -807,7 +1087,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5564, "ryu": 0.4436 }
+          "vote_shares": {
+            "ken": 0.5564,
+            "ryu": 0.4436
+          }
         }
       ]
     },
@@ -815,7 +1098,10 @@
       "id": "p045",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -5, "r": -3 },
+      "position": {
+        "q": -5,
+        "r": -3
+      },
       "total_population": 3057,
       "initial_district_id": "d1",
       "name": "North (-5,-3)",
@@ -825,7 +1111,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5112, "ryu": 0.4888 }
+          "vote_shares": {
+            "ken": 0.5112,
+            "ryu": 0.4888
+          }
         }
       ]
     },
@@ -833,7 +1122,10 @@
       "id": "p046",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -4, "r": -3 },
+      "position": {
+        "q": -4,
+        "r": -3
+      },
       "total_population": 2898,
       "initial_district_id": "d1",
       "name": "North (-4,-3)",
@@ -843,7 +1135,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5332, "ryu": 0.4668 }
+          "vote_shares": {
+            "ken": 0.5332,
+            "ryu": 0.4668
+          }
         }
       ]
     },
@@ -851,7 +1146,10 @@
       "id": "p047",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -3, "r": -3 },
+      "position": {
+        "q": -3,
+        "r": -3
+      },
       "total_population": 3029,
       "initial_district_id": "d1",
       "name": "North (-3,-3)",
@@ -861,7 +1159,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5366, "ryu": 0.4634 }
+          "vote_shares": {
+            "ken": 0.5366,
+            "ryu": 0.4634
+          }
         }
       ]
     },
@@ -869,7 +1170,10 @@
       "id": "p048",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -2, "r": -3 },
+      "position": {
+        "q": -2,
+        "r": -3
+      },
       "total_population": 2725,
       "initial_district_id": "d1",
       "name": "North (-2,-3)",
@@ -878,8 +1182,11 @@
           "id": "p048-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.5759, "ryu": 0.4241 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.5759,
+            "ryu": 0.4241
+          }
         }
       ]
     },
@@ -887,7 +1194,10 @@
       "id": "p049",
       "editable": true,
       "county_id": "north",
-      "position": { "q": -1, "r": -3 },
+      "position": {
+        "q": -1,
+        "r": -3
+      },
       "total_population": 3110,
       "initial_district_id": "d1",
       "name": "North (-1,-3)",
@@ -897,7 +1207,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5086, "ryu": 0.4914 }
+          "vote_shares": {
+            "ken": 0.5086,
+            "ryu": 0.4914
+          }
         }
       ]
     },
@@ -905,7 +1218,10 @@
       "id": "p050",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 0, "r": -3 },
+      "position": {
+        "q": 0,
+        "r": -3
+      },
       "total_population": 3039,
       "initial_district_id": "d1",
       "name": "North (0,-3)",
@@ -915,7 +1231,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.6056, "ryu": 0.3944 }
+          "vote_shares": {
+            "ken": 0.6056,
+            "ryu": 0.3944
+          }
         }
       ]
     },
@@ -923,7 +1242,10 @@
       "id": "p051",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 1, "r": -3 },
+      "position": {
+        "q": 1,
+        "r": -3
+      },
       "total_population": 3252,
       "initial_district_id": "d1",
       "name": "North (1,-3)",
@@ -933,7 +1255,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5185, "ryu": 0.4815 }
+          "vote_shares": {
+            "ken": 0.5185,
+            "ryu": 0.4815
+          }
         }
       ]
     },
@@ -941,7 +1266,10 @@
       "id": "p052",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 2, "r": -3 },
+      "position": {
+        "q": 2,
+        "r": -3
+      },
       "total_population": 3099,
       "initial_district_id": "d1",
       "name": "North (2,-3)",
@@ -951,7 +1279,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5749, "ryu": 0.4251 }
+          "vote_shares": {
+            "ken": 0.5749,
+            "ryu": 0.4251
+          }
         }
       ]
     },
@@ -959,7 +1290,10 @@
       "id": "p053",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 3, "r": -3 },
+      "position": {
+        "q": 3,
+        "r": -3
+      },
       "total_population": 3235,
       "initial_district_id": "d1",
       "name": "North (3,-3)",
@@ -969,7 +1303,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.6095, "ryu": 0.3905 }
+          "vote_shares": {
+            "ken": 0.6095,
+            "ryu": 0.3905
+          }
         }
       ]
     },
@@ -977,7 +1314,10 @@
       "id": "p054",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 4, "r": -3 },
+      "position": {
+        "q": 4,
+        "r": -3
+      },
       "total_population": 2783,
       "initial_district_id": "d1",
       "name": "North (4,-3)",
@@ -987,7 +1327,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5759, "ryu": 0.4241 }
+          "vote_shares": {
+            "ken": 0.5759,
+            "ryu": 0.4241
+          }
         }
       ]
     },
@@ -995,7 +1338,10 @@
       "id": "p055",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 5, "r": -3 },
+      "position": {
+        "q": 5,
+        "r": -3
+      },
       "total_population": 2924,
       "initial_district_id": "d1",
       "name": "North (5,-3)",
@@ -1005,7 +1351,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5444, "ryu": 0.4556 }
+          "vote_shares": {
+            "ken": 0.5444,
+            "ryu": 0.4556
+          }
         }
       ]
     },
@@ -1013,7 +1362,10 @@
       "id": "p056",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 6, "r": -3 },
+      "position": {
+        "q": 6,
+        "r": -3
+      },
       "total_population": 2946,
       "initial_district_id": "d1",
       "name": "North (6,-3)",
@@ -1022,8 +1374,11 @@
           "id": "p056-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5875, "ryu": 0.4125 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.5875,
+            "ryu": 0.4125
+          }
         }
       ]
     },
@@ -1031,7 +1386,10 @@
       "id": "p057",
       "editable": true,
       "county_id": "north",
-      "position": { "q": 7, "r": -3 },
+      "position": {
+        "q": 7,
+        "r": -3
+      },
       "total_population": 3295,
       "initial_district_id": "d1",
       "name": "North (7,-3)",
@@ -1041,7 +1399,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5170, "ryu": 0.4830 }
+          "vote_shares": {
+            "ken": 0.517,
+            "ryu": 0.483
+          }
         }
       ]
     },
@@ -1049,7 +1410,10 @@
       "id": "p058",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -6, "r": -2 },
+      "position": {
+        "q": -6,
+        "r": -2
+      },
       "total_population": 3233,
       "initial_district_id": "d2",
       "name": "Central (-6,-2)",
@@ -1059,7 +1423,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4452, "ryu": 0.5548 }
+          "vote_shares": {
+            "ken": 0.4452,
+            "ryu": 0.5548
+          }
         }
       ]
     },
@@ -1067,7 +1434,10 @@
       "id": "p059",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -5, "r": -2 },
+      "position": {
+        "q": -5,
+        "r": -2
+      },
       "total_population": 2820,
       "initial_district_id": "d2",
       "name": "Central (-5,-2)",
@@ -1077,7 +1447,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4563, "ryu": 0.5437 }
+          "vote_shares": {
+            "ken": 0.4563,
+            "ryu": 0.5437
+          }
         }
       ]
     },
@@ -1085,7 +1458,10 @@
       "id": "p060",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -4, "r": -2 },
+      "position": {
+        "q": -4,
+        "r": -2
+      },
       "total_population": 3051,
       "initial_district_id": "d2",
       "name": "Central (-4,-2)",
@@ -1095,7 +1471,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4715, "ryu": 0.5285 }
+          "vote_shares": {
+            "ken": 0.4715,
+            "ryu": 0.5285
+          }
         }
       ]
     },
@@ -1103,7 +1482,10 @@
       "id": "p061",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -3, "r": -2 },
+      "position": {
+        "q": -3,
+        "r": -2
+      },
       "total_population": 3160,
       "initial_district_id": "d2",
       "name": "Central (-3,-2)",
@@ -1113,7 +1495,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5144, "ryu": 0.4856 }
+          "vote_shares": {
+            "ken": 0.5144,
+            "ryu": 0.4856
+          }
         }
       ]
     },
@@ -1121,7 +1506,10 @@
       "id": "p062",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -2, "r": -2 },
+      "position": {
+        "q": -2,
+        "r": -2
+      },
       "total_population": 2955,
       "initial_district_id": "d2",
       "name": "Central (-2,-2)",
@@ -1131,7 +1519,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4536, "ryu": 0.5464 }
+          "vote_shares": {
+            "ken": 0.4536,
+            "ryu": 0.5464
+          }
         }
       ]
     },
@@ -1139,7 +1530,10 @@
       "id": "p063",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -1, "r": -2 },
+      "position": {
+        "q": -1,
+        "r": -2
+      },
       "total_population": 3257,
       "initial_district_id": "d2",
       "name": "Central (-1,-2)",
@@ -1149,7 +1543,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4526, "ryu": 0.5474 }
+          "vote_shares": {
+            "ken": 0.4526,
+            "ryu": 0.5474
+          }
         }
       ]
     },
@@ -1157,7 +1554,10 @@
       "id": "p064",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 0, "r": -2 },
+      "position": {
+        "q": 0,
+        "r": -2
+      },
       "total_population": 3032,
       "initial_district_id": "d2",
       "name": "Central (0,-2)",
@@ -1167,7 +1567,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4720, "ryu": 0.5280 }
+          "vote_shares": {
+            "ken": 0.472,
+            "ryu": 0.528
+          }
         }
       ]
     },
@@ -1175,7 +1578,10 @@
       "id": "p065",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 1, "r": -2 },
+      "position": {
+        "q": 1,
+        "r": -2
+      },
       "total_population": 3033,
       "initial_district_id": "d2",
       "name": "Central (1,-2)",
@@ -1185,7 +1591,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5452, "ryu": 0.4548 }
+          "vote_shares": {
+            "ken": 0.5452,
+            "ryu": 0.4548
+          }
         }
       ]
     },
@@ -1193,7 +1602,10 @@
       "id": "p066",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 2, "r": -2 },
+      "position": {
+        "q": 2,
+        "r": -2
+      },
       "total_population": 3161,
       "initial_district_id": "d2",
       "name": "Central (2,-2)",
@@ -1203,7 +1615,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5147, "ryu": 0.4853 }
+          "vote_shares": {
+            "ken": 0.5147,
+            "ryu": 0.4853
+          }
         }
       ]
     },
@@ -1211,7 +1626,10 @@
       "id": "p067",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 3, "r": -2 },
+      "position": {
+        "q": 3,
+        "r": -2
+      },
       "total_population": 3283,
       "initial_district_id": "d2",
       "name": "Central (3,-2)",
@@ -1221,7 +1639,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5025, "ryu": 0.4975 }
+          "vote_shares": {
+            "ken": 0.5025,
+            "ryu": 0.4975
+          }
         }
       ]
     },
@@ -1229,7 +1650,10 @@
       "id": "p068",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 4, "r": -2 },
+      "position": {
+        "q": 4,
+        "r": -2
+      },
       "total_population": 3197,
       "initial_district_id": "d2",
       "name": "Central (4,-2)",
@@ -1239,7 +1663,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4765, "ryu": 0.5235 }
+          "vote_shares": {
+            "ken": 0.4765,
+            "ryu": 0.5235
+          }
         }
       ]
     },
@@ -1247,7 +1674,10 @@
       "id": "p069",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 5, "r": -2 },
+      "position": {
+        "q": 5,
+        "r": -2
+      },
       "total_population": 2735,
       "initial_district_id": "d2",
       "name": "Central (5,-2)",
@@ -1257,7 +1687,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5326, "ryu": 0.4674 }
+          "vote_shares": {
+            "ken": 0.5326,
+            "ryu": 0.4674
+          }
         }
       ]
     },
@@ -1265,7 +1698,10 @@
       "id": "p070",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 6, "r": -2 },
+      "position": {
+        "q": 6,
+        "r": -2
+      },
       "total_population": 2859,
       "initial_district_id": "d2",
       "name": "Central (6,-2)",
@@ -1275,7 +1711,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5536, "ryu": 0.4464 }
+          "vote_shares": {
+            "ken": 0.5536,
+            "ryu": 0.4464
+          }
         }
       ]
     },
@@ -1283,7 +1722,10 @@
       "id": "p071",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 7, "r": -2 },
+      "position": {
+        "q": 7,
+        "r": -2
+      },
       "total_population": 3155,
       "initial_district_id": "d2",
       "name": "Central (7,-2)",
@@ -1293,7 +1735,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5056, "ryu": 0.4944 }
+          "vote_shares": {
+            "ken": 0.5056,
+            "ryu": 0.4944
+          }
         }
       ]
     },
@@ -1301,7 +1746,10 @@
       "id": "p072",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -7, "r": -1 },
+      "position": {
+        "q": -7,
+        "r": -1
+      },
       "total_population": 2861,
       "initial_district_id": "d2",
       "name": "Central (-7,-1)",
@@ -1310,8 +1758,11 @@
           "id": "p072-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4519, "ryu": 0.5481 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4519,
+            "ryu": 0.5481
+          }
         }
       ]
     },
@@ -1319,7 +1770,10 @@
       "id": "p073",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -6, "r": -1 },
+      "position": {
+        "q": -6,
+        "r": -1
+      },
       "total_population": 2869,
       "initial_district_id": "d2",
       "name": "Central (-6,-1)",
@@ -1329,7 +1783,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4620, "ryu": 0.5380 }
+          "vote_shares": {
+            "ken": 0.462,
+            "ryu": 0.538
+          }
         }
       ]
     },
@@ -1337,7 +1794,10 @@
       "id": "p074",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -5, "r": -1 },
+      "position": {
+        "q": -5,
+        "r": -1
+      },
       "total_population": 3268,
       "initial_district_id": "d2",
       "name": "Central (-5,-1)",
@@ -1347,7 +1807,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5213, "ryu": 0.4787 }
+          "vote_shares": {
+            "ken": 0.5213,
+            "ryu": 0.4787
+          }
         }
       ]
     },
@@ -1355,7 +1818,10 @@
       "id": "p075",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -4, "r": -1 },
+      "position": {
+        "q": -4,
+        "r": -1
+      },
       "total_population": 2895,
       "initial_district_id": "d2",
       "name": "Central (-4,-1)",
@@ -1365,7 +1831,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4840, "ryu": 0.5160 }
+          "vote_shares": {
+            "ken": 0.484,
+            "ryu": 0.516
+          }
         }
       ]
     },
@@ -1373,7 +1842,10 @@
       "id": "p076",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -3, "r": -1 },
+      "position": {
+        "q": -3,
+        "r": -1
+      },
       "total_population": 2784,
       "initial_district_id": "d2",
       "name": "Central (-3,-1)",
@@ -1383,7 +1855,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.5553, "ryu": 0.4447 }
+          "vote_shares": {
+            "ken": 0.5553,
+            "ryu": 0.4447
+          }
         }
       ]
     },
@@ -1391,7 +1866,10 @@
       "id": "p077",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -2, "r": -1 },
+      "position": {
+        "q": -2,
+        "r": -1
+      },
       "total_population": 2799,
       "initial_district_id": "d2",
       "name": "Central (-2,-1)",
@@ -1401,7 +1879,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4619, "ryu": 0.5381 }
+          "vote_shares": {
+            "ken": 0.4619,
+            "ryu": 0.5381
+          }
         }
       ]
     },
@@ -1409,7 +1890,10 @@
       "id": "p078",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -1, "r": -1 },
+      "position": {
+        "q": -1,
+        "r": -1
+      },
       "total_population": 3299,
       "initial_district_id": "d2",
       "name": "Central (-1,-1)",
@@ -1419,7 +1903,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4698, "ryu": 0.5302 }
+          "vote_shares": {
+            "ken": 0.4698,
+            "ryu": 0.5302
+          }
         }
       ]
     },
@@ -1427,7 +1914,10 @@
       "id": "p079",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 0, "r": -1 },
+      "position": {
+        "q": 0,
+        "r": -1
+      },
       "total_population": 3229,
       "initial_district_id": "d2",
       "name": "Central (0,-1)",
@@ -1437,7 +1927,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4901, "ryu": 0.5099 }
+          "vote_shares": {
+            "ken": 0.4901,
+            "ryu": 0.5099
+          }
         }
       ]
     },
@@ -1445,7 +1938,10 @@
       "id": "p080",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 1, "r": -1 },
+      "position": {
+        "q": 1,
+        "r": -1
+      },
       "total_population": 3226,
       "initial_district_id": "d2",
       "name": "Central (1,-1)",
@@ -1454,8 +1950,11 @@
           "id": "p080-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4567, "ryu": 0.5433 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.4567,
+            "ryu": 0.5433
+          }
         }
       ]
     },
@@ -1463,7 +1962,10 @@
       "id": "p081",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 2, "r": -1 },
+      "position": {
+        "q": 2,
+        "r": -1
+      },
       "total_population": 3275,
       "initial_district_id": "d2",
       "name": "Central (2,-1)",
@@ -1473,7 +1975,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4816, "ryu": 0.5184 }
+          "vote_shares": {
+            "ken": 0.4816,
+            "ryu": 0.5184
+          }
         }
       ]
     },
@@ -1481,7 +1986,10 @@
       "id": "p082",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 3, "r": -1 },
+      "position": {
+        "q": 3,
+        "r": -1
+      },
       "total_population": 2767,
       "initial_district_id": "d2",
       "name": "Central (3,-1)",
@@ -1491,7 +1999,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4531, "ryu": 0.5469 }
+          "vote_shares": {
+            "ken": 0.4531,
+            "ryu": 0.5469
+          }
         }
       ]
     },
@@ -1499,7 +2010,10 @@
       "id": "p083",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 4, "r": -1 },
+      "position": {
+        "q": 4,
+        "r": -1
+      },
       "total_population": 3162,
       "initial_district_id": "d2",
       "name": "Central (4,-1)",
@@ -1508,8 +2022,11 @@
           "id": "p083-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5570, "ryu": 0.4430 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.557,
+            "ryu": 0.443
+          }
         }
       ]
     },
@@ -1517,7 +2034,10 @@
       "id": "p084",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 5, "r": -1 },
+      "position": {
+        "q": 5,
+        "r": -1
+      },
       "total_population": 3282,
       "initial_district_id": "d2",
       "name": "Central (5,-1)",
@@ -1527,7 +2047,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5009, "ryu": 0.4991 }
+          "vote_shares": {
+            "ken": 0.5009,
+            "ryu": 0.4991
+          }
         }
       ]
     },
@@ -1535,7 +2058,10 @@
       "id": "p085",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 6, "r": -1 },
+      "position": {
+        "q": 6,
+        "r": -1
+      },
       "total_population": 2959,
       "initial_district_id": "d2",
       "name": "Central (6,-1)",
@@ -1545,7 +2071,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4762, "ryu": 0.5238 }
+          "vote_shares": {
+            "ken": 0.4762,
+            "ryu": 0.5238
+          }
         }
       ]
     },
@@ -1553,7 +2082,10 @@
       "id": "p086",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 7, "r": -1 },
+      "position": {
+        "q": 7,
+        "r": -1
+      },
       "total_population": 2794,
       "initial_district_id": "d2",
       "name": "Central (7,-1)",
@@ -1563,7 +2095,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5285, "ryu": 0.4715 }
+          "vote_shares": {
+            "ken": 0.5285,
+            "ryu": 0.4715
+          }
         }
       ]
     },
@@ -1571,7 +2106,10 @@
       "id": "p087",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -8, "r": 0 },
+      "position": {
+        "q": -8,
+        "r": 0
+      },
       "total_population": 2713,
       "initial_district_id": "d2",
       "name": "Central (-8,0)",
@@ -1581,7 +2119,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5584, "ryu": 0.4416 }
+          "vote_shares": {
+            "ken": 0.5584,
+            "ryu": 0.4416
+          }
         }
       ]
     },
@@ -1589,7 +2130,10 @@
       "id": "p088",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -7, "r": 0 },
+      "position": {
+        "q": -7,
+        "r": 0
+      },
       "total_population": 3094,
       "initial_district_id": "d2",
       "name": "Central (-7,0)",
@@ -1598,8 +2142,11 @@
           "id": "p088-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5488, "ryu": 0.4512 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.5488,
+            "ryu": 0.4512
+          }
         }
       ]
     },
@@ -1607,7 +2154,10 @@
       "id": "p089",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -6, "r": 0 },
+      "position": {
+        "q": -6,
+        "r": 0
+      },
       "total_population": 3274,
       "initial_district_id": "d2",
       "name": "Central (-6,0)",
@@ -1616,8 +2166,11 @@
           "id": "p089-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4836, "ryu": 0.5164 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4836,
+            "ryu": 0.5164
+          }
         }
       ]
     },
@@ -1625,7 +2178,10 @@
       "id": "p090",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -5, "r": 0 },
+      "position": {
+        "q": -5,
+        "r": 0
+      },
       "total_population": 3229,
       "initial_district_id": "d2",
       "name": "Central (-5,0)",
@@ -1635,7 +2191,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5587, "ryu": 0.4413 }
+          "vote_shares": {
+            "ken": 0.5587,
+            "ryu": 0.4413
+          }
         }
       ]
     },
@@ -1643,7 +2202,10 @@
       "id": "p091",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -4, "r": 0 },
+      "position": {
+        "q": -4,
+        "r": 0
+      },
       "total_population": 2960,
       "initial_district_id": "d2",
       "name": "Central (-4,0)",
@@ -1653,7 +2215,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.5062, "ryu": 0.4938 }
+          "vote_shares": {
+            "ken": 0.5062,
+            "ryu": 0.4938
+          }
         }
       ]
     },
@@ -1661,7 +2226,10 @@
       "id": "p092",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -3, "r": 0 },
+      "position": {
+        "q": -3,
+        "r": 0
+      },
       "total_population": 2897,
       "initial_district_id": "d2",
       "name": "Central (-3,0)",
@@ -1671,7 +2239,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5535, "ryu": 0.4465 }
+          "vote_shares": {
+            "ken": 0.5535,
+            "ryu": 0.4465
+          }
         }
       ]
     },
@@ -1679,7 +2250,10 @@
       "id": "p093",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -2, "r": 0 },
+      "position": {
+        "q": -2,
+        "r": 0
+      },
       "total_population": 2849,
       "initial_district_id": "d2",
       "name": "Central (-2,0)",
@@ -1689,7 +2263,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5587, "ryu": 0.4413 }
+          "vote_shares": {
+            "ken": 0.5587,
+            "ryu": 0.4413
+          }
         }
       ]
     },
@@ -1697,7 +2274,10 @@
       "id": "p094",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -1, "r": 0 },
+      "position": {
+        "q": -1,
+        "r": 0
+      },
       "total_population": 3216,
       "initial_district_id": "d2",
       "name": "Central (-1,0)",
@@ -1707,7 +2287,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4612, "ryu": 0.5388 }
+          "vote_shares": {
+            "ken": 0.4612,
+            "ryu": 0.5388
+          }
         }
       ]
     },
@@ -1715,7 +2298,10 @@
       "id": "p095",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 0, "r": 0 },
+      "position": {
+        "q": 0,
+        "r": 0
+      },
       "total_population": 3047,
       "initial_district_id": "d2",
       "name": "Central (0,0)",
@@ -1725,7 +2311,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5530, "ryu": 0.4470 }
+          "vote_shares": {
+            "ken": 0.553,
+            "ryu": 0.447
+          }
         }
       ]
     },
@@ -1733,7 +2322,10 @@
       "id": "p096",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 1, "r": 0 },
+      "position": {
+        "q": 1,
+        "r": 0
+      },
       "total_population": 2816,
       "initial_district_id": "d2",
       "name": "Central (1,0)",
@@ -1743,7 +2335,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.5525, "ryu": 0.4475 }
+          "vote_shares": {
+            "ken": 0.5525,
+            "ryu": 0.4475
+          }
         }
       ]
     },
@@ -1751,7 +2346,10 @@
       "id": "p097",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 2, "r": 0 },
+      "position": {
+        "q": 2,
+        "r": 0
+      },
       "total_population": 2960,
       "initial_district_id": "d2",
       "name": "Central (2,0)",
@@ -1761,7 +2359,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.5110, "ryu": 0.4890 }
+          "vote_shares": {
+            "ken": 0.511,
+            "ryu": 0.489
+          }
         }
       ]
     },
@@ -1769,7 +2370,10 @@
       "id": "p098",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 3, "r": 0 },
+      "position": {
+        "q": 3,
+        "r": 0
+      },
       "total_population": 3108,
       "initial_district_id": "d2",
       "name": "Central (3,0)",
@@ -1779,7 +2383,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4677, "ryu": 0.5323 }
+          "vote_shares": {
+            "ken": 0.4677,
+            "ryu": 0.5323
+          }
         }
       ]
     },
@@ -1787,7 +2394,10 @@
       "id": "p099",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 4, "r": 0 },
+      "position": {
+        "q": 4,
+        "r": 0
+      },
       "total_population": 2951,
       "initial_district_id": "d2",
       "name": "Central (4,0)",
@@ -1797,7 +2407,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4886, "ryu": 0.5114 }
+          "vote_shares": {
+            "ken": 0.4886,
+            "ryu": 0.5114
+          }
         }
       ]
     },
@@ -1805,7 +2418,10 @@
       "id": "p100",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 5, "r": 0 },
+      "position": {
+        "q": 5,
+        "r": 0
+      },
       "total_population": 2922,
       "initial_district_id": "d2",
       "name": "Central (5,0)",
@@ -1815,7 +2431,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.5500, "ryu": 0.4500 }
+          "vote_shares": {
+            "ken": 0.55,
+            "ryu": 0.45
+          }
         }
       ]
     },
@@ -1823,7 +2442,10 @@
       "id": "p101",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 6, "r": 0 },
+      "position": {
+        "q": 6,
+        "r": 0
+      },
       "total_population": 2812,
       "initial_district_id": "d2",
       "name": "Central (6,0)",
@@ -1833,7 +2455,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4622, "ryu": 0.5378 }
+          "vote_shares": {
+            "ken": 0.4622,
+            "ryu": 0.5378
+          }
         }
       ]
     },
@@ -1841,7 +2466,10 @@
       "id": "p102",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 7, "r": 0 },
+      "position": {
+        "q": 7,
+        "r": 0
+      },
       "total_population": 3248,
       "initial_district_id": "d2",
       "name": "Central (7,0)",
@@ -1851,7 +2479,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5117, "ryu": 0.4883 }
+          "vote_shares": {
+            "ken": 0.5117,
+            "ryu": 0.4883
+          }
         }
       ]
     },
@@ -1859,7 +2490,10 @@
       "id": "p103",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -8, "r": 1 },
+      "position": {
+        "q": -8,
+        "r": 1
+      },
       "total_population": 3265,
       "initial_district_id": "d2",
       "name": "Central (-8,1)",
@@ -1869,7 +2503,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4835, "ryu": 0.5165 }
+          "vote_shares": {
+            "ken": 0.4835,
+            "ryu": 0.5165
+          }
         }
       ]
     },
@@ -1877,7 +2514,10 @@
       "id": "p104",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -7, "r": 1 },
+      "position": {
+        "q": -7,
+        "r": 1
+      },
       "total_population": 2837,
       "initial_district_id": "d2",
       "name": "Central (-7,1)",
@@ -1886,8 +2526,11 @@
           "id": "p104-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4538, "ryu": 0.5462 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4538,
+            "ryu": 0.5462
+          }
         }
       ]
     },
@@ -1895,7 +2538,10 @@
       "id": "p105",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -6, "r": 1 },
+      "position": {
+        "q": -6,
+        "r": 1
+      },
       "total_population": 2721,
       "initial_district_id": "d2",
       "name": "Central (-6,1)",
@@ -1904,8 +2550,11 @@
           "id": "p105-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4744, "ryu": 0.5256 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.4744,
+            "ryu": 0.5256
+          }
         }
       ]
     },
@@ -1913,7 +2562,10 @@
       "id": "p106",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -5, "r": 1 },
+      "position": {
+        "q": -5,
+        "r": 1
+      },
       "total_population": 2843,
       "initial_district_id": "d2",
       "name": "Central (-5,1)",
@@ -1923,7 +2575,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5122, "ryu": 0.4878 }
+          "vote_shares": {
+            "ken": 0.5122,
+            "ryu": 0.4878
+          }
         }
       ]
     },
@@ -1931,7 +2586,10 @@
       "id": "p107",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -4, "r": 1 },
+      "position": {
+        "q": -4,
+        "r": 1
+      },
       "total_population": 3152,
       "initial_district_id": "d2",
       "name": "Central (-4,1)",
@@ -1941,7 +2599,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4960, "ryu": 0.5040 }
+          "vote_shares": {
+            "ken": 0.496,
+            "ryu": 0.504
+          }
         }
       ]
     },
@@ -1949,7 +2610,10 @@
       "id": "p108",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -3, "r": 1 },
+      "position": {
+        "q": -3,
+        "r": 1
+      },
       "total_population": 2947,
       "initial_district_id": "d2",
       "name": "Central (-3,1)",
@@ -1959,7 +2623,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5113, "ryu": 0.4887 }
+          "vote_shares": {
+            "ken": 0.5113,
+            "ryu": 0.4887
+          }
         }
       ]
     },
@@ -1967,7 +2634,10 @@
       "id": "p109",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -2, "r": 1 },
+      "position": {
+        "q": -2,
+        "r": 1
+      },
       "total_population": 3276,
       "initial_district_id": "d2",
       "name": "Central (-2,1)",
@@ -1977,7 +2647,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4952, "ryu": 0.5048 }
+          "vote_shares": {
+            "ken": 0.4952,
+            "ryu": 0.5048
+          }
         }
       ]
     },
@@ -1985,7 +2658,10 @@
       "id": "p110",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -1, "r": 1 },
+      "position": {
+        "q": -1,
+        "r": 1
+      },
       "total_population": 3102,
       "initial_district_id": "d2",
       "name": "Central (-1,1)",
@@ -1995,7 +2671,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4610, "ryu": 0.5390 }
+          "vote_shares": {
+            "ken": 0.461,
+            "ryu": 0.539
+          }
         }
       ]
     },
@@ -2003,7 +2682,10 @@
       "id": "p111",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 0, "r": 1 },
+      "position": {
+        "q": 0,
+        "r": 1
+      },
       "total_population": 2901,
       "initial_district_id": "d2",
       "name": "Central (0,1)",
@@ -2013,7 +2695,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4977, "ryu": 0.5023 }
+          "vote_shares": {
+            "ken": 0.4977,
+            "ryu": 0.5023
+          }
         }
       ]
     },
@@ -2021,7 +2706,10 @@
       "id": "p112",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 1, "r": 1 },
+      "position": {
+        "q": 1,
+        "r": 1
+      },
       "total_population": 3055,
       "initial_district_id": "d2",
       "name": "Central (1,1)",
@@ -2031,7 +2719,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4594, "ryu": 0.5406 }
+          "vote_shares": {
+            "ken": 0.4594,
+            "ryu": 0.5406
+          }
         }
       ]
     },
@@ -2039,7 +2730,10 @@
       "id": "p113",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 2, "r": 1 },
+      "position": {
+        "q": 2,
+        "r": 1
+      },
       "total_population": 2798,
       "initial_district_id": "d2",
       "name": "Central (2,1)",
@@ -2049,7 +2743,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.5080, "ryu": 0.4920 }
+          "vote_shares": {
+            "ken": 0.508,
+            "ryu": 0.492
+          }
         }
       ]
     },
@@ -2057,7 +2754,10 @@
       "id": "p114",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 3, "r": 1 },
+      "position": {
+        "q": 3,
+        "r": 1
+      },
       "total_population": 2951,
       "initial_district_id": "d2",
       "name": "Central (3,1)",
@@ -2067,7 +2767,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4984, "ryu": 0.5016 }
+          "vote_shares": {
+            "ken": 0.4984,
+            "ryu": 0.5016
+          }
         }
       ]
     },
@@ -2075,7 +2778,10 @@
       "id": "p115",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 4, "r": 1 },
+      "position": {
+        "q": 4,
+        "r": 1
+      },
       "total_population": 2867,
       "initial_district_id": "d2",
       "name": "Central (4,1)",
@@ -2085,7 +2791,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5299, "ryu": 0.4701 }
+          "vote_shares": {
+            "ken": 0.5299,
+            "ryu": 0.4701
+          }
         }
       ]
     },
@@ -2093,7 +2802,10 @@
       "id": "p116",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 5, "r": 1 },
+      "position": {
+        "q": 5,
+        "r": 1
+      },
       "total_population": 2819,
       "initial_district_id": "d2",
       "name": "Central (5,1)",
@@ -2103,7 +2815,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5010, "ryu": 0.4990 }
+          "vote_shares": {
+            "ken": 0.501,
+            "ryu": 0.499
+          }
         }
       ]
     },
@@ -2111,7 +2826,10 @@
       "id": "p117",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 6, "r": 1 },
+      "position": {
+        "q": 6,
+        "r": 1
+      },
       "total_population": 3070,
       "initial_district_id": "d2",
       "name": "Central (6,1)",
@@ -2120,8 +2838,11 @@
           "id": "p117-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4625, "ryu": 0.5375 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4625,
+            "ryu": 0.5375
+          }
         }
       ]
     },
@@ -2129,7 +2850,10 @@
       "id": "p118",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -8, "r": 2 },
+      "position": {
+        "q": -8,
+        "r": 2
+      },
       "total_population": 2978,
       "initial_district_id": "d2",
       "name": "Central (-8,2)",
@@ -2139,7 +2863,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4826, "ryu": 0.5174 }
+          "vote_shares": {
+            "ken": 0.4826,
+            "ryu": 0.5174
+          }
         }
       ]
     },
@@ -2147,7 +2874,10 @@
       "id": "p119",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -7, "r": 2 },
+      "position": {
+        "q": -7,
+        "r": 2
+      },
       "total_population": 2777,
       "initial_district_id": "d2",
       "name": "Central (-7,2)",
@@ -2157,7 +2887,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4754, "ryu": 0.5246 }
+          "vote_shares": {
+            "ken": 0.4754,
+            "ryu": 0.5246
+          }
         }
       ]
     },
@@ -2165,7 +2898,10 @@
       "id": "p120",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -6, "r": 2 },
+      "position": {
+        "q": -6,
+        "r": 2
+      },
       "total_population": 2821,
       "initial_district_id": "d2",
       "name": "Central (-6,2)",
@@ -2175,7 +2911,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.5201, "ryu": 0.4799 }
+          "vote_shares": {
+            "ken": 0.5201,
+            "ryu": 0.4799
+          }
         }
       ]
     },
@@ -2183,7 +2922,10 @@
       "id": "p121",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -5, "r": 2 },
+      "position": {
+        "q": -5,
+        "r": 2
+      },
       "total_population": 3161,
       "initial_district_id": "d2",
       "name": "Central (-5,2)",
@@ -2192,8 +2934,11 @@
           "id": "p121-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.5230, "ryu": 0.4770 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.523,
+            "ryu": 0.477
+          }
         }
       ]
     },
@@ -2201,7 +2946,10 @@
       "id": "p122",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -4, "r": 2 },
+      "position": {
+        "q": -4,
+        "r": 2
+      },
       "total_population": 2820,
       "initial_district_id": "d2",
       "name": "Central (-4,2)",
@@ -2211,7 +2959,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4573, "ryu": 0.5427 }
+          "vote_shares": {
+            "ken": 0.4573,
+            "ryu": 0.5427
+          }
         }
       ]
     },
@@ -2219,7 +2970,10 @@
       "id": "p123",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -3, "r": 2 },
+      "position": {
+        "q": -3,
+        "r": 2
+      },
       "total_population": 2855,
       "initial_district_id": "d2",
       "name": "Central (-3,2)",
@@ -2229,7 +2983,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5495, "ryu": 0.4505 }
+          "vote_shares": {
+            "ken": 0.5495,
+            "ryu": 0.4505
+          }
         }
       ]
     },
@@ -2237,7 +2994,10 @@
       "id": "p124",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -2, "r": 2 },
+      "position": {
+        "q": -2,
+        "r": 2
+      },
       "total_population": 3146,
       "initial_district_id": "d2",
       "name": "Central (-2,2)",
@@ -2247,7 +3007,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4599, "ryu": 0.5401 }
+          "vote_shares": {
+            "ken": 0.4599,
+            "ryu": 0.5401
+          }
         }
       ]
     },
@@ -2255,7 +3018,10 @@
       "id": "p125",
       "editable": true,
       "county_id": "central",
-      "position": { "q": -1, "r": 2 },
+      "position": {
+        "q": -1,
+        "r": 2
+      },
       "total_population": 3227,
       "initial_district_id": "d2",
       "name": "Central (-1,2)",
@@ -2265,7 +3031,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.5492, "ryu": 0.4508 }
+          "vote_shares": {
+            "ken": 0.5492,
+            "ryu": 0.4508
+          }
         }
       ]
     },
@@ -2273,7 +3042,10 @@
       "id": "p126",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 0, "r": 2 },
+      "position": {
+        "q": 0,
+        "r": 2
+      },
       "total_population": 3184,
       "initial_district_id": "d2",
       "name": "Central (0,2)",
@@ -2282,8 +3054,11 @@
           "id": "p126-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4468, "ryu": 0.5532 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.4468,
+            "ryu": 0.5532
+          }
         }
       ]
     },
@@ -2291,7 +3066,10 @@
       "id": "p127",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 1, "r": 2 },
+      "position": {
+        "q": 1,
+        "r": 2
+      },
       "total_population": 2702,
       "initial_district_id": "d2",
       "name": "Central (1,2)",
@@ -2301,7 +3079,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.5353, "ryu": 0.4647 }
+          "vote_shares": {
+            "ken": 0.5353,
+            "ryu": 0.4647
+          }
         }
       ]
     },
@@ -2309,7 +3090,10 @@
       "id": "p128",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 2, "r": 2 },
+      "position": {
+        "q": 2,
+        "r": 2
+      },
       "total_population": 3001,
       "initial_district_id": "d2",
       "name": "Central (2,2)",
@@ -2319,7 +3103,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4888, "ryu": 0.5112 }
+          "vote_shares": {
+            "ken": 0.4888,
+            "ryu": 0.5112
+          }
         }
       ]
     },
@@ -2327,7 +3114,10 @@
       "id": "p129",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 3, "r": 2 },
+      "position": {
+        "q": 3,
+        "r": 2
+      },
       "total_population": 3158,
       "initial_district_id": "d2",
       "name": "Central (3,2)",
@@ -2336,8 +3126,11 @@
           "id": "p129-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.5049, "ryu": 0.4951 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.5049,
+            "ryu": 0.4951
+          }
         }
       ]
     },
@@ -2345,7 +3138,10 @@
       "id": "p130",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 4, "r": 2 },
+      "position": {
+        "q": 4,
+        "r": 2
+      },
       "total_population": 3003,
       "initial_district_id": "d2",
       "name": "Central (4,2)",
@@ -2355,7 +3151,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.5236, "ryu": 0.4764 }
+          "vote_shares": {
+            "ken": 0.5236,
+            "ryu": 0.4764
+          }
         }
       ]
     },
@@ -2363,7 +3162,10 @@
       "id": "p131",
       "editable": true,
       "county_id": "central",
-      "position": { "q": 5, "r": 2 },
+      "position": {
+        "q": 5,
+        "r": 2
+      },
       "total_population": 3254,
       "initial_district_id": "d2",
       "name": "Central (5,2)",
@@ -2373,7 +3175,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.5584, "ryu": 0.4416 }
+          "vote_shares": {
+            "ken": 0.5584,
+            "ryu": 0.4416
+          }
         }
       ]
     },
@@ -2381,7 +3186,10 @@
       "id": "p132",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -8, "r": 3 },
+      "position": {
+        "q": -8,
+        "r": 3
+      },
       "total_population": 2810,
       "initial_district_id": "d3",
       "name": "South (-8,3)",
@@ -2391,7 +3199,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4615, "ryu": 0.5385 }
+          "vote_shares": {
+            "ken": 0.4615,
+            "ryu": 0.5385
+          }
         }
       ]
     },
@@ -2399,7 +3210,10 @@
       "id": "p133",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -7, "r": 3 },
+      "position": {
+        "q": -7,
+        "r": 3
+      },
       "total_population": 2793,
       "initial_district_id": "d3",
       "name": "South (-7,3)",
@@ -2409,7 +3223,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4353, "ryu": 0.5647 }
+          "vote_shares": {
+            "ken": 0.4353,
+            "ryu": 0.5647
+          }
         }
       ]
     },
@@ -2417,7 +3234,10 @@
       "id": "p134",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -6, "r": 3 },
+      "position": {
+        "q": -6,
+        "r": 3
+      },
       "total_population": 3049,
       "initial_district_id": "d3",
       "name": "South (-6,3)",
@@ -2426,8 +3246,11 @@
           "id": "p134-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.3925, "ryu": 0.6075 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.3925,
+            "ryu": 0.6075
+          }
         }
       ]
     },
@@ -2435,7 +3258,10 @@
       "id": "p135",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -5, "r": 3 },
+      "position": {
+        "q": -5,
+        "r": 3
+      },
       "total_population": 3131,
       "initial_district_id": "d3",
       "name": "South (-5,3)",
@@ -2444,8 +3270,11 @@
           "id": "p135-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4676, "ryu": 0.5324 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.4676,
+            "ryu": 0.5324
+          }
         }
       ]
     },
@@ -2453,7 +3282,10 @@
       "id": "p136",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -4, "r": 3 },
+      "position": {
+        "q": -4,
+        "r": 3
+      },
       "total_population": 2719,
       "initial_district_id": "d3",
       "name": "South (-4,3)",
@@ -2463,7 +3295,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4319, "ryu": 0.5681 }
+          "vote_shares": {
+            "ken": 0.4319,
+            "ryu": 0.5681
+          }
         }
       ]
     },
@@ -2471,7 +3306,10 @@
       "id": "p137",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -3, "r": 3 },
+      "position": {
+        "q": -3,
+        "r": 3
+      },
       "total_population": 3063,
       "initial_district_id": "d3",
       "name": "South (-3,3)",
@@ -2481,7 +3319,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4063, "ryu": 0.5937 }
+          "vote_shares": {
+            "ken": 0.4063,
+            "ryu": 0.5937
+          }
         }
       ]
     },
@@ -2489,7 +3330,10 @@
       "id": "p138",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -2, "r": 3 },
+      "position": {
+        "q": -2,
+        "r": 3
+      },
       "total_population": 2824,
       "initial_district_id": "d3",
       "name": "South (-2,3)",
@@ -2499,7 +3343,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4865, "ryu": 0.5135 }
+          "vote_shares": {
+            "ken": 0.4865,
+            "ryu": 0.5135
+          }
         }
       ]
     },
@@ -2507,7 +3354,10 @@
       "id": "p139",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -1, "r": 3 },
+      "position": {
+        "q": -1,
+        "r": 3
+      },
       "total_population": 3198,
       "initial_district_id": "d3",
       "name": "South (-1,3)",
@@ -2517,7 +3367,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3951, "ryu": 0.6049 }
+          "vote_shares": {
+            "ken": 0.3951,
+            "ryu": 0.6049
+          }
         }
       ]
     },
@@ -2525,7 +3378,10 @@
       "id": "p140",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 0, "r": 3 },
+      "position": {
+        "q": 0,
+        "r": 3
+      },
       "total_population": 3153,
       "initial_district_id": "d3",
       "name": "South (0,3)",
@@ -2535,7 +3391,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4269, "ryu": 0.5731 }
+          "vote_shares": {
+            "ken": 0.4269,
+            "ryu": 0.5731
+          }
         }
       ]
     },
@@ -2543,7 +3402,10 @@
       "id": "p141",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 1, "r": 3 },
+      "position": {
+        "q": 1,
+        "r": 3
+      },
       "total_population": 3120,
       "initial_district_id": "d3",
       "name": "South (1,3)",
@@ -2552,8 +3414,11 @@
           "id": "p141-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4780, "ryu": 0.5220 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.478,
+            "ryu": 0.522
+          }
         }
       ]
     },
@@ -2561,7 +3426,10 @@
       "id": "p142",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 2, "r": 3 },
+      "position": {
+        "q": 2,
+        "r": 3
+      },
       "total_population": 3197,
       "initial_district_id": "d3",
       "name": "South (2,3)",
@@ -2571,7 +3439,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4662, "ryu": 0.5338 }
+          "vote_shares": {
+            "ken": 0.4662,
+            "ryu": 0.5338
+          }
         }
       ]
     },
@@ -2579,7 +3450,10 @@
       "id": "p143",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 3, "r": 3 },
+      "position": {
+        "q": 3,
+        "r": 3
+      },
       "total_population": 2892,
       "initial_district_id": "d3",
       "name": "South (3,3)",
@@ -2589,7 +3463,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4418, "ryu": 0.5582 }
+          "vote_shares": {
+            "ken": 0.4418,
+            "ryu": 0.5582
+          }
         }
       ]
     },
@@ -2597,7 +3474,10 @@
       "id": "p144",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 4, "r": 3 },
+      "position": {
+        "q": 4,
+        "r": 3
+      },
       "total_population": 3167,
       "initial_district_id": "d3",
       "name": "South (4,3)",
@@ -2607,7 +3487,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4617, "ryu": 0.5383 }
+          "vote_shares": {
+            "ken": 0.4617,
+            "ryu": 0.5383
+          }
         }
       ]
     },
@@ -2615,7 +3498,10 @@
       "id": "p145",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -8, "r": 4 },
+      "position": {
+        "q": -8,
+        "r": 4
+      },
       "total_population": 3116,
       "initial_district_id": "d3",
       "name": "South (-8,4)",
@@ -2624,8 +3510,11 @@
           "id": "p145-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.3941, "ryu": 0.6059 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.3941,
+            "ryu": 0.6059
+          }
         }
       ]
     },
@@ -2633,7 +3522,10 @@
       "id": "p146",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -7, "r": 4 },
+      "position": {
+        "q": -7,
+        "r": 4
+      },
       "total_population": 3061,
       "initial_district_id": "d3",
       "name": "South (-7,4)",
@@ -2643,7 +3535,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4737, "ryu": 0.5263 }
+          "vote_shares": {
+            "ken": 0.4737,
+            "ryu": 0.5263
+          }
         }
       ]
     },
@@ -2651,7 +3546,10 @@
       "id": "p147",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -6, "r": 4 },
+      "position": {
+        "q": -6,
+        "r": 4
+      },
       "total_population": 2806,
       "initial_district_id": "d3",
       "name": "South (-6,4)",
@@ -2661,7 +3559,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4283, "ryu": 0.5717 }
+          "vote_shares": {
+            "ken": 0.4283,
+            "ryu": 0.5717
+          }
         }
       ]
     },
@@ -2669,7 +3570,10 @@
       "id": "p148",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -5, "r": 4 },
+      "position": {
+        "q": -5,
+        "r": 4
+      },
       "total_population": 3157,
       "initial_district_id": "d3",
       "name": "South (-5,4)",
@@ -2678,8 +3582,11 @@
           "id": "p148-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4636, "ryu": 0.5364 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.4636,
+            "ryu": 0.5364
+          }
         }
       ]
     },
@@ -2687,7 +3594,10 @@
       "id": "p149",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -4, "r": 4 },
+      "position": {
+        "q": -4,
+        "r": 4
+      },
       "total_population": 2834,
       "initial_district_id": "d3",
       "name": "South (-4,4)",
@@ -2697,7 +3607,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4611, "ryu": 0.5389 }
+          "vote_shares": {
+            "ken": 0.4611,
+            "ryu": 0.5389
+          }
         }
       ]
     },
@@ -2705,7 +3618,10 @@
       "id": "p150",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -3, "r": 4 },
+      "position": {
+        "q": -3,
+        "r": 4
+      },
       "total_population": 3219,
       "initial_district_id": "d3",
       "name": "South (-3,4)",
@@ -2715,7 +3631,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.3913, "ryu": 0.6087 }
+          "vote_shares": {
+            "ken": 0.3913,
+            "ryu": 0.6087
+          }
         }
       ]
     },
@@ -2723,7 +3642,10 @@
       "id": "p151",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -2, "r": 4 },
+      "position": {
+        "q": -2,
+        "r": 4
+      },
       "total_population": 2880,
       "initial_district_id": "d3",
       "name": "South (-2,4)",
@@ -2733,7 +3655,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4659, "ryu": 0.5341 }
+          "vote_shares": {
+            "ken": 0.4659,
+            "ryu": 0.5341
+          }
         }
       ]
     },
@@ -2741,7 +3666,10 @@
       "id": "p152",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -1, "r": 4 },
+      "position": {
+        "q": -1,
+        "r": 4
+      },
       "total_population": 2704,
       "initial_district_id": "d3",
       "name": "South (-1,4)",
@@ -2751,7 +3679,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4573, "ryu": 0.5427 }
+          "vote_shares": {
+            "ken": 0.4573,
+            "ryu": 0.5427
+          }
         }
       ]
     },
@@ -2759,7 +3690,10 @@
       "id": "p153",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 0, "r": 4 },
+      "position": {
+        "q": 0,
+        "r": 4
+      },
       "total_population": 3177,
       "initial_district_id": "d3",
       "name": "South (0,4)",
@@ -2769,7 +3703,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4991, "ryu": 0.5009 }
+          "vote_shares": {
+            "ken": 0.4991,
+            "ryu": 0.5009
+          }
         }
       ]
     },
@@ -2777,7 +3714,10 @@
       "id": "p154",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 1, "r": 4 },
+      "position": {
+        "q": 1,
+        "r": 4
+      },
       "total_population": 3201,
       "initial_district_id": "d3",
       "name": "South (1,4)",
@@ -2787,7 +3727,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4155, "ryu": 0.5845 }
+          "vote_shares": {
+            "ken": 0.4155,
+            "ryu": 0.5845
+          }
         }
       ]
     },
@@ -2795,7 +3738,10 @@
       "id": "p155",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 2, "r": 4 },
+      "position": {
+        "q": 2,
+        "r": 4
+      },
       "total_population": 3083,
       "initial_district_id": "d3",
       "name": "South (2,4)",
@@ -2805,7 +3751,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
-          "vote_shares": { "ken": 0.4079, "ryu": 0.5921 }
+          "vote_shares": {
+            "ken": 0.4079,
+            "ryu": 0.5921
+          }
         }
       ]
     },
@@ -2813,7 +3762,10 @@
       "id": "p156",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 3, "r": 4 },
+      "position": {
+        "q": 3,
+        "r": 4
+      },
       "total_population": 2808,
       "initial_district_id": "d3",
       "name": "South (3,4)",
@@ -2823,7 +3775,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4744, "ryu": 0.5256 }
+          "vote_shares": {
+            "ken": 0.4744,
+            "ryu": 0.5256
+          }
         }
       ]
     },
@@ -2831,7 +3786,10 @@
       "id": "p157",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -8, "r": 5 },
+      "position": {
+        "q": -8,
+        "r": 5
+      },
       "total_population": 3211,
       "initial_district_id": "d3",
       "name": "South (-8,5)",
@@ -2841,7 +3799,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4703, "ryu": 0.5297 }
+          "vote_shares": {
+            "ken": 0.4703,
+            "ryu": 0.5297
+          }
         }
       ]
     },
@@ -2849,7 +3810,10 @@
       "id": "p158",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -7, "r": 5 },
+      "position": {
+        "q": -7,
+        "r": 5
+      },
       "total_population": 2755,
       "initial_district_id": "d3",
       "name": "South (-7,5)",
@@ -2859,7 +3823,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4425, "ryu": 0.5575 }
+          "vote_shares": {
+            "ken": 0.4425,
+            "ryu": 0.5575
+          }
         }
       ]
     },
@@ -2867,7 +3834,10 @@
       "id": "p159",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -6, "r": 5 },
+      "position": {
+        "q": -6,
+        "r": 5
+      },
       "total_population": 3020,
       "initial_district_id": "d3",
       "name": "South (-6,5)",
@@ -2877,7 +3847,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.5024, "ryu": 0.4976 }
+          "vote_shares": {
+            "ken": 0.5024,
+            "ryu": 0.4976
+          }
         }
       ]
     },
@@ -2885,7 +3858,10 @@
       "id": "p160",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -5, "r": 5 },
+      "position": {
+        "q": -5,
+        "r": 5
+      },
       "total_population": 3043,
       "initial_district_id": "d3",
       "name": "South (-5,5)",
@@ -2895,7 +3871,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4696, "ryu": 0.5304 }
+          "vote_shares": {
+            "ken": 0.4696,
+            "ryu": 0.5304
+          }
         }
       ]
     },
@@ -2903,7 +3882,10 @@
       "id": "p161",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -4, "r": 5 },
+      "position": {
+        "q": -4,
+        "r": 5
+      },
       "total_population": 3278,
       "initial_district_id": "d3",
       "name": "South (-4,5)",
@@ -2913,7 +3895,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4074, "ryu": 0.5926 }
+          "vote_shares": {
+            "ken": 0.4074,
+            "ryu": 0.5926
+          }
         }
       ]
     },
@@ -2921,7 +3906,10 @@
       "id": "p162",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -3, "r": 5 },
+      "position": {
+        "q": -3,
+        "r": 5
+      },
       "total_population": 3220,
       "initial_district_id": "d3",
       "name": "South (-3,5)",
@@ -2931,7 +3919,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4149, "ryu": 0.5851 }
+          "vote_shares": {
+            "ken": 0.4149,
+            "ryu": 0.5851
+          }
         }
       ]
     },
@@ -2939,7 +3930,10 @@
       "id": "p163",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -2, "r": 5 },
+      "position": {
+        "q": -2,
+        "r": 5
+      },
       "total_population": 3138,
       "initial_district_id": "d3",
       "name": "South (-2,5)",
@@ -2949,7 +3943,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4094, "ryu": 0.5906 }
+          "vote_shares": {
+            "ken": 0.4094,
+            "ryu": 0.5906
+          }
         }
       ]
     },
@@ -2957,7 +3954,10 @@
       "id": "p164",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -1, "r": 5 },
+      "position": {
+        "q": -1,
+        "r": 5
+      },
       "total_population": 3044,
       "initial_district_id": "d3",
       "name": "South (-1,5)",
@@ -2967,7 +3967,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.3932, "ryu": 0.6068 }
+          "vote_shares": {
+            "ken": 0.3932,
+            "ryu": 0.6068
+          }
         }
       ]
     },
@@ -2975,7 +3978,10 @@
       "id": "p165",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 0, "r": 5 },
+      "position": {
+        "q": 0,
+        "r": 5
+      },
       "total_population": 3194,
       "initial_district_id": "d3",
       "name": "South (0,5)",
@@ -2985,7 +3991,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4726, "ryu": 0.5274 }
+          "vote_shares": {
+            "ken": 0.4726,
+            "ryu": 0.5274
+          }
         }
       ]
     },
@@ -2993,7 +4002,10 @@
       "id": "p166",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 1, "r": 5 },
+      "position": {
+        "q": 1,
+        "r": 5
+      },
       "total_population": 3020,
       "initial_district_id": "d3",
       "name": "South (1,5)",
@@ -3003,7 +4015,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
-          "vote_shares": { "ken": 0.4037, "ryu": 0.5963 }
+          "vote_shares": {
+            "ken": 0.4037,
+            "ryu": 0.5963
+          }
         }
       ]
     },
@@ -3011,7 +4026,10 @@
       "id": "p167",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 2, "r": 5 },
+      "position": {
+        "q": 2,
+        "r": 5
+      },
       "total_population": 2993,
       "initial_district_id": "d3",
       "name": "South (2,5)",
@@ -3021,7 +4039,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4567, "ryu": 0.5433 }
+          "vote_shares": {
+            "ken": 0.4567,
+            "ryu": 0.5433
+          }
         }
       ]
     },
@@ -3029,7 +4050,10 @@
       "id": "p168",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -8, "r": 6 },
+      "position": {
+        "q": -8,
+        "r": 6
+      },
       "total_population": 3075,
       "initial_district_id": "d3",
       "name": "South (-8,6)",
@@ -3039,7 +4063,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.5046, "ryu": 0.4954 }
+          "vote_shares": {
+            "ken": 0.5046,
+            "ryu": 0.4954
+          }
         }
       ]
     },
@@ -3047,7 +4074,10 @@
       "id": "p169",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -7, "r": 6 },
+      "position": {
+        "q": -7,
+        "r": 6
+      },
       "total_population": 3237,
       "initial_district_id": "d3",
       "name": "South (-7,6)",
@@ -3057,7 +4087,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.3934, "ryu": 0.6066 }
+          "vote_shares": {
+            "ken": 0.3934,
+            "ryu": 0.6066
+          }
         }
       ]
     },
@@ -3065,7 +4098,10 @@
       "id": "p170",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -6, "r": 6 },
+      "position": {
+        "q": -6,
+        "r": 6
+      },
       "total_population": 3091,
       "initial_district_id": "d3",
       "name": "South (-6,6)",
@@ -3074,8 +4110,11 @@
           "id": "p170-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ken": 0.4155, "ryu": 0.5845 }
+          "turnout_rate": 0.7,
+          "vote_shares": {
+            "ken": 0.4155,
+            "ryu": 0.5845
+          }
         }
       ]
     },
@@ -3083,7 +4122,10 @@
       "id": "p171",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -5, "r": 6 },
+      "position": {
+        "q": -5,
+        "r": 6
+      },
       "total_population": 3228,
       "initial_district_id": "d3",
       "name": "South (-5,6)",
@@ -3093,7 +4135,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4674, "ryu": 0.5326 }
+          "vote_shares": {
+            "ken": 0.4674,
+            "ryu": 0.5326
+          }
         }
       ]
     },
@@ -3101,7 +4146,10 @@
       "id": "p172",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -4, "r": 6 },
+      "position": {
+        "q": -4,
+        "r": 6
+      },
       "total_population": 2964,
       "initial_district_id": "d3",
       "name": "South (-4,6)",
@@ -3111,7 +4159,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4885, "ryu": 0.5115 }
+          "vote_shares": {
+            "ken": 0.4885,
+            "ryu": 0.5115
+          }
         }
       ]
     },
@@ -3119,7 +4170,10 @@
       "id": "p173",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -3, "r": 6 },
+      "position": {
+        "q": -3,
+        "r": 6
+      },
       "total_population": 3241,
       "initial_district_id": "d3",
       "name": "South (-3,6)",
@@ -3129,7 +4183,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
-          "vote_shares": { "ken": 0.4520, "ryu": 0.5480 }
+          "vote_shares": {
+            "ken": 0.452,
+            "ryu": 0.548
+          }
         }
       ]
     },
@@ -3137,7 +4194,10 @@
       "id": "p174",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -2, "r": 6 },
+      "position": {
+        "q": -2,
+        "r": 6
+      },
       "total_population": 2976,
       "initial_district_id": "d3",
       "name": "South (-2,6)",
@@ -3147,7 +4207,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4210, "ryu": 0.5790 }
+          "vote_shares": {
+            "ken": 0.421,
+            "ryu": 0.579
+          }
         }
       ]
     },
@@ -3155,7 +4218,10 @@
       "id": "p175",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -1, "r": 6 },
+      "position": {
+        "q": -1,
+        "r": 6
+      },
       "total_population": 2786,
       "initial_district_id": "d3",
       "name": "South (-1,6)",
@@ -3165,7 +4231,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4270, "ryu": 0.5730 }
+          "vote_shares": {
+            "ken": 0.427,
+            "ryu": 0.573
+          }
         }
       ]
     },
@@ -3173,7 +4242,10 @@
       "id": "p176",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 0, "r": 6 },
+      "position": {
+        "q": 0,
+        "r": 6
+      },
       "total_population": 3224,
       "initial_district_id": "d3",
       "name": "South (0,6)",
@@ -3183,7 +4255,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4495, "ryu": 0.5505 }
+          "vote_shares": {
+            "ken": 0.4495,
+            "ryu": 0.5505
+          }
         }
       ]
     },
@@ -3191,7 +4266,10 @@
       "id": "p177",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 1, "r": 6 },
+      "position": {
+        "q": 1,
+        "r": 6
+      },
       "total_population": 3087,
       "initial_district_id": "d3",
       "name": "South (1,6)",
@@ -3201,7 +4279,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
-          "vote_shares": { "ken": 0.4751, "ryu": 0.5249 }
+          "vote_shares": {
+            "ken": 0.4751,
+            "ryu": 0.5249
+          }
         }
       ]
     },
@@ -3209,7 +4290,10 @@
       "id": "p178",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -8, "r": 7 },
+      "position": {
+        "q": -8,
+        "r": 7
+      },
       "total_population": 3080,
       "initial_district_id": "d3",
       "name": "South (-8,7)",
@@ -3219,7 +4303,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4821, "ryu": 0.5179 }
+          "vote_shares": {
+            "ken": 0.4821,
+            "ryu": 0.5179
+          }
         }
       ]
     },
@@ -3227,7 +4314,10 @@
       "id": "p179",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -7, "r": 7 },
+      "position": {
+        "q": -7,
+        "r": 7
+      },
       "total_population": 3283,
       "initial_district_id": "d3",
       "name": "South (-7,7)",
@@ -3237,7 +4327,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
-          "vote_shares": { "ken": 0.4391, "ryu": 0.5609 }
+          "vote_shares": {
+            "ken": 0.4391,
+            "ryu": 0.5609
+          }
         }
       ]
     },
@@ -3245,7 +4338,10 @@
       "id": "p180",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -6, "r": 7 },
+      "position": {
+        "q": -6,
+        "r": 7
+      },
       "total_population": 2701,
       "initial_district_id": "d3",
       "name": "South (-6,7)",
@@ -3255,7 +4351,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4809, "ryu": 0.5191 }
+          "vote_shares": {
+            "ken": 0.4809,
+            "ryu": 0.5191
+          }
         }
       ]
     },
@@ -3263,7 +4362,10 @@
       "id": "p181",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -5, "r": 7 },
+      "position": {
+        "q": -5,
+        "r": 7
+      },
       "total_population": 3060,
       "initial_district_id": "d3",
       "name": "South (-5,7)",
@@ -3273,7 +4375,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4507, "ryu": 0.5493 }
+          "vote_shares": {
+            "ken": 0.4507,
+            "ryu": 0.5493
+          }
         }
       ]
     },
@@ -3281,7 +4386,10 @@
       "id": "p182",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -4, "r": 7 },
+      "position": {
+        "q": -4,
+        "r": 7
+      },
       "total_population": 3182,
       "initial_district_id": "d3",
       "name": "South (-4,7)",
@@ -3290,8 +4398,11 @@
           "id": "p182-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ken": 0.4605, "ryu": 0.5395 }
+          "turnout_rate": 0.6,
+          "vote_shares": {
+            "ken": 0.4605,
+            "ryu": 0.5395
+          }
         }
       ]
     },
@@ -3299,7 +4410,10 @@
       "id": "p183",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -3, "r": 7 },
+      "position": {
+        "q": -3,
+        "r": 7
+      },
       "total_population": 3050,
       "initial_district_id": "d3",
       "name": "South (-3,7)",
@@ -3309,7 +4423,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
-          "vote_shares": { "ken": 0.4915, "ryu": 0.5085 }
+          "vote_shares": {
+            "ken": 0.4915,
+            "ryu": 0.5085
+          }
         }
       ]
     },
@@ -3317,7 +4434,10 @@
       "id": "p184",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -2, "r": 7 },
+      "position": {
+        "q": -2,
+        "r": 7
+      },
       "total_population": 3088,
       "initial_district_id": "d3",
       "name": "South (-2,7)",
@@ -3327,7 +4447,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4640, "ryu": 0.5360 }
+          "vote_shares": {
+            "ken": 0.464,
+            "ryu": 0.536
+          }
         }
       ]
     },
@@ -3335,7 +4458,10 @@
       "id": "p185",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -1, "r": 7 },
+      "position": {
+        "q": -1,
+        "r": 7
+      },
       "total_population": 3059,
       "initial_district_id": "d3",
       "name": "South (-1,7)",
@@ -3345,7 +4471,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.4737, "ryu": 0.5263 }
+          "vote_shares": {
+            "ken": 0.4737,
+            "ryu": 0.5263
+          }
         }
       ]
     },
@@ -3353,7 +4482,10 @@
       "id": "p186",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 0, "r": 7 },
+      "position": {
+        "q": 0,
+        "r": 7
+      },
       "total_population": 2770,
       "initial_district_id": "d3",
       "name": "South (0,7)",
@@ -3363,7 +4495,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
-          "vote_shares": { "ken": 0.3935, "ryu": 0.6065 }
+          "vote_shares": {
+            "ken": 0.3935,
+            "ryu": 0.6065
+          }
         }
       ]
     },
@@ -3371,7 +4506,10 @@
       "id": "p187",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 1, "r": 7 },
+      "position": {
+        "q": 1,
+        "r": 7
+      },
       "total_population": 3178,
       "initial_district_id": "d3",
       "name": "South (1,7)",
@@ -3381,7 +4519,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
-          "vote_shares": { "ken": 0.4461, "ryu": 0.5539 }
+          "vote_shares": {
+            "ken": 0.4461,
+            "ryu": 0.5539
+          }
         }
       ]
     },
@@ -3389,7 +4530,10 @@
       "id": "p188",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -8, "r": 8 },
+      "position": {
+        "q": -8,
+        "r": 8
+      },
       "total_population": 3223,
       "initial_district_id": "d3",
       "name": "South (-8,8)",
@@ -3399,7 +4543,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4124, "ryu": 0.5876 }
+          "vote_shares": {
+            "ken": 0.4124,
+            "ryu": 0.5876
+          }
         }
       ]
     },
@@ -3407,7 +4554,10 @@
       "id": "p189",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -7, "r": 8 },
+      "position": {
+        "q": -7,
+        "r": 8
+      },
       "total_population": 2713,
       "initial_district_id": "d3",
       "name": "South (-7,8)",
@@ -3417,7 +4567,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4940, "ryu": 0.5060 }
+          "vote_shares": {
+            "ken": 0.494,
+            "ryu": 0.506
+          }
         }
       ]
     },
@@ -3425,7 +4578,10 @@
       "id": "p190",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -6, "r": 8 },
+      "position": {
+        "q": -6,
+        "r": 8
+      },
       "total_population": 3240,
       "initial_district_id": "d3",
       "name": "South (-6,8)",
@@ -3435,7 +4591,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4489, "ryu": 0.5511 }
+          "vote_shares": {
+            "ken": 0.4489,
+            "ryu": 0.5511
+          }
         }
       ]
     },
@@ -3443,7 +4602,10 @@
       "id": "p191",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -5, "r": 8 },
+      "position": {
+        "q": -5,
+        "r": 8
+      },
       "total_population": 2772,
       "initial_district_id": "d3",
       "name": "South (-5,8)",
@@ -3453,7 +4615,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
-          "vote_shares": { "ken": 0.4177, "ryu": 0.5823 }
+          "vote_shares": {
+            "ken": 0.4177,
+            "ryu": 0.5823
+          }
         }
       ]
     },
@@ -3461,7 +4626,10 @@
       "id": "p192",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -4, "r": 8 },
+      "position": {
+        "q": -4,
+        "r": 8
+      },
       "total_population": 2999,
       "initial_district_id": "d3",
       "name": "South (-4,8)",
@@ -3471,7 +4639,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
-          "vote_shares": { "ken": 0.4502, "ryu": 0.5498 }
+          "vote_shares": {
+            "ken": 0.4502,
+            "ryu": 0.5498
+          }
         }
       ]
     },
@@ -3479,7 +4650,10 @@
       "id": "p193",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -3, "r": 8 },
+      "position": {
+        "q": -3,
+        "r": 8
+      },
       "total_population": 3171,
       "initial_district_id": "d3",
       "name": "South (-3,8)",
@@ -3489,7 +4663,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
-          "vote_shares": { "ken": 0.4756, "ryu": 0.5244 }
+          "vote_shares": {
+            "ken": 0.4756,
+            "ryu": 0.5244
+          }
         }
       ]
     },
@@ -3497,7 +4674,10 @@
       "id": "p194",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -2, "r": 8 },
+      "position": {
+        "q": -2,
+        "r": 8
+      },
       "total_population": 2726,
       "initial_district_id": "d3",
       "name": "South (-2,8)",
@@ -3507,7 +4687,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
-          "vote_shares": { "ken": 0.4649, "ryu": 0.5351 }
+          "vote_shares": {
+            "ken": 0.4649,
+            "ryu": 0.5351
+          }
         }
       ]
     },
@@ -3515,7 +4698,10 @@
       "id": "p195",
       "editable": true,
       "county_id": "south",
-      "position": { "q": -1, "r": 8 },
+      "position": {
+        "q": -1,
+        "r": 8
+      },
       "total_population": 3241,
       "initial_district_id": "d3",
       "name": "South (-1,8)",
@@ -3525,7 +4711,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
-          "vote_shares": { "ken": 0.4739, "ryu": 0.5261 }
+          "vote_shares": {
+            "ken": 0.4739,
+            "ryu": 0.5261
+          }
         }
       ]
     },
@@ -3533,7 +4722,10 @@
       "id": "p196",
       "editable": true,
       "county_id": "south",
-      "position": { "q": 0, "r": 8 },
+      "position": {
+        "q": 0,
+        "r": 8
+      },
       "total_population": 3152,
       "initial_district_id": "d3",
       "name": "South (0,8)",
@@ -3543,7 +4735,10 @@
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
-          "vote_shares": { "ken": 0.4165, "ryu": 0.5835 }
+          "vote_shares": {
+            "ken": 0.4165,
+            "ryu": 0.5835
+          }
         }
       ]
     }
@@ -3558,22 +4753,26 @@
       "id": "sc-district-count",
       "required": true,
       "description": "All three districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
+      "criterion": {
+        "type": "district_count"
+      }
     },
     {
       "id": "sc-population-balance",
       "required": true,
       "description": "All three districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "criterion": {
+        "type": "population_balance"
+      }
     },
     {
       "id": "sc-compactness",
       "required": false,
-      "description": "All districts are reasonably compact (compactness ≥ 40%).",
+      "description": "All districts are reasonably compact (compactness \u2265 40%).",
       "criterion": {
         "type": "compactness",
         "operator": "gte",
-        "threshold": 0.40
+        "threshold": 0.4
       }
     }
   ],
@@ -3581,16 +4780,16 @@
     "character": {
       "name": "You",
       "role": "Redistricting Commissioner, Millbrook County",
-      "motivation": "Millbrook County needs new district boundaries. The three counties — North, Central, and South — each have different populations. Your job is to draw three districts with roughly equal population. The current county-aligned map is out of balance."
+      "motivation": "Millbrook County needs new district boundaries. The three counties \u2014 North, Central, and South \u2014 each have different populations. Your job is to draw three districts with roughly equal population. The current county-aligned map is out of balance."
     },
     "intro_slides": [
       {
         "heading": "Welcome to Millbrook County",
-        "body": "This is a larger map than the tutorial. Millbrook County has three regions: North, Central, and South. The current district boundaries follow county lines — but the populations aren't equal.\n\nYour job: adjust the boundaries so all three districts have roughly the same number of people."
+        "body": "This is a larger map than the tutorial. Millbrook County has three regions: North, Central, and South. The current district boundaries follow county lines \u2014 but the populations aren't equal.\n\nYour job: adjust the boundaries so all three districts have roughly the same number of people."
       },
       {
         "heading": "The Tools",
-        "body": "Select a district from the toolbar, then paint precincts to assign them. You don't need to redraw the entire map — just move a few boundary precincts to balance the populations.\n\nWatch the population balance indicator in the sidebar. When all three districts are within 10% of the target, the Submit button will activate."
+        "body": "Select a district from the toolbar, then paint precincts to assign them. You don't need to redraw the entire map \u2014 just move a few boundary precincts to balance the populations.\n\nWatch the population balance indicator in the sidebar. When all three districts are within 10% of the target, the Submit button will activate."
       }
     ],
     "objective": "Balance the three districts so each has roughly equal population (within 10%). Move boundary precincts between districts to fix the imbalance."

--- a/thoughts/shared/tickets/GAME-031-gameplay-critique-followup.md
+++ b/thoughts/shared/tickets/GAME-031-gameplay-critique-followup.md
@@ -2,8 +2,9 @@
 id: GAME-031
 title: Address gameplay critique feedback from external review
 area: game, content, balance
-status: open
+status: resolved
 created: 2026-04-27
+github_issue: 185
 ---
 
 ## Summary
@@ -13,17 +14,39 @@ produced a research document with findings on scenario difficulty, evaluation
 balance, and design feedback. This ticket tracks reviewing and acting on
 that feedback.
 
-## Current State
+## Resolution
 
-Research document filed: `thoughts/shared/research/2026-04-27-gameplay-critique.md`
-(merged in PR #111). Findings have not yet been reviewed or acted on.
+Critique reviewed and dispositioned (2026-05-02). Overall rating: 8.5/10. Findings:
+
+**Implemented (this ticket):**
+- Population tolerance tightened: scenarios 007 and 008 reduced from ±10% → ±5%.
+  These are the reform/neutral-rules scenarios where population balance is a central
+  pedagogical goal. Partisan-tactics scenarios (002–006, 009) left at ±10% — the
+  winning strategies for those scenarios are constrained by geography and cannot
+  achieve ±5% without losing the tactical clarity they're designed to teach.
+- Scenario-007 required compactness threshold raised: 0.40 → 0.50. Reform Map is
+  explicitly about compactness; a higher bar makes the lesson more meaningful.
+
+**Deferred to sub-ticket:**
+- Per-session randomization (population/lean ±5% seeded per session): filed as
+  GAME-057. Requires careful design to keep e2e tests deterministic.
+
+**Rejected for now:**
+- Optional criteria expansions (Minimal Strokes, Extreme Gerry, County-Respectful):
+  DESIGN-001 now settled on variable per-criterion stars; expanding optional criteria
+  is a content authoring task. No sub-ticket needed — authors can add when writing
+  future scenarios.
+- Size climax (s009 150+ precincts): s009 is the fun educational finale; scaling it
+  up risks breaking the light "Cats vs Dogs" tone. Deferred to post-v1 content work.
+- Dynamic hints after failed submits: low impact vs. effort for v1. Deferred.
+- Randomization of events, multi-election overlays (v2 features): deferred.
 
 ## Goals / Acceptance Criteria
 
-- [ ] Review the gameplay critique research document
-- [ ] Categorize findings: accept / reject / defer (with rationale)
-- [ ] For accepted findings: implement changes or file sub-tickets
-- [ ] Document disposition in this ticket
+- [x] Review the gameplay critique research document
+- [x] Categorize findings: accept / reject / defer (with rationale)
+- [x] For accepted findings: implement changes or file sub-tickets
+- [x] Document disposition in this ticket
 
 ## References
 

--- a/thoughts/shared/tickets/GAME-057-scenario-randomization.md
+++ b/thoughts/shared/tickets/GAME-057-scenario-randomization.md
@@ -1,0 +1,42 @@
+---
+id: GAME-057
+title: Per-session scenario randomization (population and lean offsets)
+area: game, content, replayability
+status: open
+created: 2026-05-02
+---
+
+## Summary
+
+Add optional per-session randomization to scenarios — small offsets to precinct
+population and partisan lean (±5% from scenario base values), seeded per session.
+This eliminates the "one true map" problem identified in the gameplay critique
+(GAME-031) and encourages replay by making each session subtly different.
+
+E2e tests remain deterministic: test scenarios pin to base values (seed=0 or no
+randomization flag), so the random path is exercised only by new unit tests.
+
+## Current State
+
+Scenarios are fully deterministic: precinct population and partisan lean are
+fixed values from the JSON. Replaying a scenario with the same strategy always
+produces the same result. Identified as a weakness in the gameplay critique
+(2026-04-27-gameplay-critique.md, recommendation #2).
+
+## Goals / Acceptance Criteria
+
+- [ ] Scenario generator (or loader) supports an optional `seed` parameter that
+      applies consistent ±5% offsets to precinct population and partyShare values
+- [ ] Randomization is per-session: same seed → same map; new session → new seed
+- [ ] Scenarios opt in via a JSON flag (`randomizable: true`) or generator flag;
+      tutorial scenarios default to non-randomized (determinism for learning)
+- [ ] All existing e2e tests continue to pass unmodified (tests use base/deterministic values)
+- [ ] New unit tests cover: seed reproducibility, offset bounds (never <0 or >1 for shares),
+      population totals remain positive
+
+## References
+
+- `thoughts/shared/research/2026-04-27-gameplay-critique.md` — recommendation #2
+- `game/web/src/model/scenario.ts` — scenario loading
+- `game/scenarios/` — scenario JSON files
+- GAME-031 — gameplay critique followup (parent)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -91,8 +91,8 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-006-zoom-adaptive-dot-density.md` | design, rendering | Zoom-adaptive dot density scaling + person glyph threshold (refinement on DESIGN-005, possibly post-v1) |
 | `DESIGN-007-dimensional-dot-map-demographic-overlay.md` | design, rendering | Dimensional dot map: demographic dimension switching (Option B adaptive encoding) + sorted placement toggle |
 | `GAME-056-playtest-feedback.md` | game, content, UX | Capture and act on playtest feedback — scenario balance and UX |
+| `GAME-057-scenario-randomization.md` | game, content, replayability | Per-session ±5% population/lean offsets seeded per session; e2e tests remain deterministic |
 | `GAME-030-main-menu-and-campaigns.md` | game, UX, architecture | Main menu, campaign model, campaign select, layered navigation; replaces scenario-select-as-home |
-| `GAME-031-gameplay-critique-followup.md` | game, content, balance | Review and act on external gameplay critique research (scenario difficulty, eval balance, design) |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
 | `GAME-041-split-loader.md` | game, code-quality | Split loader.ts: extract runtime-types.ts primitives; name validateScenario() internally |
 | `GAME-042-break-up-main.md` | game, code-quality | Break up main.ts god module into testable units (scenarioSelect, resultScreen, introFlow) |
@@ -107,6 +107,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| GAME-031: gameplay critique followup | Tightened pop tolerance (007/008: 10%→5%); compactness 007: 0.40→0.50; randomization→GAME-057; others deferred or rejected |
 | DESIGN-001: achievement/star system research | Variable per-criterion stars: 1 base + 1 per optional criterion; no format change needed; fixed-3 rejected; research doc written 2026-05-02 |
 | GAME-055: scenario-driven party names | `renderResults()` accepts partyLabels param; scenario party names (Ken/Ryu, Cat/Dog) shown in results panel; fallback to "Party 1"/"Party 2"; 2 e2e tests; merged PR #180 |
 | GAME-008: full accessibility pass | Okabe-Ito CVD-safe district palette, PuOr lean view, aligned party colors, keyboard precinct nav (arrow+number keys), focus rings, prefers-reduced-motion, 6 e2e a11y tests; merged PR #177, deployed v0.0.13 |


### PR DESCRIPTION
## Summary

Gameplay critique review and targeted threshold tightening (GAME-031).

- Population tolerance tightened for scenarios 007 and 008: 10% → 5%. These are the reform/neutral-rules scenarios where population balance is a central pedagogical goal. Partisan-tactics scenarios (002–006, 009) remain at 10% — their winning strategies are geometrically constrained and cannot achieve ±5% without losing tactical clarity.
- Scenario-007 required compactness threshold raised: 0.40 → 0.50. Reform Map is explicitly about compactness; higher bar makes the lesson more meaningful.
- GAME-057 filed for per-session randomization (deferred from this ticket).
- GAME-031 ticket marked resolved with full disposition documented.
- GAME-057 ticket file added.

All 111 e2e tests pass locally.

## Affected machines / services

`game/scenarios/` — scenario JSON content only. No TypeScript changes.

## Validation performed

- [x] `bazel test //web:e2e_test` — 111/111 pass

## Deployment steps

N/A — scenario content only; picked up on next release build.

## Tickets addressed

- see #185 (GAME-031)

## Rollback

Revert this commit. No data migrations; scenario JSON changes are self-contained.
