### PR TITLE
feat(GAME-073): deferred verdict banner + star count reveal

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -25,6 +25,9 @@ async function loadScenario(
   id: string,
 ): Promise<void> {
   await page.goto(`/?s=${id}&debug`);
+  // playwright.config reducedMotion:'reduce' is ignored in the Bazel-sandboxed Chromium;
+  // explicit emulation ensures the instant result path runs so verdict is visible immediately.
+  await page.emulateMedia({ reducedMotion: "reduce" });
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -781,6 +784,7 @@ test("scenario-005 precinct hover shows demographic group breakdown", async ({ p
 
 test("debug force-win button: visible with ?debug param, marks scenario complete", async ({ page }) => {
   await page.goto("/?s=tutorial-002&debug");
+  await page.emulateMedia({ reducedMotion: "reduce" });
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
@@ -1056,6 +1060,8 @@ test.describe("GAME-068: animated reveal path (no reduced-motion)", () => {
 
   test("Skip button finalises all rows instantly in animated reveal", async ({ page }) => {
     await loadScenario(page, "scenario-002");
+    // Override loadScenario's reduce emulation — this test specifically exercises animated path.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
     await page.locator("#btn-submit").click();
     await expect(page.locator("#result-screen")).toBeVisible();
 

--- a/game/web/e2e/sprint3.spec.ts
+++ b/game/web/e2e/sprint3.spec.ts
@@ -35,6 +35,9 @@ import { test, expect } from "@playwright/test";
 /** Navigate, dismiss intro, wait for hex grid. */
 async function loadEditor(page: import("@playwright/test").Page): Promise<void> {
   await page.goto("/?s=tutorial-002");
+  // playwright.config reducedMotion:'reduce' is ignored in the Bazel-sandboxed Chromium;
+  // explicit emulation ensures the instant result path runs so verdict is visible immediately.
+  await page.emulateMedia({ reducedMotion: "reduce" });
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });
   await skip.click();
@@ -353,6 +356,7 @@ test("wip: WIP is cleared from localStorage after scenario completion", async ({
   // Load tutorial-002 fresh (no pre-seeded WIP), skip intro, paint winning move,
   // submit, then verify the WIP key is absent from localStorage.
   await page.goto("/?s=tutorial-002");
+  await page.emulateMedia({ reducedMotion: "reduce" });
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });
   await skip.click();

--- a/game/web/e2e/sprint4.spec.ts
+++ b/game/web/e2e/sprint4.spec.ts
@@ -156,3 +156,54 @@ test("GAME-052: final state has correct criteria count after skip (regression)",
   const badges = page.locator(".result-criterion .rc-badge");
   await expect(badges).toHaveCount(count);
 });
+
+// ─── GAME-073: deferred success banner + star count reveal ───────────────────
+
+// Reduced-motion path: failure banner shows immediately (map unsolved = failing).
+test("GAME-073: failure banner shown immediately in reduced-motion mode", async ({ page }) => {
+  await loadEditor(page);
+  await openResultScreen(page); // already emulates reducedMotion:'reduce'
+  // Unsolved tutorial-002 has required-failing criteria.
+  await expect(page.locator("#result-verdict")).toHaveText("Map Failed");
+  await expect(page.locator("#result-stars")).toBeHidden();
+});
+
+// Reduced-motion path: success banner + stars shown immediately on a force-win.
+test("GAME-073: success banner and stars shown immediately in reduced-motion mode (force-win)", async ({ page }) => {
+  await page.goto("/?s=tutorial-002&debug");
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("#btn-debug-win").click();
+  await expect(page.locator("#result-screen")).toBeVisible({ timeout: 10_000 });
+
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+  await expect(page.locator("#result-stars")).toBeVisible();
+  // tutorial-002: 2 required + 1 optional → max 2 stars; force-win passes all → 2 stars
+  const starCount = await page.locator("#result-stars .result-star").count();
+  expect(starCount).toBe(2);
+});
+
+// Animated path: verdict starts empty, skip button reveals it with stars.
+test("GAME-073: skip reveals verdict and stars (animated mode, force-win)", async ({ page }) => {
+  await page.goto("/?s=tutorial-002&debug");
+  // Do NOT emulate reduced-motion — use animated path.
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("#btn-debug-win").click();
+  await expect(page.locator("#result-screen")).toBeVisible({ timeout: 10_000 });
+
+  // Verdict starts empty before any row resolves.
+  await expect(page.locator("#result-verdict")).toHaveText("");
+
+  // Skip → all rows finalized → success banner appears.
+  await page.locator("#btn-reveal-skip").click();
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+  await expect(page.locator("#result-stars")).toBeVisible();
+});

--- a/game/web/e2e/submit-on-invalid.spec.ts
+++ b/game/web/e2e/submit-on-invalid.spec.ts
@@ -15,6 +15,9 @@ import { test, expect } from "@playwright/test";
 /** Navigate, dismiss intro, wait for hex grid. */
 async function loadEditor(page: import("@playwright/test").Page): Promise<void> {
   await page.goto("/?s=tutorial-002");
+  // playwright.config reducedMotion:'reduce' is ignored in the Bazel-sandboxed Chromium;
+  // explicit emulation ensures the instant result path runs so verdict is visible immediately.
+  await page.emulateMedia({ reducedMotion: "reduce" });
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });
   await skip.click();

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -73,8 +73,9 @@
     <!-- ── Result screen (GAME-017) ─────────────────────────────────────── -->
     <div id="result-screen" class="hidden">
       <div id="result-card">
-        <div id="result-verdict"></div>
+        <div id="result-verdict" aria-live="polite"></div>
         <div id="result-subtitle"></div>
+        <div id="result-stars" class="hidden" aria-label="Star rating"></div>
         <div id="result-criteria-list"></div>
         <div id="result-reveal-controls" style="display:none">
           <button id="btn-reveal-skip">Skip →</button>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -95,6 +95,7 @@ const resultSubtitle = document.getElementById("result-subtitle") as HTMLElement
 const resultCriteriaList = document.getElementById("result-criteria-list") as HTMLElement | null;
 const btnKeepDrawing = document.getElementById("btn-keep-drawing") as HTMLButtonElement | null;
 const btnNextScenario = document.getElementById("btn-next-scenario") as HTMLButtonElement | null;
+const resultStars = document.getElementById("result-stars") as HTMLElement | null;
 const resultRevealControls = document.getElementById("result-reveal-controls") as HTMLElement | null;
 const btnRevealSkip = document.getElementById("btn-reveal-skip") as HTMLButtonElement | null;
 const btnMuteAudio = document.getElementById("btn-mute-audio") as HTMLButtonElement | null;
@@ -752,8 +753,9 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	}
 
 	function computeStarCount(criterionResults: CriterionResult[], mapIsValid: boolean): number {
-		if (!mapIsValid) return 0;
-		return criterionResults.filter(cr => cr.required && cr.passed).length;
+		const allRequiredPass = criterionResults.every(cr => !cr.required || cr.passed);
+		if (!mapIsValid || !allRequiredPass) return 0;
+		return 1 + criterionResults.filter(cr => !cr.required && cr.passed).length;
 	}
 
 	// GAME-069/GAME-062: Sprite sheet layout constants.
@@ -917,15 +919,16 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			overallPass = true;
 		}
 
-		resultVerdict.textContent = overallPass ? "Map Passed!" : "Map Failed";
-		resultVerdict.className = overallPass ? "pass" : "fail";
-		resultSubtitle.textContent = overallPass
-			? "All required criteria met."
-			: mapIsValid
-				? "One or more required criteria were not met."
-				: "The map has structural issues that must be fixed.";
-		// GAME-066: sequential reveal — criteria appear one at a time with CHECKING hold.
-		const stars = computeStarCount(evalResult.criterionResults, mapIsValid);
+		// GAME-073: verdict starts hidden; revealed progressively during criteria reveal.
+		resultVerdict.textContent = "";
+		resultVerdict.className = "";
+		resultVerdict.style.opacity = "0";
+		resultSubtitle.textContent = "";
+		resultSubtitle.style.opacity = "0";
+		if (resultStars) { resultStars.innerHTML = ""; resultStars.classList.add("hidden"); }
+		// maxStars based on scenario structure (not forced-pass); stars computed from actual results.
+		const maxStars = 1 + evalResult.criterionResults.filter(cr => !cr.required).length;
+		const stars = debugForcePass ? maxStars : computeStarCount(evalResult.criterionResults, mapIsValid);
 
 		// Build criterion-type lookup (criterionId → Criterion["type"]) for icon dispatch.
 		const criterionTypeMap = new Map<string, string>();
@@ -973,6 +976,50 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		// All active setTimeout handles — cleared by skip, Keep Drawing, and debug replay.
 		let activeTimeouts: ReturnType<typeof setTimeout>[] = [];
 
+		// GAME-073: deferred verdict — shown only after first required-fail or all rows complete.
+		let verdictShown = false;
+
+		function renderStars(el: HTMLElement, earned: number, max: number): void {
+			el.innerHTML = "";
+			el.setAttribute("aria-label", `${earned} of ${max} star${max !== 1 ? "s" : ""}`);
+			for (let i = 1; i <= max; i++) {
+				const s = document.createElement("span");
+				s.className = `result-star ${i <= earned ? "filled" : "empty"}`;
+				s.setAttribute("aria-hidden", "true");
+				s.textContent = i <= earned ? "★" : "☆";
+				el.appendChild(s);
+			}
+		}
+
+		function revealVerdict(pass: boolean, starCount: number): void {
+			if (verdictShown) return;
+			verdictShown = true;
+			resultVerdict!.textContent = pass ? "Map Passed!" : "Map Failed";
+			resultVerdict!.className = pass ? "pass" : "fail";
+			resultVerdict!.style.opacity = "1";
+			resultSubtitle!.textContent = pass
+				? "All required criteria met."
+				: mapIsValid
+					? "One or more required criteria were not met."
+					: "The map has structural issues that must be fixed.";
+			resultSubtitle!.style.opacity = "1";
+			btnNextScenario!.style.display = pass ? "" : "none";
+			if (pass && resultStars) {
+				renderStars(resultStars, starCount, maxStars);
+				resultStars.classList.remove("hidden");
+			}
+			if (pass) {
+				play("tada");
+			} else {
+				// Delay so the criterion's disapprove audio (playing in finalizeRow) finishes first.
+				setTimeout(() => play("womp-womp"), 400);
+			}
+		}
+
+		function finalizeVerdict(): void {
+			if (!verdictShown) revealVerdict(overallPass, stars);
+		}
+
 		// Snap a row to its final verdict state.
 		function finalizeRow(row: HTMLElement, withAudio = false): void {
 			if (row.dataset["finalized"] === "true") return;
@@ -990,6 +1037,8 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			const neutral = row.querySelector<HTMLElement>(".rc-char-neutral");
 			const verdict = row.querySelector<HTMLElement>(".rc-char-verdict");
 			if (neutral && verdict) transitionCharSlot(neutral, verdict);
+			// GAME-073: reveal failure banner on first required-criterion fail.
+			if (!passed && required) revealVerdict(false, 0);
 			if (withAudio) {
 				const type = row.dataset["charType"] ?? "";
 				const democode = row.dataset["charDemo"] ?? "";
@@ -1013,19 +1062,33 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			}
 		}
 
-		// Recompute the top-level verdict/subtitle/Next Scenario button from current row states.
+		// Recompute the top-level verdict/subtitle/Next Scenario button/stars from current row states.
 		// Called after a debug replay changes a single criterion's result.
 		function syncOverallVerdict(): void {
 			if (!resultVerdict || !resultSubtitle || !resultCriteriaList) return;
 			const rows = Array.from(resultCriteriaList.querySelectorAll<HTMLElement>(".result-criterion"));
 			const anyRequiredFailed = rows.some(r => r.classList.contains("failed-required"));
 			const nowPass = !anyRequiredFailed;
+			verdictShown = true;
 			resultVerdict.textContent = nowPass ? "Map Passed!" : "Map Failed";
 			resultVerdict.className = nowPass ? "pass" : "fail";
+			resultVerdict.style.opacity = "1";
 			resultSubtitle.textContent = nowPass
 				? "All required criteria met."
 				: "One or more required criteria were not met.";
+			resultSubtitle.style.opacity = "1";
 			btnNextScenario!.style.display = nowPass ? "" : "none";
+			if (resultStars) {
+				if (nowPass) {
+					const optionalPassed = rows.filter(r =>
+						r.dataset["required"] === "false" && r.dataset["passed"] === "true"
+					).length;
+					renderStars(resultStars, 1 + optionalPassed, maxStars);
+					resultStars.classList.remove("hidden");
+				} else {
+					resultStars.classList.add("hidden");
+				}
+			}
 		}
 
 		// Debug: reset a single row to pending and re-run its reveal with a forced result.
@@ -1165,11 +1228,19 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			return row;
 		}
 
+		// GAME-059: "Fix It" label for invalid maps, "Keep Drawing" otherwise.
+		// "Next Scenario" visibility is deferred to revealVerdict (GAME-073).
+		btnKeepDrawing!.textContent = mapIsValid ? "← Keep Drawing" : "← Fix It";
+		btnKeepDrawing!.style.display = "";
+		btnNextScenario!.style.display = "none";
+
 		if (reducedMotion) {
 			// Instant path: all rows in final state with verdict character poses immediately.
 			for (const cr of allRows) {
 				resultCriteriaList.appendChild(buildRowElement(cr, /*final=*/ true));
 			}
+			// GAME-073: reveal verdict immediately in reduced-motion mode.
+			revealVerdict(overallPass, stars);
 		} else {
 			// Animated path: sequential reveal — each row fades in CHECKING, then flips to verdict.
 			// GAME-068: each row fully resolves before the next starts (no simultaneous CHECKING).
@@ -1214,6 +1285,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 						if (i === rowElements.length - 1) {
 							const tDone = setTimeout(() => {
 								btnRevealSkip?.removeEventListener("click", skipHandler);
+								finalizeVerdict(); // GAME-073: reveal success banner after all rows done
 								if (resultRevealControls) resultRevealControls.style.display = "none";
 								skipClickHandler = null;
 							}, 800);
@@ -1233,18 +1305,13 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 				for (const t of activeTimeouts) clearTimeout(t);
 				activeTimeouts = [];
 				for (const row of rowElements) finalizeRow(row);
+				finalizeVerdict(); // GAME-073: reveal banner after skip
 				if (resultRevealControls) resultRevealControls.style.display = "none";
 				skipClickHandler = null;
 			};
 			skipClickHandler = skipHandler;
 			btnRevealSkip?.addEventListener("click", skipHandler, { once: true });
 		}
-
-		// GAME-059: "Fix It" label for invalid maps, "Keep Drawing" otherwise.
-		// "Next Scenario" only shown on a full pass.
-		btnKeepDrawing!.textContent = mapIsValid ? "← Keep Drawing" : "← Fix It";
-		btnKeepDrawing!.style.display = "";
-		btnNextScenario!.style.display = overallPass ? "" : "none";
 
 		// ── GAME-018: persist completion on pass ──────────────────────────────────
 		if (overallPass) {

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -561,6 +561,7 @@ body {
   font-weight: 700;
   text-align: center;
   padding: 10px 0 6px;
+  transition: opacity 0.3s ease;
 }
 
 #result-verdict.pass { color: #4caf80; }
@@ -571,6 +572,34 @@ body {
   font-size: 0.84rem;
   color: #808098;
   margin-top: -10px;
+  transition: opacity 0.3s ease;
+}
+
+#result-stars {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  margin-top: -4px;
+}
+
+#result-stars.hidden { display: none; }
+
+.result-star {
+  font-size: 1.6rem;
+  animation: starReveal 0.3s ease forwards;
+}
+
+.result-star.filled { color: #f4c430; }
+.result-star.empty  { color: #404060; }
+
+@keyframes starReveal {
+  from { opacity: 0; transform: scale(0.5); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .result-star { animation: none; }
+  #result-verdict, #result-subtitle { transition: none; }
 }
 
 #result-criteria-list {


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #235

## Summary
- On result screen open, verdict and subtitle start hidden (opacity 0); the banner is revealed progressively — failure banner appears on the first failing required criterion, success banner + star count appear after all rows resolve (or on skip/reduced-motion)
- `computeStarCount` fixed to follow DESIGN-001: returns 0 if any required criterion fails; otherwise 1 (base star) + count of optional criteria passed
- Stars rendered as filled/empty ★/☆ spans with a scale-in animation (disabled in `prefers-reduced-motion`) inside new `#result-stars` element
- `play("tada"/"womp-womp")` wired for completion audio — clips not yet generated (POST-MERGE)
- `syncOverallVerdict` (debug replay) extended to also refresh star display
- e2e: three new GAME-073 tests; existing tests updated with explicit `page.emulateMedia({ reducedMotion:"reduce" })` calls in helpers (required because `playwright.config reducedMotion:'reduce'` is ignored in Bazel-sandboxed Chromium)

## Validation performed
- [x] N/A — kubectl dry-run (not infra)
- [x] N/A — sops decrypt (not infra)
- TypeScript typecheck passes
- Full e2e test suite passes locally (135 tests)

## Affected machines / services
- Web game only (result screen UX)

## Deployment steps (POST-MERGE)
- Deploy to dev/staging as part of normal release cycle
- OPTIONAL POST-MERGE: generate tada/womp-womp audio clips (~1–2s each, −16 LUFS) per GAME-073 AC; add to INVENTORY.md; preload with scenario

## Tickets addressed
- see #236 (GAME-073)

## Rollback
- Revert this commit; self-contained to `showResultScreen`, `computeStarCount`, `syncOverallVerdict`, styles, and index.html
