### PR TITLE
fix(debug): finalize pending rows before per-criterion replay

### DIFF
--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -1031,13 +1031,16 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		// Debug: reset a single row to pending and re-run its reveal with a forced result.
 		// Cancels any in-flight animations (main reveal or a prior replay) before starting.
 		function debugReplayRow(row: HTMLElement, newPassed: boolean): void {
-			// Remove any stale once-listener on the Skip button from the main reveal.
+			// Finalize any in-flight reveal before starting. Calling skipClickHandler()
+			// snaps all pending rows to their natural results so only this row gets the
+			// debug override — prevents future rows from being abandoned in rc-pending.
 			if (skipClickHandler) {
 				btnRevealSkip?.removeEventListener("click", skipClickHandler);
-				skipClickHandler = null;
+				skipClickHandler(); // finalizes all pending rows + clears activeTimeouts
+			} else {
+				for (const t of activeTimeouts) clearTimeout(t);
+				activeTimeouts = [];
 			}
-			for (const t of activeTimeouts) clearTimeout(t);
-			activeTimeouts = [];
 			row.dataset["passed"] = String(newPassed);
 			row.dataset["finalized"] = "false";
 			row.className = "result-criterion rc-pending";


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #234

## Summary
- Clicking a debug pass/fail button mid-reveal was cancelling the `activeTimeouts` array without finalizing the not-yet-revealed rows, leaving them stuck in `rc-pending` (invisible, never evaluated)
- Fix: replace the bare `clearTimeout` loop with a call to `skipClickHandler()` — the existing skip handler already snaps all pending rows to their natural results and clears timeouts in one step; only after that does the target row get reset and replayed with the debug-forced result
- The `else` branch (no reveal in flight) keeps the direct `clearTimeout` loop unchanged

## Validation performed
- [ ] N/A — kubectl dry-run (not infra)
- [ ] N/A — sops decrypt (not infra)
- TypeScript typecheck passes

## Affected machines / services
- Web game only (debug-mode behaviour)

## Deployment steps (POST-MERGE)
- Deploy to dev/staging as part of normal release cycle

## Tickets addressed
- N/A (debug tooling fix)

## Rollback
- Revert this commit; self-contained to the first four lines of `debugReplayRow`
