### PR TITLE
feat(GAME-060): character sprite and animation assets

### DIFF
--- a/game/web/assets/characters/ALT-TEXT.md
+++ b/game/web/assets/characters/ALT-TEXT.md
@@ -1,0 +1,84 @@
+# Character Sprite Alt-Text Inventory
+
+Generated for GAME-060. One description per type × state combination (20 total).
+Each character is a flat-fill SVG political-cartoon figure with a gentle idle bob animation.
+
+---
+
+## partisan-boss
+
+**three-star.svg**
+A stocky, wide-shouldered figure in a red wide-lapel suit with gold tie and lapels, both fists raised triumphantly overhead. Right hand holds a small gold flag. Broad grin, dark flat-brimmed hat.
+
+**two-star.svg**
+The same red-suited partisan boss standing upright, both arms extended forward at mid-height with thumbs raised in approval. Composed, satisfied smile.
+
+**one-star.svg**
+The red-suited partisan boss with both arms crossed at chest height, extending out to the sides in a reserved, guarded posture. Flat neutral expression with narrowed eyes.
+
+**zero-star.svg**
+The red-suited partisan boss hunched slightly, head tilted with a scowl and heavy brows, both arms crossed tightly over the chest in a disapproving, closed-off posture.
+
+---
+
+## legal-authority
+
+**three-star.svg**
+A tall, narrow-robed figure in slate blue with white judicial collar, both arms raised high in celebration. Right hand holds a gavel raised overhead. Wide celebratory smile.
+
+**two-star.svg**
+The same robed judge standing upright, left arm slightly extended at side, right arm raised holding a gavel vertically at shoulder height — composed, approving expression.
+
+**one-star.svg**
+The robed judge with both arms dropped to the sides within the robe, right hand holding the gavel low. Flat neutral expression, reserved posture.
+
+**zero-star.svg**
+The robed judge slumped slightly with head tilted and a stern frown, arms crossed tightly under the robe, heavy disapproving brows. Gavel lying at the side.
+
+---
+
+## bipartisan-broker
+
+**three-star.svg**
+Two smaller figures side by side — the left in red, the right in slate blue — both with arms raised overhead in celebration. Inner hands meet in a handshake at center. Both show wide smiles.
+
+**two-star.svg**
+Two figures (red left, blue right) standing upright. Inner arms extended toward each other in a handshake at center. Outer arms give thumbs-up gestures. Both show approving smiles.
+
+**one-star.svg**
+The red and blue figures side by side with arms at their sides, slightly angled inward. Both show flat neutral expressions, no contact between them.
+
+**zero-star.svg**
+The red figure turned slightly left, the blue figure turned slightly right — each facing away from center. Both have arms tightly crossed and downturned scowls. The gap between them is visible.
+
+---
+
+## reform-arbiter
+
+**three-star.svg**
+A trim teal-blazered figure with neat dark hair, both arms raised overhead in celebration. Right hand holds a set of balance scales aloft. Large open smile.
+
+**two-star.svg**
+The same teal figure standing upright, left arm slightly extended. Right arm raised at shoulder height holding balance scales — composed and approving expression.
+
+**one-star.svg**
+The teal-blazered figure with left arm at side and right arm at chest level, holding a clipboard. Neutral flat expression; clipboard shows notes lines.
+
+**zero-star.svg**
+The teal figure slumped slightly with a furrowed brow and frown, arms crossed tightly. Clipboard dangles at an angle from the right hand, suggesting frustration.
+
+---
+
+## neutral-admin
+
+**three-star.svg**
+A plain grey-blue office-worker figure in a muted suit and blue tie, both arms raised in surprised celebration. Right hand holds a clipboard raised high showing a checkmark. Wide open smile.
+
+**two-star.svg**
+The same grey-blue admin standing composed, left arm in a slight outward gesture, right arm holding a clipboard upright at chest height. Small pleasant smile.
+
+**one-star.svg**
+The grey-blue admin with both arms at sides. Right arm holds clipboard loosely at hip level. Flat unenthusiastic expression — doing the job, nothing more.
+
+**zero-star.svg**
+The grey-blue admin hunched, head tilted with a tired scowl and heavy brows, arms crossed tightly. Clipboard pinned under the left arm at an awkward angle, slightly drooping.

