### PR TITLE
docs(sprint): regroup S12 plan — PNG sprite sheets, 3 eval states, governor done

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -118,19 +118,18 @@ outcome: all tier1+tier2 tickets closed
 
 §SPRINT12 (in progress)
 goal: character reactions + submit-on-invalid
-demo target: player submits map (valid or invalid) → result screen shows animated character + audio reaction;
-  invalid map shows Fix-It path; valid pass/fail shows correct character animation
-dependency chain:
-  DESIGN-009 [resolved] (SVG inline + CSS animation; 5 instigator types × 3 evaluation states: approve/neutral/disapprove)
-  → parallel: GAME-060 [placeholder SVGs merged] + GAME-061 [audio stubs merged]
-  → GAME-065 (sprite art refinement — replace placeholder SVGs with quality art)
-  → GAME-064 [resolved] (audio playback infrastructure)
-  → GAME-062 (character reaction system — wires everything to result screen)
-  GAME-059 [resolved] (submit-on-invalid) — done
-  GAME-063 [resolved] (asset pipeline) — done
-tier1 (core — all resolved): DESIGN-009 GAME-059 GAME-063 GAME-064
-tier2 (remaining): GAME-060 GAME-061 GAME-065 GAME-062
-  note: GAME-065 front-loaded before GAME-062; art pass before wiring
+demo target: player submits map → result screen shows animated character + audio; invalid map shows Fix-It path
+art model (updated 2026-05-13): PNG sprite sheets (neutral|approve|disapprove horizontal strip, 200px row)
+  governor done+live; 4 remaining types: commissioner party judge legislator (DESIGN-011)
+  eval states: approve/neutral/disapprove (not 1:1 star-count); broker variants (sprite-spec.json) = stretch
+resolved: DESIGN-009 GAME-059 GAME-063 GAME-064 GAME-066 GAME-068 GAME-069
+tier2 (remaining):
+  DESIGN-011 [open] (criterion→character mapping; governor done; 4 types to design)
+  GAME-060 [open] (produce commissioner/party/judge/legislator PNG sheets per DESIGN-011)
+  GAME-061 [open] (audio clips; unblocked)
+  GAME-062 [open] (wire remaining types + audio; governor already wired)
+  GAME-065 [open] (art refinement; trails GAME-060; not blocker for GAME-062)
+stretch: broker PNG variants × 3 states for scenario-006 (spec in sprite-spec.json)
 deferred to S13+: DESIGN-005/006/007 demographic overlays; DESIGN-008 geographic features; GAME-053
 
 §SPRINT13 (sketched)
@@ -160,7 +159,7 @@ GAME-058  manual playability test          any
 GAME-030  main menu+campaigns (remaining)  S14+
 
 §BLOCKING_OPEN_QUESTIONS
-DESIGN-009 open questions (SVG vs pixel art; 006 layout; tutorial animation) → resolve during DESIGN-009 work; gates GAME-060+GAME-061 (not GAME-063 — pipeline is format-agnostic)
+RESOLVED: DESIGN-009 art model → PNG sprite sheets; 3 eval states (approve/neutral/disapprove); governor done
 RESOLVED: DESIGN-001 star/achievement UX → resolved; GAME-052 shipped with emoji placeholder
 RESOLVED: OQ4 narrative asset resolution — deferred indefinitely
 RESOLVED: OQ9 StateContext redesign — deferrable past $v1

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -276,24 +276,41 @@ can be submitted and trigger a Fix-It path.
 animated character + audio reaction; invalid map shows Fix-It path; valid
 pass/fail shows correct character animation.
 
-**Dependency chain**:
-- DESIGN-009 [resolved] — SVG inline + CSS animation decided; 5 instigator
-  types × 3 evaluation states (approve/neutral/disapprove); consistency spec + audio tones per type
-- GAME-059 [resolved] — submit-on-invalid: removed validity gate from Submit button
-- GAME-063 [resolved] — asset pipeline: directory structure + Bazel integration
-- GAME-064 [resolved] — audio playback infrastructure: AudioPlayer module
-- GAME-060 / GAME-061 — placeholder SVG sprites + audio stubs merged
-- **GAME-065** — sprite art refinement: replace placeholder SVGs with quality art
-  (front-loaded before GAME-062 so wiring ships with final art)
-- GAME-062 — character reaction system: wires sprites + audio to result screen
+**Art model (updated 2026-05-13)**: PNG sprite sheets (horizontal strip:
+neutral | approve | disapprove), 200 px row height. Governor sheet is complete
+and live. Remaining types: commissioner, party, judge, legislator (DESIGN-011).
+Evaluation states are **approve / neutral / disapprove**, not 1:1 star-count poses.
+Bipartisan-broker variants (3 demographic pairs × 3 states, for scenario-006
+instigator) are defined in `tools/sprite-spec.json` and are separate from the
+per-criterion roster.
 
