### PR TITLE
feat(GAME-064): audio playback infrastructure — preload, mute toggle, autoplay handling

### DIFF
--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -33,6 +33,7 @@ ts_project(
         "//web/src/simulation:validity_lib",
         "//web/src/simulation:evaluate_lib",
         "//web/src/store:gameStore_lib",
+        "//web/src/audio:audioplayer_lib",
     ],
 )
 
@@ -66,6 +67,7 @@ esbuild(
         "//web/src/simulation:validity_lib",
         "//web/src/simulation:evaluate_lib",
         "//web/src/store:gameStore_lib",
+        "//web/src/audio:audioplayer_lib",
     ],
     output = "bundle.js",
     format = "esm",

--- a/game/web/src/audio/BUILD.bazel
+++ b/game/web/src/audio/BUILD.bazel
@@ -1,0 +1,68 @@
+"""
+Bazel targets for audio playback infrastructure (GAME-064):
+
+  audioplayer_lib — audioPlayer.ts (preload, play, setMuted, isMuted)
+
+This BUILD.bazel makes src/audio/ a separate Bazel package, so the parent's
+glob(["src/**/*.ts"]) no longer covers this directory. game/web/BUILD.bazel
+lists audioplayer_lib as an explicit dep on app_typecheck_lib and the
+esbuild app bundle.
+"""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//web/src/audio:__pkg__"],
+)
+
+# ── audioplayer_lib: preload, play, setMuted, isMuted ─────────────────────────
+
+ts_project(
+    name = "audioplayer_lib",
+    srcs = ["audioPlayer.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    visibility = ["//web:__subpackages__"],
+)
+
+# ── audioplayer_typecheck_test: type-check passes ────────────────────────────
+
+build_test(
+    name = "audioplayer_typecheck_test",
+    targets = [":audioplayer_lib"],
+    visibility = ["//visibility:public"],
+)
+
+# ── audioplayer_test_lib: compile the test ───────────────────────────────────
+
+ts_project(
+    name = "audioplayer_test_lib",
+    srcs = ["audioPlayer_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":audioplayer_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+# ── audioplayer_test: run tests with Node ────────────────────────────────────
+
+js_test(
+    name = "audioplayer_test",
+    entry_point = "audioPlayer_test.js",
+    data = [
+        ":audioplayer_test_lib",
+        ":audioplayer_lib",
+        "//web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/game/web/src/audio/audioPlayer.ts
+++ b/game/web/src/audio/audioPlayer.ts
@@ -1,0 +1,103 @@
+/**
+ * Audio playback infrastructure (GAME-064).
+ *
+ * Handles preloading clips, browser autoplay policy, mute toggle persisted to
+ * localStorage, and accessibility. Designed to be called by the character
+ * reaction system (GAME-062).
+ *
+ * Behavioral contract:
+ *   - preload() registers name → URL mappings and creates <audio> elements.
+ *   - play() silently no-ops if muted, if the name is unknown, or if the
+ *     browser blocks autoplay (catches the resulting DOMException / rejected
+ *     Promise).
+ *   - setMuted() persists the state to localStorage.
+ *   - isMuted() reads from localStorage on first access; defaults to false.
+ *   - prefers-reduced-motion does NOT affect audio (independent preferences).
+ */
+
+const MUTE_KEY = "redistricting-sim-audio-muted";
+
+/** Clip registry: name → HTMLAudioElement */
+const _clips: Map<string, HTMLAudioElement> = new Map();
+
+/** Cached mute state. `undefined` means "not yet read from localStorage". */
+let _mutedCache: boolean | undefined = undefined;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Register a set of clip names → URLs and create <audio> elements for each
+ * so the browser can begin preloading them.
+ */
+export function preload(clips: Record<string, string>): void {
+  for (const [name, url] of Object.entries(clips)) {
+    const el = new Audio(url);
+    el.preload = "auto";
+    _clips.set(name, el);
+  }
+}
+
+/**
+ * Play a registered clip by name.
+ * Silent no-op when:
+ *   - muted
+ *   - name not registered
+ *   - browser autoplay policy blocks playback
+ */
+export function play(name: string): void {
+  if (isMuted()) return;
+  const el = _clips.get(name);
+  if (el === undefined) return;
+
+  try {
+    const result = el.play();
+    // play() returns a Promise in modern browsers; catch policy rejections.
+    if (result !== undefined) {
+      result.catch(() => {
+        // Autoplay blocked or interrupted — silently ignore.
+      });
+    }
+  } catch {
+    // Synchronous throw (older browsers) — silently ignore.
+  }
+}
+
+/**
+ * Set mute state and persist it to localStorage.
+ */
+export function setMuted(muted: boolean): void {
+  _mutedCache = muted;
+  try {
+    localStorage.setItem(MUTE_KEY, muted ? "true" : "false");
+  } catch {
+    // Storage unavailable — silently ignore.
+  }
+}
+
+/**
+ * Return the current mute state. Reads from localStorage on first call;
+ * defaults to false if the key is absent or storage is unavailable.
+ */
+export function isMuted(): boolean {
+  if (_mutedCache !== undefined) return _mutedCache;
+  try {
+    const raw = localStorage.getItem(MUTE_KEY);
+    _mutedCache = raw === "true";
+  } catch {
+    _mutedCache = false;
+  }
+  return _mutedCache;
+}
+
+// ─── Test-only helpers ────────────────────────────────────────────────────────
+
+/**
+ * Reset all module-level state. FOR TESTING ONLY.
+ *
+ * Clears the clip registry and nulls the mute cache so each test starts from
+ * a known-clean slate without carrying over clips registered in prior tests.
+ */
+export function _resetForTesting(): void {
+  _clips.clear();
+  _mutedCache = undefined;
+}

--- a/game/web/src/audio/audioPlayer_test.ts
+++ b/game/web/src/audio/audioPlayer_test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for audioPlayer.ts (GAME-064).
+ *
+ * Uses the shared TAP runner. Run via Bazel:
+ *   bazel test //web/src/audio:audioplayer_test
+ *
+ * Neither `localStorage` nor `Audio` exist in Node. Both are shimmed on
+ * globalThis before the module under test is imported so the audio functions
+ * hit the shims rather than missing globals.
+ *
+ * Coverage:
+ *   mute toggle:
+ *     - setMuted(true) → isMuted() === true
+ *     - setMuted(false) → isMuted() === false
+ *     - mute state round-trips through localStorage (persisted + reloaded)
+ *   play():
+ *     - no-ops when muted (no error thrown; Audio.play() never called)
+ *     - no-ops for unknown clip name (no error thrown)
+ *     - silently no-ops when play() returns a rejected Promise (autoplay policy)
+ *     - silently no-ops when play() throws synchronously (older browsers)
+ *   preload():
+ *     - registers clip names; play() of unknown name → silent no-op
+ *     - play() of registered clip attempts playback when unmuted
+ */
+
+// ─── localStorage shim (must be set up before importing audioPlayer.ts) ──────
+
+const _store: Map<string, string> = new Map();
+
+const localStorageShim = {
+  getItem(key: string): string | null {
+    return _store.get(key) ?? null;
+  },
+  setItem(key: string, value: string): void {
+    _store.set(key, value);
+  },
+  removeItem(key: string): void {
+    _store.delete(key);
+  },
+  clear(): void {
+    _store.clear();
+  },
+};
+
+(globalThis as unknown as Record<string, unknown>)["localStorage"] = localStorageShim;
+
+// ─── Audio element shim ───────────────────────────────────────────────────────
+
+/** Tracks whether play() was called on any shim instance. */
+let _audioPlayCalled = false;
+
+/**
+ * Controls what the next AudioShim.play() call returns.
+ * Default: Promise.resolve() (normal success).
+ * Tests that exercise autoplay rejection or synchronous throw set this
+ * to the desired failure mode before calling play().
+ */
+let _nextPlayResult: "resolve" | "reject" | "throw" = "resolve";
+
+class AudioShim {
+  src: string;
+  preload: string = "auto";
+
+  constructor(src: string) {
+    this.src = src;
+  }
+
+  play(): Promise<void> {
+    _audioPlayCalled = true;
+    if (_nextPlayResult === "throw") {
+      throw new DOMException("NotAllowedError", "NotAllowedError");
+    }
+    if (_nextPlayResult === "reject") {
+      return Promise.reject(new DOMException("NotAllowedError", "NotAllowedError"));
+    }
+    return Promise.resolve();
+  }
+}
+
+(globalThis as unknown as Record<string, unknown>)["Audio"] = AudioShim;
+
+// ─── Imports (after shims are installed) ─────────────────────────────────────
+
+import { preload, play, setMuted, isMuted, _resetForTesting } from "./audioPlayer.js";
+import { test, assertEqual, assertTrue, assertFalse, assertDoesNotThrow, summarize } from "../testing/test_runner.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function resetAll(): void {
+  _store.clear();
+  _audioPlayCalled = false;
+  _nextPlayResult = "resolve";
+  // _resetForTesting() clears the clip registry and nulls the in-memory mute
+  // cache so each test begins from a clean slate without carrying over clips
+  // or stale cache values from prior tests.
+  _resetForTesting();
+}
+
+// ─── isMuted() defaults ───────────────────────────────────────────────────────
+
+test("isMuted: defaults to false when key absent from localStorage", () => {
+  resetAll();
+  assertFalse(isMuted(), "should be false by default");
+});
+
+// ─── setMuted / isMuted round-trip ───────────────────────────────────────────
+
+test("setMuted(true) → isMuted() === true", () => {
+  resetAll();
+  setMuted(true);
+  assertTrue(isMuted(), "isMuted should be true after setMuted(true)");
+});
+
+test("setMuted(false) → isMuted() === false", () => {
+  resetAll();
+  setMuted(true);
+  setMuted(false);
+  assertFalse(isMuted(), "isMuted should be false after setMuted(false)");
+});
+
+test("mute state is persisted to localStorage key", () => {
+  resetAll();
+  setMuted(true);
+  const raw = _store.get("redistricting-sim-audio-muted");
+  assertEqual(raw, "true", "localStorage should hold 'true'");
+});
+
+test("unmute state is persisted to localStorage key", () => {
+  resetAll();
+  setMuted(true);
+  setMuted(false);
+  const raw = _store.get("redistricting-sim-audio-muted");
+  assertEqual(raw, "false", "localStorage should hold 'false'");
+});
+
+// ─── play() when muted ───────────────────────────────────────────────────────
+
+test("play() no-ops when muted — no error thrown", () => {
+  resetAll();
+  preload({ beep: "stub://beep.mp3" });
+  setMuted(true);
+  assertDoesNotThrow(() => play("beep"), "play() should not throw when muted");
+});
+
+test("play() does not start audio when muted", () => {
+  resetAll();
+  preload({ beep: "stub://beep.mp3" });
+  setMuted(true);
+  _audioPlayCalled = false;
+  play("beep");
+  assertFalse(_audioPlayCalled, "Audio.play() must not be called when muted");
+});
+
+// ─── play() with unknown name ─────────────────────────────────────────────────
+
+test("play() of unknown clip name — no error thrown", () => {
+  resetAll();
+  setMuted(false);
+  assertDoesNotThrow(() => play("nonexistent"), "play() should not throw for unknown name");
+});
+
+test("play() of unknown clip name — no audio started", () => {
+  resetAll();
+  setMuted(false);
+  _audioPlayCalled = false;
+  play("nonexistent");
+  assertFalse(_audioPlayCalled, "Audio.play() must not be called for unknown name");
+});
+
+// ─── preload() + play() ───────────────────────────────────────────────────────
+
+test("preload() registers clips; play() of registered name attempts playback", () => {
+  resetAll();
+  preload({ chime: "stub://chime.mp3" });
+  setMuted(false);
+  _audioPlayCalled = false;
+  play("chime");
+  assertTrue(_audioPlayCalled, "Audio.play() should be called for a registered, unmuted clip");
+});
+
+test("preload() multiple clips; each registered independently", () => {
+  resetAll();
+  preload({ a: "stub://a.mp3", b: "stub://b.mp3" });
+  setMuted(false);
+  _audioPlayCalled = false;
+  play("a");
+  assertTrue(_audioPlayCalled, "clip 'a' should be playable");
+  _audioPlayCalled = false;
+  play("b");
+  assertTrue(_audioPlayCalled, "clip 'b' should be playable");
+});
+
+// ─── play() autoplay-rejection handling ──────────────────────────────────────
+
+test("play() silently no-ops when browser rejects play() Promise (autoplay policy)", () => {
+  resetAll();
+  preload({ blocked: "stub://blocked.mp3" });
+  setMuted(false);
+  _nextPlayResult = "reject";
+  // play() attaches a .catch() to the rejected Promise, so it must not throw
+  // synchronously and must not surface an unhandled rejection.
+  assertDoesNotThrow(() => play("blocked"), "play() must not throw on Promise rejection");
+});
+
+test("play() silently no-ops when play() throws synchronously (older browser)", () => {
+  resetAll();
+  preload({ blocked: "stub://blocked.mp3" });
+  setMuted(false);
+  _nextPlayResult = "throw";
+  assertDoesNotThrow(() => play("blocked"), "play() must not throw when Audio.play() throws synchronously");
+});
+
+summarize();

--- a/game/web/src/audio/tsconfig.json
+++ b/game/web/src/audio/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "declaration": true
+  }
+}

--- a/thoughts/shared/tickets/GAME-064-audio-playback-infrastructure.md
+++ b/thoughts/shared/tickets/GAME-064-audio-playback-infrastructure.md
@@ -4,6 +4,7 @@ title: Audio playback infrastructure — preload, mute toggle, autoplay handling
 area: game, UX, infrastructure
 status: open
 created: 2026-05-02
+github_issue: 193
 ---
 
 ## Summary


### PR DESCRIPTION
## Summary

- Adds `game/web/src/audio/audioPlayer.ts` — the `AudioPlayer` module exposing `preload()`, `play()`, `setMuted()`, and `isMuted()`.
- `play()` silently no-ops when muted, when the clip name is unknown, or when the browser blocks autoplay (catches rejected Promise from `HTMLAudioElement.play()`).
- `setMuted()` persists to localStorage key `redistricting-sim-audio-muted`; `isMuted()` reads it on first access, defaulting to `false`.
- Wires `//web/src/audio:audioplayer_lib` into `app_typecheck_lib` and the esbuild `app` bundle in `game/web/BUILD.bazel`.

## Affected machines / services

- N/A — infrastructure-only; no audio files included, no runtime behavior visible to end users until GAME-062 calls into this module.

## Validation performed

- `bazel test //web/src/audio:all` — 2/2 tests pass (`audioplayer_test`, `audioplayer_typecheck_test`).
- `bazel build //web:app` — esbuild bundle builds cleanly with the new dep wired in.
- `bazel test //web:app_typecheck_test` — type-check passes.
- Node localStorage and Audio shims are set up before module import, matching the pattern in `progress_wip_test.ts`.

## Deployment steps

- N/A — static asset; deployed as part of normal game bundle.

## Tickets addressed

- Closes #193 (GAME-064: Audio playback infrastructure)

## Rollback

- Revert this PR. The module is not called by any existing code so rollback has no user-visible effect.
