### PR TITLE
feat(spec): broker variants + approve/neutral/disapprove evaluation states; update design docs

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -121,7 +121,7 @@ goal: character reactions + submit-on-invalid
 demo target: player submits map (valid or invalid) → result screen shows animated character + audio reaction;
   invalid map shows Fix-It path; valid pass/fail shows correct character animation
 dependency chain:
-  DESIGN-009 [resolved] (SVG inline + CSS animation; 5 instigator types × 4 star states)
+  DESIGN-009 [resolved] (SVG inline + CSS animation; 5 instigator types × 3 evaluation states: approve/neutral/disapprove)
   → parallel: GAME-060 [placeholder SVGs merged] + GAME-061 [audio stubs merged]
   → GAME-065 (sprite art refinement — replace placeholder SVGs with quality art)
   → GAME-064 [resolved] (audio playback infrastructure)

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -278,7 +278,7 @@ pass/fail shows correct character animation.
 
 **Dependency chain**:
 - DESIGN-009 [resolved] — SVG inline + CSS animation decided; 5 instigator
-  types × 4 star states; consistency spec + audio tones per type
+  types × 3 evaluation states (approve/neutral/disapprove); consistency spec + audio tones per type
 - GAME-059 [resolved] — submit-on-invalid: removed validity gate from Submit button
 - GAME-063 [resolved] — asset pipeline: directory structure + Bazel integration
 - GAME-064 [resolved] — audio playback infrastructure: AudioPlayer module

--- a/thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.compressed.md
+++ b/thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.compressed.md
@@ -1,6 +1,6 @@
 <!--COMPRESSED v1; source:2026-05-02-design-009-character-reaction-visual-style.md-->
 §META
-date:2026-05-02 last_updated:2026-05-02 researcher:Claude(Sonnet 4.6)
+date:2026-05-02 last_updated:2026-05-13 researcher:Claude(Sonnet 4.6)
 topic:character-reaction-art-style-audio status:decisions-complete approved
 
 §ABBREV
@@ -8,26 +8,26 @@ ts=thoughts/shared pb=partisan-boss la=legal-authority bb=bipartisan-broker
 ra=reform-arbiter na=neutral-admin ins=instigator
 
 §SUMMARY
-Player = neutral consultant ("just a job"). $ins (boss/customer who hired player) reacts on
-star count (3/2/1/0) — not binary pass/fail. $ins animation plays LAST after all
-per-criterion animations finish. 5 $ins types, curated roster, scenarios pick one.
-Design space reserved for custom $ins art in future custom-scenario tooling (no impl now).
-Format: 20 SVG files (5 types × 4 states). Per-state files (not multi-state).
+Player = neutral consultant ("just a job"). $ins (boss/customer who hired player) shows
+evaluation state (approve/neutral/disapprove) derived from overall score — not 1:1 star-to-pose.
+Stars still computed+displayed; evaluation state drives $ins pose. $ins animation plays LAST
+after all per-criterion animations finish. 5 $ins types, curated roster, scenarios pick one.
+Format: 15 SVG files (5 types × 3 states). Per-state files (not multi-state).
 
 §ROSTER
-| type | scenarios | $ins | 3-star | 2-star | 1-star | 0-star |
-|---|---|---|---|---|---|---|
-| $pb | 002 003 004(Ken) 009(Cat) | party boss | fist pump ecstatic | satisfied thumbs up | grudging shrug | head in hands furious |
-| $la | 005 | federal judge | gavel+scales balanced beaming | measured nod | furrowed reluctant | gavel scales tipped rejection |
-| $bb | 006 | both party bosses (side-by-side) | both handshake celebratory | cautious handshake | one nods other uncertain | both crossed arms |
-| $ra | 007 008 | reform commission | bright thumbs-up balanced-scales | steady approval | reserved acknowledgment | thumbs-down head-shake |
-| $na | tutorial-001 tutorial-002 | supervisor | checkmark warm-smile | approving nod | mild nod "acceptable" | shrug disappointed |
-state CSS names: three-star two-star one-star zero-star
+| type | scenarios | $ins | approve | neutral | disapprove |
+|---|---|---|---|---|---|
+| $pb | 002 003 004(Ken) 009(Cat) | party boss | fist pump ecstatic | satisfied shrug "good enough" | head in hands furious |
+| $la | 005 | federal judge | gavel+scales balanced beaming | measured nod furrowed-but-accepting | gavel scales tipped rejection |
+| $bb | 006 | both party bosses (side-by-side) | both handshake celebratory | cautious handshake reserved | both crossed arms united frustration |
+| $ra | 007 008 | reform commission | bright thumbs-up balanced-scales | reserved acknowledgment neutral | thumbs-down head-shake |
+| $na | tutorial-001 tutorial-002 | supervisor | checkmark warm-smile | mild nod "acceptable" | shrug disappointed |
+state file+CSS names: approve neutral disapprove
 006 special: both bosses share outcome (criteria req BOTH parties); split-screen = general capability for future asymmetric outcomes
 
 §OPTIONS
 A pure-CSS: ruled out — no personality
-B inline-SVG+per-state-file: CHOSEN — 20 files (5×4); AI-gen one pose at a time; easy per-state iteration
+B inline-SVG+per-state-file: CHOSEN — 15 files (5×3); AI-gen one pose at a time; easy per-state iteration
 C pixel-art: viable future re-skin — not current approach
 D Lottie: ruled out — 40KB lib overkill
 E CSS+emoji: ruled out — placeholder only
@@ -35,7 +35,7 @@ E CSS+emoji: ruled out — placeholder only
 §FILE_SCHEMA
 path: assets/characters/{type}/{state}.svg
 types: partisan-boss legal-authority bipartisan-broker reform-arbiter neutral-admin
-states: three-star two-star one-star zero-star
+states: approve neutral disapprove
 ext: .svg now; path otherwise format-agnostic for re-skin
 
 §STYLE
@@ -54,30 +54,29 @@ cross-type: same viewBox, same body scale, same foot/head placement — one illu
 same type across states: same character, only pose+expression changes
 types differ by: accent color + silhouette shape + costume/prop (must be distinct silhouettes)
 state poses (applies to all types):