-**Tier 1 (core — all resolved)**: DESIGN-009, GAME-059, GAME-063, GAME-064
+**Dependency chain**:
+- DESIGN-009 [resolved] — character reaction visual style; 3 evaluation states
+  (approve/neutral/disapprove)
+- DESIGN-011 [open] — per-criterion character roster (governor done; 4 types to build)
+- GAME-059 [resolved] — submit-on-invalid
+- GAME-063 [resolved] — asset pipeline
+- GAME-064 [resolved] — audio playback infrastructure
+- GAME-066 [resolved] — result screen dramatic reveal (sequential criteria reveal)
+- GAME-068 [resolved] — result reveal pacing
+- GAME-069 [resolved] — per-criterion `.rc-char` slots + governor PNG wired
+- GAME-060 — produce commissioner/party/judge/legislator PNG sprite sheets (DESIGN-011)
+- GAME-061 — audio clips
+- GAME-065 — art quality iteration (trails GAME-060; not a blocker for GAME-062)
+- GAME-062 — wire remaining character types + audio to result screen
+
+**Tier 1 (core — all resolved)**: DESIGN-009, GAME-059, GAME-063, GAME-064,
+GAME-066, GAME-068, GAME-069
 
 **Tier 2 (remaining)**:
-- GAME-060: placeholder sprites merged; GAME-065 covers art refinement
-- GAME-061: audio stubs merged; final clips pending
-- GAME-065: sprite art refinement (must land before GAME-062)
-- GAME-062: character reaction system (last; wires everything)
+- DESIGN-011: finalize criterion → character mapping; drives GAME-060
+- GAME-060: produce 4 remaining PNG sprite sheets (commissioner/party/judge/legislator)
+- GAME-061: audio clips (10 clips: 5 types × pass/fail or approve/disapprove)
+- GAME-062: wire remaining types + audio (governor already wired; 4 types pending)
+- GAME-065: art refinement (polish pass after GAME-060; not a blocker)
+
+**Stretch / S12+ if time allows**:
+- Bipartisan-broker PNG variants for scenario-006 (spec in sprite-spec.json; 9 images)
 
 **Deferred to S13+**: DESIGN-005/006/007 demographic overlays; DESIGN-008
 geographic features; GAME-053 electoral outcome diff.

--- a/thoughts/shared/tickets/GAME-060-character-sprite-assets.md
+++ b/thoughts/shared/tickets/GAME-060-character-sprite-assets.md
@@ -5,41 +5,55 @@ area: game, art, content
 status: open
 created: 2026-05-02
 github_issue: 201
+last_updated: 2026-05-13
 ---
 
 ## Summary
 
-Create the instigator character art for result screen reactions — one SVG file per
-instigator type × star-count state (5 types × 4 states = 20 files). The instigator
-is the person who hired the player (party boss, judge, reform commissioner, etc.)
-and reacts based on how well the player delivered, graded by star count (3/2/1/0).
-Format and consistency spec defined by DESIGN-009. Art will be AI-generated (Claude
-SVG as primary; Grok/other multimodal models as fallback).
+Produce the PNG sprite sheets for the four character types not yet built:
+`commissioner`, `party`, `judge`, `legislator`. The `governor` sheet is already
+complete and in use (GAME-069). All four sheets follow the same horizontal-strip
+format: [neutral | approve | disapprove], 200 px row height, fixed-width poses.
+Character types and visual design are defined in DESIGN-011.
+
+The bipartisan-broker variants (3 demographic pairs × 3 evaluation states = 9 images)
+are defined in `tools/sprite-spec.json` and are generated separately via
+`gen-assets.main.kts`. They are consumed by scenario-006 as an instigator,
+not as per-criterion reaction characters.
 
 ## Current State
 
