### PR TITLE
feat(GAME-075): terrain schema + loader (PR1 of 4)

### DIFF
--- a/game/web/src/model/adapter.ts
+++ b/game/web/src/model/adapter.ts
@@ -14,7 +14,7 @@
  */
 
 import type { Scenario } from "./scenario.js";
-import type { AssignmentMap, DistrictId, Precinct } from "./types.js";
+import type { AssignmentMap, DistrictId, Precinct, TerrainTileRuntime } from "./types.js";
 import { HEX_DIRECTIONS, hexToPixel } from "./hex-geometry.js";
 
 // vote_shares is Record<PartyId, number> with branded keys; cast to plain string map at runtime
@@ -24,6 +24,8 @@ export function scenarioToSpike(scenario: Scenario): {
 	precincts: Precinct[];
 	assignments: AssignmentMap;
 	districtCount: number;
+	terrainTiles: TerrainTileRuntime[];
+	riverEdges: [number, number][];
 } {
 	// Map scenario DistrictId (branded string) → spike DistrictId (1-based number)
 	const districtIndexMap = new Map<string, DistrictId>();
@@ -38,6 +40,31 @@ export function scenarioToSpike(scenario: Scenario): {
 		if ("q" in pos) posMap.set(`${pos.q},${pos.r}`, i);
 	});
 
