### PR TITLE
fix(result-screen): preserve verdict/stars area height before reveal

### DIFF
--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -572,6 +572,7 @@ body {
   font-size: 0.84rem;
   color: #808098;
   margin-top: -10px;
+  min-height: 1.2rem; /* reserve space while hidden — prevents layout shift */
   transition: opacity 0.3s ease;
 }
 
@@ -580,9 +581,10 @@ body {
   justify-content: center;
   gap: 6px;
   margin-top: -4px;
+  min-height: 2rem; /* reserve space even when empty/hidden — prevents layout shift on reveal */
 }
 
-#result-stars.hidden { display: none; }
+#result-stars.hidden { visibility: hidden; }
 
 .result-star {
   font-size: 1.6rem;


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #236

## Summary
- `#result-stars.hidden` switched from `display:none` to `visibility:hidden` — element stays in flow so the criteria list below doesn't jump when stars appear
- `min-height:2rem` added to `#result-stars` so the empty container contributes its full row height even before any star spans are rendered
- `min-height:1.2rem` added to `#result-subtitle` so the subtitle row is reserved while `textContent` is empty and opacity is 0

## Validation performed
- [x] N/A — kubectl dry-run (not infra)
- [x] N/A — sops decrypt (not infra)
- Full e2e test suite passes locally (135 tests)

## Affected machines / services
- Web game only (result screen layout)

## Deployment steps (POST-MERGE)
- Deploy to dev/staging as part of normal release cycle

## Tickets addressed
- N/A (layout follow-up to #236 / GAME-073)

## Rollback
- Revert this commit; self-contained to two CSS rules in styles.css