-  three-star: open expansive celebratory — arms up, big gesture, leaning forward
-  two-star: positive composed — thumbs up or approving nod, upright
-  one-star: reserved ambivalent — slight lean or crossed arms, neutral expression
-  zero-star: closed negative — hunched or turned away, disapproving gesture
+  approve: open expansive celebratory — arms up, big gesture, leaning forward
+  neutral: reserved composed — slight lean or upright, neutral-to-mildly-positive expression; hands at sides or crossed; no strong gesture
+  disapprove: closed negative — hunched or turned away, disapproving gesture
 animation: subtle idle only (bob/blink/breathing 0.6-1.0s loop); pose = SVG geometry not keyframes
 prefers-reduced-motion: handled by wrapper CSS, not in SVG
 
 §AUDIO
-20 clips (5 types × 4 states); collapse to 2/type (celebratory/disappointed) if authoring 20 proves impractical
+15 clips (5 types × 3 states); collapse to 2/type (celebratory/disappointed) if authoring 15 proves impractical
 all: 0.5-1.5s loop-free board-game/casual register
-| type | 3-star | 2-star | 1-star | 0-star |
-|---|---|---|---|---|
-| $pb | triumphant brass sting | upbeat resolution chord | flat "close enough" sting | trombone wah-wah |
-| $la | formal gavel+ascending chime | measured chime | neutral gavel tap | gavel+descending tone |
-| $bb | warm celebratory chord | mild positive chord | subdued uncertain chord | dull thud resigned |
-| $ra | bright civic fanfare | soft steady chime | quiet acknowledgment | soft negative buzz |
-| $na | affirming ding warm | soft approving click | flat neutral click | brief flat shrug sound |
+| type | approve | neutral | disapprove |
+|---|---|---|---|
+| $pb | triumphant brass sting | flat "good enough" sting | trombone wah-wah |
+| $la | formal gavel+ascending chime | measured gavel tap | gavel+descending tone |
+| $bb | warm celebratory chord | subdued uncertain chord | dull thud resigned |
+| $ra | bright civic fanfare | quiet acknowledgment | soft negative buzz |
+| $na | affirming ding warm | flat neutral click | brief flat shrug sound |
 
 §DECISIONS
 1 format→inline SVG per-state file; path schema format-agnostic
 2 006 case→split-screen both bosses; general capability for asymmetric future scenarios
 3 tutorial→full $na reaction; tutorials=level-1 core loop
-4 $ins model→no player avatar; $ins reacts on star count (3/2/1/0); plays last after criteria
-5 20 files (5×4)→one file per state; AI-gen one pose at a time; easier per-state iteration
+4 $ins model→no player avatar; $ins shows evaluation state (approve/neutral/disapprove) derived from star score; plays last after criteria; supersedes 4-state (3/2/1/0 star) model
+5 15 files (5×3)→one file per state; AI-gen one pose at a time; easier per-state iteration
 6 consistency spec→embed in every GAME-060 art-gen prompt; cross-set coherence > individual perfection
 
 §REFS

--- a/thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.md
+++ b/thoughts/shared/research/2026-05-02-design-009-character-reaction-visual-style.md
@@ -1,7 +1,7 @@
 # DESIGN-009: Character Reaction Visual Style Research
 
 **Date:** 2026-05-02  
-**Last updated:** 2026-05-02  
+**Last updated:** 2026-05-13  
 **Researcher:** Claude (Sonnet 4.6)  
 **Topic:** Art style, character roster, and animation approach for result screen reactions  
 **Status:** decisions complete — approved
@@ -13,8 +13,11 @@
 The player is a neutral consultant hired to draw a map. They have no stake in the
 political outcome — it's "just a job." The person who *does* have a stake is the
 instigator: the party boss, judge, reform commissioner, or supervisor who hired or
-empowered the player. On the result screen, the instigator reacts to how well the
-player delivered — graded by star count, not binary pass/fail.
+empowered the player. On the result screen, the instigator reacts to the overall
+outcome — expressed as one of three evaluation states: **approve**, **neutral**, or
+**disapprove**. The star score is still computed from criteria (required + optional),
+but the instigator's pose is determined by the evaluation state, not mapped 1:1 to a
+star count.
 
 The instigator's animation plays last, after all per-criterion reveal animations
 finish, as the final emotional beat. Different scenarios pick from a curated roster
@@ -28,15 +31,15 @@ custom-scenario tooling, but that functionality is not implemented now.
 Five instigator types cover all current scenarios. Future scenarios pick from this
 roster (or, in future custom-scenario tooling, supply their own art).
 
-| Type | Scenarios | Instigator | 3-star | 2-star | 1-star | 0-star |
-|---|---|---|---|---|---|---|
-| Partisan Boss | 002, 003, 004 (Ken); 009 (Cat) | Party boss who hired you | Fist pump, ecstatic | Satisfied nod, thumbs up | Grudging shrug, "close enough" | Head in hands, furious |
-| Legal Authority | 005 | Federal judge | Gavel bang + scales balanced, beaming | Measured nod, gavel tap | Furrowed brow, reluctant approval | Gavel bang, scales tipped, rejection |
-| Bipartisan Broker | 006 | Both party bosses (side-by-side) | Both bosses handshake, celebratory | Cautious handshake | One boss nods, other uncertain | Both bosses crossed arms, displeased |
-| Reform Arbiter | 007, 008 | Reform commission | Bright thumbs up, balanced scales | Steady approval, nod | Reserved acknowledgment | Thumbs down, head shake |
-| Neutral Admin | tutorial-001, tutorial-002 | Supervisor | Checkmark, warm smile | Approving nod | Mild nod, "acceptable" | Shrug, disappointed |
+| Type | Scenarios | Instigator | approve | neutral | disapprove |
+|---|---|---|---|---|---|
+| Partisan Boss | 002, 003, 004 (Ken); 009 (Cat) | Party boss who hired you | Fist pump, ecstatic | Satisfied shrug, "good enough" | Head in hands, furious |
+| Legal Authority | 005 | Federal judge | Gavel bang + scales balanced, beaming | Measured nod, furrowed but accepting | Gavel bang, scales tipped, rejection |
+| Bipartisan Broker | 006 | Both party bosses (side-by-side) | Both bosses handshake, celebratory | Cautious handshake, reserved | Both bosses crossed arms, united frustration |
+| Reform Arbiter | 007, 008 | Reform commission | Bright thumbs up, balanced scales | Reserved acknowledgment, neutral | Thumbs down, head shake |
+| Neutral Admin | tutorial-001, tutorial-002 | Supervisor | Checkmark, warm smile | Mild nod, "acceptable" | Shrug, disappointed |
 
