### PR TITLE
feat(GAME-062): wire commissioner/judge/legislator/party sprites; add character_demographics to scenario

### DIFF
--- a/game/scenarios/scenario-002.json
+++ b/game/scenarios/scenario-002.json
@@ -2297,5 +2297,10 @@
     ],
     "objective": "Redraw the map so the Ken Party wins at least 3 of 4 districts."
   },
-  "instigator_character": "governor"
+  "instigator_character": "governor",
+  "character_demographics": {
+    "governor": "bm",
+    "commissioner": "bf",
+    "judge": "lm"
+  }
 }

--- a/game/scenarios/scenario-003.json
+++ b/game/scenarios/scenario-003.json
@@ -3166,5 +3166,9 @@
     ],
     "objective": "Pack Ryu voters into as few districts as possible. Ken Party must win at least 4 of 5 seats."
   },
-  "instigator_character": "party"
+  "instigator_character": "party",
+  "character_demographics": {
+    "commissioner": "wf",
+    "judge": "naf"
+  }
 }

--- a/game/scenarios/scenario-004.json
+++ b/game/scenarios/scenario-004.json
@@ -3167,5 +3167,9 @@
     ],
     "objective": "Crack the Ryu corridor across all 5 districts. Ken Party must win every seat."
   },
-  "instigator_character": "party"
+  "instigator_character": "party",
+  "character_demographics": {
+    "commissioner": "wm",
+    "judge": ""
+  }
 }

--- a/game/scenarios/scenario-005.json
+++ b/game/scenarios/scenario-005.json
@@ -5209,5 +5209,9 @@
     ],
     "objective": "Draw at least one majority-Latino district (≥ 50% Latino population) to give the Valley community a fair chance to elect their preferred representative."
   },
-  "instigator_character": "judge"
+  "instigator_character": "judge",
+  "character_demographics": {
+    "commissioner": "bf",
+    "judge": "lm"
+  }
 }

--- a/game/scenarios/scenario-006.json
+++ b/game/scenarios/scenario-006.json
@@ -3179,5 +3179,9 @@
     ],
     "objective": "Draw a map that protects incumbents of both parties — Ken Party wins at least 3 safe seats (margin ≥ 15 points), Ryu Party wins at least 2 safe seats (margin ≥ 15 points)."
   },
-  "instigator_character": "party"
+  "instigator_character": "party",
+  "character_demographics": {
+    "commissioner": "wf",
+    "judge": "naf"
+  }
 }

--- a/game/scenarios/scenario-007.json
+++ b/game/scenarios/scenario-007.json
@@ -3164,5 +3164,9 @@
     ],
     "objective": "Draw a compact, population-balanced map using only geometric criteria. No partisan data required — or allowed."
   },
-  "instigator_character": "commissioner"
+  "instigator_character": "commissioner",
+  "character_demographics": {
+    "commissioner": "wf",
+    "judge": ""
+  }
 }

--- a/game/scenarios/scenario-008.json
+++ b/game/scenarios/scenario-008.json
@@ -3164,5 +3164,9 @@
     ],
     "objective": "Apply the agreed neutral criteria. Draw a compact, population-balanced map. Watch both sides declare the process rigged."
   },
-  "instigator_character": "commissioner"
+  "instigator_character": "commissioner",
+  "character_demographics": {
+    "commissioner": "bf",
+    "judge": "lm"
+  }
 }

--- a/game/scenarios/scenario-009.json
+++ b/game/scenarios/scenario-009.json
@@ -3179,5 +3179,9 @@
     ],
     "objective": "Draw a compact, population-balanced map that locks in at least 3 safe Cat Party districts (winning margin ≥ 15 points). Bonus: leave the dogs one safe seat to chew on."
   },
-  "instigator_character": "party"
+  "instigator_character": "party",
+  "character_demographics": {
+    "commissioner": "wm",
+    "judge": "naf"
+  }
 }

--- a/game/scenarios/tutorial-001.json
+++ b/game/scenarios/tutorial-001.json
@@ -341,5 +341,8 @@
       }
     ],
     "objective": "Divide Millbrook County into 2 districts with equal population. Every precinct must be assigned. Both districts must be contiguous."
