### PR TITLE
chore: close GAME-067 + GAME-068 stale tickets

### DIFF
--- a/thoughts/shared/tickets/GAME-067-asset-versioning-and-env-badge.md
+++ b/thoughts/shared/tickets/GAME-067-asset-versioning-and-env-badge.md
@@ -2,7 +2,7 @@
 id: GAME-067
 title: Asset URL versioning + environment version badge
 area: game, build, deployment
-status: open
+status: resolved
 created: 2026-05-06
 ---
 

--- a/thoughts/shared/tickets/GAME-068-result-reveal-pacing.md
+++ b/thoughts/shared/tickets/GAME-068-result-reveal-pacing.md
@@ -2,7 +2,7 @@
 id: GAME-068
 title: Result screen reveal pacing — true sequential reveal + dedicated Skip button
 area: game, UX
-status: open
+status: resolved
 created: 2026-05-07
 ---
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -90,7 +90,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-005-population-dot-density-overlay.md` | design, rendering | Population dot density overlay: dot count per precinct proportional to population; hue-aware dot color; colorblind-safe palette |
 | `DESIGN-006-zoom-adaptive-dot-density.md` | design, rendering | Zoom-adaptive dot density scaling + person glyph threshold (refinement on DESIGN-005, possibly post-v1) |
 | `DESIGN-007-dimensional-dot-map-demographic-overlay.md` | design, rendering | Dimensional dot map: demographic dimension switching (Option B adaptive encoding) + sorted placement toggle |
-| `GAME-068-result-reveal-pacing.md` | game, UX | True sequential reveal (1 row at a time, no overlap) + dedicated Skip button; pacing followup to GAME-066 |
 | `DESIGN-011-per-criterion-character-roster.md` | design, art | Define 5-type character roster (governor/commissioner/party/judge/legislator) + sprite design notes for 4 new types |
 | `GAME-056-playtest-feedback.md` | game, content, UX | Capture and act on playtest feedback — scenario balance and UX |
 | `GAME-057-scenario-randomization.md` | game, content, replayability | Per-session ±5% population/lean offsets seeded per session; e2e tests remain deterministic |
@@ -106,7 +105,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-061-audio-clips.md` | game, audio, content | 10 audio clips (5 types × pass/fail); CC0 preferred; AI-generated fallback; depends on DESIGN-009 |
 | `GAME-062-character-reaction-system.md` | game, UX | Wire character sprites + audio to result screen; replaces emoji placeholder; depends on GAME-060/061/063/064/065 |
 | `GAME-065-character-sprite-art-refinement.md` | game, art, content | Replace placeholder SVGs with quality character art; pose/file structure unchanged; visual review required before merge |
-| `GAME-067-asset-versioning-and-env-badge.md` | game, build, deployment | Asset URL versioning (`?v=<version>`) via deployment-metadata.json + dev/staging version badge |
 
 ---
 
@@ -115,6 +113,8 @@ tests should be written alongside or before implementation, not as a backfill. W
 | Summary | Resolution |
 |---|---|
 | GAME-069: per-criterion character reactions | Per-row .rc-char slots with governor sprite + SVG placeholders; schema + scenario data; GOV_SHEET fix; merged PR #215 |
+| GAME-068: result reveal pacing | True sequential reveal (1 row at a time), dedicated Skip button; merged PR #214 |
+| GAME-067: asset URL versioning + env badge | Asset ?v= versioning via deployment-metadata.json + dev/staging badge; merged PR #212 |
 | GAME-064: audio playback infrastructure | AudioPlayer module: preload, play, mute toggle, autoplay policy, localStorage persistence; merged PR #194 |
 | GAME-063: asset pipeline | Directory structure + Bazel integration for SVG + audio delivery; deployable inclusion; merged PR #192 |
 | GAME-059: submit-on-invalid maps | Removed validity gate from Submit button; invalid maps now reach result screen; Fix-It path replaces Next Scenario; merged PR #196 |


### PR DESCRIPTION
## Summary

Mark two tickets resolved that shipped during S12 but were never closed:

- **GAME-067** (asset URL versioning + env badge) — shipped in PR #212
- **GAME-068** (result reveal pacing — sequential reveal + Skip button) — shipped in PR #214

Both moved from Open → Resolved in TICKETS.md; ticket file `status` fields updated.

## Affected machines / services

None — ticket files only.

## Validation performed

- N/A — prose/metadata change only

## Deployment steps

N/A

## Tickets addressed

- GAME-067 (ticket closure bookkeeping)
- GAME-068 (ticket closure bookkeeping)

## Rollback

N/A — revert commit if needed.
