### PR TITLE
docs: ADR + tickets for criteria-only validity model (GAME-072/073/074)

### DIFF
--- a/thoughts/shared/decisions/2026-05-18-criteria-only-validity-model.compressed.md
+++ b/thoughts/shared/decisions/2026-05-18-criteria-only-validity-model.compressed.md
@@ -1,0 +1,56 @@
+<!--COMPRESSED v1; source:2026-05-18-criteria-only-validity-model.md-->
+§META
+date:2026-05-18 status:accepted
+topic:criteria-only validity model — deprecate dual validity/criteria system
+impl:GAME-074
+
+§CONTEXT
+Two overlapping constraint systems exist:
+1. validity (validity.ts, isMapSubmittable): rules.population_tolerance + rules.contiguity → mapIsValid gate; generates buildValidityRows diagnostic rows on result screen
+2. criteria (evaluate.ts, success_criteria): explicit player-facing goals; shown in result screen list
+Overlap: tutorial-001 has both rules.population_tolerance AND population_balance criterion → duplicate rows on failure, one row on success; suppression workaround added but is wrong fix
+Root problem: validity system encodes US redistricting assumptions as engine invariants; disempowers scenario authors; contradicts educational mission (contingency of rules is the point)
+
+§DECISION
+Collapse to criteria only.
+
+One engine invariant (not a criterion): all precincts assigned → undefined simulation otherwise; shown as pre-submit UI check, never in criteria list.
+
+Everything else (population balance, contiguity, compactness, seat counts) = scenario criterion; opt-in/opt-out per scenario.
+
+§SCHEMA_CHANGES
+population_balance criterion gains tolerance field:
+  { "type": "population_balance", "tolerance": 0.05 }
+contiguity becomes opt-in criterion:
+  { "type": "contiguity" }
+rules block deprecated → migrate remaining fields → remove when empty
+
+§SIMPLIFICATIONS
+remove: isMapSubmittable | mapIsValid gate | buildValidityRows | May-2026 suppression hack
+overallPass = all required criteria pass AND all precincts assigned
+computeValidityStats: retain only all-assigned + district-in-use checks (still needed for district_count criterion)
+population+contiguity checks move into their criterion evaluators
+
+§AUTHORING_DEFAULTS
+new scenarios default to contiguity + population_balance required criteria
+editor shows warning on removal: "required by most real-world redistricting law — remove intentionally for alternative polity scenarios"
+
+§MIGRATION
+all scenario JSONs:
+  remove rules.population_tolerance → add tolerance to population_balance criterion
+  remove rules.contiguity → add contiguity criterion (all current scenarios require it)
+  remove rules block if empty
+
+§CONSEQUENCES
+scenario.ts: update criterion union type; deprecate rules
+loader.ts: validate tolerance on population_balance; remove rules parsing; warn on non-empty rules block
+validity.ts: retain only all-assigned + district-in-use
+evaluate.ts: population_balance reads tolerance from criterion; add contiguity type
+main.ts: remove isMapSubmittable/mapIsValid/buildValidityRows; update overallPass
+all scenario JSONs: migration required
+e2e tests: update validity-row + mapIsValid tests
+educational upside: all constraints visible as criteria → rules are choices not nature
+
+§REFS
+impl ticket: thoughts/shared/tickets/GAME-074-criteria-only-validity-model.md
+scenario format ADR: thoughts/shared/decisions/2026-04-24-scenario-data-format.compressed.md