+	// Build terrain tile position map for annotation derivation
+	const terrainPosMap = new Map<string, "sea" | "lake" | "mountain">();
+	for (const tile of scenario.terrain_tiles ?? []) {
+		terrainPosMap.set(`${tile.position.q},${tile.position.r}`, tile.type);
+	}
+
+	// Build ID→index map for river edge conversion (precincts are ordered by scenario.precincts array)
+	const idToIndex = new Map<string, number>();
+	scenario.precincts.forEach((pc, i) => idToIndex.set(pc.id, i));
+
+	// Build river edge set: "idxA,idxB" (both orderings) for fast passableNeighbors lookup
+	const riverPairs: [number, number][] = [];
+	const riverEdgeSet = new Set<string>();
+	for (const [aId, bId] of scenario.river_edges ?? []) {
+		const aIdx = idToIndex.get(aId);
+		const bIdx = idToIndex.get(bId);
+		if (aIdx !== undefined && bIdx !== undefined) {
+			riverPairs.push([aIdx, bIdx]);
+			riverEdgeSet.add(`${aIdx},${bIdx}`);
+			riverEdgeSet.add(`${bIdx},${aIdx}`);
+		}
+	}
+
+	const blocksContiguity = scenario.river_blocks_contiguity ?? false;
+
 	const precincts: Precinct[] = scenario.precincts.map((pc, i) => {
 		const pos = pc.position;
 		const q = "q" in pos ? (pos as { q: number; r: number }).q : 0;
@@ -50,6 +77,33 @@ export function scenarioToSpike(scenario: Scenario): {
 			const idx = posMap.get(`${q + dq},${r + dr}`);
 			return idx !== undefined ? idx : null;
 		});
+
+		// passableNeighbors: same as neighbors but river edges nulled when blocking
+		const passableNeighbors: (number | null)[] = neighbors.map((nbIdx) => {
+			if (!blocksContiguity || nbIdx === null) return nbIdx;
+			return riverEdgeSet.has(`${i},${nbIdx}`) ? null : nbIdx;
+		});
+
+		// Derive terrain annotation from adjacency (explicit value overrides derivation).
+		// Priority: explicit > coast (sea) > lakeside (lake) > foothill (mountain) > riverside (river edge).
+		// Terrain tiles are dominant features; rivers are edge features, so tiles take priority.
+		let terrain: Precinct["terrain"] = pc.terrain as Precinct["terrain"] | undefined;
+		if (terrain === undefined) {
+			let hasSea = false;
+			let hasLake = false;
+			let hasMountain = false;
+			for (const [dq, dr] of HEX_DIRECTIONS) {
+				const tileType = terrainPosMap.get(`${q + dq},${r + dr}`);
+				if (tileType === "sea") hasSea = true;
+				else if (tileType === "lake") hasLake = true;
+				else if (tileType === "mountain") hasMountain = true;
+			}
+			const isRiverside = riverPairs.some(([a, b]) => a === i || b === i);
+			if (hasSea) terrain = "coast";
+			else if (hasLake) terrain = "lakeside";
+			else if (hasMountain) terrain = "foothill";
+			else if (isRiverside) terrain = "riverside";
+		}
 
 		// Population-weighted vote shares (turnout ignored until Sprint 3)
 		// Map first scenario party → R, second → D (matches partyIdToKey in main.ts)
@@ -79,6 +133,7 @@ export function scenarioToSpike(scenario: Scenario): {
 			coord: { q, r },
 			center,
 			neighbors,
+			passableNeighbors,
 			population: pc.total_population,
 			partyShare,
 			previousResult: { winner, margin },
@@ -86,6 +141,8 @@ export function scenarioToSpike(scenario: Scenario): {
 		};
 		if (pc.name !== undefined) spikePrecinct.name = pc.name;
 		if (pc.county_id !== undefined) spikePrecinct.county_id = pc.county_id;
+		if (terrain !== undefined) spikePrecinct.terrain = terrain;
+		if (pc.has_internal_lake) spikePrecinct.has_internal_lake = true;
 		if (pc.demographic_groups.length > 1) {
 			spikePrecinct.groupShares = pc.demographic_groups.map((g) => {
 				const entry: { name: string; share: number; dimensions?: Record<string, string> } = {
@@ -108,5 +165,11 @@ export function scenarioToSpike(scenario: Scenario): {
 		assignments.set(i, spikeDistId);
 	});
 
-	return { precincts, assignments, districtCount: scenario.districts.length };
+	// Build runtime terrain tiles with pixel centers
+	const terrainTiles: TerrainTileRuntime[] = (scenario.terrain_tiles ?? []).map((tile) => ({
+		center: hexToPixel(tile.position.q, tile.position.r),
+		type: tile.type,
+	}));
+
+	return { precincts, assignments, districtCount: scenario.districts.length, terrainTiles, riverEdges: riverPairs };
 }

--- a/game/web/src/model/adapter_test.ts
+++ b/game/web/src/model/adapter_test.ts
@@ -244,4 +244,177 @@ test("scenarioToSpike: districtCount matches scenario.districts.length", () => {
 	assertEqual(districtCount, 3, "districtCount = 3");
 });
 
+// ─── Terrain ──────────────────────────────────────────────────────────────────
+
+test("scenarioToSpike: terrain tiles converted with pixel centers", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+		terrain_tiles: [
+			{ position: { q: 1, r: 0 }, type: "sea" },
+			{ position: { q: 0, r: 1 }, type: "mountain" },
+		],
+	});
+	const { terrainTiles } = scenarioToSpike(scenario);
+	assertEqual(terrainTiles.length, 2, "two terrain tiles");
+	assertEqual(terrainTiles[0]!.type, "sea", "first is sea");
+	assertEqual(terrainTiles[1]!.type, "mountain", "second is mountain");
+});
+
+test("scenarioToSpike: coast annotation derived from adjacency to sea tile", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+		terrain_tiles: [{ position: { q: 1, r: 0 }, type: "sea" }],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.terrain, "coast", "precinct adjacent to sea → coast");
+});
+
+test("scenarioToSpike: explicit terrain annotation overrides derivation", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [{
+			...makePrecinct(0, 0, [g], "d1"),
+			terrain: "lakeside" as const,
+		}],
+		terrain_tiles: [{ position: { q: 1, r: 0 }, type: "sea" }],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.terrain, "lakeside", "explicit terrain wins over derived coast");
+});
+
+test("scenarioToSpike: river edges converted to integer index pairs", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const p1 = makePrecinct(0, 0, [g], "d1");
+	const p2 = makePrecinct(1, 0, [g], "d1");
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [p1, p2],
+		river_edges: [[p1.id, p2.id]],
+	});
+	const { riverEdges } = scenarioToSpike(scenario);
+	assertEqual(riverEdges.length, 1, "one river pair");
+	assertEqual(riverEdges[0]![0], 0, "p1 → index 0");
+	assertEqual(riverEdges[0]![1], 1, "p2 → index 1");
+});
+
+test("scenarioToSpike: passableNeighbors = neighbors when river_blocks_contiguity is false", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const p1 = makePrecinct(0, 0, [g], "d1");
+	const p2 = makePrecinct(1, 0, [g], "d1");
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [p1, p2],
+		river_edges: [[p1.id, p2.id]],
+		river_blocks_contiguity: false,
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	// p1.neighbors[0] = 1 (lower-right); passableNeighbors[0] should also be 1
+	assertEqual(precincts[0]!.neighbors[0], 1, "p1.neighbors[0] = 1");
+	assertEqual(precincts[0]!.passableNeighbors![0], 1, "passable unchanged when not blocking");
+});
+
+test("scenarioToSpike: sea takes priority over lake in derivation (coast wins)", () => {
+	// Precinct at (0,0) with sea at (1,0) and lake at (-1,0) on opposite sides.
+	// Per priority: sea > lake → terrain should be "coast", not "lakeside".
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+		terrain_tiles: [
+			{ position: { q: -1, r: 0 }, type: "lake" },
+			{ position: { q: 1, r: 0 }, type: "sea" },
+		],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.terrain, "coast", "sea priority over lake → coast");
+});
+
+test("scenarioToSpike: foothill annotation derived from mountain adjacency", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+		terrain_tiles: [{ position: { q: 1, r: 0 }, type: "mountain" }],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.terrain, "foothill", "precinct adjacent to mountain → foothill");
+});
+
+test("scenarioToSpike: riverside annotation derived when no terrain tile adjacency", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const p1 = makePrecinct(0, 0, [g], "d1");
+	const p2 = makePrecinct(1, 0, [g], "d1");
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [p1, p2],
+		river_edges: [[p1.id, p2.id]],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.terrain, "riverside", "p1 in river edge → riverside");
+	assertEqual(precincts[1]!.terrain, "riverside", "p2 in river edge → riverside");
+});
+
+test("scenarioToSpike: foothill takes priority over riverside", () => {
+	// Precinct adjacent to a mountain tile AND in a river edge → foothill.
+	// Per priority: coast > lakeside > foothill > riverside.
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const p1 = makePrecinct(0, 0, [g], "d1");
+	const p2 = makePrecinct(0, 1, [g], "d1"); // adjacent to p1 via edge 1 (down)
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [p1, p2],
+		terrain_tiles: [{ position: { q: 1, r: 0 }, type: "mountain" }],
+		river_edges: [[p1.id, p2.id]],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.terrain, "foothill", "foothill priority over riverside");
+});
+
+test("scenarioToSpike: has_internal_lake round-trips through adapter", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [{
+			...makePrecinct(0, 0, [g], "d1"),
+			terrain: "lakeside" as const,
+			has_internal_lake: true,
+		}],
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	assertEqual(precincts[0]!.terrain, "lakeside", "lakeside set");
+	assertEqual(precincts[0]!.has_internal_lake, true, "has_internal_lake propagated");
+});
+
+test("scenarioToSpike: passableNeighbors nulls river edges when river_blocks_contiguity is true", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
+	const p1 = makePrecinct(0, 0, [g], "d1");
+	const p2 = makePrecinct(1, 0, [g], "d1");
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [p1, p2],
+		river_edges: [[p1.id, p2.id]],
+		river_blocks_contiguity: true,
+	});
+	const { precincts } = scenarioToSpike(scenario);
+	// neighbors retains 1 for geometry; passableNeighbors nulls it
+	assertEqual(precincts[0]!.neighbors[0], 1, "neighbors[0] still 1 (geometry preserved)");
+	assertNull(precincts[0]!.passableNeighbors![0], "passableNeighbors[0] nulled (river blocks)");
+});
+
 summarize();

