### PR TITLE
feat(GAME-080): live per-district demographic stat under district buttons

### DIFF
--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -130,6 +130,7 @@ sh_test(
         "e2e/campaign-select.spec.ts",
         "e2e/a11y.spec.ts",
         "e2e/submit-on-invalid.spec.ts",
+        "e2e/sprint5.spec.ts",
         # Playwright packages as declared Bazel deps — ensures the cache key includes
         # the playwright version and the files are available in runfiles.
         "//game:node_modules/@playwright/test",

--- a/game/web/e2e/sprint5.spec.ts
+++ b/game/web/e2e/sprint5.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Sprint 5 (S13) behavioral tests:
+ *   GAME-080 — live per-district demographic stat under district buttons
+ *
+ * On scenarios with a majority_minority criterion, each district button
+ * shows the group share % below it, highlighted green when the threshold
+ * is met. On other scenarios no stat is shown.
+ */
+
+async function loadScenario(
+  page: import("@playwright/test").Page,
+  id: string,
+): Promise<void> {
+  await page.goto(`/?s=${id}&debug`);
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Paint a set of hex [q,r] coordinates into a district via __gameStore.paintStroke.
+ * Resolves coordinates to precinct indices at runtime using the store's precinct list.
+ */
+async function paintHexes(
+  page: import("@playwright/test").Page,
+  hexes: [number, number][],
+  district: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ hexes, district }) => {
+      const store = (
+        window as unknown as Record<
+          string,
+          {
+            getState: () => {
+              paintStroke: (ids: number[], district: number) => void;
+              precincts: { coord: { q: number; r: number } }[];
+            };
+          }
+        >
+      )["__gameStore"];
+      if (!store) throw new Error("__gameStore not found on window");
+      const state = store.getState();
+      const coordToIdx = new Map<string, number>();
+      state.precincts.forEach((p, i) => {
+        coordToIdx.set(`${p.coord.q},${p.coord.r}`, i);
+      });
+      const ids = hexes.map(([q, r]) => {
+        const idx = coordToIdx.get(`${q},${r}`);
+        if (idx === undefined) throw new Error(`Hex (${q},${r}) not found in precincts`);
+        return idx;
+      });
+      state.paintStroke(ids, district);
+    },
+    { hexes, district },
+  );
+}
+
+// ─── GAME-080: District demographic stat ─────────────────────────────────────
+
+test("GAME-080: scenario-005 shows district-demo-stat under each district button", async ({
+  page,
+}) => {
+  await loadScenario(page, "scenario-005");
+  const stats = page.locator(".district-demo-stat");
+  // scenario-005 has 5 districts → 5 stat elements
+  await expect(stats).toHaveCount(5);
+});
+
+test("GAME-080: district-demo-stat shows Latino percentage text", async ({ page }) => {
+  await loadScenario(page, "scenario-005");
+  const firstStat = page.locator(".district-demo-stat").first();
+  await expect(firstStat).toBeVisible();
+  // Each stat shows "<N>% Latino" (group_filter dimension=ethnicity value=latino)
+  await expect(firstStat).toContainText("% Latino");
+});
+
+test("GAME-080: painting the winning solution gives district 1 the .met class", async ({
+  page,
+}) => {
+  await loadScenario(page, "scenario-005");
+
+  // Apply the full winning assignment from the scenarios.spec.ts winnability test.
+  // Painting only D1 valley hexes is insufficient because the original diagonal-strip
+  // precincts remain in D1, diluting the Latino share below 50%.
+  // Painting all 5 districts reassigns every precinct explicitly, giving D1 ~60% Latino.
+
+  // D1: valley consolidated (~60% Latino)
+  await paintHexes(page, [
+    [1,-3],[2,-3],[3,-3],
+    [0,-2],[1,-2],[2,-2],[3,-2],[4,-2],[5,-2],
+    [0,-1],[1,-1],[2,-1],[3,-1],[4,-1],[5,-1],
+    [1,0],[2,0],[3,0],[4,0],[5,0],
+    [1,1],[2,1],[3,1],[4,1],[5,1],
+  ], 1);
+
+  // D2: west rim
+  await paintHexes(page, [
+    [-6,1],[-5,1],[-4,1],[-3,1],[-2,1],[-1,1],
+    [-6,2],[-5,2],[-4,2],[-3,2],[-2,2],[-1,2],
+    [-6,3],[-5,3],[-4,3],[-3,3],[-2,3],
+    [-6,4],[-5,4],[-4,4],[-3,4],
+    [-6,5],[-5,5],[-4,5],
+    [-6,6],[-5,6],
+  ], 2);
+
+  // D3: northwest rim
+  await paintHexes(page, [
+    [-1,-5],
+    [-2,-4],[-1,-4],[0,-4],[1,-4],
+    [-3,-3],[-2,-3],[-1,-3],[0,-3],
+    [-4,-2],[-3,-2],[-2,-2],[-1,-2],
+    [-5,-1],[-4,-1],[-3,-1],[-2,-1],[-1,-1],
+    [-6,0],[-5,0],[-4,0],[-3,0],[-2,0],[-1,0],[0,0],
+  ], 3);
+
+  // D4: south rim
+  await paintHexes(page, [
+    [0,1],[0,2],[1,2],[2,2],[3,2],[4,2],
+    [-1,3],[0,3],[1,3],[2,3],[3,3],
+    [-2,4],[-1,4],[0,4],[1,4],[2,4],
+    [-3,5],[-2,5],[-1,5],[0,5],[1,5],
+    [-4,6],[-3,6],[-2,6],[-1,6],[0,6],
+  ], 4);
+
+  // D5: northeast rim
+  await paintHexes(page, [
+    [0,-6],[1,-6],[2,-6],[3,-6],[4,-6],[5,-6],[6,-6],
+    [0,-5],[1,-5],[2,-5],[3,-5],[4,-5],[5,-5],[6,-5],
+    [2,-4],[3,-4],[4,-4],[5,-4],[6,-4],
+    [4,-3],[5,-3],[6,-3],
+    [6,-2],[6,-1],[6,0],
+  ], 5);
+
+  // D1 now has ~60% Latino → .met; D2-D5 have ~20% → no .met
+  const metStats = page.locator(".district-demo-stat.met");
+  await expect(metStats).toHaveCount(1, { timeout: 3_000 });
+});
+
+test("GAME-080: non-majority-minority scenario shows no demographic stat", async ({ page }) => {
+  // scenario-002 has no majority_minority criterion
+  await loadScenario(page, "scenario-002");
+  const stats = page.locator(".district-demo-stat");
+  await expect(stats).toHaveCount(0);
+});
+
+test("GAME-080: stat count matches district button count", async ({ page }) => {
+  await loadScenario(page, "scenario-005");
+  const btns = page.locator("button.district-btn");
+  const stats = page.locator(".district-demo-stat");
+  const btnCount = await btns.count();
+  const statCount = await stats.count();
+  expect(statCount).toBe(btnCount);
+});

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -9,7 +9,7 @@
  */
 
 import { loadScenario } from "./model/loader.js";
