### PR TITLE
feat(GAME-066): result screen dramatic reveal — sequential criteria, icons, instigator cross-fade

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -1014,3 +1014,58 @@ test("in-game nav: without campaign context, shows plain Main Menu button (no dr
   await expect(page.locator("#btn-nav-back-trigger")).toHaveText("← Main Menu");
   await expect(page.locator("#btn-back-to-scenarios")).toBeHidden();
 });
+
+// ─── GAME-066: result screen dramatic reveal ──────────────────────────────────
+
+test("GAME-066: reduced-motion — all criterion rows visible immediately after submit", async ({ page }) => {
+  // Global playwright config sets reducedMotion:'reduce', so sequential reveal
+  // is bypassed and all rows are rendered in final state synchronously.
+  await loadScenario(page, "scenario-002");
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-screen")).toBeVisible();
+
+  // All criterion rows must be visible immediately (no sequential reveal delay).
+  const rows = page.locator(".result-criterion");
+  const count = await rows.count();
+  expect(count).toBeGreaterThan(0);
+  for (let i = 0; i < count; i++) {
+    await expect(rows.nth(i)).toBeVisible();
+    // Each row should be in a final state (passed, failed-required, or failed-optional)
+    // not still in the pending checking state.
+    await expect(rows.nth(i)).not.toHaveClass(/rc-pending/);
+  }
+});
+
+test("GAME-066: result screen shows SVG criterion icons (not bare ✓/✗ text)", async ({ page }) => {
+  // reducedMotion:'reduce' from global config — instant reveal, so we can check icons.
+  await loadScenario(page, "scenario-002");
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-screen")).toBeVisible();
+
+  // Each rc-icon slot should contain an SVG element, not bare text.
+  const icons = page.locator(".result-criterion .rc-icon svg");
+  const count = await icons.count();
+  expect(count).toBeGreaterThan(0);
+});
+
+// test.use() must be at describe scope, not inside a test() body.
+test.describe("GAME-066: animated reveal path (no reduced-motion)", () => {
+  test.use({ reducedMotion: "no-preference" });
+
+  test("clicking result screen skips sequential reveal and shows all rows", async ({ page }) => {
+    await loadScenario(page, "scenario-002");
+    await page.locator("#btn-submit").click();
+    await expect(page.locator("#result-screen")).toBeVisible();
+
+    // Immediately click to skip — all rows should be in final state.
+    await page.locator("#result-screen").click();
+
+    const rows = page.locator(".result-criterion");
+    const count = await rows.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(rows.nth(i)).toBeVisible();
+      await expect(rows.nth(i)).not.toHaveClass(/rc-pending/);
+    }
+  });
+});

--- a/game/web/e2e/sprint4.spec.ts
+++ b/game/web/e2e/sprint4.spec.ts
@@ -31,8 +31,11 @@ async function openResultScreen(page: import("@playwright/test").Page): Promise<
 }
 
 // ─── GAME-052: Animated criteria reveal ──────────────────────────────────────
+// GAME-066 supersedes the 120ms stagger: reduced-motion mode (global default) renders
+// all rows in final state immediately; animated mode uses sequential JS reveal instead.
 
