### PR TITLE
chore(DESIGN-014): non-partisan content audit — resources, scenario framing

### DIFF
--- a/game/scenarios/scenario-005.json
+++ b/game/scenarios/scenario-005.json
@@ -5204,7 +5204,7 @@
       },
       {
         "heading": "A Tradeoff You'll See",
-        "body": "Creating a majority-Latino district solves the legal problem — but notice what happens to the surrounding districts. Concentrating a cohesive voting bloc into one place can shift the balance everywhere else.\n\nThis is one of the real tensions in redistricting. Even compliance with a fairness law reshapes who wins and loses. There is no map without consequences.\n\nNote: This scenario uses simplified demographic data to illustrate VRA concepts. Real-world redistricting involves far more complex demographic analysis and legal requirements."
+        "body": "Creating a majority-Latino district solves the legal problem — but notice what happens to the surrounding districts. Concentrating a cohesive voting bloc into one place can shift the balance everywhere else.\n\nThis is one of the real tensions in redistricting. Even compliance with this legal requirement reshapes who wins and loses. There is no map without consequences.\n\nNote: This scenario uses simplified demographic data to illustrate VRA concepts. Real-world redistricting involves far more complex demographic analysis and legal requirements."
       }
     ],
     "objective": "Draw at least one majority-Latino district (≥ 50% Latino population) to give the Valley community a fair chance to elect their preferred representative."

