### PR TITLE
chore(planning): S13 sprint plan, 11 new tickets, VRA research

### DIFF
--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md
@@ -1,6 +1,6 @@
 <!--COMPRESSED v1; source:2026-04-25-sprint-roadmap.md-->
 §META
-date:2026-04-25 last_updated:2026-05-04 status:active type:sprint-roadmap
+date:2026-04-25 last_updated:2026-05-18 status:active type:sprint-roadmap
 LIVING DOC — update at sprint start (fill tickets) + after demo (outcomes, re-evaluate next)
 
 §ABBREV
@@ -31,8 +31,9 @@ see game-vision.compressed.md for full scope
 | S9 | first release | deploy pastthepost.org; legal review; basic a11y | complete — 2026-04-29 |
 | S10 | code quality + tidy | test coverage gaps; dedup; extract modules; refactor for polish readiness | complete — 2026-04-29 |
 | S11 | main menu, campaigns + polish | title screen→campaign select→scenario flow; Tier2: design research, a11y | complete — 2026-05-02 |
-| S12 | character reactions + submit-on-invalid | result screen characters animate+react; audio; allow invalid map submission | planned |
-| S13 | code quality | split loader; break up main.ts; unify type systems | sketched |
+| S12 | character reactions + submit-on-invalid | result screen characters animate+react; audio; allow invalid map submission; deferred verdict+stars | complete — 2026-05-18 |
+| S13 | gameplay polish + scenario depth | tutorial walkthroughs; VRA scenarios; terrain features; scenario-002 tuning | planned |
+| S14 | code quality | split loader; break up main.ts; unify type systems | sketched |
 
 §SPRINT1 [COMPLETE 2026-04-25]
 goal: app renders tutorial-001.json; player paints+undoes; no sim/game-loop yet
@@ -116,23 +117,37 @@ outcome: all tier1+tier2 tickets closed
   deferred: GAME-053 electoral outcome diff → discuss S12 planning; DESIGN-009 open questions resolved in ticket
   new tickets filed for S12: DESIGN-009 GAME-059 GAME-060 GAME-061 GAME-062 GAME-063 GAME-064
 
-§SPRINT12 (in progress)
+§SPRINT12 [COMPLETE 2026-05-18]
 goal: character reactions + submit-on-invalid