-test("GAME-052: criterion rows have staggered animation-delay styles", async ({ page }) => {
+test("GAME-052: criterion rows all visible immediately in reduced-motion mode", async ({ page }) => {
+  // Global playwright config sets reducedMotion:'reduce' — sequential reveal is bypassed.
   await loadEditor(page);
   await openResultScreen(page);
 
@@ -40,10 +43,10 @@ test("GAME-052: criterion rows have staggered animation-delay styles", async ({ 
   const count = await rows.count();
   expect(count).toBeGreaterThan(0);
 
-  // Row 0 → 0ms delay; row 1 → 120ms; row N → N*120ms
+  // All rows finalized immediately — no rc-pending class.
   for (let i = 0; i < count; i++) {
-    const delay = await rows.nth(i).evaluate((el) => (el as HTMLElement).style.animationDelay);
-    expect(delay).toBe(`${i * 120}ms`);
+    await expect(rows.nth(i)).toBeVisible();
+    await expect(rows.nth(i)).not.toHaveClass(/rc-pending/);
   }
 });
 

--- a/game/web/playwright.config.ts
+++ b/game/web/playwright.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
     baseURL: "http://localhost:58173",
     // Collect trace on any test failure (on-first-retry is dead config with retries:0)
     trace: "retain-on-failure",
+    // Skip sequential-reveal animations globally so existing tests don't time out
+    // waiting for 400ms×N stagger + 1200ms CHECKING hold per row. Tests that want
+    // to exercise the animated path override this with test.use({ reducedMotion: 'no-preference' }).
+    reducedMotion: "reduce",
   },
 
   projects: [

--- a/game/web/src/criterion-icons.ts
+++ b/game/web/src/criterion-icons.ts
@@ -1,0 +1,111 @@
+/**
+ * Per-criterion SVG icons for the result screen reveal sequence (GAME-066 / DESIGN-010).
+ *
+ * Each icon is a 24×24 viewBox, 2px stroke, optimised for dark backgrounds.
+ * Exported as inline SVG strings — no HTTP requests.
+ *
+ * Lookup: getCriterionIcon(criterionId, criterionType)
+ *   - criterionType is the Criterion["type"] string for scenario criteria
+ *   - criterionId prefix "validity:" is used for structural validity rows
+ */
+
+const ICONS: Record<string, string> = {
+  district_count: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <rect x="3" y="3" width="7" height="7" rx="1"/>
+    <rect x="14" y="3" width="7" height="7" rx="1"/>
+    <rect x="3" y="14" width="7" height="7" rx="1"/>
+    <rect x="14" y="14" width="7" height="7" rx="1"/>
+  </svg>`,
+
+  population_balance: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <line x1="12" y1="3" x2="12" y2="21"/>
+    <line x1="4" y1="8" x2="20" y2="8"/>
+    <path d="M4 8 Q5 12 8 14 Q11 12 12 8"/>
+    <path d="M12 8 Q13 12 16 14 Q19 12 20 8"/>
+    <line x1="9" y1="21" x2="15" y2="21"/>
+  </svg>`,
+
+  seat_count: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <rect x="6" y="10" width="12" height="7" rx="1"/>
+    <line x1="6" y1="10" x2="6" y2="7"/>
+    <line x1="18" y1="10" x2="18" y2="7"/>
+    <line x1="4" y1="17" x2="4" y2="21"/>
+    <line x1="20" y1="17" x2="20" y2="21"/>
+    <line x1="8" y1="7" x2="16" y2="7"/>
+  </svg>`,
+
+  majority_minority: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="9" cy="7" r="3"/>
+    <path d="M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2"/>
+    <circle cx="16" cy="7" r="3" stroke-dasharray="2 1"/>
+  </svg>`,
+
+  efficiency_gap: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <line x1="3" y1="21" x2="21" y2="21"/>
+    <rect x="5" y="9" width="5" height="12"/>
+    <rect x="14" y="4" width="5" height="17"/>
+  </svg>`,
+
+  mean_median: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M3 18 Q8 4 12 4 Q16 4 21 18"/>
+    <line x1="10" y1="8" x2="10" y2="20" stroke-dasharray="2 1"/>
+    <line x1="13" y1="7" x2="13" y2="20"/>
+  </svg>`,
+
+  compactness: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="7" cy="12" r="4"/>
+    <path d="M14 8 Q17 6 19 9 Q22 11 20 14 Q19 17 16 16 Q13 18 13 15 Q11 12 14 8Z"/>
+  </svg>`,
+
+  safe_seats: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M12 3 L20 7 L20 13 Q20 18 12 21 Q4 18 4 13 L4 7 Z"/>
+  </svg>`,
+
+  competitive_seats: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <line x1="3" y1="18" x2="21" y2="18"/>
+    <line x1="9" y1="18" x2="9" y2="10"/>
+    <polygon points="7,10 9,6 11,10"/>
+    <line x1="15" y1="18" x2="15" y2="10"/>
+    <polygon points="13,10 15,6 17,10"/>
+  </svg>`,
+
+  "validity:all-assigned": `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <rect x="3" y="3" width="7" height="7" rx="1"/>
+    <rect x="14" y="3" width="7" height="7" rx="1"/>
+    <rect x="3" y="14" width="7" height="7" rx="1"/>
+    <rect x="14" y="14" width="7" height="7" rx="1"/>
+    <line x1="5" y1="17" x2="7" y2="19"/>
+    <line x1="7" y1="19" x2="9" y2="15"/>
+  </svg>`,
+
+  "validity:population-balance": `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <line x1="12" y1="3" x2="12" y2="21"/>
+    <line x1="4" y1="10" x2="20" y2="10"/>
+    <path d="M4 10 Q5 15 8 17 Q11 15 12 10"/>
+    <path d="M12 10 Q13 13 16 12 Q19 11 20 10"/>
+    <line x1="9" y1="21" x2="15" y2="21"/>
+  </svg>`,
+
+  "validity:contiguity": `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M3 12 Q5 10 7 12 Q9 14 11 12"/>
+    <path d="M13 12 Q15 10 17 12 Q19 14 21 12"/>
+    <line x1="11" y1="12" x2="13" y2="12" stroke-dasharray="1 2"/>
+  </svg>`,
+};
+
+/**
+ * Return inline SVG markup for the given criterion.
+ *
+ * criterionType: the Criterion["type"] value for scenario criteria (e.g. "seat_count")
+ * criterionId:  the CriterionId string; validity rows use "validity:*" prefix
+ */
+export function getCriterionIcon(criterionId: string, criterionType: string): string {
+  // Exact type match first
+  if (criterionType in ICONS) return ICONS[criterionType]!;
+  // Validity prefix match (criterionId like "validity:contiguity-5" → "validity:contiguity")
+  if (criterionId.startsWith("validity:contiguity")) return ICONS["validity:contiguity"]!;
+  if (criterionId.startsWith("validity:all-assigned")) return ICONS["validity:all-assigned"]!;
+  if (criterionId.startsWith("validity:population-balance")) return ICONS["validity:population-balance"]!;
+  // Fallback: neutral dash
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="6" y1="12" x2="18" y2="12"/></svg>`;
+}

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -32,6 +32,7 @@ import {
 } from "./model/progress.js";
 import { CAMPAIGN_REGISTRY, getCampaign, loadLastPlayedScenario, saveLastPlayedScenario } from "./model/campaigns.js";
 import { initAssets, assetUrl } from "./assets.js";
+import { getCriterionIcon } from "./criterion-icons.js";
 
 // ─── Scenario manifest (GAME-021) ─────────────────────────────────────────────
 // Static list of all available scenarios in play order.
@@ -739,18 +740,32 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 
 	const GOVERNOR_DEMOGRAPHICS = ["wm", "bm", "af"] as const;
 
-	function renderInstigatorReaction(container: HTMLElement, type: InstigatorType, stars: number): void {
+	// GAME-066: Three-phase instigator helpers.
+	// Sheet column layout (governor): neutral 0–106px, approve 106–234px, disapprove 234–366px.
+	// Pose binary per DESIGN-010: approve=stars≥1, disapprove=stars===0.
+	// "waiting" reuses neutral column as proxy until GAME-060 waiting.svg is commissioned.
+
+	function renderInstigatorWaiting(container: HTMLElement, type: InstigatorType, demo: string): HTMLElement | null {
 		if (type === "governor") {
-			const demo = GOVERNOR_DEMOGRAPHICS[Math.floor(Math.random() * GOVERNOR_DEMOGRAPHICS.length)];
-			// Sheet is 1376×752; sprite height is fixed at 200px → scale = 200/752.
-			// Column splits (source px): neutral 0–400, approve 400–880, disapprove 880–1376.
-			// Display widths = round(col_width × 200/752): neutral=106, approve=128, disapprove=132.
-			// Element width is set per-pose so each crop window matches the column exactly — no bleed.
-			const pose = stars >= 3
-				? { offsetX: 106, width: 128, label: "The governor reacts with enthusiasm — thumbs up" }
-				: stars >= 2
-					? { offsetX: 0,   width: 106, label: "The governor looks on, arms at sides" }
-					: { offsetX: 234, width: 132, label: "The governor reacts with displeasure — thumbs down" };
+			const sprite = document.createElement("div");
+			sprite.className = "character-sprite character-governor";
+			sprite.setAttribute("role", "img");
+			sprite.setAttribute("aria-label", "The governor watches, awaiting the verdict");
+			sprite.style.width = "106px";
+			sprite.style.backgroundImage = `url('${assetUrl(`assets/characters/governor-${demo}/sheet.png`)}')`;
+			sprite.style.backgroundPosition = "0px 0%";
+			container.appendChild(sprite);
+			return sprite;
+		}
+		container.textContent = "⏳";
+		return null;
+	}
+
+	function renderInstigatorFinal(container: HTMLElement, type: InstigatorType, stars: number, demo: string): void {
+		if (type === "governor") {
+			const pose = stars >= 1
+				? { offsetX: 106, width: 128, label: "The governor approves — thumbs up" }
+				: { offsetX: 234, width: 132, label: "The governor disapproves — thumbs down" };
 			const sprite = document.createElement("div");
 			sprite.className = "character-sprite character-governor";
 			sprite.setAttribute("role", "img");
@@ -760,9 +775,33 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			sprite.style.backgroundPosition = `-${pose.offsetX}px 0%`;
 			container.appendChild(sprite);
 		} else {
-			// SVG-based types: emoji fallback until GAME-060 art is complete
-			container.textContent = stars >= 2 ? "🎉" : "💔";
+			container.textContent = stars >= 1 ? "🎉" : "💔";
 		}
+	}
+
+	function transitionInstigatorToVerdict(
+		sprite: HTMLElement | null,
+		container: HTMLElement,
+		type: InstigatorType,
+		stars: number,
+		demo: string,
+	): void {
+		if (type === "governor" && sprite) {
+			const pose = stars >= 1
+				? { offsetX: 106, width: 128, label: "The governor approves — thumbs up" }
+				: { offsetX: 234, width: 132, label: "The governor disapproves — thumbs down" };
+			sprite.style.opacity = "0";
+			setTimeout(() => {
+				sprite.setAttribute("aria-label", pose.label);
+				sprite.style.width = `${pose.width}px`;
+				sprite.style.backgroundPosition = `-${pose.offsetX}px 0%`;
+				sprite.style.opacity = "1";
+			}, 200);
+		} else if (type !== "governor") {
+			container.textContent = stars >= 1 ? "🎉" : "💔";
+		}
+		// GAME-061: audio clips registered when that ticket lands; no-ops until then
+		// audioPlayer.play(`instigator-${stars >= 1 ? "approve" : "disapprove"}-${type}`);
 	}
 
 	function showResultScreen() {
@@ -804,13 +843,14 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			: mapIsValid
 				? "One or more required criteria were not met."
 				: "The map has structural issues that must be fixed.";
-		resultReaction.innerHTML = "";
+		// GAME-066: sequential reveal — criteria appear one at a time with CHECKING hold.
+		const stars = computeStarCount(evalResult.criterionResults, mapIsValid);
 		const instigator = scenario.narrative.instigator;
-		if (instigator) {
-			const stars = computeStarCount(evalResult.criterionResults, mapIsValid);
-			renderInstigatorReaction(resultReaction, instigator.type, stars);
-		} else {
-			resultReaction.textContent = overallPass ? "🎉" : "💔";
+
+		// Build criterion-type lookup (criterionId → Criterion["type"]) for icon dispatch.
+		const criterionTypeMap = new Map<string, string>();
+		for (const sc of scenario.success_criteria) {
+			criterionTypeMap.set(sc.id as string, sc.criterion.type);
 		}
 
 		// GAME-059: for invalid maps, prepend validity failure rows before scenario criteria.
@@ -818,22 +858,33 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		const allRows: CriterionResult[] = [...validityRows, ...evalResult.criterionResults];
 
 		resultCriteriaList.innerHTML = "";
-		let rowIndex = 0;
-		for (const cr of allRows) {
-			const cls = cr.passed
+		resultReaction.innerHTML = "";
+
+		// Pick demo variant once so waiting and verdict poses use the same sprite sheet.
+		const demo = instigator?.type === "governor"
+			? GOVERNOR_DEMOGRAPHICS[Math.floor(Math.random() * GOVERNOR_DEMOGRAPHICS.length)]!
+			: "";
+
+		// Build a criterion row element.
+		// final=true → already in pass/fail state (reduced-motion or skip path).
+		// final=false → starts in rc-pending/CHECKING state; JS reveals it later.
+		function buildRowElement(cr: CriterionResult, final: boolean): HTMLElement {
+			const verdictCls = cr.passed
 				? "passed"
 				: cr.required
 					? "failed-required"
 					: "failed-optional";
 
 			const row = document.createElement("div");
-			row.className = `result-criterion ${cls}`;
-			row.style.animationDelay = `${rowIndex * 120}ms`;
-			rowIndex++;
+			row.className = final ? `result-criterion ${verdictCls}` : "result-criterion rc-pending";
+			row.dataset["passed"] = String(cr.passed);
+			row.dataset["required"] = String(cr.required);
+			row.dataset["finalized"] = String(final);
 
 			const iconEl = document.createElement("span");
 			iconEl.className = "rc-icon";
-			iconEl.textContent = cr.passed ? "✓" : "✗";
+			const criterionType = criterionTypeMap.get(cr.criterionId as string) ?? (cr.criterionId as string);
+			iconEl.innerHTML = getCriterionIcon(cr.criterionId as string, criterionType);
 
 			const body = document.createElement("div");
 			body.className = "rc-body";
@@ -851,26 +902,112 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			}
 
 			const badge = document.createElement("span");
-			badge.className = "rc-badge";
-			badge.textContent = cr.passed ? "PASS" : cr.required ? "FAIL" : "OPTIONAL";
+			badge.className = final ? "rc-badge" : "rc-badge rc-checking";
+			badge.textContent = final
+				? (cr.passed ? "PASS" : cr.required ? "FAIL" : "OPTIONAL")
+				: "CHECKING…";
 
 			row.appendChild(iconEl);
 			row.appendChild(body);
 			row.appendChild(badge);
-			resultCriteriaList.appendChild(row);
+			return row;
 		}
 
-		// Skip animation: click anywhere on result screen to reveal all rows instantly.
-		const skipHandler = () => {
-			const rows = Array.from(resultCriteriaList.querySelectorAll<HTMLElement>(".result-criterion"));
-			for (const el of rows) {
-				el.style.animation = "none";
-				el.style.opacity = "1";
+		// Snap a row to its final verdict state.
+		function finalizeRow(row: HTMLElement): void {
+			if (row.dataset["finalized"] === "true") return;
+			row.dataset["finalized"] = "true";
+			const passed = row.dataset["passed"] === "true";
+			const required = row.dataset["required"] === "true";
+			const verdictCls = passed ? "passed" : required ? "failed-required" : "failed-optional";
+			row.className = `result-criterion ${verdictCls}`;
+			row.style.opacity = "1";
+			row.style.animation = "none";
+			const badge = row.querySelector<HTMLSpanElement>(".rc-badge")!;
+			badge.classList.remove("rc-checking");
+			badge.textContent = passed ? "PASS" : required ? "FAIL" : "OPTIONAL";
+		}
+
+		const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+		if (reducedMotion) {
+			// Instant path: all rows final, instigator in verdict pose immediately.
+			for (const cr of allRows) {
+				resultCriteriaList.appendChild(buildRowElement(cr, /*final=*/ true));
 			}
-			skipClickHandler = null;
-		};
-		skipClickHandler = skipHandler;
-		resultScreen.addEventListener("click", skipHandler, { once: true });
+			if (instigator) {
+				renderInstigatorFinal(resultReaction, instigator.type, stars, demo);
+			} else {
+				resultReaction.textContent = overallPass ? "🎉" : "💔";
+			}
+		} else {
+			// Animated path: waiting instigator → sequential reveal → verdict cross-fade.
+			let waitingSprite: HTMLElement | null = null;
+			if (instigator) {
+				waitingSprite = renderInstigatorWaiting(resultReaction, instigator.type, demo);
+			} else {
+				resultReaction.textContent = "⏳";
+			}
+
+			const rowElements: HTMLElement[] = [];
+			for (const cr of allRows) {
+				const row = buildRowElement(cr, /*final=*/ false);
+				resultCriteriaList.appendChild(row);
+				rowElements.push(row);
+			}
+
+			const pendingTimeouts: ReturnType<typeof setTimeout>[] = [];
+			let delay = 0;
+
+			for (let i = 0; i < rowElements.length; i++) {
+				const row = rowElements[i]!;
+				const t1 = setTimeout(() => {
+					// Phase 1: animate row in with CHECKING badge.
+					row.classList.remove("rc-pending");
+					row.style.animation = "criterionReveal 0.3s ease forwards";
+
+					const t2 = setTimeout(() => {
+						// Phase 2: flip to final verdict with pop.
+						finalizeRow(row);
+						const badge = row.querySelector<HTMLSpanElement>(".rc-badge")!;
+						badge.classList.add("rc-pop");
+						badge.addEventListener("animationend", () => badge.classList.remove("rc-pop"), { once: true });
+
+						// After last row resolves, pause then show instigator verdict.
+						if (i === rowElements.length - 1) {
+							const tVerdict = setTimeout(() => {
+								// Natural reveal complete — deactivate skip handler.
+								resultScreen.removeEventListener("click", skipHandler);
+								skipClickHandler = null;
+								if (instigator) {
+									transitionInstigatorToVerdict(waitingSprite, resultReaction, instigator.type, stars, demo);
+								} else {
+									resultReaction.textContent = overallPass ? "🎉" : "💔";
+								}
+							}, 800);
+							pendingTimeouts.push(tVerdict);
+						}
+					}, 1200);
+					pendingTimeouts.push(t2);
+				}, delay);
+				pendingTimeouts.push(t1);
+				delay += 400;
+			}
+
+			// Skip: clear all pending timeouts, finalize all rows, show verdict instigator.
+			const skipHandler = () => {
+				for (const t of pendingTimeouts) clearTimeout(t);
+				for (const row of rowElements) finalizeRow(row);
+				if (instigator) {
+					transitionInstigatorToVerdict(waitingSprite, resultReaction, instigator.type, stars, demo);
+				} else {
+					resultReaction.textContent = overallPass ? "🎉" : "💔";
+				}
+				skipClickHandler = null;
+			};
+			skipClickHandler = skipHandler;
+			resultScreen.addEventListener("click", skipHandler, { once: true });
+		}
 
 		// GAME-059: "Fix It" label for invalid maps, "Keep Drawing" otherwise.
 		// "Next Scenario" only shown on a full pass.

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -591,11 +591,29 @@ body {
   animation: criterionReveal 0.3s ease forwards;
 }
 
+/* GAME-066: row starts hidden; JS reveals sequentially */
+.result-criterion.rc-pending {
+  opacity: 0;
+  animation: none;
+}
+
 .result-criterion .rc-icon {
   font-size: 1rem;
   flex-shrink: 0;
   margin-top: 1px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #4a6080;
+  transition: color 0.15s ease;
 }
+
+/* GAME-066: icon tints on verdict */
+.result-criterion.passed .rc-icon { color: #4caf80; }
+.result-criterion.failed-required .rc-icon { color: #e94560; }
+.result-criterion.failed-optional .rc-icon { color: #606080; }
 
 .result-criterion .rc-body {
   flex: 1;
@@ -625,6 +643,29 @@ body {
 .result-criterion.failed-required .rc-badge { background: #3a1020; color: #e94560; }
 .result-criterion.failed-optional .rc-badge { background: #2a2a3a; color: #7070a0; }
 
+/* GAME-066: CHECKING badge — muted pulse during hold phase */
+.rc-badge.rc-checking {
+  background: #1a2a3a;
+  color: #5070a0;
+  animation: rcCheckingPulse 0.8s ease-in-out infinite alternate;
+}
+
+@keyframes rcCheckingPulse {
+  from { opacity: 0.5; }
+  to   { opacity: 1; }
+}
+
+/* GAME-066: pop scale on verdict flip */
+@keyframes rcBadgePop {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.25); }
+  100% { transform: scale(1); }
+}
+
+.rc-badge.rc-pop {
+  animation: rcBadgePop 0.15s ease-out forwards;
+}
+
 @keyframes criterionReveal {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }
@@ -645,6 +686,8 @@ body {
   background-size: auto 100%;
   background-repeat: no-repeat;
   animation: characterBob 0.9s ease-in-out infinite alternate;
+  /* GAME-066: cross-fade on pose transition */
+  transition: opacity 0.2s ease;
 }
 
 @keyframes characterBob {
@@ -655,6 +698,17 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .character-sprite {
     animation: none;
+    transition: none;
+  }
+  .rc-badge.rc-checking {
+    animation: none;
+    opacity: 1;
+  }
+  .rc-badge.rc-pop {
+    animation: none;
+  }
+  .result-criterion .rc-icon {
+    transition: none;
   }
 }
 

--- a/thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.compressed.md
+++ b/thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.compressed.md
@@ -1,0 +1,80 @@
+<!--COMPRESSED v1; source:2026-05-07-design-010-result-screen-dramatic-reveal.md-->
+§META
+date:2026-05-07 researcher:Claude(Sonnet 4.6) topic:result-screen-dramatic-reveal status:decisions-complete
+gates:GAME-066
+
+§ABBREV
+ts=thoughts/shared cr=criterion ins=instigator
+
+§CURRENT_STATE
+120ms stagger; 0.3s criterionReveal; rc-icon=✓/✗ text; badge=PASS/FAIL/OPTIONAL
+$ins: final star-count pose rendered after all rows; click-to-skip removes animation
+no suspense; no per-cr icons; no character flash
+
+§CR_TYPES
+seat_count majority_minority efficiency_gap mean_median compactness safe_seats
+competitive_seats population_balance district_count
+validity rows: validity:all-assigned validity:population-balance validity:contiguity-*
+
+§D1_ICONS
+source: separate flat SVG symbol set (not char sprites); 24×24 or 36×36 viewBox (try both; pick by visual weight); 2px stroke; dark-bg optimized
+delivery: inline SVG strings exported from game/web/src/ui/criterion-icons.ts (no HTTP requests)
+placement: inside existing .rc-icon slot; replaces ✓/✗; color-tinted green/red on result; badge still shows PASS/FAIL
+
+| type | icon concept |
+|---|---|
+| district_count | 2×2 grid of squares |
+| population_balance | balance scales (level) |
+| seat_count | stylized chair/podium |
+| majority_minority | two overlapping person silhouettes, one accented |
+| efficiency_gap | two unequal bars |
+| mean_median | bell curve with offset mean/median lines |
+| compactness | circle vs irregular blob (split) |
+| safe_seats | shield with party-color fill |
+| competitive_seats | two flag markers close on a line |
+| validity:all-assigned | grid all cells filled |
+| validity:population-balance | tipped/imbalanced scales |
+| validity:contiguity-* | chain with broken link |
+
+§D2_TIMING
+two-phase per row:
+  phase1: fade-in 0.3s (criterionReveal as-is) → badge="CHECKING…" muted pulse; icon grey
+  phase2: after 1 200ms hold → badge snaps PASS/FAIL (0.15s pop scale); icon color-tints
+stagger: 400ms between rows (up from 120ms)
+skip: click → all rows instantly final (same once-listener pattern)
+"CHECKING" indicator: opacity pulse 0.8s loop (50%→100%); no spinner; no audio dependency
+why 1.2s not 3s: 3s×5cr=15s wall-clock before $ins appears; 1.2s keeps moment; skip available
+
+§D3_CHARACTER_FLASH
+no per-cr flash — no generalizable mapping from cr type → $ins concern (9×5=45 cases)
+sequence:
+  1 $ins renders in neutral/waiting pose at top of card (before criteria begin)
+  2 criteria reveal one-by-one (§D2_TIMING)
+  3 after last cr resolves: 0.8s dramatic pause
+  4 $ins cross-fades to approve or disapprove pose (0.4s); audio plays (GAME-061)
+  5 verdict text pulses once
+pose logic: BINARY — approve=any stars(1/2/3); disapprove=0 stars; not graduated
+  approve maps to three-star or two-star SVG; disapprove maps to zero-star SVG; one-star unused here
+neutral/waiting pose: new waiting.svg per $ins type (Option B — reusing approve pose misleads before reveal)
+  DESIGN-009 foot spec (feet near y=190, 200×200 viewBox) already supports foot-anchoring
+  GAME-066 constraint: CSS must pin foot-baseline so transition reads as posture change, not positional jump
+
+§D4_DESIGN009_RELATION
+cr icons: separate icon set; not derived from char sprites
+chars: 200×200 viewBox, narrative, complex fills | cr icons: 24×24, abstract/symbolic, 2px stroke
+both: transparent bg, dark-bg optimized, inline SVG
+no shared schema; cr icons in criterion-icons.ts
+
+§DECISIONS
+1 cr icons: separate flat SVG; 24 or 36px (try both); criterion-icons.ts; one per type
+2 placement: .rc-icon slot; replaces ✓/✗; color-tint on result
+3 timing: 400ms stagger (tentative/iterate); 1 200ms CHECKING hold; 150ms flip; click-to-skip
+4 $ins: binary approve(1-3 stars)/disapprove(0 stars); new waiting.svg neutral pre-reveal; 0.8s pause→pose cross-fade; foot-anchored CSS
+5 icon set separate from DESIGN-009; criterion-icons.ts as SVG strings
+
+§REFS
+$ts/research/2026-05-02-design-009-character-reaction-visual-style.compressed.md
+$ts/tickets/GAME-066-result-screen-dramatic-reveal-impl.md
+game/web/src/model/scenario.ts:175 — cr type union
+game/web/src/main.ts:768 — showResultScreen()
+game/web/styles.css:582 — .result-criterion + @keyframes criterionReveal

--- a/thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.md
+++ b/thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.md
@@ -1,0 +1,227 @@
+# DESIGN-010: Result Screen Dramatic Reveal
+## Per-criterion icons, suspense timing, character flash
+
+**Date:** 2026-05-07  
+**Researcher:** Claude (Sonnet 4.6)  
+**Topic:** Result screen UX — icons, timing, character interaction  
+**Status:** decisions-complete  
+**Gates:** GAME-066
+
+---
+
+## Current State (as of GAME-062)
+
+- Criteria fade in with 120ms stagger, 0.3s `criterionReveal` animation (opacity + translateY 8px)
+- `.rc-icon` shows ✓ or ✗ text; `.rc-badge` shows PASS / FAIL / OPTIONAL
+- Instigator renders once in final star-count pose after all rows are visible
+- Click-to-skip: instantly reveals all rows (removes animation)
+- No suspense pause; no per-criterion icons; no character flash during reveal
+
+Criterion types in the type system:
+
+| Type | Meaning |
+|---|---|
+| `seat_count` | Party wins N seats |
+| `majority_minority` | Minority representation threshold |
+| `efficiency_gap` | Partisan waste-vote fairness |
+| `mean_median` | Partisan lean statistical bias |
+| `compactness` | District shape regularity |
+| `safe_seats` | Guaranteed partisan strongholds |
+| `competitive_seats` | Number of competitive districts |
+| `population_balance` | Equal district populations |
+| `district_count` | Correct number of districts drawn |
+
+Plus validity rows (prepended for invalid maps):
+
+| ID prefix | Meaning |
+|---|---|
+| `validity:all-assigned` | All precincts assigned to a district |
+| `validity:population-balance` | Structural pop balance (not criterion) |
+| `validity:contiguity-*` | District N is contiguous |
+
+---
+
+## Decision 1: Per-Criterion Icon Spec
+
+### Icon source: separate flat SVG symbol set, not character sprites
+
+Character sprites are 200×200px narrative characters (DESIGN-009). Per-criterion icons
+are abstract symbolic concepts — different design vocabulary. Use a minimal flat SVG
+icon set (24×24 viewBox, same dark-background-optimized palette, 2px stroke weight,
+no fills except accent color), inline as `<svg>` elements.
+
+### Icon assignments
+
+| Criterion type | Icon concept | SVG description |
+|---|---|---|
+| `district_count` | Grid / map regions | 2×2 grid of squares; clean boundary lines |
+| `population_balance` | Balance scales | Simple scale beam with two pans; centered pivot |
+| `seat_count` | Legislative seat / chair | Stylized chair or podium silhouette |
+| `majority_minority` | Group / people | Two overlapping person silhouettes, one accented |
+| `efficiency_gap` | Wasted votes bar chart | Two bars, one taller, labeled visually unequal |
+| `mean_median` | Statistical distribution | Bell curve with mean/median lines offset |
+| `compactness` | Shape regularity | Circle vs. irregular blob (split icon) |
+| `safe_seats` | Partisan lock / shield | Shield with party-color fill (dynamic, based on party) |
+| `competitive_seats` | Racing / contest | Two flag markers close together on a line |
+| `validity:all-assigned` | Complete checklist | Grid with all cells filled |
+| `validity:population-balance` | Imbalanced scales | Same scales icon, tipped to one side |
+| `validity:contiguity-*` | Broken link / chain | Chain with one broken link |
+
+### Icon placement: inside the criterion row, replacing ✓/✗
+
+The `.rc-icon` slot already exists and is sized for a single character. Replace the ✓/✗
+text with the type-specific SVG icon (24×24). The icon communicates WHAT the criterion
+is; color-tinting on pass/fail communicates the verdict (icon tints green on pass,
+red on fail-required, muted on optional). The PASS/FAIL badge already handles the
+explicit verdict label — no redundancy.
+
+**Why not a separate panel element?** The row-level layout (icon | description | badge)
+is already the right information hierarchy. Adding a separate icon panel above the list
+would dilute focus and require more vertical space.
+
+---
+
+## Decision 2: Suspense Timing Spec
+
+### Two-phase reveal per row
+
+Each criterion row goes through two states:
+
+**Phase 1 — Appear (0–300ms):** Row fades in (current `criterionReveal` animation).
+Badge shows "CHECKING…" in a neutral muted style. Icon shows in neutral grey.
+
+**Phase 2 — Resolve (after 1 200ms hold):** Badge snaps to PASS / FAIL with a
+brief pop scale animation (0.15s ease-out). Icon color-tints to green/red.
+
+Total per-row duration: ~1 500ms (300ms fade + 1 200ms hold + 150ms flip).
+
+**Stagger between rows:** 400ms (up from 120ms — gives each row time to resolve
+before the next appears, maintaining a one-at-a-time feel without being glacial).
+
+**Total for 5 rows:** ~5.5s. For 8 rows (invalid map with validity rows): ~8s.
+Click-to-skip short-circuits all of this.
+
+### Skip behavior
+
+Click anywhere on result screen → skip all pending animations, jump all rows
+instantly to final resolved state. Same event listener pattern as today.
+
+### "Checking" indicator style
+
+Badge text "CHECKING…" with a subtle opacity pulse CSS animation (0.8s loop,
+50%→100% opacity). No spinner, no audio dependency. Simple and legible.
+
+Audio drum-roll is out of scope for this research (GAME-061 territory) — the visual
+alone must carry the suspense.
+
+### Why 1 200ms hold (not 3 000ms)?
+
+The ticket suggested "~3 seconds" but with stagger the actual wall-clock wait per
+criterion is ~1.5s already. 3s per criterion × 5 criteria = 15s before the instigator
+appears — too long without skipping. 1.2s hold keeps the moment without punishing
+patient players. The instigator reveal (below) adds a final beat that lands harder
+because it comes after the criteria are done.
+
+---
+
+## Decision 3: Character Flash Behavior
+
+### No per-criterion flash — instigator holds neutral, then delivers binary verdict
+
+DESIGN-009 established: instigator "plays LAST after criteria." Per-criterion flashing
+would require mapping every criterion type to an instigator concern, which doesn't
+generalize (a federal judge cares about all criteria differently than a partisan boss).
+
+**Revised sequence:**
+
+1. Instigator renders in **neutral/waiting pose** at the top of the result card before
+   criteria begin.
+2. Criteria reveal one by one (Phase 1 + Phase 2 per Decision 2).
+3. After the last criterion resolves: **0.8s dramatic pause** (all rows visible, no
+   new motion).
+4. Instigator **transitions to approve or disapprove pose** with a CSS cross-fade (0.4s).
+   Audio clip plays (GAME-061).
+5. Overall verdict text ("Map Passed!" / "Map Failed") pulses once.
+
+### Why not per-criterion flash?
+
+- 9 criterion types × 5 instigator types = 45 mapping decisions with no clear rules
+- Flash on every criterion cheapens the moment — the instigator's reaction is the
+  narrative payoff, not a running commentary
+
+### Pose logic: binary, not graduated by star count
+
+The instigator's final pose is **binary**:
+
+- **Approve** — any stars (1, 2, or 3): the player's map is accepted; they can proceed.
+  Maps to a positive pose (e.g., thumbs-up / satisfied / celebratory depending on type).
+- **Disapprove** — zero stars: the map requires rework.
+  Maps to a negative pose (e.g., head-in-hands / rejection depending on type).
+
+The star count (0/1/2/3) is still computed and displayed as the score, but the
+instigator's visual only needs two states for this sequence. The graduated DESIGN-009
+four-pose schema (three/two/one/zero-star) still applies to the sprite assets — the
+approve pose maps to `three-star` or `two-star` (whichever best fits the art),
+disapprove maps to `zero-star`. The `one-star` pose is not used in this flow.
+
+### Neutral waiting pose
+
+The instigator needs a distinct pre-reveal visual state. Options:
+
+**Option A** — Reuse an existing pose (e.g., `two-star`) as neutral waiting.
+Inexpensive; slightly misleading (implies outcome before reveal).
+
+**Option B** — Add a 5th SVG file per instigator type: `waiting.svg` (arms folded,
+watching). 5 new files. Clean semantic separation.
+
+**Recommendation: Option B** — the neutral-waiting pose is the *first* thing the
+player sees when the result screen opens. Reusing an "approve" pose before the verdict
+is known undercuts the reveal. This is the right long-term answer. GAME-066 to
+commission or generate `waiting.svg` per type alongside the four star-state files.
+
+### Foot alignment
+
+Sprites must be anchored at the feet across all poses — neutral → approve/disapprove
+should read as a change in posture/expression, not a positional jump. GAME-066
+implementation constraint: CSS `background-position` (or absolute positioning) must
+pin the character at a consistent foot-baseline across pose transitions. The
+200×200 viewBox in DESIGN-009 and the foot placement spec (feet near y=190) already
+support this — implementation must honor it.
+
+---
+
+## Decision 4: Icon-to-DESIGN-009 Relationship
+
+Per-criterion icons are **a separate flat/minimal icon set**, not derived from or
+part of the character sprite system.
+
+- Character sprites: 200×200 viewBox, narrative characters, complex fills, DESIGN-009 palette
+- Criterion icons: 24×24 or 36×36 viewBox (try both in implementation, pick by visual weight),
+  abstract/symbolic, 2px stroke, no narrative content
+
+Both use transparent backgrounds and are dark-bg optimized. Both inline as SVG.
+No shared file schema — criterion icons live at `game/web/src/ui/criterion-icons.ts`
+(exported as inline SVG strings, not separate files — too small to warrant HTTP
+requests).
+
+---
+
+## Summary of Decisions
+
+| # | Decision |
+|---|---|
+| 1 | Icons: separate flat SVG symbol set; 24×24 or 36×36 (try both); inline in TS; one per criterion type |
+| 2 | Placement: inside `.rc-icon` slot, replacing ✓/✗; color-tinted on result |
+| 3 | Timing: 400ms stagger (tentative, iterate); 1 200ms CHECKING hold; 150ms flip; click-to-skip |
+| 4 | Instigator: binary approve (any stars) / disapprove (0 stars); starts in new `waiting.svg` neutral pose; transitions after 0.8s pause; foot-anchored so transition reads as posture not position |
+| 5 | Icons separate from DESIGN-009; criterion icons in `criterion-icons.ts` as SVG strings |
+
+---
+
+## References
+
+- `thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.compressed.md`
+- `thoughts/shared/tickets/GAME-066-result-screen-dramatic-reveal-impl.md`
+- `game/web/src/model/scenario.ts` — criterion type union (line 175–183)
+- `game/web/src/main.ts` — `showResultScreen()` (line 768)
+- `game/web/styles.css` — `.result-criterion`, `@keyframes criterionReveal` (line 582–631)

--- a/thoughts/shared/tickets/DESIGN-010-result-screen-dramatic-reveal.md
+++ b/thoughts/shared/tickets/DESIGN-010-result-screen-dramatic-reveal.md
@@ -2,8 +2,9 @@
 id: DESIGN-010
 title: Result screen dramatic reveal — per-criterion icons, suspense timing, character flash
 area: design, UX, art
-status: open
+status: resolved
 created: 2026-05-07
+resolved: 2026-05-07
 ---
 
 ## Summary
@@ -25,24 +26,17 @@ single final pose. This ticket is design research — decisions here gate GAME-0
 
 ## Goals / Acceptance Criteria
 
-- [ ] Per-criterion icon spec decided: one icon per criterion type; sourced from
-      CSS/SVG inline or character-sprite sheet; documented with rationale
-      - district_count: large green ✓ checkmark
-      - population_balance: scales icon (legal-requirement framing)
-      - seat_count (governor's goal): governor neutral → flash approve/disapprove
-      - compactness: achievement sticker / badge aesthetic (TBD)
-      - other criterion types: icons TBD
-- [ ] Suspense timing spec decided: duration, animation style during "evaluating"
-      hold (spinning indicator? pulsing "…"? drum-roll audio cue?), how skip works
-- [ ] Character flash behavior spec decided: does the instigator flash on the
-      *specific* criterion they care about, on every criterion, or only on the
-      overall verdict? Pose transition animation style (instant cut vs. brief
-      fade/slide)
-- [ ] Icon placement spec: inside the criterion row (replacing the ✓/✗ icon),
-      or as a separate panel element?
-- [ ] Relationship to DESIGN-009 art spec clarified: do per-criterion icons use
-      the same style as character sprites, or a separate flat/minimal icon set?
-- [ ] Decisions documented in a research doc (`thoughts/shared/research/`)
+- [x] Per-criterion icon spec decided: separate flat SVG set (24 or 36px, try both);
+      inline in `criterion-icons.ts`; one icon per criterion type; full mapping in research doc
+- [x] Suspense timing spec decided: 400ms stagger (tentative); 1 200ms CHECKING hold
+      with pulsing badge; 150ms flip to PASS/FAIL; click-to-skip
+- [x] Character flash behavior spec decided: no per-criterion flash; instigator holds
+      new `waiting.svg` neutral pose pre-reveal; binary approve (1–3 stars) or
+      disapprove (0 stars) after 0.8s pause; 0.4s cross-fade; foot-anchored CSS
+- [x] Icon placement spec: inside `.rc-icon` slot, replacing ✓/✗; color-tinted on result
+- [x] Relationship to DESIGN-009 clarified: separate icon set; not derived from character
+      sprites; same dark-bg aesthetic but different scale and purpose
+- [x] Decisions documented in `thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.md`
 
 ## References
 

--- a/thoughts/shared/tickets/GAME-066-result-screen-dramatic-reveal-impl.md
+++ b/thoughts/shared/tickets/GAME-066-result-screen-dramatic-reveal-impl.md
@@ -23,29 +23,27 @@ for icon spec and timing decisions.
 
 ## Goals / Acceptance Criteria
 
-- [ ] Sequential reveal: criteria revealed one at a time, not stagger-simultaneously
-- [ ] Each criterion holds in "pending" state (~3s, or skip-able) before showing
-      pass/fail verdict
-- [ ] Per-criterion icon replaces the bare ✓/✗ text, per DESIGN-010 spec:
-      - district_count: checkmark icon
-      - population_balance: scales icon
-      - seat_count: instigator-specific (governor flashes neutral→approve/disapprove)
-      - compactness: achievement badge
-      - validity rows: warning icon
-- [ ] Instigator character flashes from neutral pose to reaction pose when its
-      associated criterion reveals; stays in final-verdict pose after all done
-- [ ] Click-to-skip still works: skips pending state, reveals all remaining
-      criteria instantly (no animation)
-- [ ] `prefers-reduced-motion`: all pending + flash animations suppressed; criteria
-      reveal instantly; character shown in final pose without transition
-- [ ] Audio: drum-roll or suspense sound during pending state, if GAME-061 audio
-      clips are available; graceful no-op if absent
+- [ ] Sequential reveal: criteria revealed one at a time (400ms stagger), not simultaneously
+- [ ] Each criterion holds in "CHECKING…" badge state (1 200ms) with opacity-pulse before
+      flipping to PASS/FAIL (150ms pop); per DESIGN-010 §D2_TIMING
+- [ ] Per-criterion icon (`criterion-icons.ts`) replaces ✓/✗ text; one SVG per criterion
+      type; grey during CHECKING, color-tinted (green/red) on result; per DESIGN-010 §D1_ICONS
+- [ ] Instigator renders in neutral/waiting pose before criteria begin; transitions to
+      binary approve (stars ≥ 1) or disapprove (stars === 0) 0.8s after last row resolves;
+      0.4s cross-fade; foot-baseline pinned via CSS so it reads as posture change not jump;
+      per DESIGN-010 §D3_CHARACTER_FLASH
+- [ ] Click-to-skip still works: clears all pending timeouts, instantly resolves all rows
+      to final state, shows instigator in final pose
+- [ ] `prefers-reduced-motion`: JS branch skips sequential reveal entirely; all rows
+      rendered in final state immediately; instigator shown in final pose at open
+- [ ] Audio: `audioPlayer.play("instigator-approve-{type}")` / `"instigator-disapprove-{type}"`
+      on instigator flip; graceful no-op until GAME-061 clips registered
 
 ## Test Coverage
 
-- [ ] e2e: after submit, criteria rows appear sequentially (first visible, others hidden)
-- [ ] e2e: clicking result screen during pending state reveals remaining rows instantly
-- [ ] e2e: `prefers-reduced-motion` — all rows visible immediately after submit
+- [ ] e2e: in reduced-motion mode, all rows visible immediately after submit
+- [ ] e2e: clicking result screen during CHECKING hold reveals remaining rows instantly
+- [ ] e2e: result screen shows criterion icons (SVG elements in `.rc-icon`)
 
 ## References
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -90,7 +90,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-005-population-dot-density-overlay.md` | design, rendering | Population dot density overlay: dot count per precinct proportional to population; hue-aware dot color; colorblind-safe palette |
 | `DESIGN-006-zoom-adaptive-dot-density.md` | design, rendering | Zoom-adaptive dot density scaling + person glyph threshold (refinement on DESIGN-005, possibly post-v1) |
 | `DESIGN-007-dimensional-dot-map-demographic-overlay.md` | design, rendering | Dimensional dot map: demographic dimension switching (Option B adaptive encoding) + sorted placement toggle |
-| `DESIGN-010-result-screen-dramatic-reveal.md` | design, UX, art | Per-criterion icons, suspense timing, instigator character flash — design spec gates GAME-066 |
 | `GAME-066-result-screen-dramatic-reveal-impl.md` | game, UX | Sequential criterion reveal with ~3s suspense pause, per-criterion icons, instigator flash; depends on DESIGN-010 |
 | `GAME-056-playtest-feedback.md` | game, content, UX | Capture and act on playtest feedback — scenario balance and UX |
 | `GAME-057-scenario-randomization.md` | game, content, replayability | Per-session ±5% population/lean offsets seeded per session; e2e tests remain deterministic |
@@ -117,6 +116,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | GAME-064: audio playback infrastructure | AudioPlayer module: preload, play, mute toggle, autoplay policy, localStorage persistence; merged PR #194 |
 | GAME-063: asset pipeline | Directory structure + Bazel integration for SVG + audio delivery; deployable inclusion; merged PR #192 |
 | GAME-059: submit-on-invalid maps | Removed validity gate from Submit button; invalid maps now reach result screen; Fix-It path replaces Next Scenario; merged PR #196 |
+| DESIGN-010: result screen dramatic reveal | Per-criterion icons (flat SVG set, 24/36px, criterion-icons.ts), suspense timing (400ms stagger, 1.2s CHECKING hold, click-to-skip), binary instigator pose (approve=1-3★/disapprove=0★, waiting.svg neutral pre-reveal, foot-anchored CSS); research doc finalized 2026-05-07 |
 | DESIGN-009: character reaction visual style | Inline SVG + CSS animation decided; 5 instigator types × 4 star states; consistency spec for AI generation; audio tone per type; research doc finalized |
 | GAME-052: animated criteria reveal | CSS criterionReveal keyframe (opacity+translateY), 120ms stagger, click-to-skip, 🎉/💔 reaction; 4 e2e tests; merged PR #189 |
 | GAME-031: gameplay critique followup | Tightened pop tolerance (007/008: 10%→5%); compactness 007: 0.40→0.50; randomization→GAME-057; others deferred or rejected |


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary

Implements the result screen dramatic reveal sequence designed in DESIGN-010.

- **Per-criterion SVG icons** (`criterion-icons.ts`): one icon per criterion type (district_count, population_balance, seat_count, majority_minority, efficiency_gap, mean_median, compactness, safe_seats, competitive_seats) plus validity: prefix rows; inline SVG strings (no HTTP requests); grey during CHECKING hold, colour-tinted green/red on verdict
- **Sequential reveal**: 400ms row stagger; 1 200ms CHECKING badge with opacity pulse; 150ms PASS/FAIL pop flip; click-to-skip clears all pending timeouts and shows all rows in final state immediately
- **Instigator refactored**: waiting/neutral pose shown at screen open; after last row resolves, 0.8s pause then binary approve (stars ≥ 1) or disapprove (0 stars) with 0.2s opacity cross-fade; foot-baseline preserved across pose swap
- **prefers-reduced-motion**: JS code branch skips all timeouts; renders all rows in final state synchronously; instigator shown in final pose immediately — no sequential animation at all
- **playwright.config.ts**: global `reducedMotion: 'reduce'` so existing e2e tests are unaffected by reveal timing; new animated-path test overrides to `no-preference`
- DESIGN-010 ticket resolved; GAME-066 ACs updated to match actual DESIGN-010 decisions

## Validation performed

- [x] `bazel build //web:app_typecheck_lib` passes
- [x] `bazel test //web:e2e_test` — 129/129 pass (up from 127 before this ticket)
- [x] GAME-066 e2e: reduced-motion — all rows visible immediately after submit
- [x] GAME-066 e2e: SVG icons present in `.rc-icon` slots after submit
- [x] GAME-066 e2e: clicking result screen in animated mode finalises all rows instantly
- [x] GAME-052 stagger test updated to check reduced-motion instant-reveal (superseded behaviour)

## Affected machines / services

- Browser game only (`game/web/`) — client-side JS/CSS, no server-side changes
- No backend, no database, no infrastructure changes

## Deployment steps (POST-MERGE)

- Deploy to dev: `./release.main.kts -- prepare && ./release.main.kts -- deploy --env dev --version "$VERSION"` from `game/`
- Staging/prod: standard release pipeline after manual validation on dev

## Tickets addressed

- see GAME-066
- see DESIGN-010 (resolved)

## Rollback

- Revert commit on main; redeploy to affected environment
- No data migrations, no schema changes — fully reversible