+  },
+  "character_demographics": {
+    "commissioner": "wm"
   }
 }

--- a/game/scenarios/tutorial-002.json
+++ b/game/scenarios/tutorial-002.json
@@ -4793,5 +4793,8 @@
       }
     ],
     "objective": "Balance the three districts so each has roughly equal population (within 10%). Move boundary precincts between districts to fix the imbalance."
+  },
+  "character_demographics": {
+    "commissioner": "wf"
   }
 }

--- a/game/web/e2e/sprint4.spec.ts
+++ b/game/web/e2e/sprint4.spec.ts
@@ -83,15 +83,15 @@ test("GAME-069: every criterion row has a character slot (.rc-char)", async ({ p
   }
 });
 
-// GAME-069: tutorial-002 has no character fields on criteria → all default to commissioner → placeholder SVG.
+// GAME-069: non-governor criterion rows render character sprites (not placeholder SVGs since GAME-062).
 test("GAME-069: non-governor criterion rows contain a placeholder SVG", async ({ page }) => {
   await loadEditor(page);
   await openResultScreen(page);
 
-  // All slots in tutorial-002 use the commissioner placeholder (no governor sprite).
-  // At least one .rc-char slot must contain an SVG element.
-  const svgSlots = page.locator(".rc-char svg");
-  const count = await svgSlots.count();
+  // GAME-062 replaced placeholder SVGs with real sprite divs for all character types.
+  // Check that at least one .rc-char slot contains a character-sprite div.
+  const spriteSlots = page.locator(".rc-char .character-sprite");
+  const count = await spriteSlots.count();
   expect(count).toBeGreaterThan(0);
 });
 

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -739,13 +739,16 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		return criterionResults.filter(cr => cr.required && cr.passed).length;
 	}
 
-	const GOVERNOR_DEMOGRAPHICS = ["wm", "bm", "af"] as const;
-
-	// GAME-069: Governor sprite sheet layout (200px tall canonical):
-	// Sheet: 1376×752px. Pose columns: neutral 0–400, approve 400–880, disapprove 880–1376.
-	// Row-scale (84px target height): 84/752 ≈ 0.1117.
+	// GAME-069/GAME-062: Sprite sheet layout constants.
+	// Governor sheet: 1376×752px (unique dimensions).
+	// Pose columns: neutral 0–400, approve 400–880, disapprove 880–1376.
 	const GOV_ROW_SCALE = 84 / 752;
 	const GOV_SHEET = { neutral: { x: 0, w: 400 }, approve: { x: 400, w: 480 }, disapprove: { x: 880, w: 496 } };
