### PR TITLE
chore(DESIGN-009): resolve open questions — player avatar, split-screen capability, format flexibility

### DIFF
--- a/thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.compressed.md
+++ b/thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.compressed.md
@@ -1,53 +1,87 @@
 <!--COMPRESSED v1; source:2026-05-02-design-009-character-reaction-visual-style.md-->
 §META
-date:2026-05-02 researcher:Claude(Sonnet 4.6) topic:character-reaction-art-style-audio
-tags:design,art,audio,result-screen,animation status:draft
+date:2026-05-02 last_updated:2026-05-02 researcher:Claude(Sonnet 4.6)
+topic:character-reaction-art-style-audio status:decisions-complete approved
 
 §ABBREV
 ts=thoughts/shared pb=partisan-boss la=legal-authority bb=bipartisan-broker
-ra=reform-arbiter na=neutral-admin
+ra=reform-arbiter na=neutral-admin ins=instigator
 
 §SUMMARY
-Result screen reactions come from stakeholder characters (boss,judge,commissioner) who react to the
-player's submitted map. 5 character types across 10 scenarios. Recommendation: inline SVG + CSS
-pass/fail class toggle + @keyframes. AI-generated SVG (Claude primary, other multimodal fallback).
-CC0 audio preferred; AI-generated audio as fallback.
+Player = neutral consultant ("just a job"). $ins (boss/customer who hired player) reacts on
+star count (3/2/1/0) — not binary pass/fail. $ins animation plays LAST after all
+per-criterion animations finish. 5 $ins types, curated roster, scenarios pick one.
+Design space reserved for custom $ins art in future custom-scenario tooling (no impl now).
+Format: 20 SVG files (5 types × 4 states). Per-state files (not multi-state).
 
 §ROSTER
-| type | scenarios | pass | fail |
-|---|---|---|---|
-| $pb | 002 003 004(Ken) 009(Cat) | fist pump / flag wave | head in hands |
-| $la | 005 | gavel bang (approval), scales balanced | gavel bang (reject), scales tipped |
-| $bb | 006 | handshake | crossed arms |
-| $ra | 007 008 | thumbs up, balanced scales | thumbs down, head shake |
-| $na | tutorial-001 tutorial-002 | checkmark nod | shrug |
-note: 006 special case — 2 characters simultaneously (one per party); cheering party vs silent other
+| type | scenarios | $ins | 3-star | 2-star | 1-star | 0-star |
+|---|---|---|---|---|---|---|
+| $pb | 002 003 004(Ken) 009(Cat) | party boss | fist pump ecstatic | satisfied thumbs up | grudging shrug | head in hands furious |
+| $la | 005 | federal judge | gavel+scales balanced beaming | measured nod | furrowed reluctant | gavel scales tipped rejection |
+| $bb | 006 | both party bosses (side-by-side) | both handshake celebratory | cautious handshake | one nods other uncertain | both crossed arms |
+| $ra | 007 008 | reform commission | bright thumbs-up balanced-scales | steady approval | reserved acknowledgment | thumbs-down head-shake |
+| $na | tutorial-001 tutorial-002 | supervisor | checkmark warm-smile | approving nod | mild nod "acceptable" | shrug disappointed |
+state CSS names: three-star two-star one-star zero-star
+006 special: both bosses share outcome (criteria req BOTH parties); split-screen = general capability for future asymmetric outcomes
 
 §OPTIONS
-A pure-CSS: ruled out — no character personality
-B inline-SVG+CSS-animation: RECOMMENDED — resolution-independent; hand-authorable; <8KB/char; no lib;
-  AI-gen SVG viable; CSS @keyframes; pass/fail via class toggle
-C pixel-art sprites: viable alt — retro charm; Aseprite workflow; integer CSS scaling; higher AI-gen overhead
-D Lottie: ruled out — 40KB lib; AE tooling; overkill
-E CSS+emoji: ruled out — GAME-052 placeholder; not the goal
+A pure-CSS: ruled out — no personality
+B inline-SVG+per-state-file: CHOSEN — 20 files (5×4); AI-gen one pose at a time; easy per-state iteration
+C pixel-art: viable future re-skin — not current approach
+D Lottie: ruled out — 40KB lib overkill
+E CSS+emoji: ruled out — placeholder only
 