-No character art exists. The result screen shows a 🎉/💔 emoji placeholder (GAME-052).
-DESIGN-009 defines the full consistency spec — it MUST be read before generating any
-art (embed the §CONSISTENCY section in every generation prompt).
+- `governor` sprite sheet: complete — `game/assets/characters/character-governor.png`
+- `commissioner`, `party`, `judge`, `legislator`: not yet produced
+- Old SVG placeholder files exist at `game/web/assets/characters/{type}/{state}.svg`
+  from prior work; these are superseded by the PNG sprite sheet approach and can
+  be cleaned up in this ticket or GAME-065
 
 ## Goals / Acceptance Criteria
 
-- [ ] 20 SVG files: 5 instigator types × 4 states (three-star/two-star/one-star/zero-star)
-- [ ] File naming: `assets/characters/{type}/{state}.svg`
-      types: partisan-boss, legal-authority, bipartisan-broker, reform-arbiter, neutral-admin
-- [ ] All files use `viewBox="0 0 200 200"`, transparent background
-- [ ] Character occupies center ~140×160 px; head ~y=30, feet ~y=190, centered horiz
-- [ ] Flat fills, 2–3 colors per type, 2–3 px stroke, no gradients
-- [ ] Each type has a visually distinct silhouette readable at 160 px
-- [ ] Same type across 4 states: same character, only pose+expression changes
-- [ ] State poses match DESIGN-009 spec (three-star=expansive celebratory; two-star=composed positive; one-star=reserved; zero-star=closed/disapproving)
-- [ ] Subtle idle animation (bob/blink/breathing, 0.6–1.0 s loopable) in each SVG
-- [ ] File sizes < 15 KB per SVG
-- [ ] Assets placed in `game/web/assets/characters/{type}/` (GAME-063 pipeline must be merged first)
-- [ ] Accessible alt-text description documented for each type/state combination
+- [ ] `commissioner` PNG sprite sheet produced per DESIGN-011 spec
+      (neutral / approve / disapprove poses; clipboard/folder prop)
+- [ ] `party` PNG sprite sheet produced per DESIGN-011 spec
+      (small cluster of figures with flags; neutral color body, party-tintable flags)
+- [ ] `judge` PNG sprite sheet produced per DESIGN-011 spec
+      (black-robed single figure; gavel prop; neutral / nod approve / dismissive disapprove)
+- [ ] `legislator` PNG sprite sheet produced per DESIGN-011 spec
+      (treatment decided: building/gavel/assembly; neutral / approve / disapprove)
+- [ ] All sheets follow governor format: single horizontal strip, 200 px row height,
+      equal-width poses, documented pixel offsets
+- [ ] All sheets committed to `game/assets/characters/character-<key>.png`
+- [ ] DESIGN-011 roster table updated with any design-phase changes
+- [ ] Old SVG placeholder files removed or noted as superseded
+
+## Test Coverage
+
+- [ ] Visual review: each sheet opened on dark background at display size (≈100–120 px height)
+      and all three poses read clearly as the same character in different states
 
 ## References
 
-- `thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md` — **blocks this**
-- `thoughts/shared/tickets/GAME-063-asset-pipeline.md` — asset directory must exist first
-- `thoughts/shared/tickets/GAME-062-character-reaction-system.md` — consumes these assets
+- `thoughts/shared/tickets/DESIGN-011-per-criterion-character-roster.md` — **blocks this** (art spec)
+- `game/assets/characters/character-governor.png` — format reference
+- `tools/sprite-spec.json` — broker variants (separate art, scenario-006 instigator)
+- `tools/gen-assets.main.kts` — image generation pipeline
+- `thoughts/shared/tickets/GAME-062-character-reaction-system.md` — downstream consumer

--- a/thoughts/shared/tickets/GAME-061-audio-clips.md
+++ b/thoughts/shared/tickets/GAME-061-audio-clips.md
@@ -9,12 +9,13 @@ github_issue: 199
 
 ## Summary
 
-Source or create short audio clips for each instigator type × star-count state
-to accompany the animated reactions on the result screen. Target: 20 clips
-(5 types × 4 states). Acceptable minimum: 10 clips (2 per type: celebratory /
-disappointed) if sourcing 20 distinct clips proves impractical. Prefer CC0 sources.
-If CC0 unavailable, use AI-generated audio (ElevenLabs Sound Effects, Grok, or
-similar). Tone per type defined by DESIGN-009.
+Source or create short audio clips for each instigator type × evaluation state
+to accompany the animated reactions on the result screen. Target: 15 clips
+(5 types × 3 states: approve/neutral/disapprove). Acceptable minimum: 10 clips
+(2 per type: celebratory / disappointed) if sourcing 15 distinct clips proves
+impractical. Prefer CC0 sources. If CC0 unavailable, use AI-generated audio
+(ElevenLabs Sound Effects, Grok, or similar). Tone per type defined by DESIGN-009
+(resolved — see that ticket for guidance).
 
 ## Current State
 
