### PR TITLE
feat(debug): force-win plays result screen; per-criterion pass/fail replay

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -788,8 +788,10 @@ test("debug force-win button: visible with ?debug param, marks scenario complete
   const debugBtn = page.locator("#btn-debug-win");
   await expect(debugBtn).toBeVisible();
   await debugBtn.click();
-  // No campaign context — force-win navigates to main menu via backUrl
-  await expect(page.locator("#main-menu")).toBeVisible({ timeout: 10_000 });
+  // Force-win now opens the result screen with all criteria forced to pass.
+  await expect(page.locator("#result-screen")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#btn-next-scenario")).toBeVisible();
+  // Scenario should be marked complete synchronously when result screen opens.
   const completed = await page.evaluate(() => {
     const raw = localStorage.getItem("redistricting-sim-progress");
     return raw ? JSON.parse(raw) : null;

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -880,7 +880,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		verdict.style.opacity = "1";
 	}
 
-	function showResultScreen() {
+	function showResultScreen(debugForcePass = false) {
 		if (!resultScreen || !resultVerdict || !resultSubtitle || !resultCriteriaList) return;
 		if (skipClickHandler) { btnRevealSkip?.removeEventListener("click", skipClickHandler); skipClickHandler = null; }
 
@@ -895,7 +895,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		);
 
 		// GAME-059: detect invalid map before running criterion evaluation.
-		const mapIsValid = isMapSubmittable(validity, scenario.rules);
+		let mapIsValid = isMapSubmittable(validity, scenario.rules);
 
 		const evalResult = evaluateCriteria(
 			scenario.success_criteria,
@@ -910,7 +910,12 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		);
 
 		// GAME-059: overall pass requires a valid map AND all required criteria passing.
-		const overallPass = mapIsValid && evalResult.overallPass;
+		let overallPass = mapIsValid && evalResult.overallPass;
+
+		if (debugForcePass) {
+			mapIsValid = true;
+			overallPass = true;
+		}
 
 		resultVerdict.textContent = overallPass ? "Map Passed!" : "Map Failed";
 		resultVerdict.className = overallPass ? "pass" : "fail";
@@ -948,13 +953,113 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 
 		// GAME-059: for invalid maps, prepend validity failure rows before scenario criteria.
 		const validityRows = mapIsValid ? [] : buildValidityRows(validity);
-		const allRows: CriterionResult[] = [...validityRows, ...evalResult.criterionResults];
+		const criterionRows = debugForcePass
+			? evalResult.criterionResults.map(cr => ({ ...cr, passed: true }))
+			: evalResult.criterionResults;
+		const allRows: CriterionResult[] = [...validityRows, ...criterionRows];
 
 		resultCriteriaList.innerHTML = "";
 
 		// Resolve character info for a row (validity rows default to commissioner).
 		function resolveCharInfo(cr: CriterionResult): { type: CharacterType; party_id?: string } {
 			return charInfoMap.get(cr.criterionId as string) ?? { type: "commissioner" };
+		}
+
+		// Row timing constants — shared by main reveal and per-row debug replay.
+		const ROW_FADE_MS = 300;
+		const ROW_HOLD_MS = 1200;
+		const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+		// All active setTimeout handles — cleared by skip, Keep Drawing, and debug replay.
+		let activeTimeouts: ReturnType<typeof setTimeout>[] = [];
+
+		// Snap a row to its final verdict state.
+		function finalizeRow(row: HTMLElement, withAudio = false): void {
+			if (row.dataset["finalized"] === "true") return;
+			row.dataset["finalized"] = "true";
+			const passed = row.dataset["passed"] === "true";
+			const required = row.dataset["required"] === "true";
+			const verdictCls = passed ? "passed" : required ? "failed-required" : "failed-optional";
+			row.className = `result-criterion ${verdictCls}`;
+			row.style.opacity = "1";
+			row.style.animation = "none";
+			const badge = row.querySelector<HTMLSpanElement>(".rc-badge")!;
+			badge.classList.remove("rc-checking");
+			badge.textContent = passed ? "PASS" : required ? "FAIL" : "OPTIONAL";
+			// Transition character slot neutral → verdict.
+			const neutral = row.querySelector<HTMLElement>(".rc-char-neutral");
+			const verdict = row.querySelector<HTMLElement>(".rc-char-verdict");
+			if (neutral && verdict) transitionCharSlot(neutral, verdict);
+			if (withAudio) {
+				const type = row.dataset["charType"] ?? "";
+				const democode = row.dataset["charDemo"] ?? "";
+				const audioState = passed ? "approve" : "disapprove";
+				// Governor/commissioner/legislator: gender-keyed clips.
+				// Judge: dedicated gavel clips.
+				// Party: party-approve / party-disapprove (disapprove is a stub — GAME-071).
+				let clipName: string;
+				if (type === "governor" || type === "commissioner" || type === "legislator") {
+					const gender = democode.length >= 2 ? democode.slice(-1) : "";
+					clipName = (gender === "m" || gender === "f")
+						? `${type}-${audioState}-${gender}`
+						: `${type}-${audioState}`;
+				} else if (type === "judge") {
+					clipName = `judge-${audioState}`;
+				} else {
+					// party
+					clipName = passed ? "party-approve" : "party-disapprove";
+				}
+				play(clipName);
+			}
+		}
+
+		// Debug: reset a single row to pending and re-run its reveal with a forced result.
+		// Cancels any in-flight animations (main reveal or a prior replay) before starting.
+		function debugReplayRow(row: HTMLElement, newPassed: boolean): void {
+			// Remove any stale once-listener on the Skip button from the main reveal.
+			if (skipClickHandler) {
+				btnRevealSkip?.removeEventListener("click", skipClickHandler);
+				skipClickHandler = null;
+			}
+			for (const t of activeTimeouts) clearTimeout(t);
+			activeTimeouts = [];
+			row.dataset["passed"] = String(newPassed);
+			row.dataset["finalized"] = "false";
+			row.className = "result-criterion rc-pending";
+			row.style.opacity = "";
+			// Force CSS animation reset: clear → reflow → re-trigger.
+			row.style.animation = "none";
+			void row.offsetHeight;
+			// Rebuild char slot for new verdict.
+			const charType = (row.dataset["charType"] ?? "commissioner") as CharacterType;
+			const charSlot = row.querySelector<HTMLElement>(".rc-char")!;
+			charSlot.innerHTML = "";
+			buildCharSlotChildren(charSlot, charType, newPassed);
+			// Reset badge.
+			const badge = row.querySelector<HTMLSpanElement>(".rc-badge")!;
+			badge.className = "rc-badge rc-checking";
+			badge.textContent = "CHECKING…";
+			// Register a cancel hook so Keep Drawing can abort this animation too.
+			skipClickHandler = () => {
+				for (const t of activeTimeouts) clearTimeout(t);
+				activeTimeouts = [];
+				skipClickHandler = null;
+			};
+			if (reducedMotion) {
+				finalizeRow(row, /*withAudio=*/ true);
+				skipClickHandler = null;
+			} else {
+				const t1 = setTimeout(() => {
+					row.classList.remove("rc-pending");
+					row.style.animation = `criterionReveal ${ROW_FADE_MS}ms ease forwards`;
+					const t2 = setTimeout(() => {
+						finalizeRow(row, /*withAudio=*/ true);
+						skipClickHandler = null;
+					}, ROW_HOLD_MS);
+					activeTimeouts.push(t2);
+				}, 50);
+				activeTimeouts.push(t1);
+			}
 		}
 
 		// Build a criterion row element.
@@ -1020,50 +1125,25 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			row.appendChild(body);
 			row.appendChild(badge);
 			row.appendChild(charSlot);
+
+			if (IS_DEBUG) {
+				const dbgCtrl = document.createElement("div");
+				dbgCtrl.className = "rc-debug-ctrl";
+				const btnDbgPass = document.createElement("button");
+				btnDbgPass.className = "rc-debug-pass";
+				btnDbgPass.textContent = "✓ pass";
+				btnDbgPass.addEventListener("click", () => debugReplayRow(row, true));
+				const btnDbgFail = document.createElement("button");
+				btnDbgFail.className = "rc-debug-fail";
+				btnDbgFail.textContent = "✗ fail";
+				btnDbgFail.addEventListener("click", () => debugReplayRow(row, false));
+				dbgCtrl.appendChild(btnDbgPass);
+				dbgCtrl.appendChild(btnDbgFail);
+				row.appendChild(dbgCtrl);
+			}
+
 			return row;
 		}
-
-		// Snap a row to its final verdict state.
-		function finalizeRow(row: HTMLElement, withAudio = false): void {
-			if (row.dataset["finalized"] === "true") return;
-			row.dataset["finalized"] = "true";
-			const passed = row.dataset["passed"] === "true";
-			const required = row.dataset["required"] === "true";
-			const verdictCls = passed ? "passed" : required ? "failed-required" : "failed-optional";
-			row.className = `result-criterion ${verdictCls}`;
-			row.style.opacity = "1";
-			row.style.animation = "none";
-			const badge = row.querySelector<HTMLSpanElement>(".rc-badge")!;
-			badge.classList.remove("rc-checking");
-			badge.textContent = passed ? "PASS" : required ? "FAIL" : "OPTIONAL";
-			// Transition character slot neutral → verdict.
-			const neutral = row.querySelector<HTMLElement>(".rc-char-neutral");
-			const verdict = row.querySelector<HTMLElement>(".rc-char-verdict");
-			if (neutral && verdict) transitionCharSlot(neutral, verdict);
-			if (withAudio) {
-				const type = row.dataset["charType"] ?? "";
-				const democode = row.dataset["charDemo"] ?? "";
-				const state = passed ? "approve" : "disapprove";
-				// Governor/commissioner/legislator: gender-keyed clips.
-				// Judge: dedicated gavel clips.
-				// Party: party-approve / party-disapprove (disapprove is a stub — GAME-071).
-				let clipName: string;
-				if (type === "governor" || type === "commissioner" || type === "legislator") {
-					const gender = democode.length >= 2 ? democode.slice(-1) : "";
-					clipName = (gender === "m" || gender === "f")
-						? `${type}-${state}-${gender}`
-						: `${type}-${state}`;
-				} else if (type === "judge") {
-					clipName = `judge-${state}`;
-				} else {
-					// party
-					clipName = passed ? "party-approve" : "party-disapprove";
-				}
-				play(clipName);
-			}
-		}
-
-		const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
 		if (reducedMotion) {
 			// Instant path: all rows in final state with verdict character poses immediately.
@@ -1075,8 +1155,6 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			// GAME-068: each row fully resolves before the next starts (no simultaneous CHECKING).
 			// Chain delay = 300ms fade + 1200ms hold + 150ms flip + 900ms settle = 2550ms per row.
 			// ROW_SETTLE_MS gives audio clips space to finish before the next row starts.
-			const ROW_FADE_MS = 300;
-			const ROW_HOLD_MS = 1200;
 			const ROW_FLIP_MS = 150;
 			const ROW_SETTLE_MS = 900;
 			const ROW_CHAIN_MS = ROW_FADE_MS + ROW_HOLD_MS + ROW_FLIP_MS + ROW_SETTLE_MS; // 2550ms
@@ -1091,7 +1169,6 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			// Show Skip button; hide it when reveal completes naturally.
 			if (resultRevealControls) resultRevealControls.style.display = "";
 
-			const pendingTimeouts: ReturnType<typeof setTimeout>[] = [];
 			let chainDelay = 0;
 
 			for (let i = 0; i < rowElements.length; i++) {
@@ -1120,12 +1197,12 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 								if (resultRevealControls) resultRevealControls.style.display = "none";
 								skipClickHandler = null;
 							}, 800);
-							pendingTimeouts.push(tDone);
+							activeTimeouts.push(tDone);
 						}
 					}, ROW_HOLD_MS);