-§RECOMMENDATION
-format: inline SVG + CSS .pass/.fail + @keyframes; 5 SVG files
-style: flat minimal 2-3 colors/char; silhouette-readable at 160-200px; political-cartoon/board-game-token aesthetic
-palette: $pb=party-gold/red $la=slate-blue $bb=split-half-and-half $ra=teal/green $na=muted-grey-blue
-  all against dark game background
-animation: 0.6-1.0s loopable; suppressed by prefers-reduced-motion
-audio: preloaded MP3+OGG; 10 clips (5 types × pass/fail); target <100KB/clip
-  source priority: (1)CC0 freesound.org/pixabay (2)AI-generated (3)CC-BY with attribution
+§FILE_SCHEMA
+path: assets/characters/{type}/{state}.svg
+types: partisan-boss legal-authority bipartisan-broker reform-arbiter neutral-admin
+states: three-star two-star one-star zero-star
+ext: .svg now; path otherwise format-agnostic for re-skin
 
-§OPEN_QUESTIONS
-1 pixel-art vs flat SVG — flat SVG more consistent with dark-HUD strategy aesthetic; pixel art adds retro-playful
-2 006 two-character case — simultaneous split-screen vs sequential; simultaneous more expressive, doubles layout complexity
-3 tutorial character — full $na animation vs skip for tutorials (lower emotional charge)
-all 3 to be resolved during DESIGN-009 ticket work
+§STYLE
+viewBox: 0 0 200 200 (ALL files — uniform coordinate space)
+background: transparent
+character: center 140×160px of viewBox; head near y=30; feet near y=190; centered horiz
+head-body ratio: ~1:2 (board-game token / political-cartoon)
+fills: flat; no gradients; no drop-shadows
+stroke: 2-3px primary outline; 1-2px interior detail
+colors: max 3 fills per char + shared dark outline (~#1a1a2e); transparent bg
+detail: silhouette reads clearly at 160px display — no fine detail that disappears
+palette: $pb=gold/red $la=slate-blue $bb=split-warm-red/cool-blue $ra=teal/green $na=muted-grey-blue
+
+§CONSISTENCY [EMBED IN EVERY GAME-060 ART-GEN PROMPT]
+cross-type: same viewBox, same body scale, same foot/head placement — one illustration set
+same type across states: same character, only pose+expression changes
+types differ by: accent color + silhouette shape + costume/prop (must be distinct silhouettes)
+state poses (applies to all types):
+  three-star: open expansive celebratory — arms up, big gesture, leaning forward
+  two-star: positive composed — thumbs up or approving nod, upright
+  one-star: reserved ambivalent — slight lean or crossed arms, neutral expression
+  zero-star: closed negative — hunched or turned away, disapproving gesture
+animation: subtle idle only (bob/blink/breathing 0.6-1.0s loop); pose = SVG geometry not keyframes
+prefers-reduced-motion: handled by wrapper CSS, not in SVG
+
+§AUDIO
+20 clips (5 types × 4 states); collapse to 2/type (celebratory/disappointed) if authoring 20 proves impractical
+all: 0.5-1.5s loop-free board-game/casual register
+| type | 3-star | 2-star | 1-star | 0-star |
+|---|---|---|---|---|
+| $pb | triumphant brass sting | upbeat resolution chord | flat "close enough" sting | trombone wah-wah |
+| $la | formal gavel+ascending chime | measured chime | neutral gavel tap | gavel+descending tone |
+| $bb | warm celebratory chord | mild positive chord | subdued uncertain chord | dull thud resigned |
+| $ra | bright civic fanfare | soft steady chime | quiet acknowledgment | soft negative buzz |
+| $na | affirming ding warm | soft approving click | flat neutral click | brief flat shrug sound |
+
+§DECISIONS
+1 format→inline SVG per-state file; path schema format-agnostic
+2 006 case→split-screen both bosses; general capability for asymmetric future scenarios
+3 tutorial→full $na reaction; tutorials=level-1 core loop
+4 $ins model→no player avatar; $ins reacts on star count (3/2/1/0); plays last after criteria
+5 20 files (5×4)→one file per state; AI-gen one pose at a time; easier per-state iteration
+6 consistency spec→embed in every GAME-060 art-gen prompt; cross-set coherence > individual perfection
 
 §REFS
-game/scenarios/*.json → narrative.character field (all 10 scenarios)
+game/scenarios/*.json → narrative.character (all 10 scenarios)
 $ts/tickets/DESIGN-009-character-reaction-visual-style.md
 $ts/tickets/GAME-060-character-sprite-assets.md
 $ts/tickets/GAME-061-audio-clips.md

--- a/thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.md
+++ b/thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.md
@@ -1,97 +1,200 @@
 # DESIGN-009: Character Reaction Visual Style Research
 
 **Date:** 2026-05-02  
+**Last updated:** 2026-05-02  
 **Researcher:** Claude (Sonnet 4.6)  
 **Topic:** Art style, character roster, and animation approach for result screen reactions  
-**Status:** draft — open questions to be resolved during DESIGN-009 ticket work
+**Status:** decisions complete — approved
 
 ---
 
 ## Summary
 
-Every scenario casts the player as "You" in a named role, but the *reactions* on the
-result screen should come from the stakeholders who hired or empowered you — the
-partisan boss, the judge, the reform commissioner. The result screen is the right
-moment to make them appear: they see the map you drew and respond.
+The player is a neutral consultant hired to draw a map. They have no stake in the
+political outcome — it's "just a job." The person who *does* have a stake is the
+instigator: the party boss, judge, reform commissioner, or supervisor who hired or
+empowered the player. On the result screen, the instigator reacts to how well the
+player delivered — graded by star count, not binary pass/fail.
 
-This document surveys visual style options, derives a character type taxonomy from
-the current scenario set, and makes a format recommendation.
+The instigator's animation plays last, after all per-criterion reveal animations
+finish, as the final emotional beat. Different scenarios pick from a curated roster
+of instigator types. Design space is reserved for custom instigator art in future
+custom-scenario tooling, but that functionality is not implemented now.
 
 ---
 
-## Character Roster
+## Instigator Roster
 
-All ten scenarios map to five distinct character types.
+Five instigator types cover all current scenarios. Future scenarios pick from this
+roster (or, in future custom-scenario tooling, supply their own art).
 
-| Type | Scenarios | Character who reacts | Pass | Fail |
-|---|---|---|---|---|
-| Partisan Boss | 002, 003, 004 (Ken); 009 (Cat) | Party boss who hired you | Fist pump, flag wave | Head in hands |
-| Legal Authority | 005 | Federal judge | Gavel bang (approval), scales balanced | Gavel bang (reject), scales tipped |
-| Bipartisan Broker | 006 | Both party bosses (one each side) | Handshake | Crossed arms |
-| Reform Arbiter | 007, 008 | Reform commission | Thumbs up, balanced scales | Thumbs down, head shake |
-| Neutral Admin | tutorial-001, tutorial-002 | Supervisor | Checkmark nod | Shrug |
+| Type | Scenarios | Instigator | 3-star | 2-star | 1-star | 0-star |
+|---|---|---|---|---|---|---|
+| Partisan Boss | 002, 003, 004 (Ken); 009 (Cat) | Party boss who hired you | Fist pump, ecstatic | Satisfied nod, thumbs up | Grudging shrug, "close enough" | Head in hands, furious |
+| Legal Authority | 005 | Federal judge | Gavel bang + scales balanced, beaming | Measured nod, gavel tap | Furrowed brow, reluctant approval | Gavel bang, scales tipped, rejection |
+| Bipartisan Broker | 006 | Both party bosses (side-by-side) | Both bosses handshake, celebratory | Cautious handshake | One boss nods, other uncertain | Both bosses crossed arms, displeased |
+| Reform Arbiter | 007, 008 | Reform commission | Bright thumbs up, balanced scales | Steady approval, nod | Reserved acknowledgment | Thumbs down, head shake |
+| Neutral Admin | tutorial-001, tutorial-002 | Supervisor | Checkmark, warm smile | Approving nod | Mild nod, "acceptable" | Shrug, disappointed |
 
-Scenario-006 is a special case: two characters appear simultaneously (one per party).
-The party whose interests were served cheers; the other does not.
+**State names** (CSS classes applied to the SVG): `three-star`, `two-star`, `one-star`, `zero-star`.
+
+**Scenario-006 note:** The Bipartisan Broker type shows both party bosses simultaneously.
+Both share the same outcome state (the criteria require safe seats for BOTH parties,
+so there is no asymmetric outcome in current scenarios). Split-screen layout is
+designed as a general capability for future scenarios with asymmetric party outcomes
+— the implementation supports different state per panel.
+
+**Custom scenario extensibility:** Leave design space in file layout and loading code
+for a future custom-scenario author to supply their own instigator SVG. No
+implementation required now; just avoid hard-coding the roster as a closed enum.
 
 ---
 
 ## Visual Style Options
 
 ### Option A — Pure CSS characters
-Ruled out. Cannot convey distinct character types or "cute" personality.
+Ruled out. Cannot convey distinct character types or personality.
 
-### Option B — Inline SVG + CSS animation (recommended)
-Each character is a self-contained SVG with pass/fail states toggled via CSS class.
-Animated with `@keyframes`. Resolution-independent, hand-authorable, < 8 KB per
-character, no library needed. AI-generated SVG (Claude as primary, other multimodal
-models as fallback) is the planned production method.
+### Option B — Inline SVG + CSS animation (chosen)
+Each state is a separate SVG file. Pass/fail toggling replaced by 4-state class
+system. Animated with `@keyframes`. Resolution-independent, AI-generable,
+< 10 KB per file. No library needed.
 
 ### Option C — Pixel art sprite sheets
-Viable alternative. Retro charm, Aseprite workflow, small file sizes. Requires
-integer CSS scaling (`image-rendering: pixelated`). Higher authoring overhead than
-SVG for AI generation.
+Viable future re-skin. Retro charm, smaller files, Aseprite workflow. Higher
+overhead for AI generation. Integer CSS scaling required. Not the current approach.
 
 ### Option D — Lottie
-Ruled out. 40 KB library overhead, requires AE tooling, overkill for 5 characters.
+Ruled out. 40 KB library overhead, requires AE tooling, overkill.
 
 ### Option E — CSS + emoji
-Ruled out. This is the existing GAME-052 placeholder; not the goal.
+Ruled out. Existing GAME-052 placeholder; not the goal.
 
 ---
 
 ## Recommendation
 
-**Format:** Inline SVG + CSS `.pass` / `.fail` class toggle + `@keyframes`. 5 SVG files.
+**Format:** 20 SVG files — 5 instigator types × 4 star-count states.  
+**File path schema:** `assets/characters/{type}/{state}.svg`  
+  - type: `partisan-boss`, `legal-authority`, `bipartisan-broker`, `reform-arbiter`, `neutral-admin`  
+  - state: `three-star`, `two-star`, `one-star`, `zero-star`  
+  - Extension is `.svg` now; path schema is otherwise format-agnostic for future re-skin.
 
 **Style:** Flat, minimal, 2–3 colors per character. Silhouette-readable at 160–200 px.
 Political-cartoon / board-game-token aesthetic.
 
-**Palette:** each type gets a distinct accent against the dark game background:
-- Partisan Boss: party gold / red
-- Legal Authority: slate blue
-- Bipartisan Broker: split half-and-half
-- Reform Arbiter: teal / green
-- Neutral Admin: muted grey-blue
+**Palette:**
+- Partisan Boss: party gold / red accent
+- Legal Authority: slate blue accent
+- Bipartisan Broker: split warm-red / cool-blue (one per boss)
+- Reform Arbiter: teal / green accent
+- Neutral Admin: muted grey-blue accent
+- All: dark outline (~#1a1a2e or near-black), transparent background (game provides dark HUD chrome)
 
-**Animation:** 0.6–1.0 s loopable; suppressed by `prefers-reduced-motion`.
+**Animation:** loopable 0.6–1.0 s CSS `@keyframes` within each SVG. State is set by
+loading the appropriate file (no CSS class switching needed — each file is one state).
+`prefers-reduced-motion` handled by the reaction system wrapper, not per-file.
 
-**Audio:** preloaded MP3 + OGG. 10 clips (5 types × pass/fail). Source priority:
-(1) CC0 from freesound.org / pixabay, (2) AI-generated audio, (3) CC-BY with
-attribution. Target < 100 KB per clip.
+**Audio:** 20 clips — 5 types × 4 states (or collapsed to fewer grades if authoring
+20 distinct clips proves impractical; minimum 2 per type: celebratory / disappointed).
+See GAME-061 for clip strategy. All clips: 0.5–1.5 s, loop-free, board-game/casual
+register.
 
 ---
 
-## Open Questions (to be resolved in DESIGN-009 ticket work)
+## AI Art Generation — Consistency Guidelines
 
-1. **Pixel art vs flat SVG?** Flat SVG is more consistent with the current dark-HUD
-   strategy aesthetic. Pixel art adds retro-playful feel. Decision pending.
+These constraints must be embedded in every art-generation prompt for GAME-060.
+Consistency across the set is more important than perfection of individual files.
 
-2. **Scenario-006 two-character case:** show both bosses simultaneously (split screen)
-   or sequentially? Simultaneous is more expressive but doubles layout complexity.
+### Structure
+- `viewBox="0 0 200 200"` on every SVG — uniform coordinate space
+- Transparent background — `<rect>` fill only if needed for game-specific dark background
+- Character occupies approximately the center 140×160 px of the 200×200 viewBox
+- Head-to-body ratio ≈ 1:2 (board-game token / political cartoon proportion)
+- Character is centered horizontally; feet near y=190, head near y=30
 
-3. **Tutorial character:** lowest emotional charge. Full neutral-admin reaction, or
-   skip the character animation for tutorials?
+### Style
+- Flat fills, no gradients, no drop shadows
+- Stroke weight: 2–3 px for primary outlines; 1–2 px for interior details
+- Maximum 3 fill colors per character (plus the shared outline color)
+- No fine detail that disappears at 160 px display size — silhouette must read clearly
+- Each type must be **visually distinct as a silhouette** — different head shape, hat,
+  accessory, or body outline (the player needs to recognize them at a glance)
+
+### Cross-type consistency
+- Same viewBox, same body scale, same foot/head placement across all 20 files
+- Characters should feel like they come from the same illustration set — consistent
+  line weight, same visual grammar, same level of detail
+- Different types differ in: accent color, silhouette shape, costume/prop
+- Same type across 4 states: same character, only pose and expression change
+
+### State poses (same type, 4 poses)
+- `three-star`: open, expansive, celebratory — arms up, leaning forward, big gesture
+- `two-star`: positive, composed — thumbs up or approving nod, upright
+- `one-star`: reserved, ambivalent — slight lean or crossed arms, neutral expression
+- `zero-star`: closed, negative — hunched or turned away, disapproving gesture
+
+### Animation
+- Each SVG file represents one static pose with a short looping idle animation
+- Idle animation: subtle only — gentle bob, blink, or breathing motion (0.6–1.0 s loop)
+- The pose itself (the star state) is expressed through the SVG geometry, not keyframes
+- `prefers-reduced-motion` suppression is handled by the wrapper CSS, not in the SVG
+
+---
+
+## Audio Tone Per Instigator Type
+
+| Type | 3-star | 2-star | 1-star | 0-star |
+|---|---|---|---|---|
+| Partisan Boss | Short triumphant brass sting; punchy | Upbeat resolution chord | Flat "close enough" sting | Trombone wah-wah deflation |
+| Legal Authority | Formal gavel + ascending chime | Measured chime | Single neutral gavel tap | Gavel + descending tone; austere |
+| Bipartisan Broker | Warm celebratory chord; handshake-feel | Mild positive chord | Subdued chord; uncertain | Dull thud; resigned |
+| Reform Arbiter | Bright civic fanfare; optimistic | Soft chime; steady | Quiet acknowledgment tone | Soft negative buzz or descending chime |
+| Neutral Admin | Affirming ding; warm | Soft click; approving | Flat neutral click | Brief flat shrug sound |
+
+All clips: 0.5–1.5 s, loop-free, no dramatic buildup. Board-game / casual-strategy
+tonal register.
+
+---
+
+## Decisions
+
+**1. SVG vs pixel art — inline SVG; format-agnostic path schema.**
+
+SVG is the current format. The game vision doc (§TEST) names CSS/SVG loops as the
+reference style. The dark-HUD strategy aesthetic is inconsistent with retro pixel charm.
+Path schema (`assets/characters/{type}/{state}.*`) is otherwise format-agnostic —
+no SVG-specific assumptions in loading code.
+
+**2. Scenario-006 two-character case — simultaneous split-screen; general capability.**
+
+Both party bosses appear side-by-side (shared outcome in current scenario). Designed
+as a general capability: future scenarios may have asymmetric outcomes per panel.
+
+**3. Tutorial character — full neutral-admin reaction.**
+
+Tutorials are level 1 of the core game loop. Skipping animation there creates an
+inconsistent first impression and signals reactions are optional rather than core UI.
+
+**4. Instigator model — no player avatar; instigator reacts on star count.**
+
+The player is a neutral consultant ("just a job"). The instigator (the person who hired
+the player) reacts based on how well the player delivered, graded by star count
+(3/2/1/0). This replaces the earlier "player avatar" concept. The instigator's
+animation plays last, after all per-criterion animations finish.
+
+**5. 20 files (one per state) vs 6 files (multi-state SVG).**
+
+20 files (5 types × 4 states), one SVG file per state. Simpler to AI-generate
+(describe one pose at a time), easier to iterate individual states independently.
+Can revisit merging into multi-state files if it later becomes worthwhile.
+
+**6. Consistency guidelines required for AI art generation.**
+
+A shared consistency spec (viewBox, body scale, stroke weight, style grammar) must be
+embedded in every art-generation agent prompt for GAME-060. Cross-set consistency is
+more important than perfection of any individual file.
 
 ---
 

--- a/thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md
+++ b/thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md
@@ -4,6 +4,7 @@ title: Character reaction visual style — result screen art direction
 area: design, UX, art
 status: open
 created: 2026-05-02
+github_issue: 197
 ---
 
 ## Summary
@@ -20,16 +21,20 @@ motivation) which gives us the character roster. No art style has been decided.
 
 ## Goals / Acceptance Criteria
 
-- [ ] Art style decided: inline SVG + CSS animation (preferred) or pixel art sprite
+- [x] Art style decided: inline SVG + CSS animation (preferred) or pixel art sprite
       sheet — with rationale documented
-- [ ] Open questions resolved: pixel art vs flat SVG; scenario-006 two-character
-      simultaneous vs sequential display; tutorial scenarios — full reaction or skip
-- [ ] Character roster finalized: enumerate all distinct character types across
-      scenarios and map each scenario to its character type
-- [ ] Pass/fail animation states defined per character type
-- [ ] Reference mockups or style guide produced (AI-generated SVG drafts acceptable)
-- [ ] Audio tone per character type described — input for GAME-061
-- [ ] Format decision documented: dimensions, file format, color palette
+- [x] Open questions resolved: pixel art vs flat SVG; scenario-006 two-character
+      display; tutorial scenarios; instigator model (no player avatar); 20 files
+      (one per state); consistency spec for AI art generation; format re-skinning
+      flexibility; split-screen as general capability for asymmetric party outcomes
+- [x] Character roster finalized: 5 instigator types; each scenario mapped to
+      its instigator type; custom art design space reserved (no impl)
+- [x] Animation states defined: instigator types — 3-star/2-star/1-star/0-star
+      (4 states each); instigator plays last after per-criterion animations
+- [x] Reference mockups or style guide produced (AI-generated SVG drafts acceptable)
+      NOTE: visual style guide documented; actual SVG drafts deferred to GAME-060
+- [x] Audio tone per character type described — input for GAME-061
+- [x] Format decision documented: dimensions, file format, color palette
 
 ## References
 

--- a/thoughts/shared/tickets/GAME-060-character-sprite-assets.md
+++ b/thoughts/shared/tickets/GAME-060-character-sprite-assets.md
@@ -8,25 +8,34 @@ created: 2026-05-02
 
 ## Summary
 
-Create the character art and animation assets for result screen reactions — one set
-per character type (partisan boss, legal authority, bipartisan broker, reform arbiter,
-neutral admin) with pass and fail animation states. Format and style defined by
-DESIGN-009. Art will be AI-generated (Claude SVG generation as primary approach;
-Grok/other multimodal models as fallback if quality is insufficient).
+Create the instigator character art for result screen reactions — one SVG file per
+instigator type × star-count state (5 types × 4 states = 20 files). The instigator
+is the person who hired the player (party boss, judge, reform commissioner, etc.)
+and reacts based on how well the player delivered, graded by star count (3/2/1/0).
+Format and consistency spec defined by DESIGN-009. Art will be AI-generated (Claude
+SVG as primary; Grok/other multimodal models as fallback).
 
 ## Current State
 
 No character art exists. The result screen shows a 🎉/💔 emoji placeholder (GAME-052).
+DESIGN-009 defines the full consistency spec — it MUST be read before generating any
+art (embed the §CONSISTENCY section in every generation prompt).
 
 ## Goals / Acceptance Criteria
 
-- [ ] One asset per character type × 2 states (pass / fail) — 10 assets total
-- [ ] Assets match the format decided in DESIGN-009 (SVG preferred)
-- [ ] Pass state: character expresses approval (thumbs up, cheering, etc.)
-- [ ] Fail state: character expresses disapproval (thumbs down, booing, etc.)
-- [ ] File sizes appropriate for browser delivery (target: < 20 KB per SVG)
-- [ ] Assets placed in `game/web/assets/characters/` (see GAME-063)
-- [ ] Accessible alt-text description for each character/state
+- [ ] 20 SVG files: 5 instigator types × 4 states (three-star/two-star/one-star/zero-star)
+- [ ] File naming: `assets/characters/{type}/{state}.svg`
+      types: partisan-boss, legal-authority, bipartisan-broker, reform-arbiter, neutral-admin
+- [ ] All files use `viewBox="0 0 200 200"`, transparent background
+- [ ] Character occupies center ~140×160 px; head ~y=30, feet ~y=190, centered horiz
+- [ ] Flat fills, 2–3 colors per type, 2–3 px stroke, no gradients
+- [ ] Each type has a visually distinct silhouette readable at 160 px
+- [ ] Same type across 4 states: same character, only pose+expression changes
+- [ ] State poses match DESIGN-009 spec (three-star=expansive celebratory; two-star=composed positive; one-star=reserved; zero-star=closed/disapproving)
+- [ ] Subtle idle animation (bob/blink/breathing, 0.6–1.0 s loopable) in each SVG
+- [ ] File sizes < 15 KB per SVG
+- [ ] Assets placed in `game/web/assets/characters/{type}/` (GAME-063 pipeline must be merged first)
+- [ ] Accessible alt-text description documented for each type/state combination
 
 ## References
 

--- a/thoughts/shared/tickets/GAME-062-character-reaction-system.md
+++ b/thoughts/shared/tickets/GAME-062-character-reaction-system.md
@@ -8,30 +8,34 @@ created: 2026-05-02
 
 ## Summary
 
-Wire `scenario.narrative.character` to the result screen: display the scenario
-character's animated sprite, trigger the appropriate pass/fail animation state, and
-play the matching audio clip. Replaces the 🎉/💔 emoji placeholder added in GAME-052.
-Depends on DESIGN-009 (style), GAME-060 (art assets), GAME-061 (audio clips),
-GAME-063 (asset pipeline), and GAME-064 (audio playback infrastructure).
+Wire the instigator reaction system to the result screen: resolve the instigator type
+from the scenario, load the correct star-count state SVG, inject it into
+`#result-reaction`, and play the matching audio clip. Replaces the 🎉/💔 emoji
+placeholder (GAME-052). The player is a neutral consultant; the instigator (party
+boss, judge, commissioner, etc.) reacts based on star count (3/2/1/0), not binary
+pass/fail. Animation plays last, after all per-criterion reveal animations finish.
+Depends on DESIGN-009 (style), GAME-060 (art), GAME-061 (audio), GAME-063
+(asset pipeline), and GAME-064 (audio playback infrastructure).
 
 ## Current State
 
-The result screen shows a `#result-reaction` element populated with a single emoji
-(🎉 or 💔) based on overall pass/fail. Character identity from `scenario.narrative`
-is not used on the result screen at all.
+The result screen shows a `#result-reaction` element with a single emoji (🎉/💔)
+based on overall pass/fail. Scenario instigator identity is not used on the result
+screen. No star-count grading exists on the result screen.
 
 ## Goals / Acceptance Criteria
 
-- [ ] Result screen displays the scenario character's sprite in `#result-reaction`,
-      sized and positioned per DESIGN-009 spec
-- [ ] Pass state animation plays on overall pass; fail state on overall fail
+- [ ] Instigator type resolved from scenario's `narrative.character` role
+- [ ] Star count computed from criterion results (required criteria only)
+- [ ] Correct SVG loaded from `assets/characters/{type}/{state}.svg` and injected
+      into `#result-reaction`; sized and positioned per DESIGN-009 spec
+- [ ] Star-count state maps correctly: 3 required criteria met → three-star; etc.
 - [ ] Audio clip plays on result screen open via GAME-064 AudioPlayer
 - [ ] Mute toggle visible on result screen; uses GAME-064 persistence
-- [ ] `prefers-reduced-motion`: animation suppressed; audio unaffected
-- [ ] Character type resolved from scenario's character role
-- [ ] Scenario-006 two-character case handled per DESIGN-009 decision
-      (simultaneous split-screen or sequential)
-- [ ] Fallback: if character type has no asset, emoji placeholder remains
+- [ ] `prefers-reduced-motion`: SVG idle animation suppressed (CSS); audio unaffected
+- [ ] Scenario-006 Bipartisan Broker: both bosses shown side-by-side (split-screen)
+- [ ] Fallback: if instigator type has no asset, emoji placeholder remains
+- [ ] Instigator reaction plays AFTER per-criterion animations complete (timing)
 
 ## Test Coverage
 


### PR DESCRIPTION
## Summary

- Resolves DESIGN-009 open questions: player avatar (4-state star-count reaction plays last), split-screen as general capability for asymmetric party outcomes, format re-skinning space in file layout
- Adds Player Avatar to character roster (6th type, universal across all scenarios, 4 states: 3-star/2-star/1-star/0-star)
- Documents format-agnostic path schema (`assets/characters/{type}/{state}.*`) so SVG→pixel art re-skin is less work later
- Updates compressed companion and ticket ACs accordingly

## Affected machines / services

- None — documentation only

## Validation performed

- N/A — prose/metadata changes only; no code

## Deployment steps

- N/A

## Tickets addressed

- see #195 (DESIGN-009)

## Rollback

- Revert this commit; no state or code changes to undo