--- a/thoughts/shared/decisions/2026-05-18-criteria-only-validity-model.md
+++ b/thoughts/shared/decisions/2026-05-18-criteria-only-validity-model.md
@@ -1,0 +1,129 @@
+---
+date: 2026-05-18
+status: accepted
+---
+
+# ADR: Criteria-Only Validity Model
+
+## Status
+
+Accepted. Implementation tracked in GAME-074.
+
+## Context
+
+The codebase currently has two overlapping systems for checking whether a player's
+map meets requirements:
+
+**System 1 — structural validity** (`validity.ts`, `isMapSubmittable`): computed from
+`rules.*` fields in the scenario JSON. Checks whether all precincts are assigned,
+whether population is within `rules.population_tolerance`, and whether districts are
+contiguous. Used to determine `mapIsValid`, which gates `overallPass` and triggers
+`buildValidityRows` — synthetic diagnostic rows prepended to the result screen on
+invalid maps.
+
+**System 2 — scenario criteria** (`evaluate.ts`, `success_criteria`): explicit
+player-facing goals in the scenario JSON. Includes `population_balance`,
+`district_count`, `compactness`, `seat_count`, etc. Evaluated after the player
+submits, shown as the main result screen criteria list.
+
+These systems overlap. Tutorial-001 has both `rules.population_tolerance: 0.05` AND
+a `population_balance` required criterion — the same constraint expressed twice,
+producing duplicate rows on the result screen when the map fails (one validity row,
+one criterion row), and a single row when it passes. A workaround was added to
+suppress validity rows that duplicate a scenario criterion, but this is the wrong
+fix: it papers over a design flaw.
+
+The deeper issue: the validity system encodes assumptions about what every redistricting
+scenario must require — contiguous districts, population equivalence. These are not
+universal rules. They reflect current US redistricting law. A scenario set in an
+alternative polity, a historical period, or a speculative legal environment might
+legitimately omit them. Making them engine-level invariants disempowers scenario
+authors and contradicts the game's educational purpose (which is to surface the
+contingency of these rules, not naturalize them).
+
+## Decision
+
+**Collapse to a single model: criteria only.**
+
+### The one true engine invariant
+
+"All precincts must be assigned to a district" is the only constraint enforced at the
+engine level, not via a scenario criterion. It is a mechanical game requirement: the
+election simulation produces undefined results if any precinct is unassigned. It is
+not a political or legal rule — it applies to any electoral system. It will remain as
+a pre-submit check with a clear UI message, but will NOT appear in the criteria list.
+
+Everything else — population balance, contiguity, seat counts, compactness — is a
+scenario criterion. Authors include it or not.
+
+### Schema changes
+
+`rules.population_tolerance` is removed. The `population_balance` criterion gains a
+`tolerance` field:
+
+```json
+{
+  "type": "population_balance",
+  "tolerance": 0.05
+}
+```
+
+`rules.contiguity` is removed. Contiguity becomes an opt-in criterion:
+
+```json
+{
+  "type": "contiguity"
+}
+```
+
+The `rules` block is deprecated. Any remaining fields should migrate to either
+criteria or scenario-level metadata. The block may be removed entirely once all
+scenarios are migrated.
+
+### Simplifications
+
+- `isMapSubmittable` is removed. `mapIsValid` gate on `overallPass` is removed.
+  `overallPass` = all required criteria pass AND all precincts assigned.
+- `buildValidityRows` is removed. The result screen shows only scenario criteria
+  (plus the engine's "all assigned" check if violated).
+- The suppression logic added in May 2026 is removed.
+- `computeValidityStats` is simplified: only the all-assigned and district-in-use
+  checks remain (needed for the `district_count` criterion and the engine invariant).
+  Population and contiguity checks move into their respective criterion evaluators.
+
+### Scenario authoring defaults
+
+New scenarios (and the scenario editor, when built) should default to including
+`contiguity` and `population_balance` criteria as required, since these reflect
+the most common real-world requirements. Removing them is allowed, and the editor
+should show a warning ("this criterion is required by most real-world redistricting
+laws — remove it intentionally if your scenario models a different legal context").
+
+### Migration
+
+All existing scenario JSON files are updated:
+- Remove `rules.population_tolerance`; move tolerance value to the `population_balance`
+  criterion's `tolerance` field.
+- Remove `rules.contiguity`; add a `contiguity` criterion if the scenario previously
+  required it (all current scenarios do).
+- Remove `rules` block if it becomes empty.
+- Add `character_demographics` for any scenario missing it (forward-compat).
+
+## Consequences
+
+- **Scenario JSON**: `rules` block deprecated; `population_balance` criterion gains
+  `tolerance` field; `contiguity` criterion added.
+- **`scenario.ts`**: update types for criterion union; deprecate/remove `rules`.
+- **`loader.ts`**: validate `tolerance` on `population_balance`; remove contiguity
+  and population rules parsing; add loader warning if `rules` block is non-empty.
+- **`validity.ts`**: retain only all-assigned and district-in-use checks.
+- **`evaluate.ts`**: `population_balance` reads tolerance from criterion spec;
+  add `contiguity` criterion type.
+- **`main.ts`**: remove `isMapSubmittable`, `mapIsValid`, `buildValidityRows`.
+  Update `overallPass` logic.
+- **All scenario JSON files**: migration required.
+- **e2e tests**: update any tests that relied on validity rows or `mapIsValid`
+  gating behaviour.
+- **Educational upside**: all constraints become visible to players as explicit
+  criteria, reinforcing the game's message that these rules are choices, not laws
+  of nature.

--- a/thoughts/shared/tickets/GAME-072-optional-criterion-neutral-audio.md
+++ b/thoughts/shared/tickets/GAME-072-optional-criterion-neutral-audio.md
@@ -1,0 +1,39 @@
+---
+id: GAME-072
+title: "Neutral/meh audio clip for optional criteria that fail"
+area: game, audio
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+When an optional criterion fails, the current audio plays the `party-disapprove` clip
+(a crowd boo / strong negative reaction). This is too strong — an optional criterion
+failing is a mild disappointment, not a failure. A shorter "meh", "eh", or soft-neutral
+clip would better match the emotional weight of missing a bonus criterion.
+
+## Current State
+
+- Audio selection (`finalizeRow` in `main.ts`): `else { clipName = passed ? "party-approve" : "party-disapprove"; }`
+- `party-disapprove` is itself a stub (GAME-071 fine-tuning pending)
+- No "neutral/meh" clip exists in the asset inventory
+
+## Goals / Acceptance Criteria
+
+- [ ] New audio clip: short neutral/unenthusiastic reaction (~0.5–1.5s, −16 LUFS), labelled
+      `neutral-meh` or similar in INVENTORY.md
+- [ ] Optional-fail rows play the neutral clip instead of `party-disapprove`
+- [ ] Optional-pass rows continue to use `party-approve` (or a per-type clip if GAME-071 is done)
+- [ ] Clip produced and levelled consistent with existing assets
+
+## Test Coverage
+
+- [ ] e2e: optional-fail row triggers a `play()` call with the neutral clip name
+      (verify via a test hook or spy, or assert silence vs. strong boo subjectively in manual test)
+
+## References
+
+- `game/web/src/main.ts` — `finalizeRow()` audio selection block
+- `game/web/assets/audio/INVENTORY.md` — audio clip registry
+- `thoughts/shared/tickets/GAME-071-audio-character-assignment.md` — related audio fine-tuning

--- a/thoughts/shared/tickets/GAME-073-result-screen-stars-and-success-banner.md
+++ b/thoughts/shared/tickets/GAME-073-result-screen-stars-and-success-banner.md
@@ -1,0 +1,66 @@
+---
+id: GAME-073
+title: "Result screen: deferred success banner + star count reveal"
+area: game, UX, audio
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Currently the "Map Passed!" / "Map Failed" verdict and subtitle are shown at the top
+of the result screen before any criteria are revealed. This breaks the dramatic reveal
+flow. The redesign:
+
+- **Failure**: verdict banner may appear immediately on the first failing *required*
+  criterion (to signal the map won't pass early). Optional failures remain silent.
+- **Success**: verdict banner and star count (1/2/3 stars) appear only AFTER all
+  criteria have been revealed and evaluated.
+- Stars follow the existing design (1 = required-only pass, 2 = some optional passed,
+  3 = all criteria passed).
+- Completion audio: "tada" on success, "womp-womp" on required-criterion failure.
+
+## Current State
+
+- `resultVerdict.textContent` and `resultSubtitle.textContent` set immediately in
+  `showResultScreen()` before the reveal loop starts (`main.ts` ~line 920).
+- `computeStarCount()` exists but star display is not shown in the result screen UI.
+- No tada/womp-womp audio clips exist.
+
+## Goals / Acceptance Criteria
+
+### Verdict banner timing
+- [ ] On map load into result screen: verdict banner hidden (or shows neutral "Evaluating…")
+- [ ] First failing *required* criterion reveal: show failure banner immediately
+- [ ] After all rows revealed with no required failures: show success banner + star count
+- [ ] Skip button: jumps to final state — banner + stars shown immediately
+
+### Star count UI
+- [ ] Star display element added to result screen header (1–3 star icons)
+- [ ] 1 star: all required criteria pass, zero optional pass
+- [ ] 2 stars: all required pass, some (but not all) optional pass
+- [ ] 3 stars: all criteria pass (required + all optional)
+- [ ] Stars animate in (simple fade/scale) when banner appears; no animation in reduced-motion mode
+
+### Audio
+- [ ] New "tada" clip (~1–2s, triumphant, −16 LUFS) plays when success banner appears
+- [ ] New "womp-womp" clip (~1s, failure trombone/deflated, −16 LUFS) plays when first
+      required failure is revealed
+- [ ] Clips registered in INVENTORY.md and preloaded with the scenario
+
+### Reduced-motion / final path
+- [ ] Reduced-motion path: banner + stars shown immediately in final state
+
+## Test Coverage
+
+- [ ] e2e: verdict banner hidden at start of reveal on a passing map
+- [ ] e2e: success banner + stars visible after all rows finalized on a passing map
+- [ ] e2e: failure banner visible after first required-fail row on a failing map
+- [ ] e2e: skip button shows banner + stars immediately
+
+## References
+
+- `game/web/src/main.ts` — `showResultScreen()`, `computeStarCount()`, `finalizeRow()`
+- `game/web/styles.css` — result screen layout
+- `thoughts/shared/research/2026-05-02-DESIGN-001-achievement-star-system.md` — star design
+- `thoughts/shared/tickets/GAME-072-optional-criterion-neutral-audio.md` — related audio

--- a/thoughts/shared/tickets/GAME-074-criteria-only-validity-model.md
+++ b/thoughts/shared/tickets/GAME-074-criteria-only-validity-model.md
@@ -1,0 +1,87 @@
+---
+id: GAME-074
+title: "Criteria-only validity model: deprecate dual validity/criteria system"
+area: game, architecture, scenario-format
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Implement the criteria-only validity model per the ADR
+(`thoughts/shared/decisions/2026-05-18-criteria-only-validity-model.md`).
+The dual validity/criteria system is collapsed into a single model: scenario success
+criteria are the sole source of truth for what a map must achieve. The only engine
+invariant (not a scenario criterion) is "all precincts assigned." Everything else —
+population balance, contiguity, compactness — becomes an explicit, opt-in scenario
+criterion. This removes the `mapIsValid` gate, `isMapSubmittable`, `buildValidityRows`,
+and the `rules.population_tolerance` / `rules.contiguity` fields.
+
+## Current State
+
+- `validity.ts` computes `isMapSubmittable` from `rules.*`; gates `overallPass`
+- `buildValidityRows` emits synthetic diagnostic rows that duplicate scenario criteria
+- `rules.population_tolerance` and the `population_balance` criterion express the same
+  constraint in two places; a suppression workaround was added 2026-05-18
+- `rules.contiguity` encodes a US legal requirement as a universal engine rule
+
+## Goals / Acceptance Criteria
+
+### Schema
+
+- [ ] `population_balance` criterion gains required `tolerance` field (e.g. `"tolerance": 0.05`);
+      loader validates it; evaluate.ts reads tolerance from criterion spec
+- [ ] `contiguity` added as a new criterion type (`{ "type": "contiguity" }`); evaluated
+      using the existing BFS/contiguity logic currently in `validity.ts`
+- [ ] `rules.population_tolerance` removed from schema and loader
+- [ ] `rules.contiguity` removed from schema and loader
+- [ ] Loader emits a warning (not error) if a non-empty `rules` block is present
+      (forward-compat grace period)
+- [ ] `rules` block may be omitted entirely in scenario JSON with no error
+
+### Logic
+
+- [ ] `isMapSubmittable` removed
+- [ ] `mapIsValid` removed; `overallPass` = all required criteria pass AND
+      `validity.unassignedCount === 0`
+- [ ] `buildValidityRows` removed; May-2026 duplicate-suppression code removed
+- [ ] `computeValidityStats` retains only all-assigned + district-in-use checks
+      (still needed for `district_count` criterion evaluation)
+- [ ] Population deviation check in `computeValidityStats` removed (now in criterion)
+- [ ] Contiguity check in `computeValidityStats` removed (now in criterion evaluator)
+
+### Migration: scenario JSON files
+
+All 10 scenario files updated:
+- [ ] `tutorial-001.json`: remove `rules.population_tolerance`; add `"tolerance": 0.05`
+      to `population_balance` criterion; remove `rules.contiguity`; add `contiguity` criterion
+- [ ] `tutorial-002.json`: same migration
+- [ ] `scenario-002.json` through `scenario-009.json`: same migration for each
+- [ ] `rules` block removed from all scenario files after migration
+
+### Result screen
+
+- [ ] Result screen shows only scenario criteria rows (no more `validity:*` rows)
+- [ ] If all precincts unassigned, a pre-submit UI warning is shown (existing behaviour
+      retained — this is an engine check, not a criterion); does NOT appear on result screen
+
+## Test Coverage
+
+- [ ] Unit: `population_balance` criterion reads tolerance from criterion spec
+- [ ] Unit: `contiguity` criterion evaluates correctly (BFS pass/fail per district)
+- [ ] Unit: `overallPass` is false when unassigned precincts exist, regardless of criteria
+- [ ] e2e: result screen shows no `validity:*` rows on tutorial-001 invalid submission
+- [ ] e2e: `population_balance` criterion FAIL row shown on imbalanced tutorial-001 map
+- [ ] e2e: `contiguity` criterion FAIL row shown on non-contiguous map
+- [ ] Loader test: scenario without `rules` block loads without error
+- [ ] Loader test: `population_balance` without `tolerance` → loader error
+
+## References
+
+- ADR: `thoughts/shared/decisions/2026-05-18-criteria-only-validity-model.md`
+- `game/web/src/simulation/validity.ts`
+- `game/web/src/simulation/evaluate.ts`
+- `game/web/src/model/scenario.ts`
+- `game/web/src/model/loader.ts`
+- `game/web/src/main.ts` — `buildValidityRows`, `isMapSubmittable`, `overallPass`
+- `game/scenarios/*.json` — all 10 scenario files require migration

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -103,6 +103,9 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-065-character-sprite-art-refinement.md` | game, art, content | Quality fixes for known issues (judge eye, party mouth, legislator thumb); broker PNG production (stretch); not a blocker for GAME-062 |
 | `GAME-070-audio-settings.md` | game, UX, audio | Audio settings panel (main menu Settings item): master volume slider, mute toggle, localStorage persistence; coordinates with GAME-062 result-screen toggle |
 | `GAME-071-audio-character-assignment.md` | game, audio, content | Per-scenario character/audio inventory; audio clip selection per type; timing calibration; stub resolution |
+| `GAME-072-optional-criterion-neutral-audio.md` | game, audio | Neutral/meh audio clip for optional criteria that fail — party-disapprove is too strong for a missed bonus |
+| `GAME-073-result-screen-stars-and-success-banner.md` | game, UX, audio | Deferred success banner + star count reveal; tada/womp-womp completion audio; verdict hidden until all criteria revealed |
+| `GAME-074-criteria-only-validity-model.md` | game, architecture | Collapse dual validity/criteria system; population_balance gains tolerance field; contiguity becomes opt-in criterion; remove isMapSubmittable/buildValidityRows/mapIsValid |
 
 ---
 


### PR DESCRIPTION
## Summary

- **ADR `2026-05-18-criteria-only-validity-model`** (full + compressed): documents the decision to collapse the dual validity/criteria system. The only engine-level invariant becomes "all precincts assigned"; everything else (population balance, contiguity, compactness) moves to opt-in scenario criteria. Motivated by the observation that contiguity and population equivalence are contingent legal rules, not universal game mechanics, and that encoding them as engine invariants disempowers scenario authors creating alternative-polity scenarios. The `population_balance` criterion will gain a `tolerance` field; `rules.population_tolerance` and `rules.contiguity` are deprecated.
- **GAME-072**: ticket for a neutral/meh audio clip for optional-fail criteria (party-disapprove is too strong for a missed bonus).
- **GAME-073**: ticket for the deferred success banner + star count reveal (verdict hidden until all criteria revealed; tada/womp-womp completion audio).
- **GAME-074**: implementation ticket for the criteria-only validity model (loader, evaluate, validity, main.ts, all 10 scenario JSONs).
- **TICKETS.md** updated with all three new tickets.

## Affected machines / services

- N/A — documentation and ticket files only; no code changes.

## Validation performed

- [x] kubectl dry-run passed (N/A — no k8s manifests)
- [x] sops decrypt verified (N/A — no secrets)
- [x] ADR compressed form matches full form (manually verified)
- [x] Ticket IDs (072–074) checked against TICKETS.md Resolved section — no collisions

## Deployment steps (POST-MERGE)

- N/A — no deployable artifacts changed.

## Tickets addressed

- see GAME-072, GAME-073, GAME-074 (opened, not resolved — implementation pending)

## Rollback

- Revert the squash commit. No code or data changes.
