### PR TITLE
fix(UX): remove About button from scenario-select screen

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -881,20 +881,16 @@ test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", 
 
 // ─── GAME-029: About page ───────────────────────────────────────────────────
 
-test("about page: accessible from select screen and shows educational content", async ({ page }) => {
-  await page.goto("/?campaign=educational");
-  await page.evaluate(() => {
-    localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ["tutorial-002"] }));
-  });
-  await page.reload();
-  await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
-  await page.locator("#btn-about").click();
+test("about page: accessible from main menu and shows educational content", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+  await page.locator("#btn-main-about").click();
   await expect(page.locator("#about-screen")).toBeVisible();
   await expect(page.locator("#about-screen")).toContainText("Past the Post");
   await expect(page.locator("#about-screen")).toContainText("not advocacy");
-  // Back button returns to select screen
+  // Back button returns to main menu
   await page.locator("#btn-about-close").click();
-  await expect(page.locator("#scenario-select")).toBeVisible();
+  await expect(page.locator("#main-menu")).toBeVisible();
   await expect(page.locator("#about-screen")).not.toBeVisible();
 });
 

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -37,7 +37,6 @@
       <h1>Past the Post</h1>
       <div id="scenario-cards" role="list"></div>
       <div style="display:flex;gap:16px;margin-top:16px;align-items:center;">
-        <button id="btn-about" style="background:none;border:1px solid #2a5a8c;color:#8898b0;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:0.75rem;">About</button>
         <button id="btn-reset-campaign" style="background:none;border:1px solid #555;color:#888;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:0.75rem;">Reset Campaign</button>
       </div>
     </div>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -368,15 +368,6 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			renderScenarioCards();
 		});
 
-		// About button
-		document.getElementById("btn-about")?.addEventListener("click", () => {
-			scenarioSelectEl?.classList.add("hidden");
-			document.getElementById("about-screen")?.classList.remove("hidden");
-		});
-		document.getElementById("btn-about-close")?.addEventListener("click", () => {
-			document.getElementById("about-screen")?.classList.add("hidden");
-			scenarioSelectEl?.classList.remove("hidden");
-		});
 	}
 
 	// ── Startup routing (GAME-021 / GAME-048) ────────────────────────────────


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #231

## Summary
- Removes the duplicate About button from the scenario-select screen
- About remains accessible from the main menu (`btn-main-about`), which is the appropriate entry point
- Removes the now-dead `btn-about` / `btn-about-close` event listeners from `showScenarioSelect()`

## Validation performed
- [ ] N/A — kubectl dry-run (not infra)
- [ ] N/A — sops decrypt (not infra)
- Verified: main menu About button and close flow unaffected; scenario-select no longer shows About

## Affected machines / services
- Web game only

## Deployment steps (POST-MERGE)
- Deploy to dev/staging as part of normal release cycle

## Tickets addressed
- N/A (minor UX cleanup)

## Rollback
- Revert this commit; the button and listeners are self-contained