@@ -23,10 +24,10 @@ No audio exists anywhere in the game. This is the first audio feature.
 
 ## Goals / Acceptance Criteria
 
-- [ ] Audio clips for 5 instigator types × 4 states — target 20, minimum 10 (2/type)
+- [ ] Audio clips for 5 instigator types × 3 evaluation states — target 15, minimum 10 (2/type)
 - [ ] File naming: `assets/audio/{type}-{state}.mp3` and `.ogg` (dual encoding)
-      types: partisan-boss, legal-authority, bipartisan-broker, reform-arbiter, neutral-admin
-      states: three-star, two-star, one-star, zero-star (or: win, lose if collapsed to 2/type)
+      types: governor, commissioner, party, judge, legislator
+      states: approve, neutral, disapprove (or: approve, disapprove if collapsed to 2/type)
 - [ ] Clips are short: target 0.5–1.5 s each
 - [ ] File sizes < 100 KB per clip
 - [ ] Source priority: (1) CC0 from freesound.org/pixabay, (2) AI-generated,
@@ -39,8 +40,7 @@ No audio exists anywhere in the game. This is the first audio feature.
 
 ## References
 
-- `thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md` — **blocks this**
-  (defines instigator roster and audio tone guidance per type)
+- `thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md` — resolved; defines instigator roster and audio tone guidance per type
 - `thoughts/shared/tickets/GAME-063-asset-pipeline.md` — asset directory must exist first
 - `thoughts/shared/tickets/GAME-064-audio-playback-infrastructure.md` — playback layer
 - `thoughts/shared/tickets/GAME-062-character-reaction-system.md` — wires audio playback

--- a/thoughts/shared/tickets/GAME-062-character-reaction-system.md
+++ b/thoughts/shared/tickets/GAME-062-character-reaction-system.md
@@ -4,63 +4,63 @@ title: Character reaction system — animate and audio on result screen
 area: game, UX
 status: open
 created: 2026-05-02
+last_updated: 2026-05-13
 ---
 
 ## Summary
 
-Wire the instigator reaction system to the result screen: resolve the instigator type
-from the scenario, load the correct star-count state SVG, inject it into
-`#result-reaction`, and play the matching audio clip. Replaces the 🎉/💔 emoji
-placeholder (GAME-052). The player is a neutral consultant; the instigator (party
-boss, judge, commissioner, etc.) reacts based on star count (3/2/1/0), not binary
-pass/fail. Animation plays last, after all per-criterion reveal animations finish.
-Depends on DESIGN-009 (style), GAME-060 (art), GAME-061 (audio), GAME-063
-(asset pipeline), and GAME-064 (audio playback infrastructure).
+Wire the character reaction system to the result screen: resolve character type from
+the scenario/criterion, load the correct PNG sprite sheet pose, inject it into the
+result screen, and play the matching audio clip. The evaluation state model uses
+three states — **approve**, **neutral**, **disapprove** — not a 1:1 star-count
+mapping. Replaces the 🎉/💔 emoji placeholder (GAME-052). Depends on GAME-060
+(art) and GAME-061 (audio).
+
+The **governor** per-criterion reaction is already implemented (GAME-069): each
+criterion row has an `.rc-char` slot; the governor sprite sheet is loaded and posed
+based on star count → evaluate state mapping.
 
 ## Current State
 
-The result screen shows a `#result-reaction` element with a single emoji (🎉/💔)
-based on overall pass/fail. Scenario instigator identity is not used on the result
-screen. No star-count grading exists on the result screen.
+- Governor PNG reaction: **done** — sprite loaded, 3-state (approve/neutral/disapprove)
+  mapped from star count; CSS bob animation; `prefers-reduced-motion` handled
+- Per-criterion `.rc-char` slot structure: **done** (GAME-069)
+- 4 remaining character types (commissioner/party/judge/legislator): pending GAME-060 art
+- Audio: pending GAME-061
+- Scenario-006 bipartisan-broker instigator: pending broker PNG production (stretch; spec in `tools/sprite-spec.json`; no ticket assigned yet)
 
 ## Goals / Acceptance Criteria
 