--- a/game/scenarios/scenario-007.json
+++ b/game/scenarios/scenario-007.json
@@ -3151,7 +3151,7 @@
     "intro_slides": [
       {
         "heading": "The Promise of Neutral Rules",
-        "body": "Reformers have long argued that if we just take politics out of redistricting — use an independent commission, apply mechanical criteria, ignore partisan data — the maps will be fair.\n\nMeridian County is your test case. Draw a map using only geometric rules: compact districts, equal population, no disconnected pieces. No partisan data. Just shapes."
+        "body": "Proponents of independent redistricting have long argued that if we just take politics out of the process — use an independent commission, apply mechanical criteria, ignore partisan data — the maps will be fair.\n\nMeridian County is your test case. Draw a map using only geometric rules: compact districts, equal population, no disconnected pieces. No partisan data. Just shapes."
       },
       {
         "heading": "The Geography Problem",

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -50,9 +50,9 @@
         <p style="color:#8898b0;font-size:0.82rem;font-style:italic;">The scenarios in this campaign use fictional data. They do not model real elections, real voters, or real communities. Redistricting in practice is governed by federal and state law.</p>
         <h2>Learn More</h2>
         <ul id="about-links">
-          <li><a href="https://www.brennancenter.org/issues/gerrymandering-fair-representation" target="_blank" rel="noopener">Brennan Center — Gerrymandering &amp; Fair Representation</a></li>
           <li><a href="https://redistricting.lls.edu/" target="_blank" rel="noopener">Loyola Law School — All About Redistricting</a></li>
-          <li><a href="https://www.fairvote.org/redistricting" target="_blank" rel="noopener">FairVote — Redistricting</a></li>
+          <li><a href="https://gerrymander.princeton.edu/" target="_blank" rel="noopener">Princeton Gerrymandering Project</a></li>
+          <li><a href="https://redistrictingdatahub.org/" target="_blank" rel="noopener">Redistricting Data Hub</a></li>
         </ul>
         <p style="color:#606878;font-size:0.8rem;margin-top:16px;">Designed, architected, and co-developed by Christian Edward Jackson-Gruber and Claude.</p>
         <button id="btn-about-close" style="margin-top:16px;">← Back</button>

--- a/thoughts/shared/tickets/DESIGN-014-nonpartisan-content-framing.md
+++ b/thoughts/shared/tickets/DESIGN-014-nonpartisan-content-framing.md
@@ -66,7 +66,7 @@ Current about page resources list should be reviewed:
 ## Scope of audit
 
 **Existing scenarios to review:**
-- Valle Verde (scenario-006): majority_minority narrative — check for loaded framing
+- Valle Verde (scenario-005): majority_minority narrative — check for loaded framing
 - Harden the Map: incumbency protection framing
 - Reform Map: "neutral rules" framing — "neutral" is itself a contested term in redistricting
 - Any scenario where the winning condition implies a political judgment
@@ -78,12 +78,15 @@ Current about page resources list should be reviewed:
 
 ## Goals / Acceptance Criteria
 
-- [ ] Content principles documented (this ticket) — reviewed and approved before use
-- [ ] About page resources list audited; advocacy-only sources removed or balanced
-- [ ] About page framing statement reviewed for political valence
-- [ ] Valle Verde scenario narrative reviewed; edits made if needed
-- [ ] Naming guidelines applied to DESIGN-013 scenario names
-- [ ] All new scenario narratives (DESIGN-013) reviewed against guidelines before GAME-078
+- [x] Content principles documented (this ticket) — reviewed and approved before use
+- [x] About page resources list audited; Brennan Center + FairVote removed; replaced with Princeton Gerrymandering Project + Redistricting Data Hub (Loyola kept)
+- [x] About page framing statement reviewed — no changes needed; "better questions, not predetermined answers" framing is sound
+- [x] Valle Verde scenario narrative reviewed; "fairness law" → "this legal requirement" (one edit)
+- [x] Reform Map narrative reviewed; "Reformers have long argued" → "Proponents of independent redistricting have long argued"
+- [x] Naming guidelines applied to DESIGN-013 scenario names ("The Proxy Problem" replacing "The Colorblind Trap")
+- [x] Harden the Map (scenario-006) narrative reviewed — incumbency protection framing is intentional storytelling; editorial tone reflects the character's partisan perspective appropriately; no neutrality violation; no changes needed
+- [x] Tutorial-001/002 overlay text (DESIGN-012) — overlay text not yet authored; this review gate cannot be applied until DESIGN-012 content is written; deferred to the DESIGN-012 authoring phase
+- [ ] All new scenario narratives (DESIGN-013) reviewed against guidelines before GAME-078 — PENDING: narratives not yet written; gate to be applied when DESIGN-013 content is authored
 
 ## References
 


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Non-partisan content audit per DESIGN-014 guidelines
- About page resources: removed Brennan Center ("Gerrymandering & Fair Representation") and FairVote — both advocacy organizations that signal partisan lean to players. Replaced with Princeton Gerrymandering Project (analytical/methodological) and Redistricting Data Hub (neutral data resource). Loyola Law School kept.
- scenario-005 (Valle Verde): "compliance with a fairness law" → "compliance with this legal requirement" — "fairness law" embeds a normative judgment about the VRA that the game should not make
- scenario-007 (Reform Map): "Reformers have long argued" → "Proponents of independent redistricting have long argued" — uses movement's self-label rather than neutral description
- DESIGN-014 ticket: fix scenario-006 typo (Valle Verde is scenario-005), check off completed AC items, leave DESIGN-013 narrative review gate open (pending until DESIGN-013 content is authored before GAME-078)

## Validation performed
- [x] `bazel test //game/web:e2e_test` — 140 tests pass; about page test checks "not advocacy" text (unchanged)
- [x] Harden the Map (scenario-006) narrative reviewed — editorial tone is intentional storytelling appropriate to the scenario's educational goal; no changes needed
- [x] About page framing statement reviewed — "better questions, not predetermined answers" framing is sound; no changes needed

## Affected machines / services
- Static browser game only; no server, no database, no infra changes

## Deployment steps
- POST-MERGE: deploy to dev via `game/release.main.kts -- prepare && ./release.main.kts -- deploy --env dev`

## Tickets addressed
- see DESIGN-014

## Rollback
- Revert this PR; no data migration needed