-import type { Scenario, CriterionId, CharacterType } from "./model/scenario.js";
+import type { Scenario, CriterionId, CharacterType, Criterion } from "./model/scenario.js";
 import { type MapRenderer, type ViewMode, SvgMapRenderer } from "./render/mapRenderer.js";
 import {
 	renderDistrictButtons,
@@ -18,7 +18,14 @@ import {
 	renderValidityPanel,
 } from "./render/panels.js";
 import { createGameStore } from "./store/gameStore.js";
-import { evaluateCriteria, isMapSubmittable, type CriterionResult } from "./simulation/evaluate.js";
+import {
+	evaluateCriteria,
+	isMapSubmittable,
+	computeDistrictGroupShares,
+	groupFilterLabel,
+	type CriterionResult,
+	type DistrictDemoStat,
+} from "./simulation/evaluate.js";
 import { computeValidityStats } from "./simulation/validity.js";
 import {
 	loadProgress,
@@ -456,6 +463,12 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		return;
 	}
 
+	// GAME-080: detect majority_minority criterion for live district demographic stat
+	type MMCriterion = Extract<Criterion, { type: "majority_minority" }>;
+	const majorityMinorityCriterion = scenario.success_criteria
+		.map((sc) => sc.criterion)
+		.find((c): c is MMCriterion => c.type === "majority_minority");
+
 	// ── Preload audio clips (GAME-062) ───────────────────────────────────────
 	{
 		const clips: Record<string, string> = {};
@@ -566,9 +579,24 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		renderResults(resultsEl!, state, partyLabels);
 		renderValidityPanel(validityEl!, state, scenario.rules);
 		renderLegend(legendEl!, state.districtCount);
+
+		let demoStat: DistrictDemoStat | undefined;
+		if (majorityMinorityCriterion) {
+			demoStat = {
+				shares: computeDistrictGroupShares(
+					scenario.precincts,
+					state.assignments,
+					state.districtCount,
+					majorityMinorityCriterion.group_filter,
+				),
+				label: groupFilterLabel(majorityMinorityCriterion.group_filter),
+				threshold: majorityMinorityCriterion.min_eligible_share,
+			};
+		}
+
 		renderDistrictButtons(districtBtnsEl!, state.districtCount, state.activeDistrict, (id) => {
 			store.getState().setActiveDistrict(id);
-		});
+		}, demoStat);
 
 		btnUndo!.disabled = pastStates.length === 0;
 		btnRedo!.disabled = futureStates.length === 0;