-### Schema (done)
-- [x] `narrative.instigator` optional field added to scenario format (`{ type: InstigatorType }`)
-- [x] `scenario-002.json` declares `instigator.type = "governor"`
-- [x] Instigator type resolved from `narrative.instigator.type`; absent → emoji fallback
+### Already done
+- [x] `narrative.instigator` optional field in scenario format
+- [x] Per-criterion `.rc-char` slot rendered for each criterion row (GAME-069)
+- [x] Governor sprite sheet loaded and posed; neutral → approve/disapprove cross-fade
+- [x] Star count → evaluation state mapping: disapprove=0 stars, neutral=min-required-only, approve=bonus criteria met
+- [x] `prefers-reduced-motion`: animation suppressed
 
-### Star count (done)
-- [x] Star count = number of required criteria passing; 0 if map invalid
-- [x] `prefers-reduced-motion`: sprite animation suppressed (CSS)
-
-### Governor PNG reaction (done — scenario-002)
-- [x] Governor PNG sprite sheet shown on result screen: random demographic (wm/bm/af)
-- [x] Pose mapped to star count: 3→approve, 2→neutral, 1–0→disapprove; CSS bob animation
-
-### Remaining (blocks on GAME-060 art + GAME-061 audio)
-- [ ] Correct SVG loaded from `assets/characters/{type}/{state}.svg` and injected into
-      `#result-reaction` for the 5 generic instigator types; sized per DESIGN-009 spec
+### Remaining (blocks on GAME-060 + GAME-061)
+- [ ] Commissioner, party, judge, legislator sprite sheets loaded and posed
+      per DESIGN-011 criterion → character mapping
 - [ ] Audio clip plays on result screen open via GAME-064 AudioPlayer
 - [ ] Mute toggle visible on result screen; uses GAME-064 persistence
-- [ ] Scenario-006 Bipartisan Broker: both bosses shown side-by-side (split-screen)
-- [ ] Fallback: if instigator type has no asset, emoji placeholder remains
-- [ ] Instigator reaction plays AFTER per-criterion animations complete (timing)
+- [ ] Fallback: if character type has no asset, show neutral placeholder or emoji
+- [ ] Character reaction plays AFTER per-criterion animations complete (timing)
+- [ ] Scenario-006 instigator: bipartisan-broker PNG loaded (stretch; pending broker PNG production — no ticket yet; not a blocker for GAME-062 core)
 
 ## Test Coverage
 
 - [x] e2e: `#result-reaction .character-sprite` present after scenario-002 submit
-- [ ] e2e: character element has correct aria-label matching star count
-- [ ] e2e: `<audio>` element present and wired on result screen (after GAME-061)
-- [ ] e2e: mute toggle visible; persists across result screen re-open (via localStorage)
-- [ ] e2e: `prefers-reduced-motion` — character element has `animation: none` applied
+- [ ] e2e: correct aria-label on character element
+- [ ] e2e: `<audio>` element present and wired (after GAME-061)
+- [ ] e2e: mute toggle visible; persists via localStorage
+- [ ] e2e: `prefers-reduced-motion` — animation suppressed
 
 ## References
 
-- `thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md` — **blocks this**
-- `thoughts/shared/tickets/GAME-060-character-sprite-assets.md` — **blocks this**
-- `thoughts/shared/tickets/GAME-061-audio-clips.md` — **blocks this**
-- `thoughts/shared/tickets/GAME-063-asset-pipeline.md` — **blocks this**
-- `thoughts/shared/tickets/GAME-064-audio-playback-infrastructure.md` — **blocks this**
-- `thoughts/shared/tickets/GAME-059-submit-on-invalid.md` — failure path this plays on
-- `game/web/src/main.ts` — `showResultScreen()` + `#result-reaction` element
+- `thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md` — style spec
+- `thoughts/shared/tickets/DESIGN-011-per-criterion-character-roster.md` — character roster + criterion mapping
+- `thoughts/shared/tickets/GAME-060-character-sprite-assets.md` — art (blocks remaining items)
+- `thoughts/shared/tickets/GAME-061-audio-clips.md` — audio (blocks remaining items)
+- `thoughts/shared/tickets/GAME-064-audio-playback-infrastructure.md` — AudioPlayer module
+- `game/web/src/main.ts` — `showResultScreen()` + `.rc-char` elements
+- `game/assets/characters/character-governor.png` — reference implementation