--- a/game/web/src/model/loader.ts
+++ b/game/web/src/model/loader.ts
@@ -34,7 +34,14 @@ import type {
   StateContext,
   SuccessCriterion,
   GeometrySpec,
+  TerrainTile,
+  TerrainAnnotation,
 } from "./scenario.js";
+
+// Flat-top axial hex direction vectors (mirrors HEX_DIRECTIONS in hex-geometry.ts)
+const HEX_DIRS: [number, number][] = [
+  [1, 0], [0, 1], [-1, 1], [-1, 0], [0, -1], [1, -1],
+];
 
 // ─── Epsilon for floating-point sum checks ───────────────────────────────────
 
@@ -206,6 +213,19 @@ function parsePrecinct(raw: unknown, idx: number): Omit<Precinct, "initial_distr
   if (r["neighbors"] !== undefined) {
     const nbRaw = requireArray(r["neighbors"], `${label}.neighbors`);
     pc.neighbors = nbRaw.map((n, i) => requireString(n, `${label}.neighbors[${i}]`) as PrecinctId);
+  }
+
+  // Terrain annotation (optional; derived from adjacency if absent)
+  if (r["terrain"] !== undefined) {
+    const t = requireString(r["terrain"], `${label}.terrain`);
+    const validAnnotations = ["coast", "lakeside", "riverside", "foothill"];
+    if (!validAnnotations.includes(t)) {
+      throw new Error(`${label}.terrain: unknown value "${t}"; expected one of: ${validAnnotations.join(", ")}`);
+    }
+    pc.terrain = t as TerrainAnnotation;
+  }
+  if (r["has_internal_lake"] !== undefined) {
+    pc.has_internal_lake = requireBoolean(r["has_internal_lake"], `${label}.has_internal_lake`);
   }
 
   // initial_district_id: absent, null, or a string
@@ -475,6 +495,19 @@ function parseStateContext(raw: unknown): StateContext {
   };
 }
 
+function parseTerrainTile(raw: unknown, idx: number): TerrainTile {
+  const label = `terrain_tiles[${idx}]`;
+  const r = requireObject(raw, label);
+  const posRaw = requireObject(r["position"], `${label}.position`);
+  const q = requireNumber(posRaw["q"], `${label}.position.q`);
+  const rr = requireNumber(posRaw["r"], `${label}.position.r`);
+  const type = requireString(r["type"], `${label}.type`);
+  if (type !== "sea" && type !== "lake" && type !== "mountain") {
+    throw new Error(`${label}.type: unknown value "${type}"; expected "sea", "lake", or "mountain"`);
+  }
+  return { position: { q, r: rr }, type };
+}
+
 // ─── Validation helpers ───────────────────────────────────────────────────────
 
 /** Collect all GroupId values referenced in a GroupFilter (only group_ids form; dimension form has no explicit GroupId refs). */
@@ -615,6 +648,33 @@ export function loadScenario(json: unknown): Scenario {
   let state_context: StateContext | undefined;
   if (raw["state_context"] !== undefined) {
     state_context = parseStateContext(raw["state_context"]);
+  }
+
+  // ── Parse terrain fields ─────────────────────────────────────────────────────
+  let terrain_tiles: TerrainTile[] | undefined;
+  if (raw["terrain_tiles"] !== undefined) {
+    const tilesRaw = requireArray(raw["terrain_tiles"], "terrain_tiles");
+    terrain_tiles = tilesRaw.map((t, i) => parseTerrainTile(t, i));
+  }
+
+  let river_edges: [PrecinctId, PrecinctId][] | undefined;
+  if (raw["river_edges"] !== undefined) {
+    const edgesRaw = requireArray(raw["river_edges"], "river_edges");
+    river_edges = edgesRaw.map((pair, i) => {
+      const pairArr = requireArray(pair, `river_edges[${i}]`);
+      if (pairArr.length !== 2) {
+        throw new Error(`river_edges[${i}]: expected array of 2 precinct IDs, got ${pairArr.length}`);
+      }
+      return [
+        requireString(pairArr[0], `river_edges[${i}][0]`) as PrecinctId,
+        requireString(pairArr[1], `river_edges[${i}][1]`) as PrecinctId,
+      ];
+    });
+  }
+
+  let river_blocks_contiguity: boolean | undefined;
+  if (raw["river_blocks_contiguity"] !== undefined) {
+    river_blocks_contiguity = requireBoolean(raw["river_blocks_contiguity"], "river_blocks_contiguity");
   }
 
   // ── VALIDATION INVARIANTS ────────────────────────────────────────────────────
@@ -903,6 +963,151 @@ export function loadScenario(json: unknown): Scenario {
     }
   }
 