--- a/game/web/src/render/panels.ts
+++ b/game/web/src/render/panels.ts
@@ -1,5 +1,6 @@
 import type { ScenarioRules } from "../model/scenario.js";
 import { DISTRICT_COLORS, PARTY_COLORS, PARTY_LABELS, type PartyKey } from "../model/types.js";
+import type { DistrictDemoStat } from "../simulation/evaluate.js";
 import { computeValidityStats } from "../simulation/validity.js";
 import type { GameStore } from "../store/gameStore.js";
 
@@ -55,17 +56,35 @@ export function renderDistrictButtons(
 	districtCount: number,
 	activeDistrict: number,
 	onSelect: (id: number) => void,
+	demoStat?: DistrictDemoStat,
 ): void {
 	container.innerHTML = "";
 	for (let i = 1; i <= districtCount; i++) {
 		const color = DISTRICT_COLORS[i - 1] ?? "#888";
+
+		const wrapper = document.createElement("div");
+		wrapper.className = "district-btn-wrap";
+
 		const btn = document.createElement("button");
 		btn.className = `district-btn${i === activeDistrict ? " active" : ""}`;
 		btn.textContent = `District ${i}`;
 		btn.style.background = color;
 		btn.style.color = "#fff";
 		btn.addEventListener("click", () => onSelect(i));
-		container.appendChild(btn);
+		wrapper.appendChild(btn);
+
+		if (demoStat) {
+			const share = demoStat.shares[i - 1] ?? 0;
+			const pct = Math.round(share * 100);
+			const thresholdPct = Math.round(demoStat.threshold * 100);
+			const met = pct >= thresholdPct;
+			const stat = document.createElement("div");
+			stat.className = `district-demo-stat${met ? " met" : ""}`;
+			stat.textContent = `${pct}% ${demoStat.label}`;
+			wrapper.appendChild(stat);
+		}
+
+		container.appendChild(wrapper);
 	}
 }
 

--- a/game/web/src/simulation/evaluate.ts
+++ b/game/web/src/simulation/evaluate.ts
@@ -39,6 +39,20 @@ export interface EvaluationResult {
 	overallPass: boolean;
 }
 