-					pendingTimeouts.push(t2);
+					activeTimeouts.push(t2);
 				}, rowStart);
-				pendingTimeouts.push(t1);
+				activeTimeouts.push(t1);
 
 				// Next row starts only after this row has fully resolved.
 				chainDelay += ROW_CHAIN_MS;
@@ -1133,7 +1210,8 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 
 			// Skip button: clear all pending timeouts, finalize all rows immediately.
 			const skipHandler = () => {
-				for (const t of pendingTimeouts) clearTimeout(t);
+				for (const t of activeTimeouts) clearTimeout(t);
+				activeTimeouts = [];
 				for (const row of rowElements) finalizeRow(row);
 				if (resultRevealControls) resultRevealControls.style.display = "none";
 				skipClickHandler = null;
@@ -1177,19 +1255,13 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	});
 
 	// ── Debug force-win: visible only with ?debug in URL ─────────────────────
+	// Opens the result screen with all criteria forced to pass, so the full
+	// reveal animation and audio can be tested without solving the map.
 	const btnDebugWin = document.getElementById("btn-debug-win") as HTMLButtonElement | null;
 	if (btnDebugWin && IS_DEBUG) {
 		btnDebugWin.style.display = "";
 		btnDebugWin.addEventListener("click", () => {
-			progress = markCompleted(progress, scenario.id);
-			saveProgress(progress);
-			clearWip();
-			const allComplete = SCENARIO_MANIFEST.every((e) => isCompleted(progress, e.id));
-			if (allComplete) {
-				document.getElementById("wrap-up-screen")?.classList.remove("hidden");
-			} else {
-				window.location.assign(backUrl);
-			}
+			showResultScreen(/*debugForcePass=*/ true);
 		});
 	}
 

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -717,6 +717,26 @@ body {
   background-size: auto 84px;
 }
 