--- a/thoughts/shared/tickets/GAME-065-character-sprite-art-refinement.md
+++ b/thoughts/shared/tickets/GAME-065-character-sprite-art-refinement.md
@@ -1,67 +1,48 @@
 ---
 id: GAME-065
-title: Character sprite art refinement — replace placeholder SVGs with quality art
+title: Character sprite art refinement — quality iteration after initial generation
 area: game, art, content
 status: open
 created: 2026-05-04
+last_updated: 2026-05-13
 ---
 
 ## Summary
 
-Replace the placeholder SVG character sprites (GAME-060) with quality art. The
-current AI-generated SVGs are functional and structurally correct (right viewBox,
-poses, animation, file naming) but aesthetically flat — they don't have the visual
-charm the result screen needs. This ticket covers one dedicated art pass to produce
-sprites worth shipping.
+Two-part scope:
 
-The existing SVGs serve as accurate pose/layout references; the new art should
-match the same 200×200 viewBox, file naming, and idle-bob animation convention so
-GAME-062 wiring requires no changes.
+1. **Broker initial production** (stretch): generate the 9 bipartisan-broker PNG images
+   (3 demographic variants × 3 evaluation states) using `gen-assets.main.kts` and the
+   spec in `tools/sprite-spec.json`. This is the initial production run for the broker;
+   it is not covered by GAME-060 (which covers the per-criterion roster only).
+
+2. **Quality iteration pass**: review and improve any sprite sheets that need it after
+   initial generation — the four new types from GAME-060, the broker images from part 1,
+   and optionally the governor sheet.
+
+This ticket has no fixed scope for part 2 — it is the designated place to capture and
+act on post-generation visual feedback. It is not a blocker for GAME-062 (broker wiring
+is stretch); the core GAME-062 work (governor + 4 types) can proceed without it.
 
 ## Current State
 
-20 SVG files exist at `game/web/assets/characters/{type}/{state}.svg` — correct
-structure, correct poses, but bland flat shapes that don't read as characters.
-GAME-062 (reaction system) has not been implemented yet, so this is the right
-moment for an art pass before wiring begins.
+GAME-060 art is not yet produced. This ticket opens once GAME-060 is complete.
 
 ## Goals / Acceptance Criteria
 
-- [ ] All 20 SVG files replaced with visually improved character art
-      (5 types × 4 states: three-star / two-star / one-star / zero-star)
-- [ ] Each type has a recognisable silhouette at 160 px display size
-- [ ] Same type reads as the same character across all 4 states
-      (pose + expression change; costume / silhouette stays consistent)
-- [ ] Idle-bob animation (`@keyframes idle-bob`, 0.6–1.0 s loopable) present
-      in every file — same convention as current placeholders
-- [ ] `viewBox="0 0 200 200"`, transparent background — no changes to
-      GAME-062 wiring needed
-- [ ] File sizes < 15 KB per SVG
-- [ ] ALT-TEXT.md updated to match revised designs if descriptions change
-- [ ] Visual review sign-off before merge (open in sprite-review page)
+### Broker initial production (stretch)
+- [ ] 9 broker PNG images generated via `gen-assets.main.kts` (3 variants × 3 eval states)
+- [ ] Images committed to `game/assets/characters/` per naming in `sprite-spec.json`
 
-## Approach options
-
-1. **Dedicated image-gen model → SVG trace**: Generate reference character art
-   in Grok, DALL-E, or Midjourney using the DESIGN-009 consistency spec as
-   prompt; use as visual targets; hand-author cleaner SVGs against the references.
-2. **Pixel art**: Produce 40×40 or 64×64 pixel art sprites (Aseprite or AI
-   pixel-art tool); ship as PNG with `image-rendering: pixelated` CSS scaling;
-   requires GAME-062 to load `<img>` instead of inline SVG — assess before starting.
-3. **Iterative SVG prompt engineering**: Use a model with stronger visual SVG
-   output (Grok, GPT-4o) to generate SVG directly, using DESIGN-009 §CONSISTENCY
-   verbatim in every prompt.
-
-Option 1 or 3 preserves the SVG pipeline and requires no GAME-062 changes.
-Option 2 is a format switch — decide before starting and update DESIGN-009 if chosen.
+### Quality iteration
+- [ ] Each produced sprite sheet reviewed at display size (≈100–120 px height) on dark bg
+- [ ] Any sheets identified as needing improvement: regenerated or hand-edited
+- [ ] All reviewed sheets signed off before this ticket closes
+- [ ] `ALT-TEXT.md` (if it exists) updated if descriptions change
 
 ## References
 
