### PR TITLE
chore: add GAME-058 manual playability test ticket

### DIFF
--- a/thoughts/shared/tickets/GAME-058-manual-playability-test-thresholds.md
+++ b/thoughts/shared/tickets/GAME-058-manual-playability-test-thresholds.md
@@ -1,0 +1,31 @@
+---
+id: GAME-058
+title: Manual playability test — scenarios 007 and 008 after threshold tightening
+area: game, content, QA
+status: open
+created: 2026-05-02
+---
+
+## Summary
+
+Scenarios 007 and 008 had population tolerance tightened from ±10% to ±5%, and
+scenario-007's required compactness was raised from 0.40 to 0.50 (PR #186, GAME-031).
+The e2e winnability tests confirm valid strategies exist, but a human playthrough is
+needed to verify the difficulty feels right — not frustrating, still educational.
+
+## Goals / Acceptance Criteria
+
+- [ ] Play scenario-007 (Reform Map) to completion and confirm a winning map is
+      findable within a reasonable number of attempts (target: <15 min)
+- [ ] Play scenario-008 (Both Sides Unhappy) to completion and confirm population
+      balance at ±5% is achievable without excessive trial-and-error
+- [ ] No scenario feels "broken" or impossible for a first-time player
+- [ ] If either scenario is too hard: file a sub-ticket to adjust thresholds and
+      revert to more lenient values
+
+## References
+
+- GAME-031 — gameplay critique followup (source of threshold changes)
+- PR #186 — threshold changes
+- `game/scenarios/scenario-007.json` — population_tolerance: 0.05, compactness: 0.50
+- `game/scenarios/scenario-008.json` — population_tolerance: 0.05

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -92,6 +92,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-007-dimensional-dot-map-demographic-overlay.md` | design, rendering | Dimensional dot map: demographic dimension switching (Option B adaptive encoding) + sorted placement toggle |
 | `GAME-056-playtest-feedback.md` | game, content, UX | Capture and act on playtest feedback — scenario balance and UX |
 | `GAME-057-scenario-randomization.md` | game, content, replayability | Per-session ±5% population/lean offsets seeded per session; e2e tests remain deterministic |
+| `GAME-058-manual-playability-test-thresholds.md` | game, content, QA | Manual playthrough of scenarios 007 and 008 to verify tightened thresholds (GAME-031) feel right |
 | `GAME-030-main-menu-and-campaigns.md` | game, UX, architecture | Main menu, campaign model, campaign select, layered navigation; replaces scenario-select-as-home |
 | `DESIGN-008-geographic-features.md` | design, rendering | Geographic features (lakes=aqua+wave, mountains=grey+hatch) as decorative non-precinct tiles; blocks contiguity |
 | `GAME-041-split-loader.md` | game, code-quality | Split loader.ts: extract runtime-types.ts primitives; name validateScenario() internally |


### PR DESCRIPTION
## Summary

Adds GAME-058 ticket for manual playability testing of scenarios 007 and 008 after the threshold tightening in GAME-031 (PR #186). Ticket and TICKETS.md index entry only — no code changes.

## Affected machines / services

N/A — ticket metadata only.

## Validation performed

N/A — ticket files only, no code.

## Deployment steps

None.

## Tickets addressed

N/A — this IS the ticket creation.

## Rollback

Revert this commit. No functional impact.
