### PR TITLE
fix(GAME-068): true sequential criterion reveal + dedicated Skip button

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -1049,16 +1049,19 @@ test("GAME-066: result screen shows SVG criterion icons (not bare ✓/✗ text)"
 });
 
 // test.use() must be at describe scope, not inside a test() body.
-test.describe("GAME-066: animated reveal path (no reduced-motion)", () => {
+test.describe("GAME-068: animated reveal path (no reduced-motion)", () => {
   test.use({ reducedMotion: "no-preference" });
 
-  test("clicking result screen skips sequential reveal and shows all rows", async ({ page }) => {
+  test("Skip button finalises all rows instantly in animated reveal", async ({ page }) => {
     await loadScenario(page, "scenario-002");
     await page.locator("#btn-submit").click();
     await expect(page.locator("#result-screen")).toBeVisible();
 
-    // Immediately click to skip — all rows should be in final state.
-    await page.locator("#result-screen").click();
+    // Skip button visible during animated reveal.
+    await expect(page.locator("#btn-reveal-skip")).toBeVisible();
+
+    // Click Skip → all rows in final state immediately.
+    await page.locator("#btn-reveal-skip").click();
 
     const rows = page.locator(".result-criterion");
     const count = await rows.count();
@@ -1067,5 +1070,8 @@ test.describe("GAME-066: animated reveal path (no reduced-motion)", () => {
       await expect(rows.nth(i)).toBeVisible();
       await expect(rows.nth(i)).not.toHaveClass(/rc-pending/);
     }
+
+    // Skip button gone after skipping.
+    await expect(page.locator("#result-reveal-controls")).toBeHidden();
   });
 });

--- a/game/web/e2e/sprint4.spec.ts
+++ b/game/web/e2e/sprint4.spec.ts
@@ -50,25 +50,23 @@ test("GAME-052: criterion rows all visible immediately in reduced-motion mode", 
   }
 });
 
-test("GAME-052: clicking result screen reveals all rows instantly", async ({ page }) => {
+// GAME-068: skip is now a dedicated button, not click-anywhere.
+// In reduced-motion mode (global default) all rows are already final at open — no skip needed.
+test("GAME-052: all rows in final state immediately in reduced-motion mode", async ({ page }) => {
   await loadEditor(page);
   await openResultScreen(page);
-
-  await page.locator("#result-screen").click();
 
   const rows = page.locator(".result-criterion");
   const count = await rows.count();
   expect(count).toBeGreaterThan(0);
 
   for (let i = 0; i < count; i++) {
-    const opacity = await rows.nth(i).evaluate((el) => (el as HTMLElement).style.opacity);
-    // animation shorthand is cleared; computed animationName resolves to "none"
-    const animationName = await rows.nth(i).evaluate(
-      (el) => getComputedStyle(el).animationName,
-    );
-    expect(opacity).toBe("1");
-    expect(animationName).toBe("none");
+    await expect(rows.nth(i)).toBeVisible();
+    await expect(rows.nth(i)).not.toHaveClass(/rc-pending/);
   }
+
+  // Skip button not shown in reduced-motion path.
+  await expect(page.locator("#result-reveal-controls")).toBeHidden();
 });
 
 test("GAME-052: party reaction element is populated after submit", async ({ page }) => {

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -78,6 +78,9 @@
         <div id="result-subtitle"></div>
         <div id="result-reaction"></div>
         <div id="result-criteria-list"></div>
+        <div id="result-reveal-controls" style="display:none">
+          <button id="btn-reveal-skip">Skip →</button>
+        </div>
         <div id="result-actions">
           <button id="btn-keep-drawing">← Keep Drawing</button>
           <button id="btn-next-scenario" style="display:none">Next Scenario →</button>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -95,6 +95,8 @@ const resultReaction = document.getElementById("result-reaction") as HTMLElement
 const resultCriteriaList = document.getElementById("result-criteria-list") as HTMLElement | null;
 const btnKeepDrawing = document.getElementById("btn-keep-drawing") as HTMLButtonElement | null;
 const btnNextScenario = document.getElementById("btn-next-scenario") as HTMLButtonElement | null;
+const resultRevealControls = document.getElementById("result-reveal-controls") as HTMLElement | null;
+const btnRevealSkip = document.getElementById("btn-reveal-skip") as HTMLButtonElement | null;
 
 // Intro screen refs (GAME-016)
 const introScreen = document.getElementById("intro-screen") as HTMLElement | null;
@@ -806,7 +808,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 
 	function showResultScreen() {
 		if (!resultScreen || !resultVerdict || !resultSubtitle || !resultCriteriaList || !resultReaction) return;
-		if (skipClickHandler) { resultScreen.removeEventListener("click", skipClickHandler); skipClickHandler = null; }
+		if (skipClickHandler) { btnRevealSkip?.removeEventListener("click", skipClickHandler); skipClickHandler = null; }
 
 		const state = store.getState();
 		if (state.simulationResult === null) return;
@@ -941,7 +943,14 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 				resultReaction.textContent = overallPass ? "🎉" : "💔";
 			}
 		} else {
-			// Animated path: waiting instigator → sequential reveal → verdict cross-fade.
+			// Animated path: waiting instigator → true sequential reveal → verdict cross-fade.
+			// GAME-068: each row fully resolves before the next starts (no simultaneous CHECKING).
+			// Chain delay = 300ms fade + 1200ms hold + 150ms flip = 1650ms per row.
+			const ROW_FADE_MS = 300;
+			const ROW_HOLD_MS = 1200;
+			const ROW_FLIP_MS = 150;
+			const ROW_CHAIN_MS = ROW_FADE_MS + ROW_HOLD_MS + ROW_FLIP_MS; // 1650ms
+
 			let waitingSprite: HTMLElement | null = null;
 			if (instigator) {
 				waitingSprite = renderInstigatorWaiting(resultReaction, instigator.type, demo);
@@ -956,15 +965,20 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 				rowElements.push(row);
 			}
 
+			// Show Skip button; hide it when reveal completes naturally.
+			if (resultRevealControls) resultRevealControls.style.display = "";
+
 			const pendingTimeouts: ReturnType<typeof setTimeout>[] = [];
-			let delay = 0;
+			let chainDelay = 0;
 
 			for (let i = 0; i < rowElements.length; i++) {
 				const row = rowElements[i]!;
+				const rowStart = chainDelay;
+
 				const t1 = setTimeout(() => {
 					// Phase 1: animate row in with CHECKING badge.
 					row.classList.remove("rc-pending");
-					row.style.animation = "criterionReveal 0.3s ease forwards";
+					row.style.animation = `criterionReveal ${ROW_FADE_MS}ms ease forwards`;
 
 					const t2 = setTimeout(() => {
 						// Phase 2: flip to final verdict with pop.
@@ -976,8 +990,9 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 						// After last row resolves, pause then show instigator verdict.
 						if (i === rowElements.length - 1) {
 							const tVerdict = setTimeout(() => {
-								// Natural reveal complete — deactivate skip handler.
-								resultScreen.removeEventListener("click", skipHandler);
+								// Natural reveal complete — deactivate skip.
+								btnRevealSkip?.removeEventListener("click", skipHandler);
+								if (resultRevealControls) resultRevealControls.style.display = "none";
 								skipClickHandler = null;
 								if (instigator) {
 									transitionInstigatorToVerdict(waitingSprite, resultReaction, instigator.type, stars, demo);
@@ -987,26 +1002,29 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 							}, 800);
 							pendingTimeouts.push(tVerdict);
 						}
-					}, 1200);
+					}, ROW_HOLD_MS);
 					pendingTimeouts.push(t2);
-				}, delay);
+				}, rowStart);
 				pendingTimeouts.push(t1);
-				delay += 400;
+
+				// Next row starts only after this row has fully resolved.
+				chainDelay += ROW_CHAIN_MS;
 			}
 
-			// Skip: clear all pending timeouts, finalize all rows, show verdict instigator.
+			// Skip button: clear all pending timeouts, finalize rows, show verdict.
 			const skipHandler = () => {
 				for (const t of pendingTimeouts) clearTimeout(t);
 				for (const row of rowElements) finalizeRow(row);
+				if (resultRevealControls) resultRevealControls.style.display = "none";
+				skipClickHandler = null;
 				if (instigator) {
 					transitionInstigatorToVerdict(waitingSprite, resultReaction, instigator.type, stars, demo);
 				} else {
 					resultReaction.textContent = overallPass ? "🎉" : "💔";
 				}
-				skipClickHandler = null;
 			};
 			skipClickHandler = skipHandler;
-			resultScreen.addEventListener("click", skipHandler, { once: true });
+			btnRevealSkip?.addEventListener("click", skipHandler, { once: true });
 		}
 
 		// GAME-059: "Fix It" label for invalid maps, "Keep Drawing" otherwise.

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -712,6 +712,28 @@ body {
   }
 }
 
+#result-reveal-controls {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+
+#btn-reveal-skip {
+  padding: 4px 12px;
+  background: transparent;
+  color: #5070a0;
+  border: 1px solid #2a4060;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.78rem;
+  letter-spacing: 0.03em;
+}
+
+#btn-reveal-skip:hover {
+  color: #8090c0;
+  border-color: #4a6080;
+}
+
 #result-actions {
   display: flex;
   justify-content: center;