-**State names** (CSS classes applied to the SVG): `three-star`, `two-star`, `one-star`, `zero-star`.
+**State names** (file names and CSS classes): `approve`, `neutral`, `disapprove`.
 
 **Scenario-006 note:** The Bipartisan Broker type shows both party bosses simultaneously.
 Both share the same outcome state (the criteria require safe seats for BOTH parties,
@@ -56,8 +59,8 @@ implementation required now; just avoid hard-coding the roster as a closed enum.
 Ruled out. Cannot convey distinct character types or personality.
 
 ### Option B — Inline SVG + CSS animation (chosen)
-Each state is a separate SVG file. Pass/fail toggling replaced by 4-state class
-system. Animated with `@keyframes`. Resolution-independent, AI-generable,
+Each state is a separate SVG file. Three-state evaluation system (approve/neutral/disapprove).
+Animated with `@keyframes`. Resolution-independent, AI-generable,
 < 10 KB per file. No library needed.
 
 ### Option C — Pixel art sprite sheets
@@ -74,10 +77,10 @@ Ruled out. Existing GAME-052 placeholder; not the goal.
 
 ## Recommendation
 
-**Format:** 20 SVG files — 5 instigator types × 4 star-count states.  
+**Format:** 15 SVG files — 5 instigator types × 3 evaluation states.  
 **File path schema:** `assets/characters/{type}/{state}.svg`  
   - type: `partisan-boss`, `legal-authority`, `bipartisan-broker`, `reform-arbiter`, `neutral-admin`  
-  - state: `three-star`, `two-star`, `one-star`, `zero-star`  
+  - state: `approve`, `neutral`, `disapprove`  
   - Extension is `.svg` now; path schema is otherwise format-agnostic for future re-skin.
 
 **Style:** Flat, minimal, 2–3 colors per character. Silhouette-readable at 160–200 px.
@@ -95,8 +98,8 @@ Political-cartoon / board-game-token aesthetic.
 loading the appropriate file (no CSS class switching needed — each file is one state).
 `prefers-reduced-motion` handled by the reaction system wrapper, not per-file.
 
-**Audio:** 20 clips — 5 types × 4 states (or collapsed to fewer grades if authoring
-20 distinct clips proves impractical; minimum 2 per type: celebratory / disappointed).
+**Audio:** 15 clips — 5 types × 3 states (or collapsed to 2 per type if authoring
+15 distinct clips proves impractical; minimum 2 per type: celebratory / disappointed).
 See GAME-061 for clip strategy. All clips: 0.5–1.5 s, loop-free, board-game/casual
 register.
 
@@ -123,17 +126,16 @@ Consistency across the set is more important than perfection of individual files
   accessory, or body outline (the player needs to recognize them at a glance)
 
 ### Cross-type consistency
-- Same viewBox, same body scale, same foot/head placement across all 20 files
+- Same viewBox, same body scale, same foot/head placement across all 15 files
 - Characters should feel like they come from the same illustration set — consistent
   line weight, same visual grammar, same level of detail
 - Different types differ in: accent color, silhouette shape, costume/prop
-- Same type across 4 states: same character, only pose and expression change
+- Same type across 3 states: same character, only pose and expression change
 
-### State poses (same type, 4 poses)
-- `three-star`: open, expansive, celebratory — arms up, leaning forward, big gesture
-- `two-star`: positive, composed — thumbs up or approving nod, upright
-- `one-star`: reserved, ambivalent — slight lean or crossed arms, neutral expression
-- `zero-star`: closed, negative — hunched or turned away, disapproving gesture
+### State poses (same type, 3 poses)
+- `approve`: open, expansive, celebratory — arms up, leaning forward, big gesture
+- `neutral`: reserved, composed — slight lean or upright, neutral to mildly positive expression; hands at sides or crossed; no strong gesture
+- `disapprove`: closed, negative — hunched or turned away, disapproving gesture
 
 ### Animation
 - Each SVG file represents one static pose with a short looping idle animation
@@ -145,13 +147,13 @@ Consistency across the set is more important than perfection of individual files
 
 ## Audio Tone Per Instigator Type
 
-| Type | 3-star | 2-star | 1-star | 0-star |
-|---|---|---|---|---|
-| Partisan Boss | Short triumphant brass sting; punchy | Upbeat resolution chord | Flat "close enough" sting | Trombone wah-wah deflation |
-| Legal Authority | Formal gavel + ascending chime | Measured chime | Single neutral gavel tap | Gavel + descending tone; austere |
-| Bipartisan Broker | Warm celebratory chord; handshake-feel | Mild positive chord | Subdued chord; uncertain | Dull thud; resigned |
-| Reform Arbiter | Bright civic fanfare; optimistic | Soft chime; steady | Quiet acknowledgment tone | Soft negative buzz or descending chime |
-| Neutral Admin | Affirming ding; warm | Soft click; approving | Flat neutral click | Brief flat shrug sound |
+| Type | approve | neutral | disapprove |
+|---|---|---|---|
+| Partisan Boss | Short triumphant brass sting; punchy | Flat "good enough" sting | Trombone wah-wah deflation |
+| Legal Authority | Formal gavel + ascending chime | Single measured gavel tap | Gavel + descending tone; austere |
+| Bipartisan Broker | Warm celebratory chord; handshake-feel | Subdued chord; reserved | Dull thud; resigned |
+| Reform Arbiter | Bright civic fanfare; optimistic | Quiet acknowledgment tone | Soft negative buzz or descending chime |
+| Neutral Admin | Affirming ding; warm | Flat neutral click | Brief flat shrug sound |
 
 All clips: 0.5–1.5 s, loop-free, no dramatic buildup. Board-game / casual-strategy
 tonal register.
@@ -177,16 +179,18 @@ as a general capability: future scenarios may have asymmetric outcomes per panel
 Tutorials are level 1 of the core game loop. Skipping animation there creates an
 inconsistent first impression and signals reactions are optional rather than core UI.
 
-**4. Instigator model — no player avatar; instigator reacts on star count.**
+**4. Instigator model — no player avatar; instigator shows evaluation state.**
 
 The player is a neutral consultant ("just a job"). The instigator (the person who hired
-the player) reacts based on how well the player delivered, graded by star count
-(3/2/1/0). This replaces the earlier "player avatar" concept. The instigator's
-animation plays last, after all per-criterion animations finish.
+the player) reacts based on the evaluation state (approve / neutral / disapprove) derived
+from the overall score. Stars are still computed and displayed; the evaluation state is
+determined from the star score but is not a 1:1 star-to-pose mapping. This replaces
+the earlier "player avatar" concept and supersedes the prior 4-state (3/2/1/0 star) model.
+The instigator's animation plays last, after all per-criterion animations finish.
 
