### PR TITLE
feat(GAME-065): gen-sprites harness — Gemini + Grok SVG generation CLI with tests

### DIFF
--- a/tools/gen-sprites.main.kts
+++ b/tools/gen-sprites.main.kts
@@ -1,0 +1,482 @@
+#!/usr/bin/env kotlin
+@file:DependsOn("com.github.ajalt.clikt:clikt-jvm:4.4.0")
+@file:DependsOn("com.squareup.moshi:moshi-kotlin:1.15.0")
+@file:DependsOn("com.squareup.okhttp3:okhttp:4.12.0")
+
+/**
+ * gen-sprites
+ *
+ * Generates SVG character sprites for "Past the Post" via AI model API.
+ * Supports Gemini and Grok providers; modular interface for future providers.
+ *
+ * Character types and star states are loaded from a JSON spec file
+ * (default: tools/sprite-spec.json). Edit that file to add new types or states
+ * without touching this script.
+ *
+ * Reads the DESIGN-009 consistency spec from the repo to embed in every prompt.
+ * Writes one SVG per (character-type × star-state) to:
+ *   game/web/assets/characters/{type}/{state}.svg  (or --output-dir override)
+ *
+ * Credential resolution order (first match wins):
+ *   1. --api-key flag
+ *   2. --gemini-api-key / --grok-api-key flag  (or GEMINI_API_KEY / GROK_API_KEY env var)
+ *   3. --credentials-file flag (JSON oauth or plain text — auto-detected)
+ *   4. Auto-detected: ~/.gemini/oauth_creds.json  (Gemini only; gemini-cli format)
+ *
+ * Usage:
+ *   gen-sprites.main.kts -- --provider gemini                      # auto-detect creds
+ *   gen-sprites.main.kts -- --provider gemini --api-key $KEY
+ *   gen-sprites.main.kts -- --provider gemini --credentials-file ~/my-key.txt
+ *   gen-sprites.main.kts -- --provider grok   --api-key $GROK_KEY
+ *   gen-sprites.main.kts -- --type partisan-boss --state three-star --dry-run
+ *   gen-sprites.main.kts -- --list-types
+ *   gen-sprites.main.kts -- --list-states
+ *
+ * Flags:
+ *   --provider          gemini | grok (default: gemini)
+ *   --api-key           Raw API key (any provider)
+ *   --gemini-api-key    Gemini API key (or GEMINI_API_KEY env var)
+ *   --grok-api-key      Grok API key (or GROK_API_KEY env var)
+ *   --credentials-file  Path to credentials file (JSON oauth or plain text key)
+ *   --model             Model override (default: gemini-2.5-flash or grok-3)
+ *   --characters-file   Path to sprite-spec.json (default: tools/sprite-spec.json)
+ *   --type              Limit to one character type ID (repeatable; default: all)
+ *   --state             Limit to one star state ID (repeatable; default: all)
+ *   --output-dir        Root directory for output SVGs (default: game/web/assets/characters)
+ *   --spec-file         Path to DESIGN-009 consistency spec (default: auto-detect)
+ *   --overwrite         Overwrite existing SVG files (default: skip if present)
+ *   --dry-run           Print prompts without calling API
+ *   --list-types        Print available character types and exit
+ *   --list-states       Print available star states and exit
+ */
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.choice
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+// ---------------------------------------------------------------------------
+// Domain model — loaded from sprite-spec.json, not hard-coded
+// ---------------------------------------------------------------------------
+
+@JsonClass(generateAdapter = false)
+data class CharacterType(
+    val id: String,
+    val displayName: String,
+    val role: String,
+    val palette: String,
+    val silhouetteNotes: String,
+)
+
+@JsonClass(generateAdapter = false)
+data class StarState(
+    val id: String,
+    val stars: Int,
+    val label: String,
+    val poseGuide: String,
+)
+
+@JsonClass(generateAdapter = false)
+data class SpriteSpec(
+    val characterTypes: List<CharacterType>,
+    val starStates: List<StarState>,
+)
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+
+sealed class Credential {
+    /** Raw API key — sent as x-goog-api-key (Gemini) or Authorization: Bearer (Grok). */
+    data class ApiKey(val key: String) : Credential()
+    /** OAuth access token — sent as Authorization: Bearer regardless of provider. */
+    data class BearerToken(val token: String) : Credential()
+}
+
+fun expandHome(path: String): Path =
+    Paths.get(path.replaceFirst("~", System.getProperty("user.home")))
+
+/**
+ * Parse a credential file. Two formats supported:
+ *   - JSON with "access_token" field (gemini-cli oauth format) → BearerToken
+ *   - Plain text key/token                                     → ApiKey
+ */
+fun parseCredentialFile(path: Path): Credential {
+    val content = Files.readString(path).trim()
+    return try {
+        @Suppress("UNCHECKED_CAST")
+        val map = jsonAny.fromJson(content) as? Map<String, Any?>
+        val token = (map?.get("access_token") as? String)?.takeIf { it.isNotBlank() }
+        if (token != null) Credential.BearerToken(token) else Credential.ApiKey(content)
+    } catch (_: Exception) {
+        Credential.ApiKey(content)
+    }
+}
+
+fun resolveCredential(
+    provider: String,
+    apiKeyFlag: String?,
+    providerKeyFlag: String?,
+    credFileFlag: String?,
+    autoSearchPaths: List<String>,
+): Credential {
+    val rawKey = apiKeyFlag ?: providerKeyFlag
+    if (rawKey != null) return Credential.ApiKey(rawKey)
+
+    if (credFileFlag != null) {
+        val path = expandHome(credFileFlag)
+        if (!Files.exists(path)) error("Credentials file not found: $path")
+        return parseCredentialFile(path)
+    }
+
+    for (rawPath in autoSearchPaths) {
+        val path = expandHome(rawPath)
+        if (Files.exists(path)) return parseCredentialFile(path)
+    }
+
+    error(
+        "No credentials found for provider '$provider'. " +
+        "Use --api-key, --credentials-file, or set ${provider.uppercase()}_API_KEY."
+    )
+}
+
+// ---------------------------------------------------------------------------
+// JSON + HTTP (Moshi + OkHttp)
+// ---------------------------------------------------------------------------
+
+private val moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+private val jsonAny = moshi.adapter(Any::class.java)
+private val specAdapter = moshi.adapter(SpriteSpec::class.java)
+
+fun toJson(value: Any): String = jsonAny.toJson(value)
+
+@Suppress("UNCHECKED_CAST")
+fun Any?.nav(key: String): Any? = (this as? Map<*, *>)?.get(key)
+@Suppress("UNCHECKED_CAST")
+fun Any?.nav(index: Int): Any? = (this as? List<*>)?.getOrNull(index)
+
+private val httpClient = OkHttpClient()
+private val JSON_MEDIA = "application/json; charset=utf-8".toMediaType()
+
+private fun httpPost(url: String, headers: Map<String, String>, jsonBody: String): String {
+    val req = Request.Builder()
+        .url(url)
+        .apply { headers.forEach { (k, v) -> header(k, v) } }
+        .post(jsonBody.toRequestBody(JSON_MEDIA))
+        .build()
+    val resp = httpClient.newCall(req).execute()
+    val body = resp.body?.string() ?: ""
+    if (!resp.isSuccessful) error("HTTP ${resp.code}:\n${body.take(800)}")
+    return body
+}
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+interface SpriteProvider {
+    val name: String
+    fun generate(systemPrompt: String, userPrompt: String): String
+}
+
+// ---------------------------------------------------------------------------
+// Gemini provider
+// ---------------------------------------------------------------------------
+
+class GeminiProvider(
+    private val credential: Credential,
+    private val model: String = "gemini-2.5-flash",
+) : SpriteProvider {
+    override val name = "gemini"
+
+    override fun generate(systemPrompt: String, userPrompt: String): String {
+        val url = "https://generativelanguage.googleapis.com/v1beta/models/$model:generateContent"
+        val auth: Map<String, String> = when (credential) {
+            is Credential.ApiKey      -> mapOf("x-goog-api-key" to credential.key)
+            is Credential.BearerToken -> mapOf("Authorization"  to "Bearer ${credential.token}")
+        }
+        val raw = httpPost(url, auth, toJson(mapOf(
+            "system_instruction" to mapOf("parts" to listOf(mapOf("text" to systemPrompt))),
+            "contents"           to listOf(mapOf("role" to "user", "parts" to listOf(mapOf("text" to userPrompt)))),
+            "generationConfig"   to mapOf("temperature" to 1.0, "maxOutputTokens" to 8192),
+        )))
+        val parsed = jsonAny.fromJson(raw)
+        val candidate = parsed.nav("candidates").nav(0)
+            ?: error("Gemini returned no candidates. Raw: ${raw.take(500)}")
+        val content = candidate.nav("content")
+            ?: error("Gemini candidate has no content (finishReason: ${candidate.nav("finishReason")}). Raw: ${raw.take(500)}")
+        return content.nav("parts").nav(0).nav("text") as? String
+            ?: error("Gemini text missing. Raw: ${raw.take(500)}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Grok provider (xAI — OpenAI-compatible)
+// ---------------------------------------------------------------------------
+
+class GrokProvider(
+    private val credential: Credential,
+    private val model: String = "grok-3",
+) : SpriteProvider {
+    override val name = "grok"
+
+    override fun generate(systemPrompt: String, userPrompt: String): String {
+        val bearer = when (credential) {
+            is Credential.ApiKey      -> credential.key
+            is Credential.BearerToken -> credential.token
+        }
+        val raw = httpPost("https://api.x.ai/v1/chat/completions",
+            mapOf("Authorization" to "Bearer $bearer"),
+            toJson(mapOf(
+                "model"       to model,
+                "messages"    to listOf(
+                    mapOf("role" to "system", "content" to systemPrompt),
+                    mapOf("role" to "user",   "content" to userPrompt),
+                ),
+                "temperature" to 0.8,
+                "max_tokens"  to 8192,
+            ))
+        )
+        val parsed = jsonAny.fromJson(raw)
+        val choice = parsed.nav("choices").nav(0)
+            ?: error("Grok returned no choices. Raw: ${raw.take(500)}")
+        return choice.nav("message").nav("content") as? String
+            ?: error("Grok content missing. Raw: ${raw.take(500)}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SVG extraction
+// ---------------------------------------------------------------------------
+
+fun extractSvg(raw: String): String {
+    val fenced = Regex(
+        "```(?:svg|xml)?[ \t]*\\r?\\n(<svg[\\s\\S]*?</svg>)[ \t]*\\r?\\n```",
+        RegexOption.IGNORE_CASE,
+    ).find(raw)
+    if (fenced != null) return fenced.groupValues[1].trim()
+
+    val bare = Regex("<svg[\\s\\S]*?</svg>", RegexOption.IGNORE_CASE).find(raw)
+    if (bare != null) return bare.value.trim()
+
+    error("No SVG found in model output. First 500 chars:\n${raw.take(500)}")
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+fun buildSystemPrompt(specSection: String): String = """
+You are an SVG character artist producing sprites for a browser strategy game called
+"Past the Post" — an educational gerrymandering simulator.
+
+You produce clean, minimal, political-cartoon / board-game-token style SVG art.
+
+The following consistency specification MUST be followed for every file you produce.
+Consistency across the full set of 20 sprites is more important than perfection of
+any individual file.
+
+$specSection
+
+Output the SVG inside a markdown fenced code block:
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  ...
+</svg>
+```
+Respond with ONLY the code block — no prose, no explanation.
+""".trimIndent()
+
+fun buildUserPrompt(type: CharacterType, state: StarState): String = """
+Generate one SVG sprite for the following character + state combination.
+
+CHARACTER TYPE: ${type.displayName}
+  Role: ${type.role}
+  Palette: ${type.palette}
+  Silhouette notes: ${type.silhouetteNotes}
+
+STATE: ${state.label}
+  Pose guide: ${state.poseGuide}
+
+Technical requirements (all mandatory):
+  • viewBox="0 0 200 200"; no width/height attributes; transparent background
+  • Character centred horizontally; head near y=30, feet near y=190
+  • Flat fills only — no gradients, no drop shadows, no filters
+  • Primary outline stroke-width 2–3; interior detail stroke-width 1–2
+  • Maximum 3 fill colours per character (plus shared outline #1a1a2e)
+  • @keyframes idle-bob — subtle vertical bob ≤4 px, 0.6–1.0 s, ease-in-out, infinite
+    Apply via class="character" on a <g> wrapping all elements
+  • Self-contained; no external references (no <use href="..."/>, no xlink)
+  • Target file size: under 15 KB
+
+Remember: same type across all 4 states must share the same costume and silhouette.
+Only pose and expression change between states.
+""".trimIndent()
+
+// ---------------------------------------------------------------------------
+// Loaders
+// ---------------------------------------------------------------------------
+
+fun loadSpriteSpec(path: String?): SpriteSpec {
+    val resolved: Path = when {
+        path != null -> Paths.get(path)
+        else -> listOf("tools/sprite-spec.json").map(Paths::get)
+            .firstOrNull(Files::exists)
+            ?: error("Could not find sprite-spec.json. Pass --characters-file <path>.")
+    }
+    return specAdapter.fromJson(Files.readString(resolved))
+        ?: error("Failed to parse sprite spec: $resolved")
+}
+
+fun loadSpecSection(specFile: String?): String {
+    val path: Path = when {
+        specFile != null -> Paths.get(specFile)
+        else -> listOf(
+            "thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.md",
+            "thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md",
+        ).map(Paths::get).firstOrNull(Files::exists)
+            ?: error("Could not auto-detect DESIGN-009 spec. Pass --spec-file <path>.")
+    }
+    val text = Files.readString(path)
+    val idx = text.indexOf("## AI Art Generation")
+    return if (idx >= 0) text.substring(idx) else text
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+class GenSprites : CliktCommand(
+    name = "gen-sprites",
+    help = "Generate SVG character sprites via AI model API (Gemini or Grok)",
+) {
+    val providerName by option("--provider", help = "AI provider: gemini or grok")
+        .choice("gemini", "grok").default("gemini")
+
+    val apiKeyOpt    by option("--api-key",          help = "Raw API key (any provider)")
+    val geminiApiKey by option("--gemini-api-key",    help = "Gemini API key", envvar = "GEMINI_API_KEY")
+    val grokApiKey   by option("--grok-api-key",      help = "Grok API key",   envvar = "GROK_API_KEY")
+    val credFile     by option("--credentials-file",  help = "Credentials file (JSON oauth or plain text key)")
+
+    val model          by option("--model",          help = "Model override (default: gemini-2.5-flash or grok-3)")
+    val charactersFile by option("--characters-file", help = "Path to sprite-spec.json (default: tools/sprite-spec.json)")
+
+    val typeFilter  by option("--type",  help = "Generate only this type ID (repeatable)").multiple()
+    val stateFilter by option("--state", help = "Generate only this state ID (repeatable)").multiple()
+
+    val outputDir by option("--output-dir", help = "Root directory for output SVGs")
+        .default("game/web/assets/characters")
+
+    val specFile  by option("--spec-file",   help = "Path to DESIGN-009 consistency spec (auto-detected by default)")
+    val overwrite by option("--overwrite",   help = "Overwrite existing SVG files").flag()
+    val dryRun    by option("--dry-run",     help = "Print prompts; do not call API").flag()
+    val listTypes  by option("--list-types",  help = "Print available character types and exit").flag()
+    val listStates by option("--list-states", help = "Print available star states and exit").flag()
+
+    override fun run() {
+        val spec = loadSpriteSpec(charactersFile)
+
+        if (listTypes) {
+            echo("Available character types (from ${charactersFile ?: "tools/sprite-spec.json"}):")
+            spec.characterTypes.forEach { echo("  ${it.id.padEnd(22)} ${it.displayName} — ${it.role}") }
+            return
+        }
+        if (listStates) {
+            echo("Available star states (from ${charactersFile ?: "tools/sprite-spec.json"}):")
+            spec.starStates.forEach { echo("  ${it.id.padEnd(12)} ${it.label}") }
+            return
+        }
+
+        val types  = if (typeFilter.isEmpty())  spec.characterTypes else spec.characterTypes.filter { it.id in typeFilter }
+        val states = if (stateFilter.isEmpty()) spec.starStates     else spec.starStates.filter     { it.id in stateFilter }
+
+        if (types.isEmpty())  { echo("No matching types — run --list-types.",   err = true); return }
+        if (states.isEmpty()) { echo("No matching states — run --list-states.", err = true); return }
+
+        val specSection  = loadSpecSection(specFile)
+        val systemPrompt = buildSystemPrompt(specSection)
+        val provider     = if (dryRun) null else buildProvider()
+
+        val total = types.size * states.size
+        echo("${if (dryRun) "DRY RUN" else "Generating"}: ${types.size} type(s) × ${states.size} state(s) = $total sprite(s)")
+        echo()
+
+        var generated = 0; var skipped = 0; var errors = 0
+
+        for (type in types) {
+            for (state in states) {
+                val outPath = Paths.get(outputDir, type.id, "${state.id}.svg")
+
+                if (!dryRun && !overwrite && Files.exists(outPath)) {
+                    echo("  SKIP    ${type.id}/${state.id}.svg  (exists; use --overwrite to replace)")
+                    skipped++; continue
+                }
+
+                val userPrompt = buildUserPrompt(type, state)
+
+                if (dryRun) {
+                    echo("=== ${type.id} / ${state.id} ===")
+                    echo("--- SYSTEM PROMPT (${systemPrompt.length} chars) ---")
+                    echo(systemPrompt)
+                    echo("--- USER PROMPT (${userPrompt.length} chars) ---")
+                    echo(userPrompt)
+                    echo(); generated++; continue
+                }
+
+                echo("  GEN     ${type.id}/${state.id}.svg  [${providerName}/${model ?: "default"}] ...")
+                try {
+                    val svg = extractSvg(provider!!.generate(systemPrompt, userPrompt))
+                    Files.createDirectories(outPath.parent)
+                    Files.writeString(outPath, svg)
+                    echo("  OK      $outPath  (${"%.1f".format(svg.length / 1024.0)} KB)")
+                    generated++
+                } catch (e: Exception) {
+                    echo("  ERROR   ${type.id}/${state.id}: ${e.message}", err = true)
+                    errors++
+                }
+            }
+        }
+
+        echo()
+        echo("Done: $generated generated, $skipped skipped, $errors error(s).")
+        if (errors > 0) throw SystemExit(1)
+    }
+
+    private fun buildProvider(): SpriteProvider {
+        val credential = resolveCredential(
+            provider        = providerName,
+            apiKeyFlag      = apiKeyOpt,
+            providerKeyFlag = if (providerName == "gemini") geminiApiKey else grokApiKey,
+            credFileFlag    = credFile,
+            autoSearchPaths = when (providerName) {
+                "gemini" -> listOf("~/.gemini/oauth_creds.json")
+                else     -> emptyList()
+            },
+        )
+        return when (providerName) {
+            "gemini" -> GeminiProvider(credential, model ?: "gemini-2.5-flash")
+            "grok"   -> GrokProvider(credential,   model ?: "grok-3")
+            else     -> error("Unknown provider: $providerName")
+        }
+    }
+}
+
+class SystemExit(val code: Int) : Exception()
+
+try {
+    GenSprites().main(args)
+} catch (e: SystemExit) {
+    System.exit(e.code)
+}

--- a/tools/gen-sprites.test.main.kts
+++ b/tools/gen-sprites.test.main.kts
@@ -1,0 +1,392 @@
+#!/usr/bin/env kotlin
+
+// NOTE: Kotlin scripts cannot import each other. Logic under test is duplicated
+// here from gen-sprites.main.kts. The right long-term fix is to extract shared
+// logic to a .kt lib that both scripts depend on.
+//
+// IMPORTANT: Logic under test must live in an `object`, not as top-level functions.
+// Top-level functions in .kts files are instance methods of the generated script
+// class; test classes (static nested classes) cannot reference them without the
+// outer instance, causing JUnit to silently skip all tests in such classes.
+
+@file:Repository("https://repo1.maven.org/maven2/")
+@file:DependsOn("org.junit.jupiter:junit-jupiter-api:5.11.0")
+@file:DependsOn("org.junit.jupiter:junit-jupiter-engine:5.11.0")
+@file:DependsOn("org.junit.platform:junit-platform-launcher:1.11.0")
+@file:DependsOn("com.squareup.moshi:moshi-kotlin:1.15.0")
+
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
+import org.junit.platform.launcher.core.LauncherFactory
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+// ---------------------------------------------------------------------------
+// Duplicated from gen-sprites.main.kts
+// ---------------------------------------------------------------------------
+
+@JsonClass(generateAdapter = false)
+data class CharacterType(val id: String, val displayName: String, val role: String, val palette: String, val silhouetteNotes: String)
+
+@JsonClass(generateAdapter = false)
+data class StarState(val id: String, val stars: Int, val label: String, val poseGuide: String)
+
+@JsonClass(generateAdapter = false)
+data class SpriteSpec(val characterTypes: List<CharacterType>, val starStates: List<StarState>)
+
+sealed class Credential {
+    data class ApiKey(val key: String) : Credential()
+    data class BearerToken(val token: String) : Credential()
+}
+
+object Logic {
+    private val moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+    private val jsonAny = moshi.adapter(Any::class.java)
+    val specAdapter = moshi.adapter(SpriteSpec::class.java)
+
+    fun parseCredentialFile(path: Path): Credential {
+        val content = Files.readString(path).trim()
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            val map = jsonAny.fromJson(content) as? Map<String, Any?>
+            val token = (map?.get("access_token") as? String)?.takeIf { it.isNotBlank() }
+            if (token != null) Credential.BearerToken(token) else Credential.ApiKey(content)
+        } catch (_: Exception) {
+            Credential.ApiKey(content)
+        }
+    }
+
+    fun resolveCredential(
+        provider: String,
+        apiKeyFlag: String?,
+        providerKeyFlag: String?,
+        credFileFlag: String?,
+        autoSearchPaths: List<String>,
+    ): Credential {
+        val rawKey = apiKeyFlag ?: providerKeyFlag
+        if (rawKey != null) return Credential.ApiKey(rawKey)
+        if (credFileFlag != null) {
+            val path = Paths.get(credFileFlag)
+            if (!Files.exists(path)) error("Credentials file not found: $path")
+            return parseCredentialFile(path)
+        }
+        for (rawPath in autoSearchPaths) {
+            val path = Paths.get(rawPath)
+            if (Files.exists(path)) return parseCredentialFile(path)
+        }
+        error("No credentials found for provider '$provider'.")
+    }
+
+    fun loadSpriteSpec(json: String): SpriteSpec =
+        specAdapter.fromJson(json) ?: error("Failed to parse sprite spec")
+
+    fun extractSvg(raw: String): String {
+        val fenced = Regex(
+            "```(?:svg|xml)?[ \t]*\\r?\\n(<svg[\\s\\S]*?</svg>)[ \t]*\\r?\\n```",
+            RegexOption.IGNORE_CASE,
+        ).find(raw)
+        if (fenced != null) return fenced.groupValues[1].trim()
+        val bare = Regex("<svg[\\s\\S]*?</svg>", RegexOption.IGNORE_CASE).find(raw)
+        if (bare != null) return bare.value.trim()
+        error("No SVG found in model output. First 500 chars:\n${raw.take(500)}")
+    }
+
+    fun buildUserPrompt(type: CharacterType, state: StarState): String = """
+Generate one SVG sprite for the following character + state combination.
+
+CHARACTER TYPE: ${type.displayName}
+  Role: ${type.role}
+  Palette: ${type.palette}
+  Silhouette notes: ${type.silhouetteNotes}
+
+STATE: ${state.label}
+  Pose guide: ${state.poseGuide}
+
+Technical requirements (all mandatory):
+  • viewBox="0 0 200 200"; no width/height attributes; transparent background
+  • Character centred horizontally; head near y=30, feet near y=190
+  • Flat fills only — no gradients, no drop shadows, no filters
+  • Primary outline stroke-width 2–3; interior detail stroke-width 1–2
+  • Maximum 3 fill colours per character (plus shared outline #1a1a2e)
+  • @keyframes idle-bob — subtle vertical bob ≤4 px, 0.6–1.0 s, ease-in-out, infinite
+    Apply via class="character" on a <g> wrapping all elements
+  • Self-contained; no external references (no <use href="..."/>, no xlink)
+  • Target file size: under 15 KB
+
+Remember: same type across all 4 states must share the same costume and silhouette.
+Only pose and expression change between states.
+""".trimIndent()
+
+    fun buildSystemPrompt(specSection: String): String = """
+You are an SVG character artist producing sprites for a browser strategy game called
+"Past the Post" — an educational gerrymandering simulator.
+
+You produce clean, minimal, political-cartoon / board-game-token style SVG art.
+
+The following consistency specification MUST be followed for every file you produce.
+Consistency across the full set of 20 sprites is more important than perfection of
+any individual file.
+
+$specSection
+
+Output the SVG inside a markdown fenced code block:
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  ...
+</svg>
+```
+Respond with ONLY the code block — no prose, no explanation.
+""".trimIndent()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+class SvgExtractionTest {
+    private val minimalSvg = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 200 200\">\n  <circle cx=\"100\" cy=\"100\" r=\"50\"/>\n</svg>"
+
+    @Test fun `extracts SVG from svg-fenced code block`()   { assertEquals(minimalSvg, Logic.extractSvg("```svg\n$minimalSvg\n```")) }
+    @Test fun `extracts SVG from xml-fenced code block`()   { assertEquals(minimalSvg, Logic.extractSvg("```xml\n$minimalSvg\n```")) }
+    @Test fun `extracts SVG from plain-fenced code block`() { assertEquals(minimalSvg, Logic.extractSvg("```\n$minimalSvg\n```")) }
+
+    @Test fun `extracts bare SVG with no fence`() {
+        val result = Logic.extractSvg("preamble\n$minimalSvg\ntrailing")
+        assertTrue(result.startsWith("<svg") && result.endsWith("</svg>"))
+    }
+
+    @Test fun `throws on response with no SVG`()  { assertThrows<IllegalStateException> { Logic.extractSvg("no svg here") } }
+    @Test fun `throws on empty string`()           { assertThrows<IllegalStateException> { Logic.extractSvg("") } }
+
+    @Test fun `extracted SVG does not contain fence markers`() {
+        assertFalse(Logic.extractSvg("```svg\n$minimalSvg\n```").contains("```"))
+    }
+}
+
+class CredentialFileParsingTest {
+    @TempDir lateinit var tmp: Path
+
+    @Test fun `plain text file yields ApiKey`() {
+        val f = tmp.resolve("key.txt").also { Files.writeString(it, "my-api-key\n") }
+        assertEquals(Credential.ApiKey("my-api-key"), Logic.parseCredentialFile(f))
+    }
+
+    @Test fun `plain text file is trimmed`() {
+        val f = tmp.resolve("key.txt").also { Files.writeString(it, "  trimmed  \n") }
+        assertEquals(Credential.ApiKey("trimmed"), Logic.parseCredentialFile(f))
+    }
+
+    @Test fun `gemini oauth JSON yields BearerToken`() {
+        val f = tmp.resolve("oauth.json").also {
+            Files.writeString(it, """{"access_token":"ya29.abc","token_type":"Bearer"}""")
+        }
+        assertEquals(Credential.BearerToken("ya29.abc"), Logic.parseCredentialFile(f))
+    }
+
+    @Test fun `JSON without access_token falls back to ApiKey`() {
+        val json = """{"some_other_field":"value"}"""
+        val f = tmp.resolve("other.json").also { Files.writeString(it, json) }
+        assertEquals(Credential.ApiKey(json), Logic.parseCredentialFile(f))
+    }
+
+    @Test fun `blank access_token falls back to ApiKey`() {
+        val json = """{"access_token":"   "}"""
+        val f = tmp.resolve("blank.json").also { Files.writeString(it, json) }
+        assertEquals(Credential.ApiKey(json), Logic.parseCredentialFile(f))
+    }
+}
+
+class CredentialResolutionTest {
+    @TempDir lateinit var tmp: Path
+
+    private fun keyFile(name: String, content: String) =
+        tmp.resolve(name).also { Files.writeString(it, content) }.toString()
+
+    @Test fun `api-key flag takes highest priority`() {
+        assertEquals(Credential.ApiKey("flag"), Logic.resolveCredential("gemini", "flag", "other", null, emptyList()))
+    }
+
+    @Test fun `provider key flag used when api-key absent`() {
+        assertEquals(Credential.ApiKey("prov"), Logic.resolveCredential("gemini", null, "prov", null, emptyList()))
+    }
+
+    @Test fun `credentials file used when no key flag`() {
+        val path = keyFile("key.txt", "file-key")
+        assertEquals(Credential.ApiKey("file-key"), Logic.resolveCredential("gemini", null, null, path, emptyList()))
+    }
+
+    @Test fun `oauth credentials file yields BearerToken`() {
+        val path = keyFile("oauth.json", """{"access_token":"ya29.tok"}""")
+        assertEquals(Credential.BearerToken("ya29.tok"), Logic.resolveCredential("gemini", null, null, path, emptyList()))
+    }
+
+    @Test fun `auto-search path used as last resort`() {
+        val path = keyFile("auto.txt", "auto-key")
+        assertEquals(Credential.ApiKey("auto-key"), Logic.resolveCredential("gemini", null, null, null, listOf(path)))
+    }
+
+    @Test fun `first matching auto-search path wins`() {
+        val p1 = keyFile("first.txt", "key-first")
+        val p2 = keyFile("second.txt", "key-second")
+        assertEquals(Credential.ApiKey("key-first"), Logic.resolveCredential("gemini", null, null, null, listOf(p1, p2)))
+    }
+
+    @Test fun `non-existent auto-search paths are skipped`() {
+        val path = keyFile("real.txt", "real-key")
+        assertEquals(Credential.ApiKey("real-key"), Logic.resolveCredential("gemini", null, null, null, listOf("/no/such/file", path)))
+    }
+
+    @Test fun `missing credentials file throws with path in message`() {
+        val ex = assertThrows<IllegalStateException> {
+            Logic.resolveCredential("gemini", null, null, "/nonexistent.txt", emptyList())
+        }
+        assertTrue(ex.message!!.contains("/nonexistent.txt"))
+    }
+
+    @Test fun `no credentials at all throws with provider name`() {
+        val ex = assertThrows<IllegalStateException> {
+            Logic.resolveCredential("grok", null, null, null, emptyList())
+        }
+        assertTrue(ex.message!!.contains("grok"))
+    }
+}
+
+class SpriteSpecParsingTest {
+    private val minimalSpec = """
+        {
+          "characterTypes": [
+            {"id":"partisan-boss","displayName":"Partisan Boss","role":"role","palette":"palette","silhouetteNotes":"notes"}
+          ],
+          "starStates": [
+            {"id":"three-star","stars":3,"label":"Three-star (ecstatic)","poseGuide":"arms up"}
+          ]
+        }
+    """.trimIndent()
+
+    @Test fun `parses character type fields`() {
+        val spec = Logic.loadSpriteSpec(minimalSpec)
+        assertEquals(1, spec.characterTypes.size)
+        val ct = spec.characterTypes[0]
+        assertEquals("partisan-boss", ct.id)
+        assertEquals("Partisan Boss", ct.displayName)
+        assertEquals("role", ct.role)
+    }
+
+    @Test fun `parses star state fields`() {
+        val spec = Logic.loadSpriteSpec(minimalSpec)
+        assertEquals(1, spec.starStates.size)
+        val ss = spec.starStates[0]
+        assertEquals("three-star", ss.id)
+        assertEquals(3, ss.stars)
+        assertEquals("arms up", ss.poseGuide)
+    }
+
+    @Test fun `parses multiple types and states`() {
+        val json = """
+        {
+          "characterTypes": [
+            {"id":"t1","displayName":"T1","role":"r","palette":"p","silhouetteNotes":"s"},
+            {"id":"t2","displayName":"T2","role":"r","palette":"p","silhouetteNotes":"s"}
+          ],
+          "starStates": [
+            {"id":"three-star","stars":3,"label":"Three-star","poseGuide":"up"},
+            {"id":"zero-star","stars":0,"label":"Zero-star","poseGuide":"down"}
+          ]
+        }
+        """.trimIndent()
+        val spec = Logic.loadSpriteSpec(json)
+        assertEquals(2, spec.characterTypes.size)
+        assertEquals(2, spec.starStates.size)
+    }
+
+    @Test fun `actual sprite-spec json is valid and complete`() {
+        val path = Paths.get("tools/sprite-spec.json")
+        assertTrue(Files.exists(path), "tools/sprite-spec.json must exist")
+        val spec = Logic.loadSpriteSpec(Files.readString(path))
+        assertEquals(5, spec.characterTypes.size, "Expected 5 character types")
+        assertEquals(4, spec.starStates.size,     "Expected 4 star states")
+        val typeIds  = spec.characterTypes.map { it.id }.toSet()
+        val stateIds = spec.starStates.map { it.id }.toSet()
+        assertAll(
+            { assertTrue("partisan-boss"     in typeIds) },
+            { assertTrue("legal-authority"   in typeIds) },
+            { assertTrue("bipartisan-broker" in typeIds) },
+            { assertTrue("reform-arbiter"    in typeIds) },
+            { assertTrue("neutral-admin"     in typeIds) },
+            { assertTrue("three-star" in stateIds) },
+            { assertTrue("two-star"   in stateIds) },
+            { assertTrue("one-star"   in stateIds) },
+            { assertTrue("zero-star"  in stateIds) },
+        )
+        assertEquals(setOf(0, 1, 2, 3), spec.starStates.map { it.stars }.toSet())
+        spec.characterTypes.forEach { t ->
+            assertTrue(t.displayName.isNotBlank(), "${t.id}: blank displayName")
+            assertTrue(t.role.isNotBlank(),        "${t.id}: blank role")
+            assertTrue(t.palette.isNotBlank(),     "${t.id}: blank palette")
+        }
+    }
+}
+
+class UserPromptContentTest {
+    private val type  = CharacterType("partisan-boss", "Partisan Boss", "hires player", "gold/red", "wide shoulders")
+    private val state = StarState("three-star", 3, "Three-star (ecstatic)", "arms raised high")
+    private val prompt by lazy { Logic.buildUserPrompt(type, state) }
+
+    @Test fun `contains character display name`() { assertTrue(prompt.contains("Partisan Boss")) }
+    @Test fun `contains state label`()             { assertTrue(prompt.contains("Three-star")) }
+    @Test fun `contains viewBox requirement`()     { assertTrue(prompt.contains("viewBox=\"0 0 200 200\"")) }
+    @Test fun `contains idle-bob requirement`()    { assertTrue(prompt.contains("idle-bob")) }
+    @Test fun `contains file size limit`()         { assertTrue(prompt.contains("15 KB")) }
+    @Test fun `contains outline colour`()          { assertTrue(prompt.contains("#1a1a2e")) }
+    @Test fun `contains head placement`()          { assertTrue(prompt.contains("y=30")) }
+    @Test fun `contains feet placement`()          { assertTrue(prompt.contains("y=190")) }
+}
+
+class SystemPromptContentTest {
+    private val spec = "## AI Art Generation\n- viewBox 0 0 200 200\n- Flat fills only"
+
+    @Test fun `embeds spec section verbatim`()      { assertTrue(Logic.buildSystemPrompt(spec).contains(spec)) }
+    @Test fun `instructs fenced SVG output`()        { assertTrue(Logic.buildSystemPrompt(spec).contains("```")) }
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+val request = LauncherDiscoveryRequestBuilder.request()
+    .selectors(
+        selectClass(SvgExtractionTest::class.java),
+        selectClass(CredentialFileParsingTest::class.java),
+        selectClass(CredentialResolutionTest::class.java),
+        selectClass(SpriteSpecParsingTest::class.java),
+        selectClass(UserPromptContentTest::class.java),
+        selectClass(SystemPromptContentTest::class.java),
+    )
+    .build()
+
+val listener = SummaryGeneratingListener()
+LauncherFactory.create().execute(request, listener)
+
+val summary = listener.summary
+println(
+    "\n${summary.testsSucceededCount}/${summary.testsStartedCount} tests passed" +
+    if (summary.testsFailedCount > 0L) ", ${summary.testsFailedCount} FAILED" else ""
+)
+summary.failures.forEach { f ->
+    println("  FAIL: ${f.testIdentifier.displayName}")
+    println("        ${f.exception.message}")
+}
+
+if (summary.testsFailedCount > 0L) {
+    System.err.println("Test run failed.")
+    System.exit(1)
+}

--- a/tools/sprite-spec.json
+++ b/tools/sprite-spec.json
@@ -1,0 +1,65 @@
+{
+  "characterTypes": [
+    {
+      "id": "partisan-boss",
+      "displayName": "Partisan Boss",
+      "role": "Party boss who hired the player to draw the map in their party's favour",
+      "palette": "party gold (#d4a017) and red (#c0392b) accents; shared dark outline (#1a1a2e)",
+      "silhouetteNotes": "Wide-shouldered power-broker suit jacket with visible lapels; strong hat brim or distinctive hair; props: flag or clenched fist; political-cartoon bravado"
+    },
+    {
+      "id": "legal-authority",
+      "displayName": "Legal Authority",
+      "role": "Federal judge evaluating whether the map meets constitutional requirements",
+      "palette": "slate blue (#4a6fa5) accent; formal dark robe; shared dark outline (#1a1a2e)",
+      "silhouetteNotes": "Judicial robe with wide collar; gavel as recurring prop; formal upright bearing; authority conveyed through posture not bulk"
+    },
+    {
+      "id": "bipartisan-broker",
+      "displayName": "Bipartisan Broker",
+      "role": "Both party bosses side by side, evaluating whether the map is fair to both sides",
+      "palette": "left boss warm-red (#c0392b); right boss cool-blue (#2980b9); shared dark outline (#1a1a2e)",
+      "silhouetteNotes": "Two smaller figures at half-width each within the 200x200 viewBox; mirror-image postures; opposing accent colours make them visually symmetric"
+    },
+    {
+      "id": "reform-arbiter",
+      "displayName": "Reform Arbiter",
+      "role": "Reform commission evaluating whether the map meets neutral fairness criteria",
+      "palette": "teal (#16a085) and muted green (#27ae60) accents; shared dark outline (#1a1a2e)",
+      "silhouetteNotes": "Business-casual attire; clipboard or balance-scale as prop; earnest civic-minded bearing; less imposing than Partisan Boss"
+    },
+    {
+      "id": "neutral-admin",
+      "displayName": "Neutral Admin",
+      "role": "Supervisor / tutorial guide assessing the player's work on training exercises",
+      "palette": "muted grey-blue (#7f8c8d / #a0b4c8) accents; shared dark outline (#1a1a2e)",
+      "silhouetteNotes": "Plain office attire; clipboard or checklist as prop; no political symbols; approachable and professional, not intimidating"
+    }
+  ],
+  "starStates": [
+    {
+      "id": "three-star",
+      "stars": 3,
+      "label": "Three-star (ecstatic)",
+      "poseGuide": "Open, expansive, celebratory — arms raised high or spread wide, leaning forward into the viewer, big visible gesture, wide grin or triumphant expression"
+    },
+    {
+      "id": "two-star",
+      "stars": 2,
+      "label": "Two-star (satisfied)",
+      "poseGuide": "Positive, composed — thumbs up or approving nod, upright confident posture, relaxed slight smile"
+    },
+    {
+      "id": "one-star",
+      "stars": 1,
+      "label": "One-star (disappointed)",
+      "poseGuide": "Reserved, ambivalent — slight lean, crossed arms or a restrained shrug, neutral or slightly downturned expression, subdued or absent gesture"
+    },
+    {
+      "id": "zero-star",
+      "stars": 0,
+      "label": "Zero-star (furious / despairing)",
+      "poseGuide": "Closed, negative — hunched or turned slightly away, disapproving gesture (fist, head in hands, or dismissive wave), clear frown or scowl"
+    }
+  ]
+}


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #206 (GAME-065 ticket + S12 roadmap)

## Summary

- **`tools/gen-sprites.main.kts`** — CLI harness for AI-driven SVG character sprite
  generation. Supports Gemini and Grok via a `SpriteProvider` interface; additional
  providers slot in without touching prompt or output logic.
  - Reads DESIGN-009 consistency spec from repo (auto-detect or `--spec-file`)
  - Prompt split into system (consistency spec + style role) and user (character
    type + star state + technical requirements) — each part is independently editable
  - Per-provider defaults: `gemini-2.5-flash`, `grok-3`; override with `--model`
  - API key via flag, provider-specific env var (`GEMINI_API_KEY` / `GROK_API_KEY`),
    or generic `SPRITE_API_KEY`
  - SVG extraction handles fenced code blocks (`\`\`\`svg`, `\`\`\`xml`, plain) and
    bare SVG fallback
  - `--type` / `--state` filters (repeatable); `--list-types` / `--list-states`
    for agent discovery; `--dry-run` for prompt inspection; `--overwrite` guard
  - Skips existing files by default (safe to re-run); exits 1 on any generation error

- **`tools/gen-sprites.test.main.kts`** — JUnit Jupiter test suite (24 tests):
  - `SvgExtractionTest` — fenced svg/xml/plain blocks, bare SVG, missing SVG → error
  - `UserPromptContentTest` — required fields in generated user prompt
  - `SystemPromptContentTest` — spec embedded; output format instruction present
  - `CharacterTypeTableTest` — all 5 type IDs, no duplicates, non-blank display names
  - `StarStateTableTest` — all 4 state IDs, star counts 0–3, no duplicates

## Validation performed
- [x] `tools/gen-sprites.main.kts -- --list-types` — all 5 types listed correctly
- [x] `tools/gen-sprites.main.kts -- --list-states` — all 4 states listed correctly
- [x] `tools/gen-sprites.main.kts -- --type partisan-boss --state three-star --dry-run` — full prompts printed; spec section embedded
- [x] `tools/gen-sprites.test.main.kts` — 24/24 tests pass

## Affected machines / services
- None — dev tooling only; no game files changed

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- see GAME-065

## Rollback
- Revert commit; no downstream impact