+  // ── Terrain validation ────────────────────────────────────────────────────────
+  // Terrain features (terrain_tiles, river_edges) require hex_axial geometry in v1.
+  if (geometry.type === "custom") {
+    if (terrain_tiles !== undefined && terrain_tiles.length > 0) {
+      throw new Error(
+        `Terrain validation: terrain_tiles require geometry.type "hex_axial"; custom geometry is not supported in v1`
+      );
+    }
+    if (river_edges !== undefined && river_edges.length > 0) {
+      throw new Error(
+        `Terrain validation: river_edges require geometry.type "hex_axial"; custom geometry is not supported in v1`
+      );
+    }
+  }
+
+  if (terrain_tiles !== undefined && terrain_tiles.length > 0) {
+    // Build precinct position set for overlap check
+    const precinctPosSet = new Set<string>();
+    for (const pc of rawPrecincts) {
+      const pos = pc.position;
+      if ("q" in pos) precinctPosSet.add(`${pos.q},${pos.r}`);
+    }
+
+    // Build terrain position map for lake/sea adjacency check
+    const tileTypeMap = new Map<string, string>();
+    for (const tile of terrain_tiles) {
+      const key = `${tile.position.q},${tile.position.r}`;
+      // Terrain Validation 1: tile must not overlap a precinct position
+      if (precinctPosSet.has(key)) {
+        throw new Error(
+          `Terrain validation: terrain_tile at (${tile.position.q},${tile.position.r}) overlaps precinct position`
+        );
+      }
+      tileTypeMap.set(key, tile.type);
+    }
+
+    // Terrain Validation 2: lake tile must not be adjacent to sea tile
+    for (const tile of terrain_tiles) {
+      if (tile.type !== "lake") continue;
+      for (const [dq, dr] of HEX_DIRS) {
+        const nKey = `${tile.position.q + dq},${tile.position.r + dr}`;
+        if (tileTypeMap.get(nKey) === "sea") {
+          throw new Error(
+            `Terrain validation: lake tile at (${tile.position.q},${tile.position.r}) is adjacent to sea tile at (${tile.position.q + dq},${tile.position.r + dr})`
+          );
+        }
+      }
+    }
+
+    // Terrain Validation 3: no precinct fully enclosed by mountain tiles
+    // BFS from an outside position (one step beyond min bounding box) through non-mountain positions.
+    // Any precinct position unreachable from outside is enclosed.
+    {
+      const mountainSet = new Set<string>();
+      for (const tile of terrain_tiles) {
+        if (tile.type === "mountain") mountainSet.add(`${tile.position.q},${tile.position.r}`);
+      }
+
+      if (mountainSet.size > 0) {
+        // Find bounding box of all precinct + terrain tile positions
+        const allQs: number[] = [];
+        const allRs: number[] = [];
+        for (const pc of rawPrecincts) {
+          const pos = pc.position;
+          if ("q" in pos) { allQs.push(pos.q); allRs.push(pos.r); }
+        }
+        for (const tile of terrain_tiles) {
+          allQs.push(tile.position.q);
+          allRs.push(tile.position.r);
+        }
+        const minQ = Math.min(...allQs) - 2;
+        const maxQ = Math.max(...allQs) + 2;
+        const minR = Math.min(...allRs) - 2;
+        const maxR = Math.max(...allRs) + 2;
+
+        // BFS from a corner position outside the bounding box
+        const outsideKey = `${minQ},${minR}`;
+        const visited = new Set<string>([outsideKey]);
+        const queue: string[] = [outsideKey];
+
+        while (queue.length > 0) {
+          const curr = queue.shift()!;
+          const [cq, cr] = curr.split(",").map(Number) as [number, number];
+          for (const [dq, dr] of HEX_DIRS) {
+            const nq = cq + dq;
+            const nr = cr + dr;
+            // Expand only within a reasonable search bounds
+            if (nq < minQ - 1 || nq > maxQ + 1 || nr < minR - 1 || nr > maxR + 1) continue;
+            const nKey = `${nq},${nr}`;
+            if (!visited.has(nKey) && !mountainSet.has(nKey)) {
+              visited.add(nKey);
+              queue.push(nKey);
+            }
+          }
+        }
+
+        // Check every precinct is reachable from outside
+        for (const pc of rawPrecincts) {
+          const pos = pc.position;
+          if ("q" in pos) {
+            const key = `${pos.q},${pos.r}`;
+            if (!visited.has(key)) {
+              throw new Error(
+                `Terrain validation: precinct "${pc.id}" at (${pos.q},${pos.r}) is fully enclosed by mountain tiles`
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Validate river_edges: both precinct IDs must exist AND be geometrically adjacent.
+  if (river_edges !== undefined) {
+    // Build precinct position lookup for adjacency check (hex_axial only — custom rejected above)
+    const precinctPosByid = new Map<PrecinctId, { q: number; r: number }>();
+    if (geometry.type === "hex_axial") {
+      for (const pc of rawPrecincts) {
+        const pos = pc.position;
+        if ("q" in pos) precinctPosByid.set(pc.id, { q: pos.q, r: pos.r });
+      }
+    }
+
+    for (const [aId, bId] of river_edges) {
+      if (!precinctIds.has(aId)) {
+        throw new Error(`river_edges: precinct "${aId}" does not exist in precincts`);
+      }
+      if (!precinctIds.has(bId)) {
+        throw new Error(`river_edges: precinct "${bId}" does not exist in precincts`);
+      }
+      const aPos = precinctPosByid.get(aId);
+      const bPos = precinctPosByid.get(bId);
+      if (aPos !== undefined && bPos !== undefined) {
+        const dq = bPos.q - aPos.q;
+        const dr = bPos.r - aPos.r;
+        const isAdjacent = HEX_DIRS.some(([ddq, ddr]) => ddq === dq && ddr === dr);
+        if (!isAdjacent) {
+          throw new Error(
+            `river_edges: precincts "${aId}" (${aPos.q},${aPos.r}) and "${bId}" (${bPos.q},${bPos.r}) are not geometrically adjacent`
+          );
+        }
+      }
+    }
+  }
+
   // ── Auto-fill initial_district_id for editable precincts ─────────────────────
   const fillDistrictId = default_district_id ?? districts[0]!.id;
 
@@ -950,6 +1155,9 @@ export function loadScenario(json: unknown): Scenario {
   if (instigator_character !== undefined) scenario.instigator_character = instigator_character;
   if (character_demographics !== undefined) scenario.character_demographics = character_demographics;
   if (state_context !== undefined) scenario.state_context = state_context;
+  if (terrain_tiles !== undefined) scenario.terrain_tiles = terrain_tiles;
+  if (river_edges !== undefined) scenario.river_edges = river_edges;
+  if (river_blocks_contiguity !== undefined) scenario.river_blocks_contiguity = river_blocks_contiguity;
 
   return scenario;
 }

--- a/game/web/src/model/loader_test.ts
+++ b/game/web/src/model/loader_test.ts
@@ -774,4 +774,200 @@ test("events with dimension group_filter (no group_ids) pass without group exist
   assertEqual(result.events.length, 1);
 });
 
+// ─── Terrain validation ───────────────────────────────────────────────────────
+
+test("terrain: happy path — terrain_tiles, river_edges, river_blocks_contiguity accepted", () => {
+  assertDoesNotThrow(() => loadScenario(minimalScenario({
+    precincts: [
+      {
+        id: "p1",
+        editable: true,
+        position: { q: 0, r: 0 },
+        total_population: 1000,
+        demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
+      },
+      {
+        id: "p2",
+        editable: true,
+        position: { q: 1, r: 0 },
+        total_population: 800,
+        demographic_groups: [{ id: "g2", population_share: 1.0, vote_shares: { blue: 0.5, red: 0.5 }, turnout_rate: 0.6 }],
+        terrain: "coast",
+      },
+    ],
+    terrain_tiles: [
+      { position: { q: 2, r: 0 }, type: "sea" },
+    ],
+    river_edges: [["p1", "p2"]],
+    river_blocks_contiguity: false,
+  })));
+});
+
+test("terrain: rejects terrain tile overlapping a precinct position", () => {
+  assertThrows(
+    () => loadScenario(minimalScenario({
+      terrain_tiles: [
+        { position: { q: 0, r: 0 }, type: "mountain" },
+      ],
+    })),
+    /Terrain validation.*overlaps precinct/
+  );
+});
+
+test("terrain: rejects lake tile adjacent to sea tile", () => {
+  assertThrows(
+    () => loadScenario(minimalScenario({
+      precincts: [
+        {
+          id: "p1",
+          editable: true,
+          position: { q: 5, r: 5 },
+          total_population: 1000,
+          demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
+        },
+      ],
+      terrain_tiles: [
+        { position: { q: 0, r: 0 }, type: "lake" },
+        { position: { q: 1, r: 0 }, type: "sea" },
+      ],
+    })),
+    /Terrain validation.*lake.*adjacent.*sea/
+  );
+});
+
+test("terrain: rejects precinct fully enclosed by mountain tiles", () => {
+  // p1 at (0,0); mountains at all 6 neighbors
+  assertThrows(
+    () => loadScenario(minimalScenario({
+      terrain_tiles: [
+        { position: { q: 1, r: 0 }, type: "mountain" },
+        { position: { q: 0, r: 1 }, type: "mountain" },
+        { position: { q: -1, r: 1 }, type: "mountain" },
+        { position: { q: -1, r: 0 }, type: "mountain" },
+        { position: { q: 0, r: -1 }, type: "mountain" },
+        { position: { q: 1, r: -1 }, type: "mountain" },
+      ],
+    })),
+    /Terrain validation.*enclosed by mountain/
+  );
+});
+
+test("terrain: rejects river_edges referencing unknown precinct", () => {
+  assertThrows(
+    () => loadScenario(minimalScenario({
+      river_edges: [["p1", "p_unknown"]],
+    })),
+    /river_edges.*p_unknown.*does not exist/
+  );
+});
+
+test("terrain: precinct terrain field parsed and returned", () => {
+  const result = loadScenario(minimalScenario({
+    precincts: [
+      {
+        id: "p1",
+        editable: true,
+        position: { q: 0, r: 0 },
+        total_population: 1000,
+        demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
+        terrain: "riverside",
+        has_internal_lake: true,
+      },
+    ],
+  }));
+  assertEqual(result.precincts[0]!.terrain, "riverside");
+  assertEqual(result.precincts[0]!.has_internal_lake, true);
+});
+
+test("terrain: rejects river edge between non-adjacent precincts", () => {
+  assertThrows(
+    () => loadScenario(minimalScenario({
+      precincts: [
+        {
+          id: "p1",
+          editable: true,
+          position: { q: 0, r: 0 },
+          total_population: 1000,
+          demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
+        },
+        {
+          id: "p2",
+          editable: true,
+          position: { q: 5, r: 5 },
+          total_population: 1000,
+          demographic_groups: [{ id: "g2", population_share: 1.0, vote_shares: { blue: 0.5, red: 0.5 }, turnout_rate: 0.6 }],
+        },
+      ],
+      river_edges: [["p1", "p2"]],
+    })),
+    /river_edges.*not geometrically adjacent/
+  );
+});
+
+test("terrain: rejects terrain_tiles when geometry is custom", () => {
+  assertThrows(
+    () => loadScenario(minimalScenario({
+      geometry: { type: "custom" },
+      precincts: [
+        {
+          id: "p1",
+          editable: true,
+          position: { x: 0, y: 0 },
+          total_population: 1000,
+          demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
+          neighbors: [],
+        },
+      ],
+      terrain_tiles: [{ position: { q: 1, r: 0 }, type: "sea" }],
+    })),
+    /custom geometry is not supported/
+  );
+});
+
+test("terrain: rejects river_edges when geometry is custom", () => {
+  assertThrows(
+    () => loadScenario(minimalScenario({
+      geometry: { type: "custom" },
+      precincts: [
+        {
+          id: "p1",
+          editable: true,
+          position: { x: 0, y: 0 },
+          total_population: 1000,
+          demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
+          neighbors: ["p2"],
+        },
+        {
+          id: "p2",
+          editable: true,
+          position: { x: 1, y: 0 },
+          total_population: 1000,
+          demographic_groups: [{ id: "g2", population_share: 1.0, vote_shares: { blue: 0.5, red: 0.5 }, turnout_rate: 0.6 }],
+          neighbors: ["p1"],
+        },
+      ],
+      river_edges: [["p1", "p2"]],
+    })),
+    /custom geometry is not supported/
+  );
+});
+
+test("terrain: rejects unknown terrain annotation value", () => {
+  assertThrows(
+    () => loadScenario(minimalScenario({
+      precincts: [
+        {
+          id: "p1",
+          editable: true,
+          position: { q: 0, r: 0 },
+          total_population: 1000,
+          demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
+          terrain: "volcano",
+        },
+      ],
+    })),
+    /terrain.*unknown value.*volcano/
+  );
+});
+
 summarize();

--- a/game/web/src/model/scenario.ts
+++ b/game/web/src/model/scenario.ts
@@ -42,6 +42,17 @@ export interface HexAxialPosition {
 	r: number;
 }
 
+// ─── Terrain ──────────────────────────────────────────────────────────────────
+
+export type TerrainType = "sea" | "lake" | "mountain";
+
+export type TerrainAnnotation = "coast" | "lakeside" | "riverside" | "foothill";
+
+export interface TerrainTile {
+	position: HexAxialPosition;
+	type: TerrainType;
+}
+
 export interface CartesianPosition {
 	x: number;
 	y: number;
@@ -114,6 +125,10 @@ export interface Precinct {
 	initial_district_id?: DistrictId | null;
 	name?: string;
 	tags?: string[];
+	/** Explicit terrain annotation; derived from adjacency if absent */
+	terrain?: TerrainAnnotation;
+	/** When true and terrain === "lakeside": render small internal lake within hex */
+	has_internal_lake?: boolean;
 }
 
 // ─── Events ───────────────────────────────────────────────────────────────────
@@ -263,4 +278,10 @@ export interface Scenario {
 	character_demographics?: Partial<Record<CharacterType, string>>;
 	/** v1: parsed but may be ignored by renderer */
 	state_context?: StateContext;
+	/** Non-precinct terrain tiles (sea, lake, mountain) */
+	terrain_tiles?: TerrainTile[];
+	/** Pairs of adjacent precinct IDs with a river along their shared edge */
+	river_edges?: [PrecinctId, PrecinctId][];
+	/** When true, river edges are excluded from contiguity BFS (hard boundaries) */
+	river_blocks_contiguity?: boolean;
 }

--- a/game/web/src/model/types.ts
+++ b/game/web/src/model/types.ts
@@ -61,6 +61,16 @@ export interface Precinct {
 	 * Directions: [0]=lower-right, [1]=down, [2]=lower-left, [3]=upper-left, [4]=up, [5]=upper-right
 	 */
 	neighbors: (number | null)[];
+	/**
+	 * Like neighbors, but river-edge pairs are nulled out when river_blocks_contiguity is true.
+	 * BFS uses this; geometry/rendering uses neighbors.
+	 * Absent only on legacy/test precincts without terrain — BFS falls back to neighbors.
+	 */
+	passableNeighbors?: (number | null)[];
+	/** Terrain annotation derived from adjacency (or explicitly authored) */
+	terrain?: "coast" | "lakeside" | "riverside" | "foothill";
+	/** When true: precinct is lakeside with a small lake rendered within the hex */
+	has_internal_lake?: boolean;
 	/** Population count (arbitrary units) */
 	population: number;
 	/** Partisan vote share, floats summing to 1.0 */
@@ -71,6 +81,12 @@ export interface Precinct {
 	demographics: Demographics;
 	/** Per-group population shares from scenario demographic_groups (for info panel) */
 	groupShares?: { name: string; share: number; dimensions?: Record<string, string> }[];
+}
+
+/** Runtime terrain tile (non-precinct; non-assignable; non-interactive) */
+export interface TerrainTileRuntime {
+	center: Point;
+	type: "sea" | "lake" | "mountain";
 }
 
 /** A district is identified by a 1-based integer index */
@@ -113,6 +129,10 @@ export interface GameState {
 	activeDistrict: DistrictId;
 	/** Last simulation result (null if no districts assigned) */
 	simulationResult: SimulationResult | null;
+	/** Non-precinct terrain tiles with pixel positions (absent = no terrain in scenario) */
+	terrainTiles?: TerrainTileRuntime[];
+	/** River edge pairs as precinct index pairs (absent = no rivers in scenario) */
+	riverEdges?: [number, number][];
 }
 
 /** A brush stroke undo/redo diff: maps precinctId → {from, to} */

--- a/game/web/src/store/gameStore.ts
+++ b/game/web/src/store/gameStore.ts
@@ -44,7 +44,7 @@ function cloneAssignments(m: AssignmentMap): AssignmentMap {
  * Called once in main.ts after fetching + validating the scenario JSON.
  */
 export function createGameStore(scenario: Scenario) {
-	const { precincts, assignments, districtCount } = scenarioToSpike(scenario);
+	const { precincts, assignments, districtCount, terrainTiles, riverEdges } = scenarioToSpike(scenario);
 
 	// Snapshot of initial assignments — used by resetToInitial() to restore scenario start state
 	const initialAssignments: AssignmentMap = new Map(assignments);
@@ -55,6 +55,8 @@ export function createGameStore(scenario: Scenario) {
 		assignments,
 		activeDistrict: 1,
 		simulationResult: null,
+		terrainTiles,
+		riverEdges,
 	};
 	initialState.simulationResult = runElection(initialState);
 

--- a/thoughts/shared/plans/2026-05-18-game-075-terrain.compressed.md
+++ b/thoughts/shared/plans/2026-05-18-game-075-terrain.compressed.md
@@ -1,0 +1,53 @@
+<!--COMPRESSED v1; source:2026-05-18-game-075-terrain.md-->
+§META
+date:2026-05-18 author:Claude ticket:GAME-075 status:active
+
+§ABBREV
+sc=scenario.ts ty=types.ts lo=loader.ts vl=validity.ts mr=mapRenderer.ts hg=hex-geometry.ts
+
+§GOAL
+Terrain tiles(sea/lake/mountain) + edge rivers + precinct annotations(coast/lakeside/riverside/foothill) + symbolic rendering + contiguity river-blocking + demo scenario.
+
+§CONTEXT
+sc:Precinct no terrain fields; Scenario no terrain arrays.
+ty:Precinct.neighbors(number|null)[] used by BFS + boundary renderer.
+lo: no terrain logic; idToIndex Map already built during precinct parse.
+vl:BFS at line 105 iterates p.neighbors unconditionally.
+mr:constructor groups(bottom→top): borderGroup→hexGroup→countyBorderGroup→previewBorderGroup
+
+§DESIGN_DECISION
+neighbors vs passableNeighbors: keep neighbors intact(geometry); add passableNeighbors:(number|null)[] to runtime Precinct; mirrors neighbors but nulls river-edge pairs when river_blocks_contiguity:true; BFS reads passableNeighbors; river rendering uses river_edges pairs+hexCorners() independently.
+
+River edge bridge: schema river_edges=[PrecinctId,PrecinctId][] → runtime [number,number][] via idToIndex; converted after all precincts parsed.
+
+Terrain tile pixels: hex_axial only v1; hexToPixel(q,r) from hg.
+
+§STEPS
+PR1 schema+loader(no rendering no BFS):
+  sc: add TerrainType|TerrainTile|TerrainAnnotation; extend Scenario(terrain_tiles?|river_edges?|river_blocks_contiguity?); extend Precinct(terrain?|has_internal_lake?)
+  ty: add terrain?:TerrainAnnotation|has_internal_lake?:boolean|passableNeighbors:(number|null)[] to runtime Precinct
+  lo: parse tiles+edges+precinct terrain; derive annotations from adjacency; compute passableNeighbors; add validations
+  tests: reject tile overlapping precinct; reject lake adj sea; detect mountain enclosure; derive coast; passableNeighbors river blocking
+
+PR2 renderer:
+  mr: terrainGroup(below hexes)|riverGroup(between hexes+borders); render tiles; render rivers; coast/lakeside edge strokes; internal lake ellipse(per-precinct v1; no bridging)
+  new layer order: borderGroup→terrainGroup→hexGroup→riverGroup→countyBorderGroup→previewBorderGroup
+  river coords: for [idxA,idxB] → find edge i where neighbors[i]===idxB → segment cornersA[i]→cornersA[(i+1)%6]
+  e2e: terrain visible; not paintable; river stroke visible
+
+PR3 contiguity:
+  vl: BFS uses p.passableNeighbors (one-line change)
+  unit tests: river-blocked BFS
+
+PR4 demo scenario:
+  scenario-008.json: sea+mountain+river; pop gradient(urban cluster+sparse coast/highland)
+  register in campaign JSON
+  may coordinate with GAME-078(VRA scenarios)
+
+§RISKS
+Internal lake bridging(2+ adjacent has_internal_lake→shared ellipse): deferred; v1=one ellipse per precinct.
+Annotation derivation O(n) per precinct — negligible for S13 sizes.
+foothill rendering: nice-to-have; implement in PR2 if fast else defer.
+
+§DEFER
+River endpoint reachability validation | lake+sea→river required (warning only) | foothill rendering | internal lake bridging

--- a/thoughts/shared/plans/2026-05-18-game-075-terrain.md
+++ b/thoughts/shared/plans/2026-05-18-game-075-terrain.md
@@ -1,0 +1,110 @@
+---
+date: 2026-05-18
+author: Claude (Sonnet 4.6)
+ticket: GAME-075
+status: active
+---
+
+# GAME-075 — Terrain Implementation Plan
+
+## Goal
+
+Add terrain tiles (sea/lake/mountain), edge rivers, precinct annotations (coast/lakeside/
+riverside/foothill), symbolic rendering for all terrain types, contiguity river-blocking,
+and at least one new terrain scenario.
+
+## Context / Current State
+
+- `scenario.ts` (schema): `Precinct` has no terrain fields. `Scenario` has no terrain arrays.
+- `types.ts` (runtime): `Precinct` has `neighbors: (number|null)[]` used by BFS + boundary renderer.
+- `loader.ts`: bridges schema→runtime; no terrain logic.
+- `validity.ts`: BFS at line 105 iterates `p.neighbors` unconditionally.
+- `mapRenderer.ts`: constructor appends groups in order: `borderGroup → hexGroup → countyBorderGroup → previewBorderGroup`. All inside `zoomGroup`.
+
+## Key Design Decision — neighbors vs passableNeighbors
+
+`Precinct.neighbors[i]` is used in two places that must disagree when a river blocks contiguity:
+1. `mapRenderer.ts:computeBoundarySegments` — needs all geometric neighbors to draw edge segments
+2. `validity.ts:isContiguous` (BFS) — must not traverse river-blocked edges when `river_blocks_contiguity: true`
+
+**Decision**: keep `neighbors` intact for geometry; add `passableNeighbors: (number|null)[]`
+to the runtime `Precinct` populated by the loader. `passableNeighbors` mirrors `neighbors`
+but nulls out river-edge pairs when `river_blocks_contiguity: true`. BFS reads `passableNeighbors`.
+River rendering is computed independently from `river_edges` pairs via `hexCorners()` — it does
+not depend on or modify `neighbors`.
+
+## Schema→Runtime Bridge for river_edges
+
+`river_edges` in schema: `[PrecinctId, PrecinctId][]` (string branded IDs).
+Runtime: need `[number, number][]` (integer indices into precincts array).
+Loader maintains `idToIndex: Map<PrecinctId, number>` (already built during precinct parsing).
+Loader converts river edge pairs during terrain phase, after all precincts are parsed.
+
+## Terrain tile pixel positions
+
+For `hex_axial` geometry: `hexToPixel(q, r)` from `hex-geometry.ts` gives the center.
+For `custom` geometry: terrain tiles are not supported in v1 (spec is hex-grid only).
+
+## PR Staging Plan
+
+### PR1 — Schema + Loader (no rendering, no BFS changes)
+
+Files:
+- `game/web/src/model/scenario.ts` — add `TerrainType`, `TerrainTile`, `TerrainAnnotation` types; extend `Scenario` with `terrain_tiles?`, `river_edges?`, `river_blocks_contiguity?`; extend `Precinct` with `terrain?`, `has_internal_lake?`
+- `game/web/src/model/types.ts` — add `terrain?: TerrainAnnotation`, `has_internal_lake?: boolean`, `passableNeighbors: (number|null)[]` to runtime `Precinct`
+- `game/web/src/simulation/loader.ts` — parse terrain tiles, river edges, precinct terrain; derive annotations from adjacency; compute `passableNeighbors`; add loader validations
+- `game/web/src/simulation/loader.test.ts` (or equivalent) — unit tests for validation rules
+
+Unit tests (loader):
+- Rejects terrain tile position overlapping precinct position
+- Rejects lake tile adjacent to sea tile
+- Detects precinct fully enclosed by mountain tiles
+- Derives coast annotation for precinct adjacent to sea tile
+- River edges removed from passableNeighbors when `river_blocks_contiguity: true`
+
+### PR2 — Renderer terrain layer
+
+Files:
+- `game/web/src/render/mapRenderer.ts` — add `terrainGroup` (below hexes), `riverGroup` (between hexes and borders); render terrain tiles; render rivers; coast/lakeside edge strokes; internal lake ellipse
+- `game/web/e2e/sprint5.spec.ts` (or new sprint6) — e2e tests for terrain tile visibility/non-interactivity, river stroke visibility
+
+Layer insertion in constructor (new order, bottom→top):
+  `borderGroup → terrainGroup → hexGroup → riverGroup → countyBorderGroup → previewBorderGroup`
+
+River segment coordinates: for each `[idxA, idxB]` in `river_edges`:
+- Get `cornersA = hexCorners(precincts[idxA].center)`
+- Find which edge of A is shared with B (edge `i` where `precincts[idxA].neighbors[i] === idxB`)
+- Shared edge = segment from `cornersA[i]` to `cornersA[(i+1)%6]`
+
+### PR3 — Contiguity blocking
+
+Files:
+- `game/web/src/simulation/validity.ts` — change BFS from `p.neighbors` to `p.passableNeighbors`
+- Unit tests for river-blocking BFS behavior
+
+This is deliberately a minimal diff: one line change in `isContiguous` + tests.
+
+### PR4 — Demo scenario
+
+- New `game/scenarios/scenario-008.json` using sea, mountain, and a river
+- Realistic population gradient (urban center cluster, sparse coast/highland)
+- Registered in campaign JSON
+- At minimum exercises terrain rendering and river visual; contiguity blocking optional in this scenario
+
+Note: May coordinate with GAME-078 (VRA scenarios) — if the VRA scenarios use terrain,
+scenario-008 can be a simpler standalone demo that ships with PR4 before GAME-078.
+
+## Validations Not Implemented in v1
+
+- River endpoint reachability (must reach lake/sea/mountain tile or boundary) — complex; defer
+- lake + sea present → river required connecting them — warning only (loader.ts)
+- Lake tile not adjacent to plain land (only lakeside precincts or other lake tiles) — implement
+- Foothill rendering (nice-to-have) — implement in PR2 if fast, else defer
+
+## Risks
+
+- Internal lake ellipse rendering (2+ adjacent `has_internal_lake` → shared ellipse): this is
+  non-trivial SVG geometry. V1 implementation: one ellipse per precinct (centered, 40% area),
+  no bridging. Bridging deferred as a nice-to-have unless straightforward.
+- terrain annotation derivation at load time adds O(n) scanning of terrain tiles per precinct;
+  for S13 scenarios (50–100 precincts), negligible.


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- GAME-075 PR1 of 4: terrain schema + loader (no rendering, no BFS changes — those land in PR2 and PR3)
- Adds non-precinct terrain tiles (sea/lake/mountain), edge rivers, and precinct terrain annotations (coast/lakeside/riverside/foothill) to the scenario format per DESIGN-008
- `scenario.ts`: new `TerrainType`, `TerrainAnnotation`, `TerrainTile` types; extends `Scenario` with `terrain_tiles?`, `river_edges?`, `river_blocks_contiguity?`; extends schema `Precinct` with `terrain?` and `has_internal_lake?`
- `types.ts`: extends runtime `Precinct` with optional `passableNeighbors`, `terrain`, `has_internal_lake`; extends `GameState` with optional `terrainTiles` and `riverEdges`; new `TerrainTileRuntime` interface
- `loader.ts`: parses terrain fields; validates terrain-tile-precinct-overlap, lake-adjacent-to-sea, mountain-enclosure (BFS from outside bounding box), and river-edge precinct references
- `adapter.ts`: computes `passableNeighbors` (river-blocked edges nulled when `river_blocks_contiguity: true`), derives terrain annotations from adjacency, converts river edges from string IDs to integer index pairs, builds runtime terrain tiles with pixel centers
- `gameStore.ts`: threads `terrainTiles` and `riverEdges` from adapter into `GameState`
- Plan document at `thoughts/shared/plans/2026-05-18-game-075-terrain.md` (+ compressed)

## Design decision — `neighbors` vs `passableNeighbors`
`Precinct.neighbors[i]` is used by both rendering (boundary segment computation) and BFS contiguity. When a river blocks contiguity, the renderer must still know the two precincts are geometrically adjacent (to draw the river stroke), but BFS must not traverse the river edge. Solution: keep `neighbors` intact for geometry; add `passableNeighbors` for BFS. PR3 will switch the BFS in `validity.ts` to read `passableNeighbors`.

## Validation performed
- [x] `bazel test //game/web/src/model:loader_test //game/web/src/model:adapter_test //game/web/src/simulation:validity_test //game/web/src/simulation:election_test //game/web/src/simulation:evaluate_test` — all pass
- [x] `bazel build //game/web:app` — compiles cleanly
- [x] `bazel test //game/web:e2e_test` — 140 e2e tests pass (no regression on existing scenarios)
- [x] 7 new terrain loader tests added (happy path, tile/precinct overlap, lake-adjacent-sea, mountain enclosure, river edge unknown precinct, terrain field parsing, unknown annotation)
- [x] 6 new terrain adapter tests added (terrain tile conversion, coast derivation, explicit override, river edge conversion, passableNeighbors with/without blocking)

## Affected machines / services
- Static browser game only; no server, no database, no infra changes

## Deployment steps
- POST-MERGE: no deploy needed; PR2 (renderer) lands the visible terrain features. Existing scenarios are unaffected (all terrain fields optional).

## Tickets addressed
- see GAME-075 (PR1 of 4 — schema + loader; renderer/contiguity/scenario follow in PR2/3/4)

## Rollback
- Revert this PR; no data migration needed (all new fields optional and absent from existing scenarios)