-**5. 20 files (one per state) vs 6 files (multi-state SVG).**
+**5. 15 files (one per state) vs 6 files (multi-state SVG).**
 
-20 files (5 types × 4 states), one SVG file per state. Simpler to AI-generate
+15 files (5 types × 3 states), one SVG file per state. Simpler to AI-generate
 (describe one pose at a time), easier to iterate individual states independently.
 Can revisit merging into multi-state files if it later becomes worthwhile.
 

--- a/thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.compressed.md
+++ b/thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.compressed.md
@@ -48,14 +48,18 @@ why 1.2s not 3s: 3s×5cr=15s wall-clock before $ins appears; 1.2s keeps moment; 
 §D3_CHARACTER_FLASH
 no per-cr flash — no generalizable mapping from cr type → $ins concern (9×5=45 cases)
 sequence:
-  1 $ins renders in neutral/waiting pose at top of card (before criteria begin)
+  1 $ins renders in waiting/pre-reveal pose at top of card (before criteria begin)
   2 criteria reveal one-by-one (§D2_TIMING)
   3 after last cr resolves: 0.8s dramatic pause
-  4 $ins cross-fades to approve or disapprove pose (0.4s); audio plays (GAME-061)
+  4 $ins cross-fades to approve/neutral/disapprove pose (0.4s); audio plays (GAME-061)
   5 verdict text pulses once
-pose logic: BINARY — approve=any stars(1/2/3); disapprove=0 stars; not graduated
-  approve maps to three-star or two-star SVG; disapprove maps to zero-star SVG; one-star unused here
-neutral/waiting pose: new waiting.svg per $ins type (Option B — reusing approve pose misleads before reveal)
+pose logic: THREE STATES — approve/neutral/disapprove derived from star score (not 1:1 star-to-pose)
+  approve=strong result; neutral=acceptable/minimum; disapprove=0 stars/rework needed
+  thresholds = implementation decision (e.g. disapprove=0 stars; neutral=required-only; approve=bonus met)
+  maps directly to approve.svg / neutral.svg / disapprove.svg from DESIGN-009
+  supersedes prior binary (approve=1-3 stars / disapprove=0 stars) model
+waiting/pre-reveal pose: new waiting.svg per $ins type — semantically distinct from neutral evaluation state
+  (Option B — reusing approve/neutral pose misleads before reveal)
   DESIGN-009 foot spec (feet near y=190, 200×200 viewBox) already supports foot-anchoring
   GAME-066 constraint: CSS must pin foot-baseline so transition reads as posture change, not positional jump
 
@@ -69,7 +73,7 @@ no shared schema; cr icons in criterion-icons.ts
 1 cr icons: separate flat SVG; 24 or 36px (try both); criterion-icons.ts; one per type
 2 placement: .rc-icon slot; replaces ✓/✗; color-tint on result
 3 timing: 400ms stagger (tentative/iterate); 1 200ms CHECKING hold; 150ms flip; click-to-skip
-4 $ins: binary approve(1-3 stars)/disapprove(0 stars); new waiting.svg neutral pre-reveal; 0.8s pause→pose cross-fade; foot-anchored CSS
+4 $ins: three-state approve/neutral/disapprove (derived from star score); new waiting.svg pre-reveal pose (distinct from neutral evaluation state); 0.8s pause→pose cross-fade; foot-anchored CSS
 5 icon set separate from DESIGN-009; criterion-icons.ts as SVG strings
 
 §REFS