+
+	// All other character sheets: 1408×768px, equal-thirds columns (469/469/470).
+	const CHAR_ROW_SCALE = 84 / 768;
+	const CHAR_SHEET_WIDTH = 1408;
+	const CHAR_SHEET = { neutral: { x: 0, w: 469 }, approve: { x: 469, w: 469 }, disapprove: { x: 938, w: 470 } };
 
 	// Placeholder SVG for non-governor character types.
 	function charPlaceholderSvg(state: "neutral" | "approve" | "disapprove"): string {
@@ -773,7 +776,6 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		slot: HTMLElement,
 		charType: CharacterType,
 		passed: boolean,
-		demo: string,
 	): { neutral: HTMLElement; verdict: HTMLElement } {
 		const neutralEl = document.createElement("div");
 		neutralEl.className = "rc-char-neutral";
@@ -781,10 +783,14 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		verdictEl.className = "rc-char-verdict";
 		verdictEl.style.opacity = "0";
 
+		// Demographic variant: read from scenario, fall back to "" (generic/no-suffix).
+		const demo = scenario.character_demographics?.[charType] ?? "";
+
 		if (charType === "governor") {
 			const n = GOV_SHEET.neutral;
 			const v = passed ? GOV_SHEET.approve : GOV_SHEET.disapprove;
-			const img = assetUrl(`assets/characters/governor-${demo}/sheet.png`);
+			const govDemo = demo || "wm"; // loader enforces non-empty; fallback guards stale/direct scenarios
+			const img = assetUrl(`assets/characters/governor-${govDemo}/sheet.png`);
 			const makeSprite = (col: { x: number; w: number }, label: string): HTMLElement => {
 				const s = document.createElement("div");
 				s.className = "character-sprite character-governor character-sprite--row";
@@ -799,8 +805,26 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			neutralEl.appendChild(makeSprite(n, "Character awaiting verdict"));
 			verdictEl.appendChild(makeSprite(v, passed ? "Approves" : "Disapproves"));
 		} else {
-			neutralEl.innerHTML = charPlaceholderSvg("neutral");
-			verdictEl.innerHTML = charPlaceholderSvg(passed ? "approve" : "disapprove");
+			// charType is commissioner | judge | legislator | party — all use 1408×768 sheets.
+			// party has no demographic variants (path: party/sheet.png).
+			// judge allows empty demo → bare judge/ directory; all others require non-empty (enforced by loader).
+			const dir = (charType !== "party" && demo) ? `${charType}-${demo}` : charType;
+			const img = assetUrl(`assets/characters/${dir}/sheet.png`);
+			const n = CHAR_SHEET.neutral;
+			const v = passed ? CHAR_SHEET.approve : CHAR_SHEET.disapprove;
+			const makeSprite = (col: { x: number; w: number }, label: string): HTMLElement => {
+				const s = document.createElement("div");
+				s.className = `character-sprite character-${charType} character-sprite--row`;
+				s.setAttribute("role", "img");
+				s.setAttribute("aria-label", label);
+				s.style.width = `${Math.round(col.w * CHAR_ROW_SCALE)}px`;
+				s.style.backgroundImage = `url('${img}')`;
+				s.style.backgroundPosition = `-${Math.round(col.x * CHAR_ROW_SCALE)}px 0%`;
+				s.style.backgroundSize = `${Math.round(CHAR_SHEET_WIDTH * CHAR_ROW_SCALE)}px 84px`;
+				return s;
+			};
+			neutralEl.appendChild(makeSprite(n, "Character awaiting verdict"));
+			verdictEl.appendChild(makeSprite(v, passed ? "Approves" : "Disapproves"));
 		}
 
 		slot.appendChild(neutralEl);
@@ -886,15 +910,6 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 
 		resultCriteriaList.innerHTML = "";
 
-		// Pick demo variant deterministically from scenario ID so the same character
-		// appears every time this scenario is played (and can match the intro screen later).
-		const demoIdx =
-			(scenario.id as string)
-				.split("")
-				.reduce((acc, c) => acc + c.charCodeAt(0), 0) %
-			GOVERNOR_DEMOGRAPHICS.length;
-		const demo = GOVERNOR_DEMOGRAPHICS[demoIdx]!;
-
 		// Resolve character info for a row (validity rows default to commissioner).
 		function resolveCharInfo(cr: CriterionResult): { type: CharacterType; party_id?: string } {
 			return charInfoMap.get(cr.criterionId as string) ?? { type: "commissioner" };
@@ -920,7 +935,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			const charInfo = resolveCharInfo(cr);
 			const charSlot = document.createElement("div");
 			charSlot.className = "rc-char";
-			buildCharSlotChildren(charSlot, charInfo.type, cr.passed, demo);
+			buildCharSlotChildren(charSlot, charInfo.type, cr.passed);
 			if (final) {
 				charSlot.querySelector<HTMLElement>(".rc-char-neutral")!.style.opacity = "0";
 				charSlot.querySelector<HTMLElement>(".rc-char-verdict")!.style.opacity = "1";

--- a/game/web/src/model/loader.ts
+++ b/game/web/src/model/loader.ts
@@ -587,6 +587,31 @@ export function loadScenario(json: unknown): Scenario {
     instigator_character = icVal as CharacterType;
   }
 
+  let character_demographics: Partial<Record<CharacterType, string>> | undefined;
+  if (raw["character_demographics"] !== undefined) {
+    const cd = raw["character_demographics"];
+    if (typeof cd !== "object" || cd === null || Array.isArray(cd)) {
+      throw new Error("character_demographics: must be an object");
+    }
+    const validChars: string[] = ["governor", "commissioner", "judge", "legislator"];
+    // Types that have no bare directory — a demographic suffix is required.
+    const requiresSuffix = new Set(["governor", "commissioner", "legislator"]);
+    character_demographics = {};
+    for (const key of Object.keys(cd)) {
+      if (key === "party") {
+        throw new Error(`character_demographics: "party" has no demographic variants and must be omitted`);
+      }
+      if (!validChars.includes(key)) {
+        throw new Error(`character_demographics: unknown key "${key}"; expected one of: ${validChars.join(", ")}`);
+      }
+      const val = requireString((cd as Record<string, unknown>)[key], `character_demographics.${key}`);
+      if (requiresSuffix.has(key) && val === "") {
+        throw new Error(`character_demographics.${key}: demographic suffix must be non-empty (no bare "${key}/" directory exists)`);
+      }
+      character_demographics[key as CharacterType] = val;
+    }
+  }
+
   let state_context: StateContext | undefined;
   if (raw["state_context"] !== undefined) {
     state_context = parseStateContext(raw["state_context"]);
@@ -923,6 +948,7 @@ export function loadScenario(json: unknown): Scenario {
   if (group_schema !== undefined) scenario.group_schema = group_schema;
   if (default_district_id !== undefined) scenario.default_district_id = default_district_id;
   if (instigator_character !== undefined) scenario.instigator_character = instigator_character;
+  if (character_demographics !== undefined) scenario.character_demographics = character_demographics;
   if (state_context !== undefined) scenario.state_context = state_context;
 
   return scenario;

--- a/game/web/src/model/scenario.ts
+++ b/game/web/src/model/scenario.ts
@@ -256,6 +256,11 @@ export interface Scenario {
 	narrative: Narrative;
 	/** Which character type plays the instigator role in this scenario. Resolves "instigator" character refs on criteria. */
 	instigator_character?: CharacterType;
+	/** Demographic variant per character type for result-screen sprites.
+	 *  Key = CharacterType (excluding "party", which has no variants); value = demographic suffix
+	 *  (e.g. "wm", "bm", "af", "lm", "naf", "wf", "bf"). Empty string is valid only for "judge"
+	 *  (resolves to the bare judge/ directory); governor/commissioner/legislator require a non-empty suffix. */
+	character_demographics?: Partial<Record<CharacterType, string>>;
 	/** v1: parsed but may be ignored by renderer */
 	state_context?: StateContext;
 }


### PR DESCRIPTION
## Prerequisites
- [ ] N/A | Parent PR merged: none

## Summary
- Wires all 5 character types (commissioner, judge, legislator, party, governor) to their PNG sprite sheets on the result screen — previously only governor was wired; the other 4 fell through to placeholder SVGs.
- Adds `character_demographics` optional field to `Scenario` (TypeScript model + JSON loader) so each scenario JSON can specify which demographic variant to show per character type, instead of a random or hash-derived selection.
- All 10 scenario JSON files updated with `character_demographics` mappings (game content files, not infrastructure; classified as D by diff-summary heuristic but contain no new services/pipelines).
- Sprite sheet layout constants (`CHAR_SHEET`, `CHAR_ROW_SCALE`) added for the 1408×768 non-governor sheet format.

## Validation performed
- [ ] N/A | kubectl dry-run passed (N/A — not a k8s change)
- [ ] N/A | sops decrypt verified (N/A — no secrets)
- [x] Bazel build `//web/...` passes cleanly

## Affected machines / services
- Game web app (client-side only; no server changes)
- Scenario JSON files are game content shipped with the web app bundle; no new services or pipelines introduced

## Deployment steps (POST-MERGE)
- Standard game release via `game/release.main.kts -- deploy --env dev` (branch test) or full semver release from main

## Tickets addressed
- see #TBD (GAME-062)

## Rollback
- Revert this commit; prior behavior showed placeholder SVGs for non-governor characters on the result screen