+export interface DistrictDemoStat {
+	shares: number[];
+	label: string;
+	threshold: number;
+}
+
+export function groupFilterLabel(filter: GroupFilter): string {
+	if ("dimension" in filter) {
+		const v = filter.value;
+		return v.charAt(0).toUpperCase() + v.slice(1);
+	}
+	return (filter.group_ids as string[]).join(", ");
+}
+
 // ─── Helper: comparison operator ─────────────────────────────────────────────
 
 function applyOp(actual: number, op: CompareOp, threshold: number): boolean {
@@ -102,7 +116,7 @@ function matchesGroupFilter(group: DemographicGroup, filter: GroupFilter): boole
 // Returns the fraction of each district's total population that belongs to
 // groups matching the filter.  Range: 0.0–1.0.
 
-function computeDistrictGroupShares(
+export function computeDistrictGroupShares(
 	scenarioPrecincts: ScenarioPrecinct[],
 	assignments: AssignmentMap,
 	districtCount: number,

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -51,6 +51,24 @@ body {
   border-color: white;
 }
 
+.district-btn-wrap {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.district-demo-stat {
+  font-size: 0.68rem;
+  color: #a0a8c0;
+  white-space: nowrap;
+}
+
+.district-demo-stat.met {
+  color: #6fcf97;
+  font-weight: 600;
+}
+
 #btn-undo, #btn-redo, #btn-county-toggle {
   padding: 4px 10px;
   background: #0f3460;


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #238

## Summary
- Adds a live per-district demographic stat beneath each district button on scenarios that have a `majority_minority` criterion (GAME-080 Phase 1)
- Stat is derived automatically from the existing criterion's `group_filter` and `min_eligible_share` — no new scenario spec fields required
- Districts meeting or exceeding the threshold are highlighted green (`.met` CSS class); all others show in muted text
- Stats update on every paint stroke via the existing `updateUI()` subscription

**Approach:** scan `scenario.success_criteria` for a `majority_minority` criterion at load time; call the newly-exported `computeDistrictGroupShares` in `updateUI()` to get per-district shares on each render; pass as an optional `demoStat` param to `renderDistrictButtons`.

## Validation performed
- [x] `bazel build //game/web:app_typecheck_lib` — TypeScript type check passes
- [x] `bazel test //game/web:e2e_test` — all 140 tests pass (5 new GAME-080 tests added)
- [x] Verified on scenario-005 (Valle Verde): stat shows "N% Latino" under each of 5 district buttons; painting the valley into D1 shows 1 `.met` district

## Affected machines / services
- Static browser game only; no server, no database, no infra changes

## Deployment steps
- POST-MERGE: deploy to dev via `game/release.main.kts -- prepare && ./release.main.kts -- deploy --env dev`

## Affected components (detail)
- `game/web/src/simulation/evaluate.ts` — exported `computeDistrictGroupShares`, added `DistrictDemoStat` interface and `groupFilterLabel` helper
- `game/web/src/render/panels.ts` — `renderDistrictButtons` gains optional `demoStat?: DistrictDemoStat` param
- `game/web/src/main.ts` — detects criterion at load, computes stat in `updateUI()`
- `game/web/styles.css` — `.district-demo-stat` and `.met` styles
- `game/web/e2e/sprint5.spec.ts` — 5 new e2e tests
- `game/web/BUILD.bazel` — registers `sprint5.spec.ts` in test data

## Test plan
- [x] `GAME-080: scenario-005 shows district-demo-stat under each district button`
- [x] `GAME-080: district-demo-stat shows Latino percentage text`
- [x] `GAME-080: painting the winning solution gives district 1 the .met class`
- [x] `GAME-080: non-majority-minority scenario shows no demographic stat`
- [x] `GAME-080: stat count matches district button count`

## Tickets addressed
- see GAME-080

## Rollback
- Revert this PR; no data migration needed