--- a/thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.md
+++ b/thoughts/shared/research/2026-05-07-design-010-result-screen-dramatic-reveal.md
@@ -134,12 +134,12 @@ generalize (a federal judge cares about all criteria differently than a partisan
 
 **Revised sequence:**
 
-1. Instigator renders in **neutral/waiting pose** at the top of the result card before
-   criteria begin.
+1. Instigator renders in **waiting pose** (`waiting.svg`) at the top of the result card before
+   criteria begin. This is a pre-reveal pose, semantically distinct from the `neutral` evaluation state.
 2. Criteria reveal one by one (Phase 1 + Phase 2 per Decision 2).
 3. After the last criterion resolves: **0.8s dramatic pause** (all rows visible, no
    new motion).
-4. Instigator **transitions to approve or disapprove pose** with a CSS cross-fade (0.4s).
+4. Instigator **transitions to approve, neutral, or disapprove pose** with a CSS cross-fade (0.4s).
    Audio clip plays (GAME-061).
 5. Overall verdict text ("Map Passed!" / "Map Failed") pulses once.
 
@@ -149,26 +149,27 @@ generalize (a federal judge cares about all criteria differently than a partisan
 - Flash on every criterion cheapens the moment — the instigator's reaction is the
   narrative payoff, not a running commentary
 
-### Pose logic: binary, not graduated by star count
+### Pose logic: three evaluation states
 
-The instigator's final pose is **binary**:
+The instigator's final pose uses three states (see DESIGN-009):
 
-- **Approve** — any stars (1, 2, or 3): the player's map is accepted; they can proceed.
-  Maps to a positive pose (e.g., thumbs-up / satisfied / celebratory depending on type).
-- **Disapprove** — zero stars: the map requires rework.
-  Maps to a negative pose (e.g., head-in-hands / rejection depending on type).
+- **Approve** — strong result: the player's map is accepted with enthusiasm.
+  Maps to the `approve` SVG (celebratory, arms up).
+- **Neutral** — acceptable result: the map passes minimum requirements but is unremarkable.
+  Maps to the `neutral` SVG (reserved, composed).
+- **Disapprove** — failure: the map requires rework.
+  Maps to the `disapprove` SVG (negative, closed gesture).
 
-The star count (0/1/2/3) is still computed and displayed as the score, but the
-instigator's visual only needs two states for this sequence. The graduated DESIGN-009
-four-pose schema (three/two/one/zero-star) still applies to the sprite assets — the
-approve pose maps to `three-star` or `two-star` (whichever best fits the art),
-disapprove maps to `zero-star`. The `one-star` pose is not used in this flow.
+The star count is still computed and displayed as the score. The evaluation state
+(approve / neutral / disapprove) is derived from the star score; the exact thresholds
+are an implementation decision (e.g., disapprove = 0 stars, neutral = required-only,
+approve = bonus criteria met). This supersedes the earlier binary approve/disapprove model.
 
 ### Neutral waiting pose
 
 The instigator needs a distinct pre-reveal visual state. Options:
 
-**Option A** — Reuse an existing pose (e.g., `two-star`) as neutral waiting.
+**Option A** — Reuse an existing evaluation pose (e.g., `neutral`) as the waiting pose.
 Inexpensive; slightly misleading (implies outcome before reveal).
 
 **Option B** — Add a 5th SVG file per instigator type: `waiting.svg` (arms folded,
@@ -177,7 +178,7 @@ watching). 5 new files. Clean semantic separation.
 **Recommendation: Option B** — the neutral-waiting pose is the *first* thing the
 player sees when the result screen opens. Reusing an "approve" pose before the verdict
 is known undercuts the reveal. This is the right long-term answer. GAME-066 to
-commission or generate `waiting.svg` per type alongside the four star-state files.
+commission or generate `waiting.svg` per type alongside the three evaluation-state files.
 
 ### Foot alignment
 
@@ -213,7 +214,7 @@ requests).
 | 1 | Icons: separate flat SVG symbol set; 24×24 or 36×36 (try both); inline in TS; one per criterion type |
 | 2 | Placement: inside `.rc-icon` slot, replacing ✓/✗; color-tinted on result |
 | 3 | Timing: 400ms stagger (tentative, iterate); 1 200ms CHECKING hold; 150ms flip; click-to-skip |
-| 4 | Instigator: binary approve (any stars) / disapprove (0 stars); starts in new `waiting.svg` neutral pose; transitions after 0.8s pause; foot-anchored so transition reads as posture not position |
+| 4 | Instigator: three-state approve / neutral / disapprove (derived from star score); starts in new `waiting.svg` pre-reveal pose; transitions after 0.8s pause; foot-anchored so transition reads as posture not position |
 | 5 | Icons separate from DESIGN-009; criterion icons in `criterion-icons.ts` as SVG strings |
 
 ---

--- a/tools/gen-assets.main.kts
+++ b/tools/gen-assets.main.kts
@@ -146,9 +146,8 @@ data class CharacterType(
 )
 
 @JsonClass(generateAdapter = false)
-data class StarState(
+data class EvaluationState(
     val id: String,
-    val stars: Int,
     val label: String,
     val poseGuide: String,
 )
@@ -156,7 +155,7 @@ data class StarState(
 @JsonClass(generateAdapter = false)
 data class SpriteSpec(
     val characterTypes: List<CharacterType>,
-    val starStates: List<StarState>,
+    val evaluationStates: List<EvaluationState>,
     val provider: String? = null,
     val model: String? = null,
 )
@@ -509,7 +508,7 @@ Output the SVG inside a markdown fenced code block:
 Respond with ONLY the code block — no prose, no explanation.
 """.trimIndent()
 
-fun buildSpritePrompt(type: CharacterType, state: StarState): String = """
+fun buildSpritePrompt(type: CharacterType, state: EvaluationState): String = """
 Generate one SVG sprite for the following character + state combination.
 
 CHARACTER TYPE: ${type.displayName}
@@ -551,7 +550,7 @@ Style rules:
 - White background
 """.trimIndent()
 
-fun buildImagePrompt(type: CharacterType, state: StarState, styleSpec: String): String = """
+fun buildImagePrompt(type: CharacterType, state: EvaluationState, styleSpec: String): String = """
 $styleSpec
 
 CHARACTER: ${type.displayName}
@@ -772,9 +771,9 @@ abstract class BaseGenCommand(
         },
     )
 
-    protected fun filteredSpec(spec: SpriteSpec): Pair<List<CharacterType>, List<StarState>> {
-        val types  = if (typeFilter.isEmpty())  spec.characterTypes else spec.characterTypes.filter { it.id in typeFilter }
-        val states = if (stateFilter.isEmpty()) spec.starStates     else spec.starStates.filter     { it.id in stateFilter }
+    protected fun filteredSpec(spec: SpriteSpec): Pair<List<CharacterType>, List<EvaluationState>> {
+        val types  = if (typeFilter.isEmpty())  spec.characterTypes   else spec.characterTypes.filter   { it.id in typeFilter }
+        val states = if (stateFilter.isEmpty()) spec.evaluationStates else spec.evaluationStates.filter { it.id in stateFilter }
         return types to states
     }
 
@@ -784,8 +783,8 @@ abstract class BaseGenCommand(
             spec.characterTypes.forEach { echo("  ${it.id.padEnd(22)} ${it.displayName} — ${it.role}") }
         }
         if (listStates) {
-            echo("Available star states (from ${charactersFile ?: "tools/sprite-spec.json"}):")
-            spec.starStates.forEach { echo("  ${it.id.padEnd(12)} ${it.label}") }
+            echo("Available evaluation states (from ${charactersFile ?: "tools/sprite-spec.json"}):")
+            spec.evaluationStates.forEach { echo("  ${it.id.padEnd(12)} ${it.label}") }
         }
     }
 }
@@ -1014,9 +1013,8 @@ class DescribeCommand : CliktCommand(
                 palette        = palette,
                 silhouetteNotes = description,
             )),