--- a/thoughts/shared/tickets/GAME-068-result-reveal-pacing.md
+++ b/thoughts/shared/tickets/GAME-068-result-reveal-pacing.md
@@ -1,0 +1,46 @@
+---
+id: GAME-068
+title: Result screen reveal pacing — true sequential reveal + dedicated Skip button
+area: game, UX
+status: open
+created: 2026-05-07
+---
+
+## Summary
+
+The GAME-066 sequential reveal uses a 400ms stagger between rows, which is much
+shorter than the ~1650ms per-row duration (300ms fade + 1200ms hold + 150ms flip).
+This causes multiple rows to be in CHECKING state simultaneously — producing a
+"wave of criteria, then wave of results" feel rather than true one-at-a-time
+suspense. Additionally, click-anywhere-to-skip is unintuitive; replace with a
+visible "Skip →" button.
+
+## Current State
+
+- 400ms stagger → rows heavily overlap in CHECKING state (GAME-066)
+- Skip: click anywhere on result screen (implicit, undiscoverable)
+- No drum-roll audio yet (GAME-061 pending)
+
+## Goals / Acceptance Criteria
+
+- [ ] True sequential reveal: each row's full cycle (fade + hold + flip) completes
+      before the next row starts — no simultaneous CHECKING states
+- [ ] Per-row timing: 300ms fade → 1200ms CHECKING hold → 150ms flip → next row
+      (chain delay ≈ 1650ms between row starts)
+- [ ] Dedicated "Skip →" button visible during animated reveal; hidden otherwise
+      (reduced-motion path, already-done state)
+- [ ] Clicking "Skip →" clears all pending timeouts and finalises all rows instantly
+- [ ] Remove click-anywhere-to-skip (replaced by the button)
+- [ ] prefers-reduced-motion: no change — already renders instantly with no button
+
+## Test Coverage
+
+- [ ] e2e: updated skip test uses "Skip →" button, not result screen click
+- [ ] e2e: verify only one row visible at a time during animated reveal (optional — hard to time)
+
+## References
+
+- `thoughts/shared/tickets/GAME-066-result-screen-dramatic-reveal-impl.md` — parent
+- `game/web/index.html` — result screen HTML
+- `game/web/src/main.ts` — `showResultScreen()` reveal loop
+- `game/web/styles.css` — `#btn-reveal-skip`

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -90,7 +90,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-005-population-dot-density-overlay.md` | design, rendering | Population dot density overlay: dot count per precinct proportional to population; hue-aware dot color; colorblind-safe palette |
 | `DESIGN-006-zoom-adaptive-dot-density.md` | design, rendering | Zoom-adaptive dot density scaling + person glyph threshold (refinement on DESIGN-005, possibly post-v1) |
 | `DESIGN-007-dimensional-dot-map-demographic-overlay.md` | design, rendering | Dimensional dot map: demographic dimension switching (Option B adaptive encoding) + sorted placement toggle |
-| `GAME-066-result-screen-dramatic-reveal-impl.md` | game, UX | Sequential criterion reveal with ~3s suspense pause, per-criterion icons, instigator flash; depends on DESIGN-010 |
+| `GAME-068-result-reveal-pacing.md` | game, UX | True sequential reveal (1 row at a time, no overlap) + dedicated Skip button; pacing followup to GAME-066 |
 | `GAME-056-playtest-feedback.md` | game, content, UX | Capture and act on playtest feedback — scenario balance and UX |
 | `GAME-057-scenario-randomization.md` | game, content, replayability | Per-session ±5% population/lean offsets seeded per session; e2e tests remain deterministic |
 | `GAME-058-manual-playability-test-thresholds.md` | game, content, QA | Manual playthrough of scenarios 007 and 008 to verify tightened thresholds (GAME-031) feel right |
@@ -116,6 +116,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | GAME-064: audio playback infrastructure | AudioPlayer module: preload, play, mute toggle, autoplay policy, localStorage persistence; merged PR #194 |
 | GAME-063: asset pipeline | Directory structure + Bazel integration for SVG + audio delivery; deployable inclusion; merged PR #192 |
 | GAME-059: submit-on-invalid maps | Removed validity gate from Submit button; invalid maps now reach result screen; Fix-It path replaces Next Scenario; merged PR #196 |
+| GAME-066: result screen dramatic reveal | Per-criterion SVG icons, sequential reveal, binary instigator cross-fade, prefers-reduced-motion fast path; merged PR #213 |
 | DESIGN-010: result screen dramatic reveal | Per-criterion icons (flat SVG set, 24/36px, criterion-icons.ts), suspense timing (400ms stagger, 1.2s CHECKING hold, click-to-skip), binary instigator pose (approve=1-3★/disapprove=0★, waiting.svg neutral pre-reveal, foot-anchored CSS); research doc finalized 2026-05-07 |
 | DESIGN-009: character reaction visual style | Inline SVG + CSS animation decided; 5 instigator types × 4 star states; consistency spec for AI generation; audio tone per type; research doc finalized |
 | GAME-052: animated criteria reveal | CSS criterionReveal keyframe (opacity+translateY), 120ms stagger, click-to-skip, 🎉/💔 reaction; 4 e2e tests; merged PR #189 |


### PR DESCRIPTION
## Prerequisites
- [x] N/A — no parent PR

## Summary

Fixes the reveal pacing from GAME-066: the 400ms stagger caused rows to pile up in
CHECKING state simultaneously (wave of criteria → wave of results). This changes to
a true chain where each row's full cycle completes before the next starts.

- **Chain delay**: 300ms fade + 1200ms CHECKING hold + 150ms flip = 1650ms per row;
  next row starts only after current row has fully resolved — no simultaneous CHECKING
- **Skip button**: dedicated `#btn-reveal-skip` button replaces click-anywhere-to-skip;
  visible only during animated reveal, hidden in reduced-motion path and after completion
- Sprint4 GAME-052 test updated to reflect that skip is now via button, not screen click

## Validation performed

- [x] `bazel build //web:app_typecheck_lib` passes
- [x] `bazel test //web:e2e_test` — 129/129 pass
- [x] GAME-068 skip button test: visible during animated reveal, hides after skip
- [x] GAME-052 test updated: reduced-motion instant-reveal + no skip button shown

## Affected machines / services

- Browser game only (`game/web/`) — client-side JS/CSS, no server-side changes

## Deployment steps (POST-MERGE)

- Deploy to dev: `./release.main.kts -- deploy --env dev --version <version>` from `game/`

## Tickets addressed

- see GAME-068

## Rollback

- Revert commit on main; redeploy — no data migrations, fully reversible