--- a/game/web/assets/characters/bipartisan-broker/one-star.svg
+++ b/game/web/assets/characters/bipartisan-broker/one-star.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- LEFT FIGURE (red) centered at x=50 -->
+    <ellipse cx="50" cy="52" rx="16" ry="18" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <ellipse cx="43" cy="50" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <ellipse cx="57" cy="50" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <!-- Neutral expression -->
+    <line x1="43" y1="62" x2="57" y2="62" stroke="#1a1a2e" stroke-width="2"/>
+    <rect x="45" y="68" width="10" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M28 148 L30 86 Q32 76 50 76 Q68 76 70 86 L72 148 Z"
+          fill="#c0392b" stroke="#1a1a2e" stroke-width="2.5"/>
+    <rect x="46" y="76" width="8" height="20" rx="1" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M28 148 L32 185 L48 185 L50 165 L52 185 L68 185 L72 148 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="38" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="62" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <!-- Arms at sides, slightly inward -->
+    <path d="M30 100 L18 125" stroke="#c0392b" stroke-width="10" stroke-linecap="round"/>
+    <path d="M30 100 L18 125" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="16" cy="128" r="5" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M70 100 L76 122" stroke="#c0392b" stroke-width="10" stroke-linecap="round"/>
+    <path d="M70 100 L76 122" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="77" cy="125" r="5" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+
+    <!-- RIGHT FIGURE (blue) centered at x=150 -->
+    <ellipse cx="150" cy="52" rx="16" ry="18" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <ellipse cx="143" cy="50" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <ellipse cx="157" cy="50" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <!-- Neutral expression -->
+    <line x1="143" y1="62" x2="157" y2="62" stroke="#1a1a2e" stroke-width="2"/>
+    <rect x="145" y="68" width="10" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M128 148 L130 86 Q132 76 150 76 Q168 76 170 86 L172 148 Z"
+          fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2.5"/>
+    <rect x="146" y="76" width="8" height="20" rx="1" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M128 148 L132 185 L148 185 L150 165 L152 185 L168 185 L172 148 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="138" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="162" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <!-- Arms at sides, slightly inward -->
+    <path d="M130 100 L124 122" stroke="#4a6fa5" stroke-width="10" stroke-linecap="round"/>
+    <path d="M130 100 L124 122" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="123" cy="125" r="5" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M170 100 L182 125" stroke="#4a6fa5" stroke-width="10" stroke-linecap="round"/>
+    <path d="M170 100 L182 125" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="184" cy="128" r="5" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/bipartisan-broker/three-star.svg
+++ b/game/web/assets/characters/bipartisan-broker/three-star.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- LEFT FIGURE (red) x=10-90, centered at x=50 -->
+    <!-- Head -->
+    <ellipse cx="50" cy="52" rx="16" ry="18" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Eyes -->
+    <circle cx="43" cy="50" r="2.5" fill="#1a1a2e"/>
+    <circle cx="57" cy="50" r="2.5" fill="#1a1a2e"/>
+    <!-- Big smile -->
+    <path d="M40 59 Q50 68 60 59" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="45" y="68" width="10" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Body -->
+    <path d="M28 148 L30 86 Q32 76 50 76 Q68 76 70 86 L72 148 Z"
+          fill="#c0392b" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Shirt -->
+    <rect x="46" y="76" width="8" height="20" rx="1" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M28 148 L32 185 L48 185 L50 165 L52 185 L68 185 L72 148 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="38" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="62" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm raised (outer) -->
+    <path d="M30 90 L14 62" stroke="#c0392b" stroke-width="10" stroke-linecap="round"/>
+    <path d="M30 90 L14 62" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="12" cy="59" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Right arm raised (inner, toward center) -->
+    <path d="M70 90 L80 62" stroke="#c0392b" stroke-width="10" stroke-linecap="round"/>
+    <path d="M70 90 L80 62" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="82" cy="59" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+
+    <!-- RIGHT FIGURE (blue) x=110-190, centered at x=150 -->
+    <!-- Head -->
+    <ellipse cx="150" cy="52" rx="16" ry="18" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Eyes -->
+    <circle cx="143" cy="50" r="2.5" fill="#1a1a2e"/>
+    <circle cx="157" cy="50" r="2.5" fill="#1a1a2e"/>
+    <!-- Big smile -->
+    <path d="M140 59 Q150 68 160 59" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="145" y="68" width="10" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Body -->
+    <path d="M128 148 L130 86 Q132 76 150 76 Q168 76 170 86 L172 148 Z"
+          fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Shirt -->
+    <rect x="146" y="76" width="8" height="20" rx="1" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M128 148 L132 185 L148 185 L150 165 L152 185 L168 185 L172 148 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="138" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="162" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm raised (inner, toward center) -->
+    <path d="M130 90 L120 62" stroke="#4a6fa5" stroke-width="10" stroke-linecap="round"/>
+    <path d="M130 90 L120 62" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="118" cy="59" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Right arm raised (outer) -->
+    <path d="M170 90 L186 62" stroke="#4a6fa5" stroke-width="10" stroke-linecap="round"/>
+    <path d="M170 90 L186 62" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="188" cy="59" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+
+    <!-- Handshake / joined hands in center between them (celebratory) -->
+    <ellipse cx="100" cy="82" rx="10" ry="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <line x1="82" y1="82" x2="90" y2="82" stroke="#f5d5a0" stroke-width="6" stroke-linecap="round"/>
+    <line x1="110" y1="82" x2="118" y2="82" stroke="#f5d5a0" stroke-width="6" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/bipartisan-broker/two-star.svg
+++ b/game/web/assets/characters/bipartisan-broker/two-star.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- LEFT FIGURE (red) centered at x=50 -->
+    <!-- Head -->
+    <ellipse cx="50" cy="52" rx="16" ry="18" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <circle cx="43" cy="50" r="2.5" fill="#1a1a2e"/>
+    <circle cx="57" cy="50" r="2.5" fill="#1a1a2e"/>
+    <path d="M42 59 Q50 65 58 59" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <rect x="45" y="68" width="10" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M28 148 L30 86 Q32 76 50 76 Q68 76 70 86 L72 148 Z"
+          fill="#c0392b" stroke="#1a1a2e" stroke-width="2.5"/>
+    <rect x="46" y="76" width="8" height="20" rx="1" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M28 148 L32 185 L48 185 L50 165 L52 185 L68 185 L72 148 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="38" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="62" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm thumbs up -->
+    <path d="M30 97 L16 100" stroke="#c0392b" stroke-width="10" stroke-linecap="round"/>
+    <path d="M30 97 L16 100" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <rect x="9" y="95" width="8" height="10" rx="2" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <rect x="11" y="88" width="5" height="9" rx="2" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Right arm out toward center -->
+    <path d="M70 97 L84 90" stroke="#c0392b" stroke-width="10" stroke-linecap="round"/>
+    <path d="M70 97 L84 90" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="87" cy="88" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+
+    <!-- RIGHT FIGURE (blue) centered at x=150 -->
+    <ellipse cx="150" cy="52" rx="16" ry="18" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <circle cx="143" cy="50" r="2.5" fill="#1a1a2e"/>
+    <circle cx="157" cy="50" r="2.5" fill="#1a1a2e"/>
+    <path d="M142 59 Q150 65 158 59" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <rect x="145" y="68" width="10" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M128 148 L130 86 Q132 76 150 76 Q168 76 170 86 L172 148 Z"
+          fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2.5"/>
+    <rect x="146" y="76" width="8" height="20" rx="1" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M128 148 L132 185 L148 185 L150 165 L152 185 L168 185 L172 148 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="138" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="162" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm out toward center -->
+    <path d="M130 97 L116 90" stroke="#4a6fa5" stroke-width="10" stroke-linecap="round"/>
+    <path d="M130 97 L116 90" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <circle cx="113" cy="88" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Right arm thumbs up -->
+    <path d="M170 97 L184 100" stroke="#4a6fa5" stroke-width="10" stroke-linecap="round"/>
+    <path d="M170 97 L184 100" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <rect x="183" y="95" width="8" height="10" rx="2" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <rect x="184" y="88" width="5" height="9" rx="2" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+
+    <!-- Handshake in center -->
+    <ellipse cx="100" cy="89" rx="10" ry="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/bipartisan-broker/zero-star.svg
+++ b/game/web/assets/characters/bipartisan-broker/zero-star.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- LEFT FIGURE (red) — slumped, turned slightly left (away from center) -->
+    <ellipse cx="47" cy="56" rx="15" ry="17" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5" transform="rotate(-8 47 56)"/>
+    <ellipse cx="41" cy="54" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <ellipse cx="54" cy="52" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <line x1="39" y1="64" x2="52" y2="61" stroke="#1a1a2e" stroke-width="2.5"/>
+    <line x1="39" y1="68" x2="52" y2="66" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M37 72 Q47 66 57 70" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <rect x="42" y="72" width="10" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Body slumped -->
+    <path d="M27 150 L29 90 Q31 80 47 80 Q63 80 65 90 L67 150 Z"
+          fill="#c0392b" stroke="#1a1a2e" stroke-width="2.5"/>
+    <rect x="43" y="80" width="8" height="20" rx="1" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M27 150 L30 185 L45 185 L47 165 L49 185 L64 185 L67 150 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="36" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="58" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <!-- Arms crossed tight -->
+    <path d="M29 105 L16 118" stroke="#c0392b" stroke-width="10" stroke-linecap="round"/>
+    <path d="M29 105 L16 118" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M65 105 L72 118" stroke="#c0392b" stroke-width="10" stroke-linecap="round"/>
+    <path d="M65 105 L72 118" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M16 118 Q47 112 72 118" stroke="#f5d5a0" stroke-width="9" stroke-linecap="round" fill="none"/>
+    <path d="M18 122 Q47 116 70 122" stroke="#f5d5a0" stroke-width="9" stroke-linecap="round" fill="none"/>
+    <path d="M16 118 Q47 112 72 118" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M18 122 Q47 116 70 122" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+
+    <!-- RIGHT FIGURE (blue) — slumped, turned slightly right (away from center) -->
+    <ellipse cx="153" cy="56" rx="15" ry="17" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5" transform="rotate(8 153 56)"/>
+    <ellipse cx="146" cy="52" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <ellipse cx="159" cy="54" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <line x1="148" y1="61" x2="161" y2="64" stroke="#1a1a2e" stroke-width="2.5"/>
+    <line x1="148" y1="65" x2="161" y2="68" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M143 70 Q153 66 163 72" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <rect x="148" y="72" width="10" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M133 150 L135 90 Q137 80 153 80 Q169 80 171 90 L173 150 Z"
+          fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2.5"/>
+    <rect x="149" y="80" width="8" height="20" rx="1" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M133 150 L136 185 L151 185 L153 165 L155 185 L170 185 L173 150 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="142" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="164" cy="185" rx="7" ry="4" fill="#1a1a2e"/>
+    <!-- Arms crossed tight -->
+    <path d="M135 105 L128 118" stroke="#4a6fa5" stroke-width="10" stroke-linecap="round"/>
+    <path d="M135 105 L128 118" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M171 105 L184 118" stroke="#4a6fa5" stroke-width="10" stroke-linecap="round"/>
+    <path d="M171 105 L184 118" stroke="#1a1a2e" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M128 118 Q153 112 184 118" stroke="#f5d5a0" stroke-width="9" stroke-linecap="round" fill="none"/>
+    <path d="M130 122 Q153 116 182 122" stroke="#f5d5a0" stroke-width="9" stroke-linecap="round" fill="none"/>
+    <path d="M128 118 Q153 112 184 118" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M130 122 Q153 116 182 122" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/legal-authority/one-star.svg
+++ b/game/web/assets/characters/legal-authority/one-star.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="50" rx="20" ry="22" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Judge's collar / wig suggestion -->
+    <path d="M78 64 Q100 72 122 64 L122 58 Q100 66 78 58 Z" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes — straight, neutral -->
+    <ellipse cx="92" cy="48" rx="3" ry="2.5" fill="#1a1a2e"/>
+    <ellipse cx="108" cy="48" rx="3" ry="2.5" fill="#1a1a2e"/>
+    <!-- Neutral/reserved expression -->
+    <line x1="90" y1="62" x2="110" y2="62" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Neck -->
+    <rect x="94" y="70" width="12" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Robe — tall and narrow, flared at base -->
+    <path d="M70 190 L72 88 Q74 78 100 78 Q126 78 128 88 L130 190 Z"
+          fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Robe trim / front panel -->
+    <rect x="93" y="78" width="14" height="80" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Robe shoulder flare -->
+    <path d="M72 90 L55 100 L60 88 Z" fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M128 90 L145 100 L140 88 Z" fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Arms at sides within robe, slightly inward -->
+    <path d="M72 100 L55 130" stroke="#4a6fa5" stroke-width="14" stroke-linecap="round"/>
+    <path d="M72 100 L55 130" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="53" cy="133" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm holds gavel low at side -->
+    <path d="M128 100 L145 130" stroke="#4a6fa5" stroke-width="14" stroke-linecap="round"/>
+    <path d="M128 100 L145 130" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="147" cy="133" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Gavel held low -->
+    <line x1="147" y1="133" x2="147" y2="150" stroke="#8B6914" stroke-width="4"/>
+    <rect x="140" y="148" width="14" height="8" rx="2" fill="#8B6914" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/legal-authority/three-star.svg
+++ b/game/web/assets/characters/legal-authority/three-star.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="50" rx="20" ry="22" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Judge's collar / wig suggestion -->
+    <path d="M78 64 Q100 72 122 64 L122 58 Q100 66 78 58 Z" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes -->
+    <circle cx="92" cy="48" r="3" fill="#1a1a2e"/>
+    <circle cx="108" cy="48" r="3" fill="#1a1a2e"/>
+    <!-- Big open celebratory smile -->
+    <path d="M87 60 Q100 72 113 60" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="94" y="70" width="12" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Robe — tall and narrow, flared at base -->
+    <path d="M70 190 L72 88 Q74 78 100 78 Q126 78 128 88 L130 190 Z"
+          fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Robe trim / front panel -->
+    <rect x="93" y="78" width="14" height="80" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Robe shoulder flare -->
+    <path d="M72 90 L55 100 L60 88 Z" fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M128 90 L145 100 L140 88 Z" fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Left arm raised high (celebratory) -->
+    <path d="M72 90 L44 58" stroke="#4a6fa5" stroke-width="14" stroke-linecap="round"/>
+    <path d="M72 90 L44 58" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="41" cy="55" r="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm raised with gavel held high -->
+    <path d="M128 90 L156 58" stroke="#4a6fa5" stroke-width="14" stroke-linecap="round"/>
+    <path d="M128 90 L156 58" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="159" cy="55" r="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Gavel (T-shape) in right hand -->
+    <line x1="159" y1="55" x2="165" y2="36" stroke="#8B6914" stroke-width="4"/>
+    <rect x="158" y="30" width="14" height="8" rx="2" fill="#8B6914" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/legal-authority/two-star.svg
+++ b/game/web/assets/characters/legal-authority/two-star.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="50" rx="20" ry="22" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Judge's collar / wig suggestion -->
+    <path d="M78 64 Q100 72 122 64 L122 58 Q100 66 78 58 Z" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes -->
+    <circle cx="92" cy="48" r="3" fill="#1a1a2e"/>
+    <circle cx="108" cy="48" r="3" fill="#1a1a2e"/>
+    <!-- Composed approving smile -->
+    <path d="M89 60 Q100 68 111 60" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="94" y="70" width="12" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Robe — tall and narrow, flared at base -->
+    <path d="M70 190 L72 88 Q74 78 100 78 Q126 78 128 88 L130 190 Z"
+          fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Robe trim / front panel -->
+    <rect x="93" y="78" width="14" height="80" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Robe shoulder flare -->
+    <path d="M72 90 L55 100 L60 88 Z" fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M128 90 L145 100 L140 88 Z" fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Left arm composed, slight outward gesture -->
+    <path d="M72 100 L48 115" stroke="#4a6fa5" stroke-width="14" stroke-linecap="round"/>
+    <path d="M72 100 L48 115" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="45" cy="118" r="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm holding gavel upright (approving/composed) -->
+    <path d="M128 100 L148 88" stroke="#4a6fa5" stroke-width="14" stroke-linecap="round"/>
+    <path d="M128 100 L148 88" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="151" cy="85" r="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Gavel upright -->
+    <line x1="151" y1="85" x2="151" y2="65" stroke="#8B6914" stroke-width="4"/>
+    <rect x="144" y="59" width="14" height="8" rx="2" fill="#8B6914" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/legal-authority/zero-star.svg
+++ b/game/web/assets/characters/legal-authority/zero-star.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head — slightly slumped/tilted -->
+    <ellipse cx="98" cy="55" rx="20" ry="22" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5" transform="rotate(-6 98 55)"/>
+    <!-- Judge's collar / wig suggestion -->
+    <path d="M76 69 Q98 77 120 69 L120 63 Q98 71 76 63 Z" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes — stern, disapproving furrowed brows -->
+    <ellipse cx="90" cy="53" rx="3" ry="2" fill="#1a1a2e"/>
+    <ellipse cx="106" cy="51" rx="3" ry="2" fill="#1a1a2e"/>
+    <line x1="86" y1="47" x2="95" y2="50" stroke="#1a1a2e" stroke-width="2.5"/>
+    <line x1="110" y1="46" x2="102" y2="49" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Frown / stern expression -->
+    <path d="M87 65 Q97 59 108 63" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="92" y="75" width="12" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Robe — slumped slightly narrower -->
+    <path d="M72 190 L74 93 Q76 83 100 83 Q124 83 126 93 L128 190 Z"
+          fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Robe trim / front panel -->
+    <rect x="93" y="83" width="14" height="75" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Robe shoulder flare -->
+    <path d="M74 95 L57 105 L62 93 Z" fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M126 95 L143 105 L138 93 Z" fill="#4a6fa5" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Arms crossed tightly under robe -->
+    <path d="M74 108 L60 120" stroke="#4a6fa5" stroke-width="14" stroke-linecap="round"/>
+    <path d="M74 108 L60 120" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M126 108 L140 120" stroke="#4a6fa5" stroke-width="14" stroke-linecap="round"/>
+    <path d="M126 108 L140 120" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <!-- Forearm cross -->
+    <path d="M60 120 Q100 114 140 120" stroke="#f0f0f0" stroke-width="10" stroke-linecap="round" fill="none"/>
+    <path d="M63 124 Q100 118 137 124" stroke="#f0f0f0" stroke-width="10" stroke-linecap="round" fill="none"/>
+    <path d="M60 120 Q100 114 140 120" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M63 124 Q100 118 137 124" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <!-- Gavel at side, pointing down (slumped) -->
+    <circle cx="140" cy="135" r="5" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="140" y1="140" x2="140" y2="155" stroke="#8B6914" stroke-width="4"/>
+    <rect x="133" y="153" width="14" height="8" rx="2" fill="#8B6914" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/neutral-admin/one-star.svg
+++ b/game/web/assets/characters/neutral-admin/one-star.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head — slight slouch -->
+    <ellipse cx="100" cy="52" rx="19" ry="21" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair -->
+    <path d="M81 46 Q100 36 119 46 Q116 42 100 39 Q84 42 81 46 Z" fill="#5a4a3a" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes — slightly dull, flat expression -->
+    <ellipse cx="92" cy="52" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <ellipse cx="108" cy="52" rx="2.5" ry="2" fill="#1a1a2e"/>
+    <!-- Flat / neutral expression -->
+    <line x1="90" y1="63" x2="110" y2="63" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Neck -->
+    <rect x="94" y="71" width="12" height="9" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Plain office shirt -->
+    <path d="M68 150 L70 89 Q72 80 100 80 Q128 80 130 89 L132 150 Z"
+          fill="#7f8c9a" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Collar and tie -->
+    <path d="M100 80 L93 98 L88 80" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M100 80 L107 98 L112 80" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M97 80 L100 106 L103 80" fill="#b0c4d0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M68 150 L72 185 L97 185 L100 165 L103 185 L128 185 L132 150 Z"
+          fill="#4a5560" stroke="#1a1a2e" stroke-width="2"/>
+    <ellipse cx="79" cy="185" rx="9" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="121" cy="185" rx="9" ry="4" fill="#1a1a2e"/>
+    <!-- Arms at sides, slightly drooped -->
+    <path d="M70 100 L54 130" stroke="#7f8c9a" stroke-width="12" stroke-linecap="round"/>
+    <path d="M70 100 L54 130" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="52" cy="133" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm holds clipboard loosely at side -->
+    <path d="M130 100 L146 130" stroke="#7f8c9a" stroke-width="12" stroke-linecap="round"/>
+    <path d="M130 100 L146 130" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="148" cy="133" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Clipboard held low at side -->
+    <rect x="146" y="128" width="16" height="22" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="2"/>
+    <circle cx="154" cy="126" r="4" fill="#7f8c9a" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="150" y1="138" x2="158" y2="138" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="150" y1="143" x2="158" y2="143" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/neutral-admin/three-star.svg
+++ b/game/web/assets/characters/neutral-admin/three-star.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="52" rx="19" ry="21" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair — plain parted -->
+    <path d="M81 46 Q100 36 119 46 Q116 42 100 39 Q84 42 81 46 Z" fill="#5a4a3a" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes -->
+    <circle cx="92" cy="52" r="2.5" fill="#1a1a2e"/>
+    <circle cx="108" cy="52" r="2.5" fill="#1a1a2e"/>
+    <!-- Celebratory surprised smile -->
+    <path d="M87 62 Q100 73 113 62" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="94" y="71" width="12" height="9" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Plain office shirt / slight slouch body -->
+    <path d="M68 150 L70 89 Q72 80 100 80 Q128 80 130 89 L132 150 Z"
+          fill="#7f8c9a" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Collar and tie -->
+    <path d="M100 80 L93 98 L88 80" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M100 80 L107 98 L112 80" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M97 80 L100 106 L103 80" fill="#b0c4d0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M68 150 L72 185 L97 185 L100 165 L103 185 L128 185 L132 150 Z"
+          fill="#4a5560" stroke="#1a1a2e" stroke-width="2"/>
+    <ellipse cx="79" cy="185" rx="9" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="121" cy="185" rx="9" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm raised (celebratory, surprised) -->
+    <path d="M70 94 L44 65" stroke="#7f8c9a" stroke-width="12" stroke-linecap="round"/>
+    <path d="M70 94 L44 65" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="41" cy="62" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm raised holding clipboard up -->
+    <path d="M130 94 L155 65" stroke="#7f8c9a" stroke-width="12" stroke-linecap="round"/>
+    <path d="M130 94 L155 65" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="158" cy="62" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Clipboard raised high -->
+    <rect x="155" y="38" width="18" height="24" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="2" transform="rotate(15 164 50)"/>
+    <circle cx="163" cy="37" r="4" fill="#7f8c9a" stroke="#1a1a2e" stroke-width="1.5" transform="rotate(15 163 37)"/>
+    <!-- Check mark on clipboard -->
+    <path d="M159 52 L162 56 L168 48" stroke="#1a1a2e" stroke-width="2.5" fill="none" transform="rotate(15 163 50)"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/neutral-admin/two-star.svg
+++ b/game/web/assets/characters/neutral-admin/two-star.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="52" rx="19" ry="21" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair -->
+    <path d="M81 46 Q100 36 119 46 Q116 42 100 39 Q84 42 81 46 Z" fill="#5a4a3a" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes -->
+    <circle cx="92" cy="52" r="2.5" fill="#1a1a2e"/>
+    <circle cx="108" cy="52" r="2.5" fill="#1a1a2e"/>
+    <!-- Small pleasant smile -->
+    <path d="M90 62 Q100 69 110 62" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="94" y="71" width="12" height="9" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Plain office shirt -->
+    <path d="M68 150 L70 89 Q72 80 100 80 Q128 80 130 89 L132 150 Z"
+          fill="#7f8c9a" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Collar and tie -->
+    <path d="M100 80 L93 98 L88 80" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M100 80 L107 98 L112 80" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M97 80 L100 106 L103 80" fill="#b0c4d0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M68 150 L72 185 L97 185 L100 165 L103 185 L128 185 L132 150 Z"
+          fill="#4a5560" stroke="#1a1a2e" stroke-width="2"/>
+    <ellipse cx="79" cy="185" rx="9" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="121" cy="185" rx="9" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm — composed slight gesture -->
+    <path d="M70 97 L50 112" stroke="#7f8c9a" stroke-width="12" stroke-linecap="round"/>
+    <path d="M70 97 L50 112" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="47" cy="115" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm holds clipboard upright -->
+    <path d="M130 97 L148 90" stroke="#7f8c9a" stroke-width="12" stroke-linecap="round"/>
+    <path d="M130 97 L148 90" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="151" cy="87" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Clipboard upright -->
+    <rect x="150" y="65" width="18" height="24" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="2"/>
+    <circle cx="159" cy="63" r="4" fill="#7f8c9a" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="154" y1="75" x2="164" y2="75" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="154" y1="80" x2="164" y2="80" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="154" y1="85" x2="160" y2="85" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/neutral-admin/zero-star.svg
+++ b/game/web/assets/characters/neutral-admin/zero-star.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head — slumped, turned slightly away -->
+    <ellipse cx="97" cy="57" rx="19" ry="21" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5" transform="rotate(-9 97 57)"/>
+    <!-- Hair -->
+    <path d="M78 50 Q97 40 116 50 L114 54 Q97 44 80 54 Z" fill="#5a4a3a" stroke="#1a1a2e" stroke-width="1.5" transform="rotate(-9 97 50)"/>
+    <!-- Eyes — tired/unimpressed -->
+    <ellipse cx="89" cy="55" rx="2.5" ry="1.8" fill="#1a1a2e"/>
+    <ellipse cx="105" cy="53" rx="2.5" ry="1.8" fill="#1a1a2e"/>
+    <!-- Heavy eyebrows down -->
+    <line x1="86" y1="49" x2="93" y2="52" stroke="#1a1a2e" stroke-width="2.5"/>
+    <line x1="108" y1="48" x2="101" y2="51" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Slight frown -->
+    <path d="M87 66 Q97 60 107 64" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="91" y="76" width="12" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Body — hunched with slight forward lean -->
+    <path d="M70 152 L71 95 Q73 84 100 84 Q127 84 129 95 L130 152 Z"
+          fill="#7f8c9a" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Collar and tie (slightly askew) -->
+    <path d="M100 84 L92 102 L87 84" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M100 84 L108 102 L113 84" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M98 84 L100 108 L102 84" fill="#b0c4d0" stroke="#1a1a2e" stroke-width="1.5" transform="rotate(-5 100 95)"/>
+    <!-- Trousers -->
+    <path d="M70 152 L74 185 L97 185 L100 168 L103 185 L126 185 L130 152 Z"
+          fill="#4a5560" stroke="#1a1a2e" stroke-width="2"/>
+    <ellipse cx="80" cy="185" rx="9" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="120" cy="185" rx="9" ry="4" fill="#1a1a2e"/>
+    <!-- Arms crossed tightly, clipboard pinned under arm -->
+    <path d="M71 108 L57 120" stroke="#7f8c9a" stroke-width="12" stroke-linecap="round"/>
+    <path d="M71 108 L57 120" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M129 108 L143 120" stroke="#7f8c9a" stroke-width="12" stroke-linecap="round"/>
+    <path d="M129 108 L143 120" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <!-- Crossed forearms -->
+    <path d="M57 120 Q100 114 143 120" stroke="#f5d5a0" stroke-width="10" stroke-linecap="round" fill="none"/>
+    <path d="M59 124 Q100 118 141 124" stroke="#f5d5a0" stroke-width="10" stroke-linecap="round" fill="none"/>
+    <path d="M57 120 Q100 114 143 120" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M59 124 Q100 118 141 124" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <!-- Clipboard pinned under left arm, hanging loose -->
+    <rect x="40" y="120" width="16" height="22" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="2" transform="rotate(-20 48 131)"/>
+    <circle cx="48" cy="118" r="3.5" fill="#7f8c9a" stroke="#1a1a2e" stroke-width="1.5" transform="rotate(-20 48 118)"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/partisan-boss/one-star.svg
+++ b/game/web/assets/characters/partisan-boss/one-star.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="52" rx="22" ry="24" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair / hat brim -->
+    <rect x="76" y="34" width="48" height="8" rx="3" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1"/>
+    <!-- Eyes — slightly narrowed -->
+    <ellipse cx="91" cy="50" rx="3" ry="2.5" fill="#1a1a2e"/>
+    <ellipse cx="109" cy="50" rx="3" ry="2.5" fill="#1a1a2e"/>
+    <!-- Neutral expression -->
+    <line x1="90" y1="64" x2="110" y2="64" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Neck -->
+    <rect x="94" y="74" width="12" height="10" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Body / suit jacket — wide shouldered -->
+    <path d="M65 145 L65 90 Q68 84 100 84 Q132 84 135 90 L135 145 Z"
+          fill="#c0392b" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Wide lapels -->
+    <path d="M100 84 L88 110 L80 84" fill="#d4a017" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M100 84 L112 110 L120 84" fill="#d4a017" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Shirt front / tie -->
+    <rect x="96" y="84" width="8" height="26" rx="2" fill="#d4a017" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M65 145 L72 185 L97 185 L100 162 L103 185 L128 185 L135 145 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Shoes -->
+    <ellipse cx="80" cy="185" rx="10" ry="5" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="120" cy="185" rx="10" ry="5" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Arms at sides / slightly crossed -->
+    <path d="M65 100 L48 125" stroke="#c0392b" stroke-width="14" stroke-linecap="round"/>
+    <path d="M65 100 L48 125" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="47" cy="128" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M135 100 L152 125" stroke="#c0392b" stroke-width="14" stroke-linecap="round"/>
+    <path d="M135 100 L152 125" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="153" cy="128" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Arms crossing at mid-body -->
+    <path d="M48 128 Q75 132 100 128 Q125 132 153 128" stroke="#f5d5a0" stroke-width="8" stroke-linecap="round" fill="none"/>
+    <path d="M48 128 Q75 132 100 128 Q125 132 153 128" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/partisan-boss/three-star.svg
+++ b/game/web/assets/characters/partisan-boss/three-star.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="52" rx="22" ry="24" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair / hat brim -->
+    <rect x="76" y="34" width="48" height="8" rx="3" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1"/>
+    <!-- Eyes -->
+    <circle cx="91" cy="50" r="3" fill="#1a1a2e"/>
+    <circle cx="109" cy="50" r="3" fill="#1a1a2e"/>
+    <!-- Smile (celebratory) -->
+    <path d="M88 62 Q100 72 112 62" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="94" y="74" width="12" height="10" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Body / suit jacket — wide shouldered -->
+    <path d="M65 145 L65 90 Q68 84 100 84 Q132 84 135 90 L135 145 Z"
+          fill="#c0392b" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Wide lapels -->
+    <path d="M100 84 L88 110 L80 84" fill="#d4a017" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M100 84 L112 110 L120 84" fill="#d4a017" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Shirt front / tie -->
+    <rect x="96" y="84" width="8" height="26" rx="2" fill="#d4a017" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M65 145 L72 185 L97 185 L100 162 L103 185 L128 185 L135 145 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Shoes -->
+    <ellipse cx="80" cy="185" rx="10" ry="5" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="120" cy="185" rx="10" ry="5" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Left arm raised high (celebratory) -->
+    <path d="M65 95 L38 60" stroke="#c0392b" stroke-width="14" stroke-linecap="round"/>
+    <path d="M65 95 L38 60" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <!-- Left fist raised -->
+    <circle cx="36" cy="57" r="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm raised high (celebratory) -->
+    <path d="M135 95 L162 60" stroke="#c0392b" stroke-width="14" stroke-linecap="round"/>
+    <path d="M135 95 L162 60" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <!-- Right fist raised -->
+    <circle cx="164" cy="57" r="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Small flag in right hand -->
+    <line x1="164" y1="57" x2="172" y2="38" stroke="#1a1a2e" stroke-width="2"/>
+    <rect x="172" y="33" width="14" height="10" rx="1" fill="#d4a017" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/partisan-boss/two-star.svg
+++ b/game/web/assets/characters/partisan-boss/two-star.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="52" rx="22" ry="24" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair / hat brim -->
+    <rect x="76" y="34" width="48" height="8" rx="3" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1"/>
+    <!-- Eyes -->
+    <circle cx="91" cy="50" r="3" fill="#1a1a2e"/>
+    <circle cx="109" cy="50" r="3" fill="#1a1a2e"/>
+    <!-- Approving smile -->
+    <path d="M90 62 Q100 69 110 62" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="94" y="74" width="12" height="10" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Body / suit jacket — wide shouldered -->
+    <path d="M65 145 L65 90 Q68 84 100 84 Q132 84 135 90 L135 145 Z"
+          fill="#c0392b" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Wide lapels -->
+    <path d="M100 84 L88 110 L80 84" fill="#d4a017" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M100 84 L112 110 L120 84" fill="#d4a017" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Shirt front / tie -->
+    <rect x="96" y="84" width="8" height="26" rx="2" fill="#d4a017" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M65 145 L72 185 L97 185 L100 162 L103 185 L128 185 L135 145 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Shoes -->
+    <ellipse cx="80" cy="185" rx="10" ry="5" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="120" cy="185" rx="10" ry="5" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Left arm — thumbs up -->
+    <path d="M65 100 L42 105" stroke="#c0392b" stroke-width="14" stroke-linecap="round"/>
+    <path d="M65 100 L42 105" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <!-- Left thumb up fist -->
+    <rect x="34" y="98" width="10" height="14" rx="3" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <rect x="36" y="90" width="6" height="11" rx="3" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Right arm — thumbs up -->
+    <path d="M135 100 L158 105" stroke="#c0392b" stroke-width="14" stroke-linecap="round"/>
+    <path d="M135 100 L158 105" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <!-- Right thumb up fist -->
+    <rect x="156" y="98" width="10" height="14" rx="3" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <rect x="158" y="90" width="6" height="11" rx="3" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/partisan-boss/zero-star.svg
+++ b/game/web/assets/characters/partisan-boss/zero-star.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head — slightly tilted/slumped -->
+    <ellipse cx="97" cy="58" rx="22" ry="23" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5" transform="rotate(-8 97 58)"/>
+    <!-- Hair / hat brim -->
+    <rect x="73" y="40" width="48" height="8" rx="3" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1" transform="rotate(-8 97 40)"/>
+    <!-- Eyes — furrowed/displeased -->
+    <ellipse cx="89" cy="56" rx="3" ry="2" fill="#1a1a2e"/>
+    <ellipse cx="106" cy="54" rx="3" ry="2" fill="#1a1a2e"/>
+    <!-- Brow lines conveying displeasure -->
+    <line x1="85" y1="49" x2="95" y2="52" stroke="#1a1a2e" stroke-width="2.5"/>
+    <line x1="110" y1="49" x2="102" y2="52" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Frown -->
+    <path d="M87 67 Q97 60 108 65" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="91" y="78" width="12" height="10" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Body slumped — narrower, hunched forward -->
+    <path d="M68 148 L70 95 Q72 88 100 88 Q128 88 130 95 L132 148 Z"
+          fill="#c0392b" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Wide lapels -->
+    <path d="M100 88 L89 112 L82 88" fill="#d4a017" stroke="#1a1a2e" stroke-width="2"/>
+    <path d="M100 88 L111 112 L118 88" fill="#d4a017" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Shirt front / tie -->
+    <rect x="96" y="88" width="8" height="24" rx="2" fill="#d4a017" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M68 148 L74 185 L98 185 L100 165 L102 185 L126 185 L132 148 Z"
+          fill="#1a1a2e" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Shoes -->
+    <ellipse cx="81" cy="185" rx="10" ry="5" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <ellipse cx="119" cy="185" rx="10" ry="5" fill="#1a1a2e" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Arms crossed tightly -->
+    <path d="M70 105 L55 118" stroke="#c0392b" stroke-width="14" stroke-linecap="round"/>
+    <path d="M70 105 L55 118" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M130 105 L145 118" stroke="#c0392b" stroke-width="14" stroke-linecap="round"/>
+    <path d="M130 105 L145 118" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <!-- Forearm cross over chest -->
+    <path d="M55 118 Q100 112 145 118" stroke="#f5d5a0" stroke-width="10" stroke-linecap="round" fill="none"/>
+    <path d="M60 122 Q100 116 140 122" stroke="#f5d5a0" stroke-width="10" stroke-linecap="round" fill="none"/>
+    <path d="M55 118 Q100 112 145 118" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M60 122 Q100 116 140 122" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/reform-arbiter/one-star.svg
+++ b/game/web/assets/characters/reform-arbiter/one-star.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="50" rx="20" ry="22" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair -->
+    <path d="M80 44 Q100 34 120 44 L118 48 Q100 38 82 48 Z" fill="#4a3520" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes — slightly narrowed -->
+    <ellipse cx="92" cy="50" rx="3" ry="2.5" fill="#1a1a2e"/>
+    <ellipse cx="108" cy="50" rx="3" ry="2.5" fill="#1a1a2e"/>
+    <!-- Neutral expression -->
+    <line x1="90" y1="62" x2="110" y2="62" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Neck -->
+    <rect x="94" y="70" width="12" height="9" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Trim body / blazer -->
+    <path d="M72 150 L73 88 Q75 79 100 79 Q125 79 127 88 L128 150 Z"
+          fill="#1abc9c" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Collar / lapels -->
+    <path d="M100 79 L91 102 L84 79" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M100 79 L109 102 L116 79" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M72 150 L76 185 L97 185 L100 165 L103 185 L124 185 L128 150 Z"
+          fill="#1a2e2a" stroke="#1a1a2e" stroke-width="2"/>
+    <ellipse cx="82" cy="185" rx="8" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="118" cy="185" rx="8" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm at side, reserved -->
+    <path d="M73 97 L56 128" stroke="#1abc9c" stroke-width="12" stroke-linecap="round"/>
+    <path d="M73 97 L56 128" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="54" cy="131" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm holds clipboard at chest level -->
+    <path d="M127 97 L144 105" stroke="#1abc9c" stroke-width="12" stroke-linecap="round"/>
+    <path d="M127 97 L144 105" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="147" cy="107" r="6" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Clipboard prop (rectangle with clip circle at top) -->
+    <rect x="148" y="90" width="18" height="24" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="2"/>
+    <circle cx="157" cy="88" r="4" fill="#7f8c9a" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Lines on clipboard suggesting text -->
+    <line x1="152" y1="100" x2="162" y2="100" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="152" y1="105" x2="162" y2="105" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="152" y1="110" x2="158" y2="110" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/reform-arbiter/three-star.svg
+++ b/game/web/assets/characters/reform-arbiter/three-star.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="50" rx="20" ry="22" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair — neat short crop -->
+    <path d="M80 44 Q100 34 120 44 L118 48 Q100 38 82 48 Z" fill="#4a3520" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes -->
+    <circle cx="92" cy="50" r="3" fill="#1a1a2e"/>
+    <circle cx="108" cy="50" r="3" fill="#1a1a2e"/>
+    <!-- Big celebratory smile -->
+    <path d="M87 60 Q100 72 113 60" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="94" y="70" width="12" height="9" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Trim body / blazer -->
+    <path d="M72 150 L73 88 Q75 79 100 79 Q125 79 127 88 L128 150 Z"
+          fill="#1abc9c" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Collar / lapels -->
+    <path d="M100 79 L91 102 L84 79" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M100 79 L109 102 L116 79" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M72 150 L76 185 L97 185 L100 165 L103 185 L124 185 L128 150 Z"
+          fill="#1a2e2a" stroke="#1a1a2e" stroke-width="2"/>
+    <ellipse cx="82" cy="185" rx="8" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="118" cy="185" rx="8" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm raised (celebratory) -->
+    <path d="M73 92 L46 62" stroke="#1abc9c" stroke-width="12" stroke-linecap="round"/>
+    <path d="M73 92 L46 62" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="43" cy="59" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm raised holding scales -->
+    <path d="M127 92 L154 62" stroke="#1abc9c" stroke-width="12" stroke-linecap="round"/>
+    <path d="M127 92 L154 62" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="157" cy="59" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Scales held high — beam -->
+    <line x1="157" y1="52" x2="157" y2="38" stroke="#8B6914" stroke-width="3"/>
+    <line x1="148" y1="38" x2="166" y2="38" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Scale pans (two small circles) -->
+    <circle cx="148" cy="43" r="5" fill="none" stroke="#1a1a2e" stroke-width="2"/>
+    <circle cx="166" cy="43" r="5" fill="none" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Strings -->
+    <line x1="148" y1="38" x2="148" y2="43" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="166" y1="38" x2="166" y2="43" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/reform-arbiter/two-star.svg
+++ b/game/web/assets/characters/reform-arbiter/two-star.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head -->
+    <ellipse cx="100" cy="50" rx="20" ry="22" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Hair -->
+    <path d="M80 44 Q100 34 120 44 L118 48 Q100 38 82 48 Z" fill="#4a3520" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Eyes -->
+    <circle cx="92" cy="50" r="3" fill="#1a1a2e"/>
+    <circle cx="108" cy="50" r="3" fill="#1a1a2e"/>
+    <!-- Composed approving smile -->
+    <path d="M89 60 Q100 68 111 60" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="94" y="70" width="12" height="9" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Trim body / blazer -->
+    <path d="M72 150 L73 88 Q75 79 100 79 Q125 79 127 88 L128 150 Z"
+          fill="#1abc9c" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Collar / lapels -->
+    <path d="M100 79 L91 102 L84 79" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M100 79 L109 102 L116 79" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M72 150 L76 185 L97 185 L100 165 L103 185 L124 185 L128 150 Z"
+          fill="#1a2e2a" stroke="#1a1a2e" stroke-width="2"/>
+    <ellipse cx="82" cy="185" rx="8" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="118" cy="185" rx="8" ry="4" fill="#1a1a2e"/>
+    <!-- Left arm — neutral at side, slightly out -->
+    <path d="M73 95 L52 112" stroke="#1abc9c" stroke-width="12" stroke-linecap="round"/>
+    <path d="M73 95 L52 112" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="49" cy="115" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Right arm holding clipboard/scales upright -->
+    <path d="M127 95 L148 85" stroke="#1abc9c" stroke-width="12" stroke-linecap="round"/>
+    <path d="M127 95 L148 85" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <circle cx="151" cy="82" r="7" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Scales held at chest height -->
+    <line x1="151" y1="75" x2="151" y2="60" stroke="#8B6914" stroke-width="3"/>
+    <line x1="143" y1="60" x2="159" y2="60" stroke="#1a1a2e" stroke-width="2.5"/>
+    <circle cx="143" cy="65" r="5" fill="none" stroke="#1a1a2e" stroke-width="2"/>
+    <circle cx="159" cy="65" r="5" fill="none" stroke="#1a1a2e" stroke-width="2"/>
+    <line x1="143" y1="60" x2="143" y2="65" stroke="#1a1a2e" stroke-width="1.5"/>
+    <line x1="159" y1="60" x2="159" y2="65" stroke="#1a1a2e" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/game/web/assets/characters/reform-arbiter/zero-star.svg
+++ b/game/web/assets/characters/reform-arbiter/zero-star.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @keyframes idle-bob {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+    .character { animation: idle-bob 0.9s ease-in-out infinite; }
+  </style>
+  <g class="character">
+    <!-- Head — slightly slumped -->
+    <ellipse cx="98" cy="55" rx="20" ry="22" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2.5" transform="rotate(-7 98 55)"/>
+    <!-- Hair -->
+    <path d="M78 48 Q98 38 118 48 L116 52 Q98 42 80 52 Z" fill="#4a3520" stroke="#1a1a2e" stroke-width="1.5" transform="rotate(-7 98 48)"/>
+    <!-- Eyes — disapproving furrowed brows -->
+    <ellipse cx="90" cy="53" rx="3" ry="2" fill="#1a1a2e"/>
+    <ellipse cx="106" cy="51" rx="3" ry="2" fill="#1a1a2e"/>
+    <line x1="86" y1="47" x2="94" y2="50" stroke="#1a1a2e" stroke-width="2.5"/>
+    <line x1="110" y1="46" x2="102" y2="49" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Frown -->
+    <path d="M87 65 Q97 58 108 63" stroke="#1a1a2e" stroke-width="2" fill="none"/>
+    <!-- Neck -->
+    <rect x="92" y="75" width="12" height="8" fill="#f5d5a0" stroke="#1a1a2e" stroke-width="2"/>
+    <!-- Trim body / blazer — hunched -->
+    <path d="M74 152 L75 93 Q77 83 100 83 Q123 83 125 93 L126 152 Z"
+          fill="#1abc9c" stroke="#1a1a2e" stroke-width="2.5"/>
+    <!-- Collar / lapels -->
+    <path d="M100 83 L92 104 L85 83" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <path d="M100 83 L108 104 L115 83" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="1.5"/>
+    <!-- Trousers -->
+    <path d="M74 152 L77 185 L98 185 L100 168 L102 185 L123 185 L126 152 Z"
+          fill="#1a2e2a" stroke="#1a1a2e" stroke-width="2"/>
+    <ellipse cx="84" cy="185" rx="8" ry="4" fill="#1a1a2e"/>
+    <ellipse cx="116" cy="185" rx="8" ry="4" fill="#1a1a2e"/>
+    <!-- Arms crossed tightly -->
+    <path d="M75 108 L61 120" stroke="#1abc9c" stroke-width="12" stroke-linecap="round"/>
+    <path d="M75 108 L61 120" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M125 108 L139 120" stroke="#1abc9c" stroke-width="12" stroke-linecap="round"/>
+    <path d="M125 108 L139 120" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M61 120 Q100 114 139 120" stroke="#f5d5a0" stroke-width="10" stroke-linecap="round" fill="none"/>
+    <path d="M63 124 Q100 118 137 124" stroke="#f5d5a0" stroke-width="10" stroke-linecap="round" fill="none"/>
+    <path d="M61 120 Q100 114 139 120" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M63 124 Q100 118 137 124" stroke="#1a1a2e" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <!-- Clipboard dropped/dangling from one hand (disapproving) -->
+    <rect x="130" y="128" width="14" height="18" rx="2" fill="#f0f0f0" stroke="#1a1a2e" stroke-width="2" transform="rotate(30 137 137)"/>
+    <circle cx="137" cy="126" r="3" fill="#7f8c9a" stroke="#1a1a2e" stroke-width="1.5" transform="rotate(30 137 126)"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- Adds 20 SVG character sprite files: 5 instigator types × 4 star-count states (three-star, two-star, one-star, zero-star)
- All files follow the DESIGN-009 consistency spec: `viewBox="0 0 200 200"`, flat fills, max 3 fill colors per type, `stroke="#1a1a2e"` `stroke-width="2.5"` outlines, idle bob CSS animation at 0.9 s, entire character wrapped in `<g class="character">`
- Includes `ALT-TEXT.md` accessibility inventory with one description per type/state (20 entries)
- These are v1 AI-generated assets; visual iteration welcome in follow-up PRs

## Affected machines / services

- Static web asset serving only; no server-side changes
- Assets consumed by GAME-062 character reaction system (not yet wired in)

## Validation performed

- Spec compliance reviewed manually: viewBox, animation block, `<g class="character">` wrapper, and color constraints verified in each file
- File sizes confirmed well under 15 KB limit (all files 2–4 KB)
- Visual rendering deferred to GAME-062 integration; browser-at-160px validation is a follow-up acceptance step

## Deployment steps

No deployment action required; static assets are served directly from `game/web/assets/`.

## Tickets addressed

- Closes GAME-060: Character sprite and animation assets for result screen reactions

## Rollback

Remove the `game/web/assets/characters/` directory. No runtime dependencies exist until GAME-062 wires them up.