-- `thoughts/shared/tickets/DESIGN-009-character-reaction-visual-style.md` — style spec
-  (§CONSISTENCY section must be embedded in every art-gen prompt)
-- `game/web/assets/characters/` — current placeholder SVGs
-- `game/web/assets/characters/ALT-TEXT.md` — accessibility descriptions
-- `thoughts/shared/tickets/GAME-062-character-reaction-system.md` — downstream consumer
-- Sprite review page: regenerate on demand from the grid template in the Visual
-  review AC above (dark background, 5×4 grid, idle-bob animation, file:/// paths
-  to `game/web/assets/characters/{type}/{state}.svg`)
+- `thoughts/shared/tickets/GAME-060-character-sprite-assets.md` — primary art production
+- `thoughts/shared/tickets/DESIGN-011-per-criterion-character-roster.md` — art spec
+- `tools/sprite-spec.json` — broker variants spec
+- `game/assets/characters/` — sprite sheet files

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -101,10 +101,10 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-043-unify-type-systems.md` | game, code-quality | Unify spike and scenario type systems; retire adapter.ts and types.ts spike layer |
 | `GAME-046-panels-unit-tests.md` | game, testing | Unit tests for render/panels.ts (deferred): jsdom or extract-pure-helpers approach |
 | `GAME-053-electoral-outcome-visual-diff.md` | game, UX | Electoral outcome comparison (player map vs baseline) on result screen; placeholder |
-| `GAME-060-character-sprite-assets.md` | game, art, content | Character sprite + animation assets (5 types × 4 star states); placeholder SVGs merged; art refinement in GAME-065 |
-| `GAME-061-audio-clips.md` | game, audio, content | 10 audio clips (5 types × pass/fail); CC0 preferred; AI-generated fallback; depends on DESIGN-009 |
-| `GAME-062-character-reaction-system.md` | game, UX | Wire character sprites + audio to result screen; replaces emoji placeholder; depends on GAME-060/061/063/064/065 |
-| `GAME-065-character-sprite-art-refinement.md` | game, art, content | Replace placeholder SVGs with quality character art; pose/file structure unchanged; visual review required before merge |
+| `GAME-060-character-sprite-assets.md` | game, art, content | Produce PNG sprite sheets for commissioner/party/judge/legislator (governor done); 3 evaluation states each; per DESIGN-011 |
+| `GAME-061-audio-clips.md` | game, audio, content | 15 audio clips (5 types × 3 eval states: approve/neutral/disapprove); min 10 (2/type); CC0 preferred; AI-generated fallback |
+| `GAME-062-character-reaction-system.md` | game, UX | Wire remaining character types + audio to result screen; governor already wired; approve/neutral/disapprove model; depends on GAME-060/061 |
+| `GAME-065-character-sprite-art-refinement.md` | game, art, content | Broker PNG initial production (stretch; 9 images via gen-assets.main.kts) + quality iteration pass after GAME-060; not a blocker for GAME-062 core |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [ ] N/A | Parent PR merged: #220

## Summary
- Regroup Sprint 12 plan to reflect current implementation reality: governor PNG reaction is live, art model has moved to PNG sprite sheets (not SVGs), evaluation states are approve/neutral/disapprove (not star-count)
- Update GAME-060 ticket: produce 4 PNG sprite sheets (commissioner/party/judge/legislator) per DESIGN-011; drop old SVG scope
- Update GAME-062 ticket: governor marked done; remaining items reference PNG model and DESIGN-011
- Update GAME-065 ticket: quality iteration pass after GAME-060; covers broker PNG variants; not a blocker for GAME-062
- Update TICKETS.md index rows to match revised ticket scopes
- Update sprint roadmap (.md + .compressed.md): add resolved tickets (GAME-066/068/069), document art model, reframe Tier 2 with DESIGN-011

## Validation performed
- [ ] N/A — documentation-only changes; no code changes

## Affected machines / services
- None — thoughts/ docs only

## Deployment steps (POST-MERGE)
- None

## Tickets addressed
- see GAME-060, GAME-062, GAME-065 (tickets updated, not resolved)

## Rollback
- Revert PR; no side effects