+/* Debug per-criterion pass/fail controls — only rendered in ?debug mode */
+.rc-debug-ctrl {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-left: 6px;
+  flex-shrink: 0;
+}
+.rc-debug-ctrl button {
+  font-size: 0.6rem;
+  padding: 2px 5px;
+  border-radius: 3px;
+  border: 1px solid;
+  cursor: pointer;
+  background: transparent;
+  line-height: 1;
+}
+.rc-debug-pass { color: #4caf80; border-color: #4caf80; }
+.rc-debug-fail { color: #e94560; border-color: #e94560; }
+
 @media (prefers-reduced-motion: reduce) {
   .character-sprite {
     transition: none;


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #232

## Summary
- Debug force-win (`⚡ Force Win`) now opens the result screen with all criteria forced to pass, running the full sequential reveal animation instead of navigating away — lets animators and testers verify the reveal flow without solving a map
- In debug mode (`?debug`), each criterion row gains `✓ pass` and `✗ fail` buttons; clicking either cancels any in-flight animation and re-runs the single-row reveal with the chosen verdict (audio + character sprite transition included), enabling per-criterion audio and animation testing in isolation
- Shared `activeTimeouts` array replaces the previous `pendingTimeouts` local so both the main reveal, skip handler, debug replay, and Keep Drawing all cancel from the same source — no more orphaned audio after clicking Fix It during a replay

## Validation performed
- [ ] N/A — kubectl dry-run (not infra)
- [ ] N/A — sops decrypt (not infra)
- TypeScript typecheck passes (`bazel test //game/web:app_typecheck_test`)
- Built clean (`bazel build //game/web:app`)
- Manually verified: Force Win opens result screen with all-green criteria reveal; pass/fail buttons replay individual rows with correct audio

## Affected machines / services
- Web game only (debug-mode behaviour; no change to production path)

## Deployment steps (POST-MERGE)
- Deploy to dev/staging as part of normal release cycle

## Tickets addressed
- N/A (debug tooling improvement)

## Rollback
- Revert this commit; changes are self-contained to `showResultScreen` and the debug win button