-            starStates = listOf(StarState(
+            evaluationStates = listOf(EvaluationState(
                 id        = stateId,
-                stars     = 1,
                 label     = stateLabel,
                 poseGuide = stateGuide,
             )),

--- a/tools/gen-assets.test.main.kts
+++ b/tools/gen-assets.test.main.kts
@@ -38,12 +38,12 @@ import java.util.Base64
 data class CharacterType(val id: String, val displayName: String, val role: String, val palette: String, val silhouetteNotes: String)
 
 @JsonClass(generateAdapter = false)
-data class StarState(val id: String, val stars: Int, val label: String, val poseGuide: String)
+data class EvaluationState(val id: String, val label: String, val poseGuide: String)
 
 @JsonClass(generateAdapter = false)
 data class SpriteSpec(
     val characterTypes: List<CharacterType>,
-    val starStates: List<StarState>,
+    val evaluationStates: List<EvaluationState>,
     val provider: String? = null,
     val model: String? = null,
 )
@@ -123,7 +123,7 @@ object Logic {
         error("No SVG found in model output. First 500 chars:\n${raw.take(500)}")
     }
 
-    fun buildSpritePrompt(type: CharacterType, state: StarState): String = """
+    fun buildSpritePrompt(type: CharacterType, state: EvaluationState): String = """
 Generate one SVG sprite for the following character + state combination.
 
 CHARACTER TYPE: ${type.displayName}
@@ -178,7 +178,7 @@ Output the SVG inside a markdown fenced code block:
 Respond with ONLY the code block — no prose, no explanation.
 """.trimIndent()
 
-    fun buildImagePrompt(type: CharacterType, state: StarState, styleSpec: String): String = """
+    fun buildImagePrompt(type: CharacterType, state: EvaluationState, styleSpec: String): String = """
 $styleSpec
 
 CHARACTER: ${type.displayName}
@@ -275,9 +275,8 @@ The 2–3 features most essential for recognizing this subject. An artist must g
             palette = palette,
             silhouetteNotes = silhouetteNotes,
         )),
-        starStates = listOf(StarState(
+        evaluationStates = listOf(EvaluationState(
             id = "default",
-            stars = 1,
             label = "Default",
             poseGuide = "neutral pose",
         )),
@@ -307,11 +306,11 @@ class SvgExtractionTest {
 
 class SpritePromptContentTest {
     private val type  = CharacterType("partisan-boss", "Partisan Boss", "hires player", "gold/red", "wide shoulders")
-    private val state = StarState("three-star", 3, "Three-star (ecstatic)", "arms raised high")
+    private val state = EvaluationState("approve", "Approve (ecstatic)", "arms raised high")
     private val prompt by lazy { Logic.buildSpritePrompt(type, state) }
 
     @Test fun `contains character display name`()  { assertTrue(prompt.contains("Partisan Boss")) }
-    @Test fun `contains state label`()             { assertTrue(prompt.contains("Three-star")) }
+    @Test fun `contains state label`()             { assertTrue(prompt.contains("Approve")) }
     @Test fun `contains viewBox requirement`()     { assertTrue(prompt.contains("viewBox=\"0 0 200 200\"")) }
     @Test fun `contains idle-bob requirement`()    { assertTrue(prompt.contains("idle-bob")) }
     @Test fun `contains file size limit`()         { assertTrue(prompt.contains("15 KB")) }
@@ -362,12 +361,12 @@ class GrokImageDecodingTest {
 
 class ImagePromptContentTest {
     private val type  = CharacterType("partisan-boss", "Partisan Boss", "hires player", "gold suit; red tie", "oversized round head")
-    private val state = StarState("thumbs-up", 3, "Thumbs up (ecstatic)", "arm raised, big grin")
+    private val state = EvaluationState("approve", "Approve (ecstatic)", "arm raised, big grin")
     private val style = "Bold outlines, flat fills, Vault Boy style"
     private val prompt by lazy { Logic.buildImagePrompt(type, state, style) }
 
     @Test fun `contains character display name`()  { assertTrue(prompt.contains("Partisan Boss")) }
-    @Test fun `contains state label`()             { assertTrue(prompt.contains("Thumbs up")) }
+    @Test fun `contains state label`()             { assertTrue(prompt.contains("Approve")) }
     @Test fun `contains palette`()                 { assertTrue(prompt.contains("gold suit")) }
     @Test fun `contains silhouette notes`()        { assertTrue(prompt.contains("oversized round head")) }
     @Test fun `contains pose guide`()              { assertTrue(prompt.contains("arm raised")) }
@@ -555,10 +554,10 @@ class SpriteSpecParsingTest {
     private val minimalSpec = """
         {
           "characterTypes": [
-            {"id":"partisan-boss","displayName":"Partisan Boss","role":"role","palette":"palette","silhouetteNotes":"notes"}
+            {"id":"broker-wm-bm","displayName":"Bipartisan Broker","role":"role","palette":"palette","silhouetteNotes":"notes"}
           ],
-          "starStates": [
-            {"id":"three-star","stars":3,"label":"Three-star (ecstatic)","poseGuide":"arms up"}
+          "evaluationStates": [
+            {"id":"approve","label":"Approve","poseGuide":"arms up"}
           ]
         }
     """.trimIndent()
@@ -566,20 +565,20 @@ class SpriteSpecParsingTest {
     @Test fun `parses character type fields`() {
         val spec = Logic.loadSpriteSpec(minimalSpec)
         assertEquals(1, spec.characterTypes.size)
-        assertEquals("partisan-boss", spec.characterTypes[0].id)
-        assertEquals("Partisan Boss", spec.characterTypes[0].displayName)
+        assertEquals("broker-wm-bm", spec.characterTypes[0].id)
+        assertEquals("Bipartisan Broker", spec.characterTypes[0].displayName)
     }
-    @Test fun `parses star state fields`() {
+    @Test fun `parses evaluation state fields`() {
         val spec = Logic.loadSpriteSpec(minimalSpec)
-        assertEquals(1, spec.starStates.size)
-        assertEquals("three-star", spec.starStates[0].id)
-        assertEquals(3, spec.starStates[0].stars)
+        assertEquals(1, spec.evaluationStates.size)
+        assertEquals("approve", spec.evaluationStates[0].id)
+        assertEquals("Approve", spec.evaluationStates[0].label)
     }
     @Test fun `parses spec with provider field`() {
         val json = """
             {
               "characterTypes": [{"id":"t1","displayName":"T1","role":"r","palette":"p","silhouetteNotes":"n"}],
-              "starStates": [{"id":"s1","stars":1,"label":"S1","poseGuide":"g"}],
+              "evaluationStates": [{"id":"approve","label":"Approve","poseGuide":"g"}],
               "provider": "grok",
               "model": "grok-3"
             }
@@ -597,17 +596,21 @@ class SpriteSpecParsingTest {
         val path = Paths.get("tools/sprite-spec.json")
         assertTrue(Files.exists(path), "tools/sprite-spec.json must exist")
         val spec = Logic.loadSpriteSpec(Files.readString(path))
-        assertEquals(5, spec.characterTypes.size, "Expected 5 character types")
-        assertEquals(4, spec.starStates.size,     "Expected 4 star states")
+        assertEquals(3, spec.characterTypes.size,    "Expected 3 character types")
+        assertEquals(3, spec.evaluationStates.size,  "Expected 3 evaluation states")
         val typeIds  = spec.characterTypes.map { it.id }.toSet()
-        val stateIds = spec.starStates.map { it.id }.toSet()
-        assertTrue("partisan-boss" in typeIds)
-        assertTrue("three-star"   in stateIds)
+        val stateIds = spec.evaluationStates.map { it.id }.toSet()
+        assertTrue("broker-wm-bm" in typeIds)
+        assertTrue("approve"      in stateIds)
+        assertTrue("neutral"      in stateIds)
+        assertTrue("disapprove"   in stateIds)
         spec.characterTypes.forEach { t ->
             assertTrue(t.palette.isNotBlank(),         "${t.id}: blank palette")
             assertTrue(t.silhouetteNotes.isNotBlank(), "${t.id}: blank silhouetteNotes")
         }
-        assertEquals(setOf(0, 1, 2, 3), spec.starStates.map { it.stars }.toSet())
+        spec.evaluationStates.forEach { s ->
+            assertTrue(s.poseGuide.isNotBlank(), "${s.id}: blank poseGuide")
+        }
     }
 }
 
@@ -653,7 +656,7 @@ class SpriteSpecRoundTripTest {
         val json = Logic.specAdapter.toJson(original)
         val deserialized = Logic.loadSpriteSpec(json)
         assertEquals(original.characterTypes.size, deserialized.characterTypes.size)
-        assertEquals(original.starStates.size, deserialized.starStates.size)
+        assertEquals(original.evaluationStates.size, deserialized.evaluationStates.size)
         assertEquals(original.provider, deserialized.provider)
         assertEquals(original.model, deserialized.model)
     }
@@ -670,13 +673,12 @@ class SpriteSpecRoundTripTest {
         assertEquals("A test character", type.silhouetteNotes)
     }
 
-    @Test fun `spec preserves all star state fields after round-trip`() {
+    @Test fun `spec preserves all evaluation state fields after round-trip`() {
         val spec = Logic.buildTestSpriteSpec()
         val json = Logic.specAdapter.toJson(spec)
         val restored = Logic.loadSpriteSpec(json)
-        val state = restored.starStates[0]
+        val state = restored.evaluationStates[0]
         assertEquals("default", state.id)
-        assertEquals(1, state.stars)
         assertEquals("Default", state.label)
         assertEquals("neutral pose", state.poseGuide)
     }

--- a/tools/sprite-spec.json
+++ b/tools/sprite-spec.json
@@ -1,65 +1,42 @@
 {
   "characterTypes": [
     {
-      "id": "partisan-boss",
-      "displayName": "Partisan Boss",
-      "role": "Party boss who hired the player to draw the map in their party's favour",
-      "palette": "party gold (#d4a017) and red (#c0392b) accents; shared dark outline (#1a1a2e)",
-      "silhouetteNotes": "Wide-shouldered power-broker suit jacket with visible lapels; strong hat brim or distinctive hair; props: flag or clenched fist; political-cartoon bravado"
+      "id": "broker-wm-bm",
+      "displayName": "Bipartisan Broker (WM + BM)",
+      "role": "Two party representatives — one from each side — shaking hands above a shared 'Bipartisanship!' banner, evaluating whether the map is fair to both parties",
+      "palette": "left figure magenta (#FF00FF) accoutrements (tie, lapel pin); right figure cyan (#00FFFF) accoutrements; banner diagonal barber-pole stripes in magenta and cyan; shared dark outline (#1a1a2e). Magenta and cyan are runtime-tintable party-colour placeholders.",
+      "silhouetteNotes": "Two figures waist-up, facing slightly inward toward each other, clasping hands in a firm handshake at centre. Left: white male in business suit, magenta tie and lapel pin. Right: Black male in business suit, cyan tie and lapel pin. Feet and lower body hidden by a wide rectangular 'Bipartisanship!' banner spanning the full width at the bottom of the frame; banner text in white block letters with dark outline; banner background has diagonal barber-pole stripes of magenta and cyan. Expressions mirror the evaluation-state energy."
     },
     {
-      "id": "legal-authority",
-      "displayName": "Legal Authority",
-      "role": "Federal judge evaluating whether the map meets constitutional requirements",
-      "palette": "slate blue (#4a6fa5) accent; formal dark robe; shared dark outline (#1a1a2e)",
-      "silhouetteNotes": "Judicial robe with wide collar; gavel as recurring prop; formal upright bearing; authority conveyed through posture not bulk"
+      "id": "broker-wf-bf",
+      "displayName": "Bipartisan Broker (WF + BF)",
+      "role": "Two party representatives — one from each side — shaking hands above a shared 'Bipartisanship!' banner, evaluating whether the map is fair to both parties",
+      "palette": "left figure magenta (#FF00FF) accoutrements (scarf or ribbon pin); right figure cyan (#00FFFF) accoutrements; banner diagonal barber-pole stripes in magenta and cyan; shared dark outline (#1a1a2e). Magenta and cyan are runtime-tintable party-colour placeholders.",
+      "silhouetteNotes": "Two figures waist-up, facing slightly inward toward each other, clasping hands in a firm handshake at centre. Left: white female in business jacket, magenta scarf or ribbon pin. Right: Black female in business jacket, cyan scarf or ribbon pin. Feet and lower body hidden by a wide rectangular 'Bipartisanship!' banner spanning the full width at the bottom of the frame; banner text in white block letters with dark outline; banner background has diagonal barber-pole stripes of magenta and cyan. Expressions mirror the evaluation-state energy."
     },
     {
-      "id": "bipartisan-broker",
-      "displayName": "Bipartisan Broker",
-      "role": "Both party bosses side by side, evaluating whether the map is fair to both sides",
-      "palette": "left boss warm-red (#c0392b); right boss cool-blue (#2980b9); shared dark outline (#1a1a2e)",
-      "silhouetteNotes": "Two smaller figures at half-width each within the 200x200 viewBox; mirror-image postures; opposing accent colours make them visually symmetric"
-    },
-    {
-      "id": "reform-arbiter",
-      "displayName": "Reform Arbiter",
-      "role": "Reform commission evaluating whether the map meets neutral fairness criteria",
-      "palette": "teal (#16a085) and muted green (#27ae60) accents; shared dark outline (#1a1a2e)",
-      "silhouetteNotes": "Business-casual attire; clipboard or balance-scale as prop; earnest civic-minded bearing; less imposing than Partisan Boss"
-    },
-    {
-      "id": "neutral-admin",
-      "displayName": "Neutral Admin",
-      "role": "Supervisor / tutorial guide assessing the player's work on training exercises",
-      "palette": "muted grey-blue (#7f8c8d / #a0b4c8) accents; shared dark outline (#1a1a2e)",
-      "silhouetteNotes": "Plain office attire; clipboard or checklist as prop; no political symbols; approachable and professional, not intimidating"
+      "id": "broker-lm-af",
+      "displayName": "Bipartisan Broker (LM + AF)",
+      "role": "Two party representatives — one from each side — shaking hands above a shared 'Bipartisanship!' banner, evaluating whether the map is fair to both parties",
+      "palette": "left figure magenta (#FF00FF) accoutrements (tie, lapel pin); right figure cyan (#00FFFF) accoutrements (scarf or ribbon pin); banner diagonal barber-pole stripes in magenta and cyan; shared dark outline (#1a1a2e). Magenta and cyan are runtime-tintable party-colour placeholders.",
+      "silhouetteNotes": "Two figures waist-up, facing slightly inward toward each other, clasping hands in a firm handshake at centre. Left: Latino male in business suit, magenta tie and lapel pin. Right: Asian female in business jacket, cyan scarf or ribbon pin. Feet and lower body hidden by a wide rectangular 'Bipartisanship!' banner spanning the full width at the bottom of the frame; banner text in white block letters with dark outline; banner background has diagonal barber-pole stripes of magenta and cyan. Expressions mirror the evaluation-state energy."
     }
   ],
-  "starStates": [
+  "evaluationStates": [
     {
-      "id": "three-star",
-      "stars": 3,
-      "label": "Three-star (ecstatic)",
-      "poseGuide": "Open, expansive, celebratory — arms raised high or spread wide, leaning forward into the viewer, big visible gesture, wide grin or triumphant expression"
+      "id": "approve",
+      "label": "Approve",
+      "poseGuide": "Vigorous, celebratory handshake — both figures leaning slightly toward each other; free hands raised or gesturing outward in celebration; wide grins, high energy. This criterion passed their bipartisan fairness check."
     },
     {
-      "id": "two-star",
-      "stars": 2,
-      "label": "Two-star (satisfied)",
-      "poseGuide": "Positive, composed — thumbs up or approving nod, upright confident posture, relaxed slight smile"
+      "id": "neutral",
+      "label": "Neutral",
+      "poseGuide": "Firm, reserved handshake; upright postures; polite but noncommittal expressions; free hands at sides. This criterion is acceptable but uninspiring — neither a clear pass nor a clear failure."
     },
     {
-      "id": "one-star",
-      "stars": 1,
-      "label": "One-star (disappointed)",
-      "poseGuide": "Reserved, ambivalent — slight lean, crossed arms or a restrained shrug, neutral or slightly downturned expression, subdued or absent gesture"
-    },
-    {
-      "id": "zero-star",
-      "stars": 0,
-      "label": "Zero-star (furious / despairing)",
-      "poseGuide": "Closed, negative — hunched or turned slightly away, disapproving gesture (fist, head in hands, or dismissive wave), clear frown or scowl"
+      "id": "disapprove",
+      "label": "Disapprove",
+      "poseGuide": "Both figures still standing together as allies — they are united in their verdict, not in conflict with each other. Both slumped or leaning slightly outward with dejected or dismayed expressions directed at the viewer; the handshake still maintained as a sign of unity but lacking energy, or free hands thrown up in frustration. This criterion failed their bipartisan fairness check."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replaces 5 old character-type entries in `tools/sprite-spec.json` with 3 bipartisan-broker demographic variants: `broker-wm-bm` (white male + Black male), `broker-wf-bf` (white female + Black female), `broker-lm-af` (Latino male + Asian female)
- Each variant: two figures waist-up, shaking hands, feet hidden by a shared "Bipartisanship!" banner with barber-pole stripes in magenta (#FF00FF) and cyan (#00FFFF) — runtime-tintable party-color placeholders
- Replaces `starStates` (4 poses mapped to 0–3 stars) with `evaluationStates`: `approve`, `neutral`, `disapprove` — three per-criterion verdict poses. The overall star rating is computed from multiple criteria; each criterion gets one of these three character expressions. The poses are not mapped directly to a star count.
- All pose guides frame the characters as allies united in their verdict, never as adversaries
- Updates DESIGN-009 (md + compressed): 4 star-count states → 3 evaluation states throughout; roster table, state names, file count (20→15), audio table, consistency guidelines, decisions
- Updates DESIGN-010 (md + compressed): binary approve/disapprove → three-state; clarifies `waiting.svg` pre-reveal pose is semantically distinct from the `neutral` evaluation state
- Updates sprint roadmap (md + compressed): DESIGN-009 summary line updated

## Affected machines / services
- N/A — spec and design docs only; no runtime code changed

## Validation performed
- [ ] N/A — prose/config only; no kubectl dry-run or sops decrypt required

## Deployment steps
- N/A — spec drives future art generation (gen-assets.main.kts); no deploy needed

## Tickets addressed
- N/A — no ticket opened for this spec update

## Rollback
- Revert commit; re-push