-demo target: player submits map → result screen shows animated character + audio; invalid map shows Fix-It path
-art model (updated 2026-05-13): PNG sprite sheets (neutral|approve|disapprove horizontal strip, 200px row)
-  governor done+live; 4 remaining types: commissioner party judge legislator (DESIGN-011)
-  eval states: approve/neutral/disapprove (not 1:1 star-count); broker variants (sprite-spec.json) = stretch
-resolved: DESIGN-009 DESIGN-011 GAME-059 GAME-060 GAME-061 GAME-063 GAME-064 GAME-066 GAME-068 GAME-069
-tier2 (remaining):
-  GAME-062 [open] (wire commissioner/judge/legislator/party sprites + audio; governor done; SVG placeholders standing in)
-  GAME-065 [open] (art refinement; trails GAME-060; not blocker for GAME-062)
-  GAME-071 [open] (audio fine-tuning; stub resolution; per-scenario character/audio inventory)
-stretch: broker PNG variants × 3 states for scenario-006 (spec in sprite-spec.json)
-deferred to S13+: DESIGN-005/006/007 demographic overlays; DESIGN-008 geographic features; GAME-053
+outcome: all core tickets resolved; GAME-062 all 4 types wired(#227); GAME-073 deferred verdict+stars+tada/womp-womp(#236 #237); GAME-065+GAME-071 moved to S13 stretch
+resolved: DESIGN-009 DESIGN-011 GAME-059 GAME-060 GAME-061 GAME-062 GAME-063 GAME-064 GAME-066 GAME-067 GAME-068 GAME-069 GAME-073
+PRs: #192 #194 #196 #212 #213 #214 #215 #225 #226 #227 #228 #236 #237
 
-§SPRINT13 (sketched)
+§SPRINT13 (planned)
+goal: gameplay polish + scenario depth
+demo target: district demographic rollup live; 5-district layout no scroll; tutorial-001 guided; terrain features available
+priority note: VRA scenarios motivate sprint but can slip to S15/Backlog (S14=code-quality only); UI improvements are primary deliverable; Valle Verde tests GAME-080
+tier1-UI:
+  DESIGN-014 (non-partisan framing guidelines + about-page/Valle-Verde audit; prereq for scenario narrative authoring)
+  GAME-080 (district demographic rollup: live % derived from criteria; compact stat under district button)
+  DESIGN-015 (information density redesign: 5-district overflow; layout options; GAME-080 stat placement; DESIGN-004 fate)
+  GAME-081 (implement information density; trails DESIGN-015)
+tier1-content:
+  DESIGN-008 (expanded: terrain model — tiles+edge rivers+precinct annotations+rendering+validity rules)
+  GAME-075 (terrain implementation: schema+generator+renderer+contiguity; ≥1 terrain scenario)
+  DESIGN-012 (tutorial overlay UX design)
+  GAME-076 (tutorial-001 guided walkthrough: overlay engine + 9-step script)
+  GAME-077 (tutorial-002 guided mode; trails GAME-076)
+tier2 (can slip to S15/Backlog — S14 is code-quality only):
+  DESIGN-013 (VRA scenario design; trails DESIGN-014)
+  GAME-078 (VRA scenarios; trails DESIGN-013+GAME-075)
+  GAME-079 (scenario-002 playability tuning)
+stretch: GAME-065(art refinement) GAME-071(audio fine-tuning)
+research: thoughts/shared/research/2026-05-18-vra-legal-political-landscape.md
+
+§SPRINT14 (sketched)
 goal: code quality — split modules, unify type systems
-tickets: GAME-041 split loader; GAME-042 break up main.ts; GAME-043 unify type systems
+tickets: GAME-041 split loader; GAME-042 break up main.ts; GAME-043 unify type systems; GAME-046 panels unit tests
 rationale: isolated sprint; no feature work mixed in; large refactors need focused review
 
 §BACKLOG (not sprint-assigned)
@@ -146,10 +161,10 @@ DESIGN-005 population dot-density overlay  S14+
 DESIGN-006 zoom-adaptive dot density       S14+
 DESIGN-007 dimensional dot map overlay     S14+
 DESIGN-008 geographic features             S14+
-GAME-041  split loader.ts                  S13
-GAME-042  break up main.ts                 S13
-GAME-043  unify type systems               S13
-GAME-046  panels unit tests                S13
+GAME-041  split loader.ts                  S14
+GAME-042  break up main.ts                 S14
+GAME-043  unify type systems               S14
+GAME-046  panels unit tests                S14
 GAME-053  electoral outcome visual diff    S13+
 GAME-056  playtest feedback                any
 GAME-057  scenario randomization           any

--- a/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
+++ b/thoughts/shared/plans/2026-04-25-sprint-roadmap.md
@@ -45,7 +45,10 @@ See `thoughts/shared/vision/game-vision.compressed.md` for full scope.
 | 8 | Hardening | CSP, extract CSS, loader error handling, scenario compression | complete — 2026-04-28 |
 | 9 | First release | Deploy to pastthepost.org; legal review; basic accessibility | complete — 2026-04-29 |
 | 10 | Code quality + tidy | Test coverage gaps, deduplication, module extraction, pre-polish housekeeping | complete — 2026-04-29 |
-| 11 | Main menu, campaigns + polish | Title screen → campaign select → scenario flow; optional: design research, accessibility | backlog |
+| 11 | Main menu, campaigns + polish | Title screen → campaign select → scenario flow; optional: design research, accessibility | complete — 2026-05-02 |
+| 12 | Character reactions + submit-on-invalid | Result screen animated character + audio; invalid map Fix-It path; deferred verdict + stars | complete — 2026-05-18 |
+| 13 | Gameplay polish + scenario depth | Tutorial walkthroughs; VRA scenarios; terrain features; scenario-002 tuning | planned |
+| 14 | Code quality | Split loader; break up main.ts; unify type systems | sketched |
 
 ---
 
@@ -235,7 +238,7 @@ extract modules. Makes Sprint 11 design work safer and faster to implement.
 
 ---
 
-## Sprint 11 — Main Menu, Campaigns + Polish [BACKLOG]
+## Sprint 11 — Main Menu, Campaigns + Polish [COMPLETE 2026-05-02]
 
 **Goal**: First-impression polish sprint — proper main menu, campaign navigation
 model, and the most impactful UX improvements. Players should experience the
@@ -244,30 +247,21 @@ game as a real game, not a scenario picker.
 **Demo target**: A player lands on a title screen, picks a campaign, plays a
 scenario, and returns to the menu — end-to-end navigation working.
 
-**Tier 1 (core delivery):**
-- GAME-047: Campaign data model + authored campaign definitions
-- GAME-048: Campaign-driven scenario select (routing + data wiring)
-- GAME-049: Campaign select screen
-- GAME-050: Main menu / title screen
-- GAME-051: In-game navigation cleanup
+**Outcome**: All Tier 1 and Tier 2 tickets closed. Tier 1: GAME-047 campaign
+data model + registry (#159); GAME-048 campaign-driven scenario select (#162);
+GAME-049 campaign select screen (#169); GAME-050 main menu / title screen (#165);
+GAME-051 in-game navigation cleanup (#175). Tier 2: DESIGN-001 star system
+research; GAME-008 full a11y pass (CVD-safe palette, keyboard nav, ARIA); GAME-031
+gameplay critique followup; GAME-052 animated criteria reveal (#189). GAME-053
+deferred.
 
-**Tier 2 (if Tier 1 done early):**
-- DESIGN-001: Achievement/star UX research (blocks animated criteria eval)
-- GAME-008: Full accessibility pass (remainder after S9 basics)
-- GAME-031: Gameplay critique followup
-- GAME-052: Animated criteria evaluation (blocked on DESIGN-001)
-- GAME-053: Electoral outcome visual diff (placeholder)
-
-**Deferred to S12:** DESIGN-005/006/007 (demographic overlays), DESIGN-008
-(geographic features) — these require dedicated research + implementation time
-that would crowd out the navigation work.
-
-**Known tickets (Tier 1)**: GAME-047, GAME-048, GAME-049, GAME-050, GAME-051.
-**Known tickets (Tier 2)**: DESIGN-001, GAME-008, GAME-031, GAME-052, GAME-053.
+**Tickets (Tier 1)**: GAME-047, GAME-048, GAME-049, GAME-050, GAME-051
+**Tickets (Tier 2)**: DESIGN-001, GAME-008, GAME-031, GAME-052
+PRs: #159 #162 #165 #169 #175 #177 #180 #189
 
 ---
 
-## Sprint 12 — Character Reactions + Submit-on-Invalid [IN PROGRESS]
+## Sprint 12 — Character Reactions + Submit-on-Invalid [COMPLETE 2026-05-18]
 
 **Goal**: Result screen shows animated character sprites with audio; invalid maps
 can be submitted and trigger a Fix-It path.
@@ -276,57 +270,79 @@ can be submitted and trigger a Fix-It path.
 animated character + audio reaction; invalid map shows Fix-It path; valid
 pass/fail shows correct character animation.
 
-**Art model (updated 2026-05-13)**: PNG sprite sheets (horizontal strip:
-neutral | approve | disapprove), 200 px row height. Governor sheet is complete
-and live. Remaining types: commissioner, party, judge, legislator (DESIGN-011).
-Evaluation states are **approve / neutral / disapprove**, not 1:1 star-count poses.
-Bipartisan-broker variants (3 demographic pairs × 3 states, for scenario-006
-instigator) are defined in `tools/sprite-spec.json` and are separate from the
-per-criterion roster.
+**Outcome**: All core tickets resolved. DESIGN-009 (character visual style);
+DESIGN-011 (per-criterion character roster); GAME-059 (submit-on-invalid; PR #196);
+GAME-060 (PNG sprite sheets); GAME-061 (12 audio clips at −16 LUFS; PR #225);
+GAME-062 (all 4 character types wired; PR #227); GAME-063 (asset pipeline; PR #192);
+GAME-064 (audio infrastructure; PR #194); GAME-066 (dramatic reveal; PR #213);
+GAME-067 (asset versioning; PR #212); GAME-068 (reveal pacing; PR #214); GAME-069
+(per-criterion character slots; PR #215); GAME-073 (deferred verdict + stars +
+tada/womp-womp audio; PRs #236 #237). GAME-065 and GAME-071 moved to S13 as stretch.
 
-**Dependency chain**:
-- DESIGN-009 [resolved] — character reaction visual style; 3 evaluation states
-  (approve/neutral/disapprove)
-- DESIGN-011 [resolved] — per-criterion character roster; all 4 types done
-- GAME-059 [resolved] — submit-on-invalid
-- GAME-060 [resolved] — commissioner/party/judge/legislator PNG sheets produced
-- GAME-061 [resolved] — 12 real audio clips active; stubs + tuning deferred to GAME-071
-- GAME-063 [resolved] — asset pipeline
-- GAME-064 [resolved] — audio playback infrastructure
-- GAME-066 [resolved] — result screen dramatic reveal (sequential criteria reveal)
-- GAME-068 [resolved] — result reveal pacing
-- GAME-069 [resolved] — per-criterion `.rc-char` slots + governor PNG wired
-- GAME-062 — wire remaining character types + audio to result screen (SVG placeholders standing in)
-- GAME-065 — art quality iteration (trails GAME-060; not a blocker for GAME-062)
-- GAME-071 — audio fine-tuning; stub resolution; per-scenario character/audio inventory
+**Resolved**: DESIGN-009, DESIGN-011, GAME-059, GAME-060, GAME-061, GAME-062,
+GAME-063, GAME-064, GAME-066, GAME-067, GAME-068, GAME-069, GAME-073
 
-**Tier 1 (core — all resolved)**: DESIGN-009, GAME-059, GAME-063, GAME-064,
-GAME-066, GAME-068, GAME-069
+**Moved to S13 stretch**: GAME-065 (art refinement), GAME-071 (audio fine-tuning)
 
-**Tier 2 (remaining)**:
-- GAME-062: wire remaining types + audio (governor already wired; 4 types pending)
-- GAME-065: art refinement (polish pass after GAME-060; not a blocker)
-- GAME-071: audio fine-tuning; stub resolution; per-scenario character/audio inventory
-
-**Stretch / S12+ if time allows**:
-- Bipartisan-broker PNG variants for scenario-006 (spec in sprite-spec.json; 9 images)
-
-**Deferred to S13+**: DESIGN-005/006/007 demographic overlays; DESIGN-008
-geographic features; GAME-053 electoral outcome diff.
+PRs: #192 #194 #196 #212 #213 #214 #215 #225 #226 #227 #228 #236 #237
 
 ---
 
-## Sprint 12+ (later)
+## Sprint 13 — Gameplay Polish + Scenario Depth [PLANNED]
 
-| Ticket | Area | Notes |
-|---|---|---|
-| DESIGN-005 | Population dot-density overlay | Deferred from S11 |
-| DESIGN-006 | Zoom-adaptive dot density | Deferred from S11; refinement on DESIGN-005 |
-| DESIGN-007 | Dimensional dot map demographic overlay | Deferred from S11 |
-| DESIGN-008 | Geographic features (lakes, mountains) | Decorative tiles; blocks contiguity |
-| GAME-041 | Split loader.ts | Structural; own sprint alongside GAME-042/043 |
-| GAME-042 | Break up main.ts | Structural; own sprint |
-| GAME-043 | Unify type systems | Largest refactor; own sprint; do last |
+**Goal**: Tutorial walkthroughs, new VRA scenarios with terrain features, population
+realism, scenario-002 difficulty tuning.
+
+**Demo target**: Tutorial-001 has full step-by-step guided walkthrough; at least
+one new VRA-era scenario is playable; maps feel geographically plausible with
+terrain features.
+
+**Priority note**: The VRA scenarios are the motivation for this sprint, but the UI
+improvements they surface are more urgent than the scenarios themselves. VRA scenarios
+can slip to S14 if needed; Valle Verde already exercises majority_minority for testing
+GAME-080. The sprint succeeds if the UI improvements land — the scenarios are a bonus.
+
+**Tier 1 (UI improvements — primary drivers):**
+- DESIGN-014: non-partisan content framing guidelines + about-page/Valle-Verde audit;
+  prerequisite for all new scenario narrative authoring
+- GAME-080: district demographic rollup — live per-district demographic stat derived
+  from criteria; compact line under district button; updates on paint
+- DESIGN-015: information density redesign — 5-district overflow; evaluate layout options;
+  specify where GAME-080 stat lives; DESIGN-004 fate
+- GAME-081: implement information density improvements (trails DESIGN-015)
+
+**Tier 1 (content infrastructure):**
+- DESIGN-008 (expanded): full terrain model spec — tiles, edge rivers, precinct annotations,
+  symbolic rendering, map validity rules
+- GAME-075: terrain implementation — schema, generator, renderer, contiguity, ≥1 terrain scenario
+- DESIGN-012: tutorial overlay UX design (step model, highlight, input pause, skip/persist)
+- GAME-076: tutorial-001 guided walkthrough — overlay engine + 9-step script
+- GAME-077: tutorial-002 guided mode — advanced feature walkthrough (trails GAME-076)
+
+**Tier 2 (can slip to S15/Backlog — S14 is code-quality only, no feature work):**
+- DESIGN-013: VRA scenario design (trails DESIGN-014 for framing guidelines)
+- GAME-078: VRA scenario implementation (trails DESIGN-013 + GAME-075)
+- GAME-079: scenario-002 playability tuning
+
+**Stretch:**
+- GAME-065: art refinement (judge eye, party mouth, legislator thumb; broker PNGs)
+- GAME-071: audio fine-tuning; stub resolution; per-scenario character/audio inventory
+
+**Research available:**
+- `thoughts/shared/research/2026-05-18-vra-legal-political-landscape.md` — legal/political
+  background for DESIGN-013/DESIGN-014 scenario authoring
+
+---
+
+## Sprint 14 — Code Quality [SKETCHED]
+
+**Goal**: Split modules, unify type systems. No feature work mixed in.
+
+**Rationale**: Large structural refactors need focused review; mixing with feature
+work creates compounding rebase conflicts and harder-to-review PRs.
+
+**Tickets**: GAME-041 (split loader.ts), GAME-042 (break up main.ts),
+GAME-043 (unify type systems), GAME-046 (panels unit tests)
 
 ---
 
@@ -340,10 +356,10 @@ geographic features; GAME-053 electoral outcome diff.
 | CI-001 | GitHub Action ticket-close sync | Any (low priority) |
 | AGENT-003 | Infra PR review bot comment handling | Any |
 | DESIGN-004 | Legend layout (horizontal strip above map) | Any |
-| GAME-041 | Split loader.ts into focused modules | S12 |
-| GAME-042 | Break up main.ts god module | S12 |
-| GAME-043 | Unify spike + scenario type systems | S12 |
-| GAME-046 | Unit tests for render/panels.ts | S12 |
+| GAME-041 | Split loader.ts into focused modules | S14 |
+| GAME-042 | Break up main.ts god module | S14 |
+| GAME-043 | Unify spike + scenario type systems | S14 |
+| GAME-046 | Unit tests for render/panels.ts | S14 |
 
 ---
 

--- a/thoughts/shared/research/2026-05-18-vra-legal-political-landscape.compressed.md
+++ b/thoughts/shared/research/2026-05-18-vra-legal-political-landscape.compressed.md
@@ -1,0 +1,73 @@
+<!--COMPRESSED v1; source:2026-05-18-vra-legal-political-landscape.md-->
+§META
+date:2026-05-18 researcher:claude(web-search-researcher) branch:main repo:cgruber/redistricting-sim
+topic:vra-legal-political-landscape
+tags:VRA,voting-rights-act,racial-gerrymander,Bethune-Hill,Callais,Section2,Section5,Virginia,Louisiana,proxy-race,BISG
+status:complete last_updated:2026-05-18
+
+§ABBREV
+S2=Section2 S5=Section5 BVAP=Black-Voting-Age-Population MMD=majority-minority-district
+BH=Bethune-Hill Cal=Callais(Louisiana-v-Callais-2026) Mil=Allen-v-Milligan-2023
+Shelby=Shelby-County-v-Holder-2013 Gingles=Thornburg-v-Gingles-1986
+Shaw=Shaw-v-Reno-1993 Miller=Miller-v-Johnson-1995 Rucho=Rucho-v-Common-Cause-2019
+RPV=racially-polarized-voting BISG=Bayesian-Improved-Surname-Geocoding
+
+§SUMMARY
+1965-2026 arc: Equal Protection Clause(prohibit racial classification) vs VRA(remedy racial discrimination in voting)
+$Cal tips balance toward colorblind principle: reimports intent requirement into $S2
+Combined with $Rucho(2019, partisan non-justiciable): both racial+partisan challenges now largely foreclosed
+Virginia/$BH saga = clearest dual-failure zone for game scenarios
+
+§SECTION5
+$S5=preclearance: covered jurisdictions(mostly South+VA) must get federal pre-approval before any voting law change; burden on jurisdiction
+$Shelby(2013,5-4,Roberts): S4(b) coverage formula unconstitutional(based on 1964-72 data, not current); $S5 not struck but inoperative; Congress hasn't passed new formula
+Effect: TX,VA,others immediately free to change electoral laws without DOJ preapproval
+
+§SECTION2
+Nationwide+permanent; prohibits voting procedure that "results in" race-based denial/abridgement(1982: results not intent)
+$Gingles framework: 3 preconditions→ (1)minority group sufficiently large+compact; (2)politically cohesive; (3)majority votes as bloc; then totality of circumstances
+
+§CALLAIS_2026 [CRITICAL]
+Background: LA 2022 map had 1 majority-Black district/6(Black=~⅓ population); courts found likely $S2 violation; LA drew 2nd majority-Black district 2024(Cleo Fields,D-6); separate plaintiffs challenged as racial gerrymander
+Ruling(Apr 29 2026, 6-3, Alito): struck down LA's 2nd majority-Black district
+3 key changes:
+1. Illustrative maps tightened: challengers must show map fully achieves ALL state goals; sophisticated software raises plaintiff burden
+2. Partisan explanation for bloc voting: Gingles prong 3 NOT satisfied if bloc voting "explained by partisan affiliation"; race+party collinearity in South makes this nearly unprovable
+3. Intent required: $S2 violated "only when evidence supports strong inference that State intentionally drew districts to afford minority voters less opportunity because of their race"; re-imports intent standard 1982 amendments explicitly rejected
+Aftermath: LA Republicans advanced map eliminating 2nd majority-Black district; AL pushed to lift $Mil order; Brennan Center: 15+ Black-held House seats at risk
+$Rucho+$Cal = colorblind trap: racial gerrymandering labeled as partisan → no federal challenge possible from either direction
+
+§ALLEN_MILLIGAN_2023
+AL 2021 map: 1 majority-Black district/7(Black=~27%); SC 5-4(Roberts+Kavanaugh+3 liberals) reaffirmed $Gingles
+AL's defiant 2023 revised map rejected; special master Remedial Plan 3: D7=51.9% BVAP, D2=48.7% BVAP
+2024: 2 AL Democratic wins first time since 2008; brief reprieve before $Cal
+
+§BETHUNE_HILL_VIRGINIA [KEY FOR GAME]
+2011 VA maps: R-legislature drew 12 majority-Black districts with explicit 55% BVAP floor; cited S5 compliance; DOJ granted preclearance 2011
+Theory: lower BVAP wouldn't produce majority-minority actual votes(turnout gap), so safety cushion needed
+Litigation filed Dec 2014: 55% floor = race as predominant factor overriding compactness+county integrity
+BH Round 1(Mar 1 2017, SC 6-2, Kennedy): district court used wrong standard; racial predominance claim doesn't require bizarre shapes first
+On remand(Jun 2018, 2-1): 11 of 12 districts unconstitutional; mechanical 55% floor = dispositive evidence of racial predominance; VRA compliance defense failed(no strong basis in evidence floor was required; DOJ had precleared lower BVAP before)
+Remedial maps: special master Grofman drew new 100-district maps; 2019 elections → Democrats won VA House majority first time since 1995
+BH Standing case(Jun 17 2019, 5-4): VA House lacked standing; attorney general(D) is sole state representative in federal court; appeal dismissed; remedial maps locked in
+TWO-FAILURE ZONE: BVAP too low→VRA violation | BVAP mechanically floored too high→racial gerrymander; narrow legally defensible middle path
+
+§VIRGINIA_REDISTRICTING
+2021: Independent Redistricting Commission created by 2020 constitutional amendment; deadlocked 8-8; VA Supreme Court appointed Trende(R)+Grofman(D) as special masters; maps adopted Dec 2021; Princeton "A" grade
+2026: VA Dems passed constitutional amendment for congressional redistricting; VA Supreme Court struck down May 8 2026(procedural: required 2 successive General Assemblies, passed only 1); SC dismissed emergency appeal May 15 2026; 2022/2024 maps remain
+
+§PROXY_RACE
+Why: Shaw/$Miller says can't use race as predominant factor; $S2 requires measuring racial effects; many states don't collect race in voter registration
+$BISG: Bayes rule combining surname frequency tables + block-level census demographics → probability distribution over race per voter; BIFSG adds first name; validated in redistricting; dominant RPV analysis method
+Ecological inference methods: homogeneous precinct analysis | ecological regression(ER,can produce out-of-bounds) | ecological inference(EI,Gary King,constrained estimation,now standard in VRA litigation)
+Geographic proxies: poverty rate, median income, language minority %, residential patterns, party registration/history; legal status murky; post-$Cal if state claims partisan motivation → racial effects much harder to challenge
+
+§EDUCATIONAL_CONTRASTS
+A. Two-edged VRA sword($BH): R legislature cited S5→DOJ preclearance→same maps struck as racial gerrymander; fail in two directions
+B. Packing vs cracking($Mil): 1 Black-majority→remedy→1 strong+1 49% opportunity district; 49% rejected as insufficient; functional opportunity required not just formal majority
+C. $Cal trap(LA 2024-26): what S2 required in 2024 = what 14A prohibits in 2026; same map remedied VRA violation→now unconstitutional
+D. Colorblind trap($Rucho+$Cal): South: Black=Democratic; cracking D-vote=cracking Black precincts=racial labeled as partisan; neither racial nor partisan challenge survives
+E. Commission failure(VA 2021): independent bipartisan commission deadlocked; academics drew maps; structure rules shape outcomes as much as member composition
+
+§KEY_CASES
+Gingles 1986 | Shaw 1993 | Miller 1995 | Shelby 2013 | Rucho 2019 | Milligan 2023 | Callais 2026 | BH 2017/2018 | BH-Standing 2019

--- a/thoughts/shared/research/2026-05-18-vra-legal-political-landscape.md
+++ b/thoughts/shared/research/2026-05-18-vra-legal-political-landscape.md
@@ -1,0 +1,240 @@
+---
+date: 2026-05-18
+researcher: claude (web-search-researcher)
+branch: main
+repository: cgruber/redistricting-sim
+topic: vra-legal-political-landscape
+tags: VRA, voting-rights-act, racial-gerrymander, Bethune-Hill, Callais, Section2, Section5, redistricting, Virginia, Louisiana, proxy-race, BISG
+status: complete
+last_updated: 2026-05-18
+last_updated_by: claude
+---
+
+## Summary
+
+The arc from 1965 to 2026 is a story of two competing constitutional principles — the Equal
+Protection Clause's prohibition on racial classification vs. the VRA's mandate to remedy racial
+discrimination in voting. For sixty years, courts tried to hold both simultaneously. Louisiana v.
+Callais (April 29, 2026) tips the balance sharply toward the colorblind principle by reinstating
+an intentional-discrimination requirement for Section 2 claims. Combined with Rucho v. Common Cause
+(2019, partisan gerrymandering non-justiciable), both racial AND partisan gerrymander challenges
+are now largely foreclosed. Virginia's Bethune-Hill saga remains the clearest single illustration
+of the dual-failure zone players can be taught to navigate.
+
+---
+
+## 1. VRA Section 2 and Section 5
+
+### Section 5 — Preclearance (1965–2013)
+
+Required covered jurisdictions (mostly Southern states, including Virginia) to obtain federal
+pre-approval before implementing any voting law change. Burden of proof on the jurisdiction.
+Enormously powerful for redistricting: any new map in a covered state had to be precleared.
+
+**Shelby County v. Holder (June 25, 2013)**: 5–4, Roberts majority. Section 4(b)'s coverage
+formula (based on 1964–1972 data) held unconstitutional as no longer responsive to current
+conditions. Section 5 itself was not struck down but was rendered inoperative — no covered
+jurisdictions remain unless Congress enacts a new formula. Congress has not done so.
+Immediate effect: Texas, Virginia, and other formerly covered states gained freedom to change
+electoral laws without DOJ preapproval.
+
+### Section 2 — Nationwide Permanent Prohibition
+
+Applies everywhere, permanently. Prohibits any voting standard or procedure that "results in"
+the denial or abridgement of the right to vote on account of race (1982 amendment: results
+standard, not intent). The operative redistricting framework comes from Thornburg v. Gingles
+(1986): three preconditions (sufficiently large/compact minority group; group is politically
+cohesive; majority votes as bloc) plus totality of circumstances.
+
+---
+
+## 2. Recent VRA Developments (2020–2026)
+
+### Allen v. Milligan (June 8, 2023)
+
+Alabama's 2021 congressional map had one majority-Black district out of seven (Black voters
+~27% of state population). Supreme Court ruled 5–4 (Roberts + Kavanaugh + 3 liberals),
+reaffirming Gingles. Alabama's defiant July 2023 revised map rejected by district court;
+special master drew Remedial Plan 3 (District 7 at 51.9% BVAP, District 2 at 48.7% BVAP).
+2024 elections produced two Democratic wins in Alabama for first time since 2008.
+
+Allen v. Milligan turned out to be a brief reprieve before Callais.
+
+### Louisiana v. Callais (April 29, 2026) — The Critical Case
+
+**Background**: Louisiana's 2022 map had one majority-Black district out of six (Black residents
+~one-third of population). After courts found a likely Section 2 violation, Louisiana drew a
+second majority-Black district in 2024 (District 6, represented by Cleo Fields). A separate
+group then challenged that second district as an unconstitutional racial gerrymander.
+
+**Ruling**: 6–3, Alito majority. Struck down Louisiana's second majority-Black district.
+Three key changes to the Gingles framework:
+
+1. **Illustrative maps standard tightened**: challengers must show their illustrative map fully
+   achieves all legitimate state redistricting goals. Modern software is held against plaintiffs.
+
+2. **Partisan explanation for bloc voting**: the third Gingles precondition (majority bloc voting)
+   cannot be satisfied if that bloc voting is "explained by partisan affiliation." In highly
+   polarized electorates where race and party correlate strongly, this is often impossible to disentangle.
+
+3. **Intentional discrimination required**: Section 2 is violated "only when the evidence supports
+   a strong inference that the State intentionally drew its districts to afford minority voters less
+   opportunity because of their race." This re-imports a discriminatory-intent standard that the
+   1982 VRA amendments explicitly rejected.
+
+**Immediate aftermath**: Louisiana Republicans advanced a new map eliminating one majority-Black
+district. Alabama pushed to lift the Milligan-mandated order. Virginia Republicans moved to
+preserve their existing maps. Brennan Center: at least 15 current House seats held by Black
+members could be redrawn under Callais.
+
+**Combined with Rucho (2019)**: Partisan gerrymandering is non-justiciable in federal court.
+After Rucho + Callais, states can label racial cracking-and-packing as partisan and face no
+legal challenge from either direction — the "colorblind trap."
+
+---
+
+## 3. Virginia Redistricting — The Bethune-Hill Saga
+
+The cleanest two-way-failure story in American redistricting.
+
+### 2011 Maps and the 55% BVAP Floor
+
+Post-2010 census, Republican-controlled Virginia legislature drew 12 majority-Black districts
+with an explicit 55% Black Voting-Age Population floor, citing VRA Section 5 compliance.
+DOJ granted preclearance in June 2011. The floor theory: lower BVAP minority-majority districts
+might not produce actual majority-minority turnout, so a safety cushion was needed.
+
+### Bethune-Hill Litigation
+
+**December 2014**: voters sued, alleging 12 districts were unconstitutional racial gerrymanders
+under Shaw v. Reno (1993) and Miller v. Johnson (1995). Core argument: the 55% floor made race
+the "predominant factor" overriding compactness, county integrity, and other traditional criteria.
+
+**Bethune-Hill v. Virginia State Board of Elections — Round 1 (March 1, 2017)**: Supreme Court
+6–2 (Kennedy majority) reversed the district court. Wrong standard applied: there is no
+precondition requiring "bizarre" shapes before a racial predominance claim can proceed.
+
+**On Remand — June 2018**: District court 2–1: 11 of 12 challenged districts were
+unconstitutional. Mechanical 55% BVAP floor was dispositive evidence of racial predominance.
+The state's VRA compliance defense failed: no "strong basis in evidence" that 55% was
+required — especially since DOJ had precleared lower-BVAP configurations in prior cycles.
+
+**Remedial maps**: special master Bernard Grofman drew new maps covering all 100 districts
+(necessary due to cascading adjustments). **2019 elections under court-drawn maps**: Democrats
+won a majority in the Virginia House of Delegates for the first time since 1995.
+
+**Virginia House of Delegates v. Bethune-Hill (June 17, 2019)**: Supreme Court 5–4: Virginia
+House of Delegates lacked standing to defend the state's redistricting plan (only the attorney
+general, a Democrat, can represent the state in federal court). Appeal dismissed; remedial maps
+locked in without merits review of the 2018 ruling.
+
+### Virginia's 2021 Redistricting
+
+New constitutional Independent Redistricting Commission deadlocked completely (8–8 on every
+proposed map). Virginia Supreme Court appointed two special masters (Trende for Republicans,
+Grofman for Democrats). Final maps adopted December 2021, rated "A" by Princeton Gerrymandering
+Project — no significant partisan advantage, unusual outcome for a post-census cycle.
+
+### Virginia 2026
+
+Democrats passed a constitutional amendment to allow congressional redistricting. Virginia
+Supreme Court struck it down May 8, 2026 (procedural flaw: requires two successive General
+Assemblies; this passed only one). U.S. Supreme Court dismissed emergency appeal May 15, 2026.
+Virginia must use 2022/2024 maps for the upcoming election cycle.
+
+---
+
+## 4. Inferring Race Without Race Data
+
+### Why the Problem Arises
+
+Two competing legal pressures: Shaw/Miller says you can't use race as the *predominant factor*
+in drawing lines. But Section 2 (pre-Callais) could still require remedying racial vote dilution,
+which requires measuring racial effects. Many states don't collect race in voter registration.
+
+### Bayesian Improved Surname Geocoding (BISG)
+
+Primary academic and legal method for inferring voter race. Combines:
+- Census surname frequency tables (racial distribution by last name)
+- Census block-level demographics (racial composition of residence block)
+Output: probability distribution over race/ethnicity for each individual. BIFSG adds first
+name for better accuracy. Validated against self-reported race data; dominant method for
+racially polarized voting analysis in VRA litigation.
+
+### Ecological Inference for Racially Polarized Voting
+
+Three methods used to prove Gingles third precondition from aggregate data:
+1. **Homogeneous precinct analysis**: look at overwhelmingly single-race precincts; subject to
+   ecological fallacy
+2. **Ecological Regression (ER)**: regress vote share against racial composition; can produce
+   out-of-bounds estimates
+3. **Ecological Inference (EI)** (Gary King): constrained estimation; now the standard in VRA
+   litigation
+
+### Geographic Proxies in Line-Drawing
+
+When mapmakers can't use race directly: poverty rate, median income, language minority data,
+residential patterns, party registration / voting history. Legal status is murky — no clear
+constitutional prohibition on using income or neighborhood data. But courts assess totality:
+a district that perfectly tracks racial demographics while claiming neutral criteria can still
+evidence racial predominance (Miller). Post-Callais, if the state labels it partisan, that
+explanation is much harder to rebut under the new intent requirement.
+
+---
+
+## 5. Educational Angles for Game Scenarios
+
+### Contrast A — The Two-Edged VRA Sword (Bethune-Hill)
+Republican legislature → cited VRA Section 5 → got DOJ preclearance → same maps later struck
+down as unconstitutional racial gerrymanders. Perfect "fail in two directions" tension:
+- BVAP too low → VRA violation
+- BVAP mechanically floored too high → racial sorting, 14th Amendment violation
+The legally defensible path is narrow and requires craft, not a threshold.
+
+### Contrast B — Packing vs. Cracking (Alabama pre/post-Milligan)
+Six white-majority + one Black-majority → remedy → one strong majority-Black + one 49% BVAP
+"opportunity district." Is 49% sufficient? Alabama Republicans said yes; courts said no.
+Illustrates that the law requires functional minority opportunity, not just a formal majority.
+
+### Contrast C — The Callais Trap (Louisiana 2024–2026)
+What Section 2 required in 2024 is now what the 14th Amendment prohibits in 2026.
+Almost too clean: the same map that remedied a VRA violation is now evidence of a
+constitutional violation.
+
+### Contrast D — The Colorblind Trap (Rucho + Callais)
+South: Black voters overwhelmingly vote Democratic. Cracking the Democratic vote = cracking
+Black precincts = functionally racial, labeled as partisan. After Rucho (partisan non-justiciable)
+and Callais (VRA requires intent, not effects), neither challenge can succeed. Map can look like
+racial gerrymandering and neither racial nor partisan law can touch it.
+
+### Contrast E — Commission Failure (Virginia 2021)
+Independent commission → deadlocked → court-appointed academics drew maps. Bipartisan
+composition does not guarantee agreement when stakes are existential. Commission structure
+rules (tiebreaking, defaults) shape outcomes as much as member composition.
+
+---
+
+## Gaps and Limitations
+
+- Full text of Callais majority opinion would benefit from direct reading for precise quotes;
+  this summary is from secondary sources (Constitution Center, Brennan Center, NPR, Brookings)
+  published within days of the April 29, 2026 ruling.
+- Virginia 2026 redistricting litigation may still be unfolding at state level.
+- No controlling case law specifically addresses when BISG-derived race estimates in
+  redistricting constitute "using race" for constitutional purposes.
+
+---
+
+## Key Cases
+
+| Case | Year | Holding |
+|------|------|---------|
+| Thornburg v. Gingles | 1986 | Three-prong test for Section 2 vote dilution |
+| Shaw v. Reno | 1993 | Race-predominant districts subject to strict scrutiny |
+| Miller v. Johnson | 1995 | Race as predominant factor, not just visible shape |
+| Shelby County v. Holder | 2013 | Section 4(b) coverage formula unconstitutional; Section 5 inoperative |
+| Rucho v. Common Cause | 2019 | Partisan gerrymandering non-justiciable in federal court |
+| Allen v. Milligan | 2023 | Reaffirmed Gingles; Alabama must draw second Black-opportunity district |
+| Louisiana v. Callais | 2026 | Gutted Section 2: requires intentional discrimination; partisan explanation defeats Gingles prong 3 |
+| Bethune-Hill v. Virginia SBE | 2017/2018 | 11 Virginia House districts unconstitutional racial gerrymanders; 55% BVAP floor was racial predominance |
+| Virginia House of Delegates v. Bethune-Hill | 2019 | House lacked standing; remedial maps locked in |

--- a/thoughts/shared/tickets/DESIGN-008-geographic-features.md
+++ b/thoughts/shared/tickets/DESIGN-008-geographic-features.md
@@ -1,73 +1,217 @@
 ---
 id: DESIGN-008
-title: Geographic features — lakes, mountains as decorative non-precinct tiles
+title: Geographic features — terrain tiles, edge rivers, precinct annotations, symbolic rendering
 area: design, rendering
 status: open
 created: 2026-04-27
+last_updated: 2026-05-18
 ---
 
 ## Summary
 
-Add flavor/orientation geographic features (lakes, rivers, hills) to scenario maps as
-decorative non-precinct hex tiles. Features are purely cosmetic — they don't participate
-in population, simulation, or contiguity — but they:
-1. Make maps feel like real places (Civ/SimCity aesthetic)
-2. Break up the uniform hex field for player orientation
-3. Provide natural "holes" in hex-of-hexes regions (a lake in the center, etc.)
+Full terrain model for scenario maps: non-precinct terrain tiles (sea, lake, mountain),
+precinct terrain annotations (coast, lakeside, riverside, foothill), and edge-based rivers.
+Together these make maps feel geographically plausible — urban clusters near coasts,
+population thinning toward highlands, natural district boundaries along rivers — without
+requiring painterly rendering. Style is symbolic (Civ/SimCity: solid fills + simple glyphs),
+consistent with the game's dark strategy-game aesthetic.
 
-## Design decisions (from 2026-04-27 session)
+This ticket covers the design spec. Implementation is GAME-075.
 
-- Feature tiles colored in grey (mountains/hills) or aqua/teal (lakes/water)
-- Animated texture: wave pattern for water, hatching/bump for terrain
-- Colors must not overlap with the district color palette (currently 5-8 colors for parties)
-- Features block adjacency for contiguity: a precinct separated from its district only
-  by a feature tile is NOT contiguous with it (feature = physical barrier)
-- Features are static per scenario (not editable by player)
+---
 
-## Scenario format change
+## Terrain model
 
-Add optional `features` array to scenario JSON:
+### Non-precinct tiles (zero pop, non-assignable, block contiguity)
+
+| Type | Description | Constraints |
+|------|-------------|-------------|
+| `sea` | Open ocean, map perimeter | Never adjacent to `lake` tile |
+| `lake` | Inland water body | Surrounded only by `lakeside` precincts or other `lake` tiles; lake tiles and sea tiles must have at least one precinct between them; if map also has `sea`, at least one river must connect them |
+| `mountain` | Highland ridge | Never fully encloses a precinct; use elongated ridge shapes, not circular blobs |
+
+### Precinct annotations (assignable, reduced population, visual treatment)
+
+| Annotation | Derivation | Notes |
+|------------|------------|-------|
+| `coast` | Derived: adjacent to `sea` tile(s) | Shoreline treatment on sea-facing edges |
+| `lakeside` | Derived: adjacent to `lake` tile(s), OR explicitly authored | Explicit flag for small internal lakes (no separate tile needed) |
+| `riverside` | Derived: adjacent to `river` edge(s) | |
+| `foothill` | Derived: adjacent to `mountain` tile(s) | Never fully enclosed by mountain tiles |
+
+Population for annotated precincts is authored lower in scenario JSON — the engine does not
+enforce a specific reduction, just applies the visual treatment. Realistic gradients are an
+authoring concern, not an engine rule.
+
+### Edge features
+
+**River**: flows along hex edges (Civ-style), not tiles. Valid endpoints: lake tile edge,
+sea tile edge, mountain tile edge, map boundary. If both `lake` and `sea` exist on a map,
+at least one river must connect them. Rivers cannot cross mountain tiles.
+
+Rivers can source at mountains and drain to lakes; a second river can connect lake to sea.
+River-through-lake-to-sea chains are valid (mountain → lake → river → sea).
+
+Scenario JSON: `"river_edges": [["p001","p002"],["p002","p003"]]` — each pair is two
+adjacent precinct IDs with a river flowing along their shared edge.
+
+Per-scenario control: `"river_blocks_contiguity": true` removes river-edge pairs from the
+contiguity BFS, making the river a hard district boundary. Default: `false` (bridgeable).
+
+---
+
+## Map validity rules
+
+1. No `lake` tile adjacent to a `sea` tile (minimum one precinct buffer between them)
+2. Lake + sea both present on map → at least one river must connect them
+3. No precinct fully enclosed by mountain tiles — BFS from map boundary through non-mountain
+   tiles must reach every precinct
+4. River endpoints must be a lake tile edge, sea tile edge, mountain tile edge, or map boundary
+5. No `lake` tile adjacent to a plain land precinct (must be surrounded by `lakeside` precincts
+   or other `lake` tiles only)
+
+---
+
+## Symbolic rendering spec
+
+### Terrain tiles
+
+| Type | Fill | Glyph | Notes |
+|------|------|-------|-------|
+| `sea` | `#3a7fc1` (ocean blue) | Optional `∿` wave centered | Dark; readable against district fills |
+| `lake` | `#4dd0e1` (aqua) | Optional small wave or none | Lighter than sea; clearly distinguishable |
+| `mountain` | `#6b7280` (slate grey) | 2–3 `△` glyphs centered | No animation; static glyphs sufficient |
+
+All terrain tiles rendered on a dedicated SVG layer **below** the precinct hex layer. Terrain
+tile positions carry no `path.hex` element and are not interactive.
+
+### Precinct annotations (additional rendering on normal precincts)
+
+- **Coast**: distinct stroke color or thicker stroke on sea-facing edges (shoreline indicator)
+- **Lakeside**: same treatment on lake-facing edges; if `has_internal_lake: true`, render a
+  small aqua ellipse (~40% of hex area) centered within the hex fill
+- **Riverside**: blue river stroke along river edge(s) — handled by the river layer (see below)
+- **Foothill**: subtle grey tint or light hatch on mountain-facing edges (nice-to-have; may defer
+  to post-S13 if implementation time is tight)
+
+### Rivers
+
+Blue stroke along the computed hex edge: `#38bdf8`, ~2–3px, 70% opacity. Drawn on a layer
+**above** precinct hex fills but **below** district outlines. `hexCorners()` in
+`hex-geometry.ts` gives exact pixel coordinates for each corner pair; the shared edge between
+two hexes is the line segment between the two corners they share.
+
+### Internal lakes (small lake within a single precinct)
+
+When `has_internal_lake: true` on a `lakeside` precinct, render a simple aqua ellipse
+(~40% hex area) centered within the hex. Two adjacent `has_internal_lake` precincts render a
+shared elongated ellipse bridging both hexes. Three–four adjacent ones form an obloid shape
+spanning the cluster.
+
+---
+
+## Scenario format changes
+
+### Top-level additions
+
 ```json
-"features": [
-  { "position": { "q": 0, "r": 0 }, "type": "lake" },
-  { "position": { "q": 1, "r": -1 }, "type": "lake" },
-  { "position": { "q": 0, "r": 2 }, "type": "mountain" }
-]
+{
+  "terrain_tiles": [
+    { "position": { "q": 0, "r": 0 }, "type": "sea" },
+    { "position": { "q": 2, "r": -1 }, "type": "mountain" },
+    { "position": { "q": 4, "r":  1 }, "type": "lake" }
+  ],
+  "river_edges": [
+    ["p012", "p013"],
+    ["p013", "p019"]
+  ],
+  "river_blocks_contiguity": false
+}
 ```
 
-Feature types (v1): `lake`, `mountain`. Renderer maps type → color + texture.
+### Precinct-level additions
 
-## Renderer changes
+```json
+{
+  "id": "p011",
+  "terrain": "lakeside",
+  "has_internal_lake": false,
+  "population": 340
+}
+```
 
-- Feature tiles rendered as filled hexes with type-specific color + animated texture
-  - `lake`: aqua/teal (`#4fa3bf` or similar), animated wave SVG pattern
-  - `mountain`: grey (`#8a9bb0` or similar), static hatching
-- Feature tiles are NOT `path.hex` elements — use a separate SVG layer below hex layer
-- Feature tile positions excluded from neighbor calculation in contiguity BFS
+`terrain` on a precinct is optional. Derived annotations (coast, lakeside, riverside,
+foothill) can be computed from adjacency at load time. The loader should accept explicit
+values as overrides and prefer them over derivation.
 
-## Loader changes
+---
 
-- Parse optional `features` array; validate positions don't overlap with precinct positions
-- Feature positions included in neighbor graph as "blocking" nodes (not passable)
+## Population gradient approach
+
+Population realism is achieved through scenario authoring, not engine rules. For new scenarios:
+
+- Designate one or more urban center hexes in the generator
+- Assign population by distance decay: precincts near urban centers get higher population;
+  precincts near terrain tiles (mountain, sea, lake edges) get lower population
+- Coastal, lakeside, riverside, and foothill precincts are authored with reduced population
+  reflecting partial land area or topographic constraints
+
+Existing scenarios are **not** retroactively normalized. New terrain-based scenarios get
+realistic gradients from authoring.
+
+---
+
+## Authoring guidelines
+
+- **Mountain shapes**: use elongated ridge forms (length >> width). Circular mountain clusters
+  read as volcanoes and disorienting. The enclosed-precinct BFS rule catches the degenerate case.
+- **Lake placement**: lake tiles must be surrounded by lakeside precincts; a lake tile that
+  would touch open land or sea directly is invalid and the loader should reject it.
+- **River paths**: each pair in `river_edges` must be genuinely adjacent in the hex grid.
+  Rivers should follow geographic logic (flow downhill from mountains to sea/lake).
+
+---
+
+## Future: Map Editor Behavior (not S13 scope)
+
+When a map editor is built, lakeside placement should follow these auto-conversion rules:
+
+- Single isolated `lakeside` precinct → renders internal lake within hex (`has_internal_lake: true`)
+- Two adjacent `lakeside` precincts → shared internal lake stretching between them
+- Three–four adjacent `lakeside` precincts → obloid lake spanning the cluster
+- `lakeside` precinct with all 6 neighbors being `lakeside` or `lake` tiles → auto-converts
+  to a `lake` tile (non-precinct, zero pop)
+
+River placement: plopping a river segment on a hex edge sets `river_edges` for that pair.
+Dragging a path auto-chains segments.
+
+---
 
 ## Goals / Acceptance Criteria
 
-- [ ] Scenario format: optional `features` array with position + type
-- [ ] Loader: parses features; validates no overlap with precincts
-- [ ] Renderer: feature layer below hex layer; lake = aqua + wave; mountain = grey + hatch
-- [ ] Contiguity: feature positions block adjacency (BFS treats them as walls)
-- [ ] At least one scenario (new or retrofitted) includes a lake feature
-- [ ] e2e: feature tiles visible in map; correct color; don't affect precinct painting
+- [ ] Terrain model spec finalized (this document) — reviewed before GAME-075 starts
+- [ ] JSON schema additions documented: `terrain_tiles`, `river_edges`, `river_blocks_contiguity`,
+      precinct `terrain` and `has_internal_lake` fields
+- [ ] Rendering spec finalized: colors, glyphs, river stroke, internal lake ellipse
+- [ ] Map validity rules documented and ready for implementation
+- [ ] At least one new scenario designed using terrain features (for GAME-075 implementation test)
 
-## Out of scope (v1)
+## Out of scope (this ticket)
 
-- Rivers (linear features spanning edges rather than cells)
+- Implementation (GAME-075)
+- Editor auto-conversion behaviors (documented above for future reference only)
+- Animated water textures (static symbolic rendering sufficient for v1)
+- Elevation affecting gameplay criteria (population gradient is authoring only)
+- Foothill visual rendering is nice-to-have; implement in GAME-075 if time allows
 - Named features with labels
-- Player-visible feature interaction
-- Elevation/terrain affecting population density
+- Estuaries (lake + sea adjacency forbidden; model as sea tiles extending inland or use river)
+
+---
 
 ## References
 
-- GAME-027 — hex-of-hexes shape (implement first; features go inside hex region)
-- GAME-028 — backport (coordinate features with backport if adding to old scenarios)
-- Visual aesthetic: `thoughts/shared/research/` — Civ/SimCity dark HUD, map-first
+- GAME-075 — terrain implementation (trails this)
+- DESIGN-013 / GAME-078 — VRA scenarios that use terrain features
+- `game/web/src/model/hex-geometry.ts` — `hexCorners()` for edge coordinate computation
+- Visual aesthetic: `thoughts/shared/vision/game-vision.compressed.md`
+- 2026-05-18 design session — full terrain model discussion

--- a/thoughts/shared/tickets/DESIGN-012-tutorial-overlay-ux.md
+++ b/thoughts/shared/tickets/DESIGN-012-tutorial-overlay-ux.md
@@ -1,0 +1,117 @@
+---
+id: DESIGN-012
+title: Tutorial overlay UX — step-by-step guided walkthrough design
+area: design, UX, tutorial
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Design the step-by-step tutorial overlay system that guides new players through the game UI
+during tutorial-001 and tutorial-002. The overlay displays contextual instructions in the
+upper-right of the map (over the map layer, not in the sidebar), highlights relevant UI
+elements, optionally pauses input, and advances through a scripted sequence. This design doc
+must answer: sequencing model, highlight mechanics, input-pause semantics, skip/dismiss rules,
+skip-tutorial persistence, and the content format for tutorial steps — before GAME-076
+implementation begins.
+
+## Design questions to resolve
+
+1. Advance triggers: click-target only, or also any-click / auto-advance-after-N-seconds?
+2. Highlight mechanism: CSS ring/glow on target + dim surroundings, or pointer arrow, or both?
+3. Can a highlight target be a hex region (the map itself) or only named elements?
+4. Panel repositioning: does the panel move if it would obscure the highlighted element?
+5. Input pause granularity: block all input, or only non-target input?
+
+## Positioning and layout spec
+
+- Overlay panel: upper-right corner of the map SVG, over the map layer
+- Semi-transparent dark background (`rgba(0,0,0,0.75)` or similar)
+- Panel width ~220–260px; readable without obscuring map center
+- If highlighted element is in upper-right, panel may shift left or downward (anti-obstruction)
+
+## Step data model
+
+Each tutorial step is an object:
+
+```typescript
+interface TutorialStep {
+  text: string;                    // instruction text shown in panel
+  highlight?: string;              // CSS selector for element to highlight
+  pauseInput: boolean;             // block all non-target interactions
+  advanceTrigger:
+    | { type: "click-target" }     // advance when highlighted element is clicked
+    | { type: "any-map-click" }    // advance on any precinct click
+    | { type: "auto"; delayMs: number }  // advance after N ms
+    | { type: "condition"; event: string }  // advance on named game event
+  ;
+}
+```
+
+Tutorial is a named array of steps keyed by scenario ID or campaign type.
+
+## Highlight mechanics
+
+- Target element receives a CSS class (e.g. `tutorial-highlight`) that adds a glowing ring
+- All other interactive elements receive a `tutorial-dimmed` class (reduced opacity, pointer-events: none)
+- Highlight must work for: buttons, sidebar panels, the map hex area
+- Highlighting a specific precinct: use precinct ID to locate the SVG path and apply ring
+- Highlight is non-destructive: CSS overlay only, does not affect element functionality
+
+## Input pause semantics
+
+- When `pauseInput: true`: all map painting and button interactions blocked except the
+  designated advance target
+- Escape key and "Skip tutorial" button remain active during any pause
+- Visual affordance: blocked elements show `not-allowed` cursor
+- Blocked click attempts are silently ignored (no error, no visual feedback)
+
+## Skip / disable
+
+- "Skip tutorial" button always visible in tutorial overlay panel
+- Skipping marks tutorial as completed in localStorage key `tutorial-<scenarioId>-complete`
+- Tutorial not re-shown after completion on replay (courtesy skip)
+- Tutorial campaign remains accessible; skip does not remove it
+- Reset: `?resetTutorial=1` URL param clears localStorage flag (for testing / fresh replays)
+- Full settings-panel reset hookup deferred to GAME-070 / settings sprint
+
+## Tutorial-001 step script (proposed — finalize during GAME-076 implementation)
+
+| Step | Text | Highlight | Pause | Advance |
+|------|------|-----------|-------|---------|
+| 1 | "Welcome! Click **District 2** to start painting." | `#btn-district-2` | yes | click-target |
+| 2 | "Now click precincts on the map to paint them as District 2." | map hex area | yes | condition: 5-precincts-painted |
+| 3 | "Made a mistake? Click **Undo** to go back." | `#btn-undo` | yes | click-target |
+| 4 | "**Redo** restores changes you undid." | `#btn-redo` | yes | click-target |
+| 5 | "This panel shows map validity — all districts must be contiguous and balanced." | validity panel | no | auto 4000ms |
+| 6 | "Hover any precinct to see its population and lean data." | sidebar precinct panel | no | auto 4000ms |
+| 7 | "Toggle between **District view** and **Lean view** here." | `#btn-view-toggle` | yes | click-target |
+| 8 | "**County borders** shows county boundaries as an overlay." | `#btn-county-borders` | no | auto 3000ms |
+| 9 | "When you're happy with your map, click **Submit**." | `#btn-submit` | no | auto 2000ms (tutorial ends) |
+
+## Tutorial-002 step script (sketched — finalize in GAME-077)
+
+Tutorial-002 is a 196-precinct map with 4 districts. Proposed themes:
+- Criteria panel: what each criterion means, how to read pass/fail
+- Demographic overlay: switching between party lean and demographic views
+- Goal orientation: the scenario has an explicit majority_minority criterion; walk the player
+  toward understanding what "the minority community needs an effective district" means in
+  map terms
+
+## Goals / Acceptance Criteria
+
+- [ ] Step data model finalized and documented
+- [ ] Highlight mechanics spec finalized (CSS approach; targets; dimming)
+- [ ] Input pause semantics fully specified
+- [ ] Skip / disable behavior specified (localStorage key, reset mechanism)
+- [ ] Tutorial-001 step script reviewed and signed off (9 steps above, or revised)
+- [ ] Tutorial-002 themes outlined (details finalized in GAME-077)
+- [ ] Panel positioning and anti-obstruction rule specified
+
+## References
+
+- GAME-076 — tutorial-001 implementation (trails this)
+- GAME-077 — tutorial-002 (trails GAME-076)
+- `game/web/index.html` — element IDs for highlight selectors
+- `game/web/styles.css` — overlay/panel styling conventions

--- a/thoughts/shared/tickets/DESIGN-013-vra-scenario-design.md
+++ b/thoughts/shared/tickets/DESIGN-013-vra-scenario-design.md
@@ -1,0 +1,161 @@
+---
+id: DESIGN-013
+title: VRA scenario design — "The 55% Problem" and "The Proxy Problem"
+area: design, content
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Design two new educational scenarios exploring the Voting Rights Act and race-conscious
+redistricting, placed in the Educational campaign after Valle Verde (scenario-006). The
+scenarios use the Virginia Bethune-Hill saga and Louisiana v. Callais (April 2026) as
+narrative anchors. Together they form a two-part contrast: (A) the dual-failure zone of
+majority-minority districting under the VRA, and (B) the current "colorblind trap" where
+both VRA and partisan-gerrymander challenges are now largely foreclosed.
+
+See research: `thoughts/shared/research/2026-05-18-vra-legal-political-landscape.md`
+
+Prior research on the game's Gingles / majority_minority model:
+`thoughts/shared/research/2026-04-24-vra-and-bloc-voting-model.md`
+
+---
+
+## Scenario A — "The 55% Problem"
+
+### Educational goal
+
+A district drawn *more* majority-minority than necessary can be struck down as an
+unconstitutional racial gerrymander. The player must achieve minority representation without
+mechanically targeting a racial percentage — navigating between two failure modes.
+
+### Narrative framing (fictional names, real legal pattern)
+
+Opening slides: "The legislature drew District 4 with a mechanical 55% minority-voter floor —
+citing federal preclearance as justification. Courts have since ruled this unconstitutional:
+race was the *predominant factor*, overriding compactness and county integrity. You must redraw
+to give the minority community real representation — without using race as your primary compass."
+
+### Two failure modes
+
+- **Fail A (VRA violation)**: the minority-opportunity district BVAP drops below the functional
+  threshold where minority voters can reliably elect their preferred candidate. `majority_minority`
+  criterion fails.
+- **Fail B (racial gerrymander)**: the map achieves BVAP concentration only by fragmenting
+  naturally compact geographic areas. `compactness` criterion fails. (The game cannot formally
+  adjudicate intent, but the compactness failure stands in for the legal judgment.)
+- **Pass**: functional minority-opportunity district that also satisfies compactness and
+  minimizes county splits.
+
+### Criteria
+
+| Criterion | Required | Notes |
+|-----------|----------|-------|
+| `majority_minority` | yes | Functional threshold (minority voters can elect preferred candidate) |
+| `compactness` | yes | Tightened threshold — forces geographic integrity |
+| `county_splits` | optional (bonus) | Minimizing splits earns extra star |
+
+### Starting map
+
+The initial assignment has the "illegal" 55%-floor configuration: a highly elongated,
+fragmented district that achieves BVAP but fails compactness badly. Player cannot win by
+submitting unchanged.
+
+### Map design notes
+
+- Use terrain features (DESIGN-008 / GAME-075): coastal or riverine geography creates natural
+  compactness anchors that the player can use to draw a coherent district
+- Use `group_schema` + `ethnicity` dimension (same pattern as Valle Verde / GAME-026)
+- Realistic population gradient: minority community concentrated in an urban coastal/riverside
+  cluster; rural areas more mixed
+- Scenario file: coordinate ID with GAME-078 implementation
+
+---
+
+## Scenario B — "The Proxy Problem"
+
+### Educational goal
+
+Post-Callais (2026), what Section 2 required in 2024 is now what the 14th Amendment prohibits.
+States can label racial cracking-and-packing as partisan and face no legal challenge from either
+direction (Rucho foreclosed partisan claims in 2019; Callais now requires intent for VRA claims).
+The player experiences trying to achieve minority representation using only proxy data — no
+explicit race column.
+
+### Narrative framing
+
+Opening slides: "The Supreme Court just struck down the majority-minority district that courts
+ordered drawn two years ago. Race-conscious redistricting is now constitutionally suspect.
+You're the new chair. The community still needs fair representation — but you can't look at
+racial data. Use what you can see: income, language, voting history. Draw a fair map."
+
+### Mechanic: hidden race data
+
+- Scenario has `"hide_race_demographics": true` flag
+- Demographic panel shows **proxy fields only**: median income, language-minority %, party lean,
+  voting history lean — but NOT the race/ethnicity column
+- `majority_minority` criterion is still present and evaluated against the underlying (hidden)
+  racial data
+- Player must reason from proxies to find the minority community's geographic footprint
+- Result screen reveal: after evaluation, the race data is shown — "here's where the minority
+  community actually lived" — so the player can see how well their proxy reasoning worked
+
+### Criteria
+
+| Criterion | Required | Notes |
+|-----------|----------|-------|
+| `majority_minority` | yes | Evaluated against hidden race data |
+| `population_balance` | yes | Standard |
+| `compactness` | optional (bonus) | |
+| `efficiency_gap` | optional (bonus) | Bonus for drawing fair partisan outcomes too |
+
+### New scenario format fields required
+
+- `hide_race_demographics: boolean` — flag in scenario JSON; demographic panel respects it
+- Precinct data: add `income_median`, `language_minority_pct` fields alongside existing
+  `group_percentages` (which are hidden but still used for criterion evaluation)
+
+### Map design notes
+
+- Same region as Scenario A (or adjacent), showing the "before" and "after" of the legal shift
+- Terrain features: a river that roughly follows the minority community boundary, making the
+  geographic inference task tractable
+- Enough proxy signal correlation (income + language + lean) that a careful player can find
+  the right district shape
+
+---
+
+## Campaign placement
+
+Both scenarios placed in the Educational campaign after Valle Verde (scenario-006):
+- Scenario A: position 7 in Educational campaign (currently scenarios 002–009 fill 1–8)
+- Scenario B: position 8 (pushing existing scenarios 007–009 to positions 9–11)
+
+Exact scenario file IDs and manifest order determined during GAME-078 implementation.
+
+---
+
+## Goals / Acceptance Criteria
+
+- [ ] Scenario A narrative, criteria, starting map layout, and two fail modes designed
+- [ ] Scenario B narrative, criteria, proxy-data mechanic, and result-screen reveal designed
+- [ ] `hide_race_demographics` flag and proxy precinct fields specified for loader/schema
+- [ ] Terrain feature requirements communicated to GAME-075 (both scenarios need terrain)
+- [ ] Both scenarios reviewed for educational accuracy and political balance
+- [ ] Campaign placement determined; manifest order specified for GAME-078
+
+## Out of scope (this ticket)
+
+- Implementation (GAME-078)
+- Actual scenario JSON authoring (GAME-078)
+- Map generator updates (GAME-075)
+
+## References
+
+- Research: `thoughts/shared/research/2026-05-18-vra-legal-political-landscape.md`
+- Prior VRA/Gingles research: `thoughts/shared/research/2026-04-24-vra-and-bloc-voting-model.md`
+- GAME-078 — implementation (trails this)
+- GAME-075 / DESIGN-008 — terrain features (both scenarios need terrain; coordinate map design)
+- GAME-026 — Valle Verde (majority_minority criterion, group_schema, ethnicity dimension)
+- Key cases: Bethune-Hill v. Virginia; Louisiana v. Callais (2026); Thornburg v. Gingles

--- a/thoughts/shared/tickets/DESIGN-014-nonpartisan-content-framing.md
+++ b/thoughts/shared/tickets/DESIGN-014-nonpartisan-content-framing.md
@@ -1,0 +1,94 @@
+---
+id: DESIGN-014
+title: Non-partisan content framing — guidelines and content audit
+area: design, content, legal
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+This game's core value proposition is educational — teaching how redistricting works, not
+advocating for a political outcome. That value is undermined if the scenario narratives,
+resources list, or framing appear to take sides on contested legal and political questions.
+This ticket defines content guidelines for presenting contested redistricting topics (VRA,
+majority-minority districts, partisan gerrymandering) in a genuinely non-partisan way, and
+applies them to existing content and all new scenarios in DESIGN-013.
+
+Non-partisan framing is not the same as "both sides" framing. It means: present what courts
+held, what the legal standards are, and what the genuine constitutional tensions are — without
+editorializing about whether those outcomes were correct.
+
+## Core principles
+
+**Source standards:**
+- Cite primary sources (court opinions, DOJ documents, Census Bureau data) wherever possible
+- Academic and methodological sources are acceptable (Princeton Gerrymandering Project,
+  MIT Election Lab, Gary King's ecological inference work, Redistricting Data Hub)
+- Advocacy organization sources (Brennan Center, NAACP LDF, Heritage Foundation, etc.) should
+  be removed from the about page / resources list or balanced with opposing-perspective sources
+  — they are credible legally but signal partisanship to players
+
+**Scenario narrative language:**
+- "The Supreme Court held X" not "The Supreme Court wrongly held X" or "correctly held X"
+- "Some argue X; others argue Y" for contested policy conclusions
+- "The law currently requires X" rather than implying the law should require something different
+- Describe effects factually ("this district has 48% Black voters") not normatively
+  ("this district fails Black voters")
+- Avoid loaded political vocabulary: "voter suppression," "rigging," "fair maps" — use the
+  legal/technical terms instead
+
+**Scenario naming:**
+- Avoid names that embed a political judgment — "The Colorblind Trap" implies the colorblind
+  principle is a trap, which is a contested political conclusion
+- Better: descriptive names that frame the mechanic, not the outcome
+  - "The 55% Problem" → acceptable (describes a legal threshold issue)
+  - "The Colorblind Trap" → rename to "Drawing Without Data" or "The Proxy Problem"
+  - DESIGN-013 names to be finalized per these guidelines
+
+**The genuine tension — acknowledge it:**
+The Equal Protection Clause's prohibition on racial classification and the VRA's mandate to
+remedy racial discrimination in voting are both real constitutional principles with serious
+jurisprudential histories. The game should surface this tension — it IS the educational
+lesson — without resolving which principle is correct. A good frame: "The law has changed how
+it balances these two principles over time. Here's what each approach produces in practice."
+
+## About page / resources audit
+
+Current about page resources list should be reviewed:
+- Remove or balance any sources that are primarily advocacy organizations
+- Add: primary source links (key court opinions on Oyez or Justia)
+- Add: academic sources (Princeton Gerrymandering Project, Redistricting Data Hub)
+- Keep or remove NAACP LDF / Brennan Center depending on whether opposing-perspective
+  sources can be added alongside them; if not, replace with primary sources
+- The game's own framing statement on the about page should be audited for political valence
+
+## Scope of audit
+
+**Existing scenarios to review:**
+- Valle Verde (scenario-006): majority_minority narrative — check for loaded framing
+- Harden the Map: incumbency protection framing
+- Reform Map: "neutral rules" framing — "neutral" is itself a contested term in redistricting
+- Any scenario where the winning condition implies a political judgment
+
+**New content covered by this ticket:**
+- DESIGN-013 scenario narratives (Scenario A and B) must comply with these guidelines
+  before GAME-078 implementation begins
+- Tutorial-001 / tutorial-002 overlay text (DESIGN-012) should be reviewed
+
+## Goals / Acceptance Criteria
+
+- [ ] Content principles documented (this ticket) — reviewed and approved before use
+- [ ] About page resources list audited; advocacy-only sources removed or balanced
+- [ ] About page framing statement reviewed for political valence
+- [ ] Valle Verde scenario narrative reviewed; edits made if needed
+- [ ] Naming guidelines applied to DESIGN-013 scenario names
+- [ ] All new scenario narratives (DESIGN-013) reviewed against guidelines before GAME-078
+
+## References
+
+- Research: `thoughts/shared/research/2026-05-18-vra-legal-political-landscape.md`
+- DESIGN-013 — VRA scenario design (apply guidelines before authoring narratives)
+- GAME-078 — VRA scenario implementation (trails this for narrative content)
+- `game/web/index.html` — about page content
+- LEGAL-001 — prior content risk assessment

--- a/thoughts/shared/tickets/DESIGN-015-information-density-redesign.md
+++ b/thoughts/shared/tickets/DESIGN-015-information-density-redesign.md
@@ -1,0 +1,97 @@
+---
+id: DESIGN-015
+title: Information density redesign — surfacing game state at 5+ districts without scrolling
+area: design, UX
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+With 5 districts the right sidebar scrolls off-screen, hiding game state information the
+player needs while actively painting. The sidebar is currently doing too many jobs: district
+selector, population validity, precinct detail on hover, and (once GAME-080 ships) district
+demographic stats. This design ticket defines the right layout approach before implementation
+begins (GAME-081).
+
+The constraint: the map must remain the dominant visual element. Information density must
+increase without visually crowding the map or burying the district selector.
+
+## Current sidebar jobs (in order from top to bottom)
+
+1. District selector buttons (with population balance; soon demographic stat per GAME-080)
+2. Map validity panel (contiguous, balanced, unassigned count)
+3. Precinct hover detail (population, lean, demographics on mouseover)
+
+With 5 districts, item 1 alone can overflow. Items 2 and 3 are pushed below the fold.
+
+## Options to evaluate
+
+**Option A — District overlays on the map**
+Key per-district stats (district label, population %, demographic %) rendered as SVG text
+overlaid inside each district's hex cluster. The sidebar district buttons become compact
+(just color + label, no inline stats). Stats live on the map where the player's eye already is.
+
+Pros: eliminates sidebar overflow; stats are spatially connected to the district.
+Cons: text placement on irregular hex clusters is tricky (centroid calculation, avoiding
+overlap); small text may be hard to read over colored hexes; clutters the map.
+
+**Option B — Tabbed / collapsible sidebar**
+Sidebar gains tabs or accordion sections: "Districts" tab (selector + stats), "Map" tab
+(validity panel), "Precinct" tab (hover detail). Player switches between views.
+
+Pros: all info still in sidebar; no map changes.
+Cons: adds cognitive overhead; player can't see precinct detail and district stats simultaneously.
+
+**Option C — HUD strip above or below map**
+A thin horizontal strip above or below the map shows: 5 district color swatches with population %
+and demographic %; overall validity indicators. Sidebar retains precinct hover detail only.
+Coordinates with DESIGN-004 (legend → horizontal strip).
+
+Pros: frees sidebar entirely for precinct detail; district status always visible regardless
+of map size; no overlap with map content.
+Cons: takes vertical screen space; district strip + legend strip + map + sidebar may feel crowded.
+
+**Option D — Combined: compact map overlays + slim sidebar**
+District labels + key stat (population balance only) overlaid on map as in Option A.
+Sidebar retains precinct hover detail + a condensed validity summary. Demographic stat
+(GAME-080) shown in a small district detail area that appears when a district is active,
+not always-visible.
+
+Pros: map carries spatial district info; sidebar stays focused on precinct detail.
+Cons: requires map overlay rendering work; detail panel is click-activated, not always visible.
+
+## Design decision required
+
+Choose one approach (or a hybrid), specify:
+1. What information moves where
+2. How district demographic stat (GAME-080 Phase 1) fits into the chosen layout
+3. How the layout behaves at different viewport widths (desktop-first but not desktop-only)
+4. How the active district is visually indicated in the new layout
+5. Whether DESIGN-004 (legend strip) is folded into this work or stays separate
+
+## Relationship to DESIGN-004
+
+DESIGN-004 proposes moving the legend to a horizontal strip above the map, freeing sidebar
+space. That work is complementary: if DESIGN-015 also uses a horizontal strip (Option C),
+the two can be combined. If DESIGN-015 takes a different approach, DESIGN-004 remains
+independent. This ticket should decide whether to absorb or defer DESIGN-004.
+
+## Goals / Acceptance Criteria
+
+- [ ] All four options (or others) evaluated against constraints
+- [ ] One approach chosen with rationale documented
+- [ ] Visual spec produced: layout diagram or annotated mockup (ASCII or simple SVG is fine)
+- [ ] GAME-080 Phase 1 demographic stat placement specified in chosen layout
+- [ ] DESIGN-004 fate decided: absorb into GAME-081 or keep separate
+- [ ] Viewport behavior at narrower desktop widths specified
+
+## References
+
+- GAME-081 — implementation (trails this)
+- GAME-080 — district demographic rollup (phase 1 stat must fit in chosen layout)
+- DESIGN-004 — legend layout (horizontal strip; potentially absorbed here)
+- `game/web/styles.css` — current sidebar layout
+- `game/web/index.html` — current sidebar structure
+- Visual aesthetic: dark HUD chrome, map-first, strategy-game feel
+  (`thoughts/shared/vision/game-vision.compressed.md`)

--- a/thoughts/shared/tickets/GAME-073-result-screen-stars-and-success-banner.md
+++ b/thoughts/shared/tickets/GAME-073-result-screen-stars-and-success-banner.md
@@ -2,7 +2,7 @@
 id: GAME-073
 title: "Result screen: deferred success banner + star count reveal"
 area: game, UX, audio
-status: open
+status: resolved
 created: 2026-05-18
 ---
 

--- a/thoughts/shared/tickets/GAME-075-terrain-implementation.md
+++ b/thoughts/shared/tickets/GAME-075-terrain-implementation.md
@@ -1,0 +1,86 @@
+---
+id: GAME-075
+title: Terrain implementation — tiles, edge rivers, precinct annotations, renderer
+area: game, rendering, content
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Implement the terrain system specified in DESIGN-008: non-precinct terrain tiles (sea, lake,
+mountain), precinct terrain annotations (coast, lakeside, riverside, foothill), edge-based
+rivers, symbolic rendering for all terrain types, map validity rules, and population-gradient
+generator support. Deliver at least one new scenario that exercises terrain features.
+
+## Current State
+
+Scenario JSON has no terrain support. The hex renderer draws precincts only; contiguity BFS
+operates on precinct adjacency with no concept of terrain barriers or river edges.
+
+## Goals / Acceptance Criteria
+
+### Schema (loader.ts)
+
+- [ ] `terrain_tiles` array in scenario JSON: `{ position: {q,r}, type: "sea"|"lake"|"mountain" }`
+- [ ] `river_edges` array: pairs of adjacent precinct IDs `[["p001","p002"], ...]`
+- [ ] `river_blocks_contiguity` boolean field (default: `false`)
+- [ ] Precinct-level `terrain` field: `"coast"|"lakeside"|"riverside"|"foothill"` (optional; derived if absent)
+- [ ] Precinct-level `has_internal_lake` boolean (default: `false`)
+- [ ] Loader derives annotations from adjacency when not explicitly authored; explicit values override
+- [ ] Loader validates: no terrain tile position overlaps precinct position
+- [ ] Loader rejects: `lake` tile adjacent to `sea` tile
+- [ ] Loader rejects: precinct fully enclosed by mountain tiles (BFS reachability from map boundary)
+- [ ] Loader warns (non-fatal): lake + sea present without a connecting river path
+
+### Renderer (mapRenderer.ts / main.ts)
+
+- [ ] Terrain tile layer rendered below precinct hex layer (separate SVG group)
+- [ ] `sea`: fill `#3a7fc1`, optional `∿` wave glyph centered
+- [ ] `lake`: fill `#4dd0e1`, optional small wave glyph
+- [ ] `mountain`: fill `#6b7280`, two or three `△` glyphs centered
+- [ ] Terrain tiles not interactive (no hover, no click, no district assignment affordance)
+- [ ] Coast precincts: distinct stroke on sea-facing edge(s)
+- [ ] Lakeside precincts: distinct stroke on lake-facing edge(s); if `has_internal_lake: true`,
+      render small aqua ellipse (~40% hex area) within the hex fill
+- [ ] Two adjacent `has_internal_lake` precincts: shared elongated ellipse bridging both
+- [ ] Rivers: blue stroke `#38bdf8` ~2–3px 70% opacity along river edges, layer above precinct
+      fills; edge coordinates derived from shared hex corners via `hexCorners()`
+- [ ] Foothill precincts: subtle grey tint on mountain-facing edges (nice-to-have; skip if time)
+
+### Contiguity (simulation/evaluate.ts or loader.ts)
+
+- [ ] Terrain tile positions excluded from adjacency graph (non-passable nodes)
+- [ ] When `river_blocks_contiguity: true`: river edge pairs removed from adjacency graph
+- [ ] Existing contiguity BFS behavior unchanged for scenarios with no terrain fields
+
+### Population gradient (generator)
+
+- [ ] Generator updated with distance-weighted population assignment from a designated urban center
+- [ ] New terrain-based scenarios use this generator (existing scenarios untouched)
+
+### New scenario
+
+- [ ] At least one new scenario authored using terrain features: sea/coast, mountain ridge,
+      and/or river
+- [ ] Scenario uses realistic population gradient (urban cluster, sparse highlands/coast)
+- [ ] Coordinate with DESIGN-013 / GAME-078 — VRA scenarios may serve as the terrain showcase
+
+## Test Coverage
+
+- [ ] Unit: loader rejects terrain tile overlapping precinct position
+- [ ] Unit: loader rejects lake tile adjacent to sea tile
+- [ ] Unit: BFS enclosed-precinct validation correctly identifies invalid mountain enclosure
+- [ ] Unit: river edges removed from adjacency graph when `river_blocks_contiguity: true`
+- [ ] Unit: derived coast annotation correct for precinct adjacent to sea tile
+- [ ] e2e: terrain tiles visible on map (sea blue, lake aqua, mountain grey)
+- [ ] e2e: terrain tiles not paintable (click on sea tile → no district change)
+- [ ] e2e: river stroke visible between two designated precincts
+
+## References
+
+- DESIGN-008 — full terrain spec (read before implementing)
+- `game/web/src/model/hex-geometry.ts` — `hexCorners()` for edge coordinate calculation
+- `game/web/src/simulation/loader.ts` — schema + validation
+- `game/web/src/main.ts` / `mapRenderer.ts` — rendering layers
+- DESIGN-013 / GAME-078 — VRA scenarios that consume terrain features

--- a/thoughts/shared/tickets/GAME-076-tutorial-001-walkthrough.md
+++ b/thoughts/shared/tickets/GAME-076-tutorial-001-walkthrough.md
@@ -1,0 +1,69 @@
+---
+id: GAME-076
+title: Tutorial-001 guided walkthrough — overlay engine + step script
+area: game, UX, tutorial
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Implement the tutorial overlay system (designed in DESIGN-012) for tutorial-001. Build the
+overlay engine — step sequencing, UI element highlighting, input pause, skip/persist — and
+deliver the full tutorial-001 step script guiding a new player from opening the map editor
+through submitting their first attempt.
+
+## Current State
+
+tutorial-001 has narrative intro slides (GAME-016) but no in-game guidance once the player
+enters the map editor. Players are dropped into the editor with no instructions.
+
+## Goals / Acceptance Criteria
+
+### Overlay engine
+
+- [ ] Tutorial overlay panel: upper-right of map SVG, over map layer, `rgba(0,0,0,0.75)` background
+- [ ] Step data model implemented per DESIGN-012 spec: text, highlight selector, pauseInput, advanceTrigger
+- [ ] Highlight mechanism: CSS `tutorial-highlight` ring/glow on target; `tutorial-dimmed` on rest
+- [ ] Highlight works for: named button IDs, sidebar panel divs, the map hex SVG area
+- [ ] `pauseInput: true` blocks map painting + all buttons except designated advance target
+- [ ] Blocked click attempts silently ignored; cursor shows `not-allowed`
+- [ ] Escape key and "Skip tutorial" always active regardless of pause state
+- [ ] Advance triggers implemented: `click-target`, `any-map-click`, `auto` (setTimeout), `condition`
+- [ ] `condition: "5-precincts-painted"` trigger implemented for step 2
+- [ ] Skip button marks `tutorial-tutorial-001-complete` in localStorage; overlay dismissed
+- [ ] Tutorial not re-shown after localStorage flag set
+- [ ] `?resetTutorial=1` URL param clears tutorial localStorage flags
+
+### Tutorial-001 step script (9 steps per DESIGN-012)
+
+- [ ] Step 1: "Welcome! Click District 2 to start painting." — highlight district-2 button, pause, click-target
+- [ ] Step 2: "Click precincts to paint them as District 2." — highlight map, pause, 5-precincts condition
+- [ ] Step 3: "Made a mistake? Click Undo." — highlight undo, pause, click-target
+- [ ] Step 4: "Redo restores undone changes." — highlight redo, pause, click-target
+- [ ] Step 5: "This panel shows map validity — contiguity and balance." — highlight validity panel, auto 4s
+- [ ] Step 6: "Hover any precinct to see its data." — highlight sidebar, auto 4s
+- [ ] Step 7: "Toggle between District view and Lean view." — highlight view toggle, pause, click-target
+- [ ] Step 8: "County borders shows county boundaries." — highlight county button, auto 3s
+- [ ] Step 9: "When ready, click Submit." — highlight submit, auto 2s, tutorial ends
+
+### Scenario activation
+
+- [ ] Tutorial overlay activates only when `?s=tutorial-001` (or scenario has `tutorial: true` flag)
+- [ ] No overlay shown for non-tutorial scenarios
+
+## Test Coverage
+
+- [ ] e2e: tutorial overlay visible on tutorial-001 load (panel text matches step 1)
+- [ ] e2e: step advances to step 2 on district-2 button click
+- [ ] e2e: skip button dismisses overlay
+- [ ] e2e: overlay not re-shown after skip (localStorage flag set)
+- [ ] e2e: input blocked during paused step — painting attempt has no effect
+- [ ] e2e: `?resetTutorial=1` clears flag and overlay re-appears on next load
+
+## References
+
+- DESIGN-012 — overlay UX spec (approve before implementation)
+- `game/web/index.html` — element IDs for highlight selectors
+- `game/web/src/main.ts` — editor entry point, district buttons, undo/redo
+- GAME-077 — tutorial-002 (trails this; reuses overlay engine)

--- a/thoughts/shared/tickets/GAME-077-tutorial-002-guided-mode.md
+++ b/thoughts/shared/tickets/GAME-077-tutorial-002-guided-mode.md
@@ -1,0 +1,48 @@
+---
+id: GAME-077
+title: Tutorial-002 guided mode — advanced feature walkthrough
+area: game, UX, tutorial
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Extend the tutorial overlay engine (GAME-076) to tutorial-002 with a step script covering
+advanced features: the criteria panel, demographic filters, and navigating toward goal
+achievement on the larger 196-precinct, 4-district map. Exact step script is finalized
+during implementation based on what GAME-076 delivered.
+
+## Current State
+
+tutorial-002 is a 196-precinct map with 3 counties and 4 districts. No in-game guidance.
+Players can reach it from the Tutorial campaign but the map is significantly more complex
+than tutorial-001 with no explicit goal hand-holding.
+
+## Goals / Acceptance Criteria
+
+- [ ] Tutorial-002 step script designed (refine during GAME-076 implementation; themes below)
+- [ ] Steps cover at minimum: criteria panel walkthrough, demographic overlay toggle, goal hint
+- [ ] Overlay engine from GAME-076 reused with no required modifications (extend only if needed)
+- [ ] Skip / persist behavior identical to tutorial-001 (localStorage key `tutorial-tutorial-002-complete`)
+
+### Proposed step themes
+
+1. "This scenario has more districts and a larger map — zoom and pan with mouse/trackpad."
+2. "Check the criteria panel — it tells you what your map needs to achieve." [highlight criteria list or submit-preview area]
+3. "The majority_minority criterion means one district must give the minority community a real voice." [highlight criterion row]
+4. "Use the demographic overlay to see where the minority community is concentrated." [highlight view toggle, pause until toggled]
+5. "Try to draw District 3 to include that community." [highlight district-3 button, soft hint — not forced]
+6. "When your map meets all required criteria, Submit to see your results."
+
+## Test Coverage
+
+- [ ] e2e: tutorial-002 overlay activates on load
+- [ ] e2e: criteria panel highlight step visible and advances correctly
+
+## References
+
+- GAME-076 — overlay engine (implement first)
+- DESIGN-012 — overlay UX spec
+- `game/public/scenarios/tutorial-002.json` — map details
+- GAME-014 — scale tutorial scenario (original ticket for tutorial-002 map)

--- a/thoughts/shared/tickets/GAME-078-vra-scenarios-implementation.md
+++ b/thoughts/shared/tickets/GAME-078-vra-scenarios-implementation.md
@@ -1,0 +1,69 @@
+---
+id: GAME-078
+title: VRA scenario implementation — "The 55% Problem" and "The Proxy Problem"
+area: game, content
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Implement the two VRA-era scenarios designed in DESIGN-013: Scenario A ("The 55% Problem" —
+dual failure zone of majority-minority districting) and Scenario B ("The Proxy Problem" —
+proxy-based redistricting post-Callais). Both scenarios use terrain features from GAME-075.
+They are placed in the Educational campaign after Valle Verde.
+
+## Current State
+
+No scenarios explore VRA compliance tension or post-Callais redistricting. Valle Verde
+(scenario-006) introduces `majority_minority` but does not surface the legal conflict between
+VRA compliance and the racial gerrymander prohibition.
+
+## Goals / Acceptance Criteria
+
+### Scenario A — "The 55% Problem"
+
+- [ ] Map authored: coastal or riverine terrain (GAME-075), realistic population gradient,
+      minority community concentrated in urban cluster
+- [ ] Starting map: high-BVAP configuration that fails `compactness` (the "illegal 55% floor" state)
+- [ ] `majority_minority` criterion: functional threshold (minority voters can elect preferred candidate)
+- [ ] `compactness` criterion: required, tightened threshold
+- [ ] `county_splits` criterion: optional bonus star
+- [ ] Intro narrative (slides): Virginia Bethune-Hill pattern, fictional names and places
+- [ ] Both fail states reachable: low BVAP (VRA fail) and fragmented district (compactness fail)
+- [ ] Scenario file authored and added to manifest
+
+### Scenario B — "The Proxy Problem"
+
+- [ ] `hide_race_demographics: boolean` field added to scenario JSON schema + loader
+- [ ] Demographic panel respects flag: shows only proxy fields (income, language_minority_pct,
+      party lean) when `hide_race_demographics: true`; hides race/ethnicity column
+- [ ] Proxy precinct fields added: `income_median: number`, `language_minority_pct: number`
+- [ ] `majority_minority` criterion evaluated against underlying (hidden) racial data as normal
+- [ ] Result screen: when `hide_race_demographics: true`, reveal race data after evaluation
+      ("here's where the minority community actually lived" comparison)
+- [ ] Map authored: same region as Scenario A or adjacent; river roughly follows community boundary
+- [ ] Intro narrative (slides): post-Callais framing, fictional context
+- [ ] Scenario file authored and added to manifest
+
+### Campaign placement
+
+- [ ] Both scenarios added to Educational campaign in CAMPAIGN_REGISTRY
+- [ ] Scenario IDs and file names assigned (coordinate with existing 007–009 IDs)
+- [ ] Manifest updated; scenario-select and campaign-progress screens reflect new scenarios
+
+## Test Coverage
+
+- [ ] e2e: Scenario A — submit starting map → fails (compactness criterion)
+- [ ] e2e: Scenario A — known solution path satisfies majority_minority + compactness
+- [ ] e2e: Scenario B — demographic panel does not show race column when flag set
+- [ ] e2e: Scenario B — result screen shows race-data reveal section after evaluation
+- [ ] e2e: both scenarios appear in Educational campaign scenario select
+
+## References
+
+- DESIGN-013 — scenario design spec (approve before authoring maps)
+- GAME-075 / DESIGN-008 — terrain features (implement first; both scenarios use terrain)
+- GAME-026 — Valle Verde (group_schema, ethnicity dimension, majority_minority criterion)
+- Research: `thoughts/shared/research/2026-05-18-vra-legal-political-landscape.md`
+- `game/web/src/store/campaigns.ts` — CAMPAIGN_REGISTRY

--- a/thoughts/shared/tickets/GAME-079-scenario-002-playability-tuning.md
+++ b/thoughts/shared/tickets/GAME-079-scenario-002-playability-tuning.md
@@ -1,0 +1,43 @@
+---
+id: GAME-079
+title: Scenario-002 playability tuning — tighten trivially-easy first educational scenario
+area: game, content
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Scenario-002 (the first scenario in the Educational campaign) can be solved with very minimal
+map alteration, undermining the educational goal of requiring players to engage meaningfully
+with the redistricting criteria it introduces. Investigate why and tighten it — via threshold
+adjustment, starting map modification, or addition of a required criterion — so the scenario
+requires genuine deliberate effort.
+
+## Current State
+
+Players can satisfy all required criteria in scenario-002 with only a handful of precinct swaps
+from the initial state. The scenario does not require engaging with the redistricting mechanics
+it is meant to teach.
+
+## Goals / Acceptance Criteria
+
+- [ ] Root cause identified: which criteria are trivially satisfied by the starting map?
+- [ ] Solution designed: threshold tightening, starting map modification, or additional criterion
+- [ ] Updated scenario requires a meaningful number of deliberate moves (target: 10+ swaps)
+- [ ] Existing e2e tests for scenario-002 updated to match new thresholds / layout
+- [ ] Winnability: at least one known solution path documented; e2e solve test still passes
+- [ ] Manual playthrough confirms the scenario feels like it requires genuine engagement
+
+## Test Coverage
+
+- [ ] e2e: submitting the starting map unchanged fails at least one required criterion
+- [ ] e2e: known solution path still passes all required criteria
+- [ ] Manual: full playthrough requires reasoning about the goal, not just random swaps
+
+## References
+
+- `game/public/scenarios/scenario-002.json` — current scenario definition
+- `game/web/e2e/scenarios.spec.ts` — existing scenario-002 e2e tests
+- GAME-031 — prior threshold tuning (what was already tightened; don't double-tighten blindly)
+- GAME-058 — manual playability test (related; can combine effort)

--- a/thoughts/shared/tickets/GAME-080-district-demographic-rollup.md
+++ b/thoughts/shared/tickets/GAME-080-district-demographic-rollup.md
@@ -1,0 +1,83 @@
+---
+id: GAME-080
+title: District demographic rollup — live aggregate stats per district while painting
+area: game, UX
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+While painting districts, players have no way to see aggregate demographic data for the
+district as a whole — only per-precinct data on hover. This makes majority_minority scenarios
+(Valle Verde, and the planned VRA scenarios) nearly unplayable: the player cannot know
+whether District 3 has achieved 50%+ Latino representation without submitting and checking
+the result screen. Add live per-district demographic rollup derived automatically from the
+active scenario criteria.
+
+## Design principles
+
+**Scenario-aware, derived not configured**: do not add UI fields to the scenario spec.
+Instead, scan the active criteria for any that reference a demographic dimension and
+automatically surface that dimension in the district display. If a `majority_minority`
+criterion exists with `group: "latino"`, the UI shows % Latino per district. No extra
+scenario JSON needed.
+
+**Categorical mapping (criteria → dimensions):**
+- `majority_minority` criterion → show the criterion's target group % per district
+- `efficiency_gap` or `mean_median` → could show lean/party split % (already partially shown)
+- No criterion references a dimension → no demographic stat shown (keeps simple scenarios clean)
+
+**Phase 1 (this ticket):** compact one-line stat under each district button.
+**Phase 2 (future ticket):** expandable district detail panel with full demographic breakdown.
+
+## Implementation approach
+
+At map load, inspect `scenario.criteria` for criteria that reference demographic groups.
+For `majority_minority`:
+- Find the `group` field (e.g. `"latino"`)
+- At paint time, iterate all precincts assigned to each district, compute the weighted
+  average of that group's percentage (weighted by precinct population)
+- Display result as "48% Latino" under the District 3 button
+
+The computation runs on every paint action (already happens for population balance).
+The group lookup uses the same `group_percentages` data already in precinct objects.
+
+## Goals / Acceptance Criteria
+
+### Phase 1 — compact stat under district button
+
+- [ ] On scenario load: scan criteria for demographic dimension references
+- [ ] If `majority_minority` criterion found: identify target group key
+- [ ] For each district: compute live weighted-average % of that group across assigned precincts
+- [ ] Display as compact line under district button: e.g. "48% Latino" or "51% Black VAP"
+- [ ] Updates live on every paint / undo / redo action
+- [ ] No display shown for scenarios with no demographic criterion (no regression for
+      simple scenarios)
+- [ ] Label uses human-readable group name from `scenario.group_schema` if available,
+      falls back to raw key
+
+### Display spec
+
+- One line below the district button's population balance indicator
+- Format: `{N}% {GroupName}` — e.g. "48% Latino", "51% Black"
+- Color: neutral (no red/green — the player decides if it's sufficient)
+- If the criterion has a threshold, optionally show a faint target indicator
+  (e.g. subtle underline changes when threshold is met) — nice-to-have, not required
+
+## Test Coverage
+
+- [ ] Unit: `computeDistrictDemographic(precincts, districtId, groupKey)` returns correct
+      weighted average for a known assignment
+- [ ] Unit: returns `null` (no display) when no criteria reference a demographic dimension
+- [ ] e2e: Valle Verde — district buttons show Latino % while painting
+- [ ] e2e: painting a precinct into a district updates the displayed % immediately
+- [ ] e2e: tutorial-001 (no demographic criterion) — no demographic stat shown
+
+## References
+
+- `game/web/src/simulation/evaluate.ts` — `majority_minority` evaluator (has group lookup logic)
+- `game/web/src/main.ts` — district button rendering, paint event handler
+- `game/public/scenarios/scenario-006.json` (Valle Verde) — test scenario with majority_minority
+- DESIGN-015 / GAME-081 — information density redesign (coordinates layout; Phase 2 panel trails this)
+- DESIGN-013 / GAME-078 — VRA scenarios (primary motivation; Valle Verde is sufficient for testing)

--- a/thoughts/shared/tickets/GAME-081-information-density-implementation.md
+++ b/thoughts/shared/tickets/GAME-081-information-density-implementation.md
@@ -1,0 +1,46 @@
+---
+id: GAME-081
+title: Information density implementation — game state layout improvements
+area: game, UX
+status: open
+created: 2026-05-18
+---
+
+## Summary
+
+Implement the layout approach selected in DESIGN-015 to resolve the 5-district sidebar
+overflow problem and surface game state information without requiring the player to scroll.
+
+## Current State
+
+With 5 or more districts, the right sidebar overflows: map validity panel and precinct
+hover detail are pushed below the fold. Players cannot see overall map status while
+actively painting. Once GAME-080 ships, the demographic stat adds further pressure.
+
+## Goals / Acceptance Criteria
+
+- [ ] DESIGN-015 approved before implementation begins
+- [ ] Chosen layout approach implemented per DESIGN-015 spec
+- [ ] 5-district scenario (scenario-007 or similar) fits without scrolling at standard
+      desktop viewport (1280px wide)
+- [ ] District selector, validity summary, and precinct hover detail all visible
+      simultaneously
+- [ ] GAME-080 Phase 1 demographic stat integrates cleanly into new layout
+- [ ] If DESIGN-004 is absorbed: legend strip implementation included
+- [ ] Viewport behavior at narrower widths (1024px) verified; no broken layouts
+
+## Test Coverage
+
+- [ ] e2e: 5-district scenario — district buttons, validity panel, and precinct hover
+      panel all visible without scroll
+- [ ] e2e: layout stable across precinct hover, district select, paint actions
+- [ ] e2e: no regression on 3-district scenarios (tutorial, simple scenarios)
+- [ ] e2e: legend visible in new position (if DESIGN-004 absorbed)
+
+## References
+
+- DESIGN-015 — layout design spec (must be approved first)
+- GAME-080 — district demographic rollup (coordinate placement of demographic stat)
+- DESIGN-004 — legend layout (may be absorbed here)
+- `game/web/styles.css` — layout
+- `game/web/index.html` — sidebar structure

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -104,8 +104,18 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-070-audio-settings.md` | game, UX, audio | Audio settings panel (main menu Settings item): master volume slider, mute toggle, localStorage persistence; coordinates with GAME-062 result-screen toggle |
 | `GAME-071-audio-character-assignment.md` | game, audio, content | Per-scenario character/audio inventory; audio clip selection per type; timing calibration; stub resolution |
 | `GAME-072-optional-criterion-neutral-audio.md` | game, audio | Neutral/meh audio clip for optional criteria that fail — party-disapprove is too strong for a missed bonus |
-| `GAME-073-result-screen-stars-and-success-banner.md` | game, UX, audio | Deferred success banner + star count reveal; tada/womp-womp completion audio; verdict hidden until all criteria revealed |
 | `GAME-074-criteria-only-validity-model.md` | game, architecture | Collapse dual validity/criteria system; population_balance gains tolerance field; contiguity becomes opt-in criterion; remove isMapSubmittable/buildValidityRows/mapIsValid |
+| `DESIGN-012-tutorial-overlay-ux.md` | design, UX, tutorial | Tutorial overlay UX spec: step sequencing model, highlight mechanics, input-pause semantics, skip/persist, tutorial-001 step script |
+| `DESIGN-013-vra-scenario-design.md` | design, content | VRA scenario design: "The 55% Problem" (Bethune-Hill dual-failure zone) and proxy-only redistricting post-Callais |
+| `DESIGN-014-nonpartisan-content-framing.md` | design, content | Non-partisan content guidelines: source standards, narrative language, naming conventions, about-page audit; prerequisite for VRA scenario authoring |
+| `DESIGN-015-information-density-redesign.md` | design, UX | Layout redesign for 5+ districts: evaluate map overlays, HUD strip, tabbed sidebar; specify where GAME-080 demographic stat lives; DESIGN-004 fate |
+| `GAME-075-terrain-implementation.md` | game, rendering, content | Terrain tiles (sea/lake/mountain), edge rivers, precinct annotations, symbolic renderer, map validity rules, population-gradient generator |
+| `GAME-076-tutorial-001-walkthrough.md` | game, UX, tutorial | Tutorial-001 guided walkthrough: overlay engine + 9-step script (district select → paint → undo/redo → UI tour → submit) |
+| `GAME-077-tutorial-002-guided-mode.md` | game, UX, tutorial | Tutorial-002 guided mode: advanced feature walkthrough (criteria panel, demographic overlay, goal orientation) |
+| `GAME-078-vra-scenarios-implementation.md` | game, content | Implement VRA scenarios: Scenario A + Scenario B; terrain features; proxy-data mechanic; hides race demographics; result-screen reveal |
+| `GAME-079-scenario-002-playability-tuning.md` | game, content | Tighten scenario-002 — trivially-easy first educational campaign scenario requires genuine engagement |
+| `GAME-080-district-demographic-rollup.md` | game, UX | Live per-district demographic stat derived from criteria (majority_minority → show % of target group); compact line under district button; updates on paint |
+| `GAME-081-information-density-implementation.md` | game, UX | Implement DESIGN-015 layout: district state visible at 5+ districts without scrolling; integrates GAME-080 stat placement |
 
 ---
 
@@ -113,6 +123,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| GAME-073: deferred verdict banner + star count reveal | Verdict hidden until all criteria revealed; stars animate in; tada/womp-womp audio; layout preservation (visibility:hidden + min-height); merged PRs #236 #237 |
 | GAME-062: character reaction system | CHAR_POSES measured for all 1408×768 sheets; commissioner/judge/legislator/party wired in buildCharSlotChildren(); demographic selection reads scenario.character_demographics; placeholder SVG retained as unknown-type fallback; e2e tests for commissioner sprite + aria-labels; broker/scenario-006 deferred to GAME-065 |
 | GAME-061: audio clips | 12 real clips active (governor/commissioner/legislator gender-keyed, judge/party gender-neutral), all −16 LUFS; stubs for neutral variants + party-disapprove deferred to GAME-071 fine-tuning |
 | GAME-060: character sprite assets | commissioner/judge/legislator/party PNG sheets produced with demographic variants (1408×768, 3-state); old SVG placeholders deleted |


### PR DESCRIPTION
## Summary

- Closes out sprint S11 and S12 in the roadmap and adds Sprint 13 (tutorial system + VRA scenarios) with Sprint 14 sketched (information density + terrain)
- Adds 11 new design/game tickets: DESIGN-012–015, GAME-075–081
- Resolves GAME-073 (result-screen stars & success banner), expands DESIGN-008 with a full terrain model, and adds VRA legal/political-landscape research docs
- No game code, build files, or test files are touched

## Affected machines / services

N/A — docs-only change

## Validation performed

- [x] `jj status` confirms only thoughts/shared/ files changed; no game code touched
- [x] Ticket IDs checked against TICKETS.md and Resolved section — no collisions
- [x] TICKETS.md Open section lists DESIGN-012–015, GAME-075–081; Resolved section includes GAME-073
- [x] Sprint roadmap updated: S11 complete, S12 complete, S13 planned, S14 sketched
- [x] Compressed sprint roadmap matches .md counterpart

## Deployment steps

N/A — no deployable artifacts

## Tickets addressed

- Resolves GAME-073 (result screen stars & success banner)
- New tickets: DESIGN-012, DESIGN-013, DESIGN-014, DESIGN-015, GAME-075, GAME-076, GAME-077, GAME-078, GAME-079, GAME-080, GAME-081

## Rollback

N/A — reverting this PR has no production impact; ticket files and docs can be restored from git history if needed
