### PR TITLE
feat(GAME-075): contiguity BFS reads passableNeighbors (PR3 of 4)

### DIFF
--- a/game/web/src/simulation/validity.ts
+++ b/game/web/src/simulation/validity.ts
@@ -102,7 +102,11 @@ function isContiguous(
 		const curr = queue.shift()!;
 		const p = precincts[curr];
 		if (p === undefined) continue;
-		for (const nbId of p.neighbors) {
+		// passableNeighbors mirrors neighbors but nulls river-blocked edges when the
+		// scenario sets river_blocks_contiguity. Fall back to neighbors when absent
+		// (legacy/test precincts constructed without terrain data).
+		const traversable = p.passableNeighbors ?? p.neighbors;
+		for (const nbId of traversable) {
 			if (nbId !== null && inSet.has(nbId) && !visited.has(nbId)) {
 				visited.add(nbId);
 				queue.push(nbId);

--- a/game/web/src/simulation/validity_test.ts
+++ b/game/web/src/simulation/validity_test.ts
@@ -201,4 +201,74 @@ test("contiguity: two non-adjacent precincts in same district — not contiguous
   assertEqual(stats.contiguity!.get(2), true, "single-precinct district 2 is contiguous");
 });
 
+// ─── River-blocking contiguity (GAME-075) ─────────────────────────────────────
+
+/** Build a precinct with both neighbors and an explicit passableNeighbors override. */
+function makePrecinctWithBlocked(
+  id: number,
+  neighbors: (number | null)[],
+  passableNeighbors: (number | null)[],
+): Precinct {
+  return {
+    id,
+    coord: { q: 0, r: id },
+    center: { x: id * 10, y: 0 },
+    neighbors,
+    passableNeighbors,
+    population: 100,
+    partyShare: { R: 0.5, D: 0.5, L: 0, G: 0, I: 0 },
+    previousResult: { winner: "D", margin: 0 },
+    demographics: { male: 0.49, female: 0.49, nonbinary: 0.02 },
+  };
+}
+
+test("contiguity: river-blocked edge (passableNeighbors null) breaks BFS traversal", () => {
+  // P0 — P1 (adjacent geographically, river blocks)
+  // P0.neighbors[0] = 1 (river edge); P0.passableNeighbors[0] = null
+  // P1.neighbors[3] = 0; P1.passableNeighbors[3] = null
+  // Same district assignment → should be non-contiguous because the river blocks traversal.
+  const p0 = makePrecinctWithBlocked(
+    0,
+    [1, null, null, null, null, null],
+    [null, null, null, null, null, null],
+  );
+  const p1 = makePrecinctWithBlocked(
+    1,
+    [null, null, null, 0, null, null],
+    [null, null, null, null, null, null],
+  );
+  const precincts = [p0, p1];
+  const assignments = new Map([[0, 1], [1, 1]]);
+  const stats = computeValidityStats(precincts, assignments, 1, RULES_REQUIRED);
+  assertNotNull(stats.contiguity, "contiguity map should exist");
+  assertEqual(stats.contiguity!.get(1), false, "river-blocked edge should break contiguity");
+});
+
+test("contiguity: passableNeighbors absent falls back to neighbors", () => {
+  // Legacy precincts (no passableNeighbors) — BFS uses neighbors as before.
+  // P0 — P1 contiguous via neighbors[0]/neighbors[3].
+  const precincts = [P0, P1];
+  const assignments = new Map([[0, 1], [1, 1]]);
+  const stats = computeValidityStats(precincts, assignments, 1, RULES_REQUIRED);
+  assertNotNull(stats.contiguity, "contiguity map should exist");
+  assertEqual(stats.contiguity!.get(1), true, "legacy precincts (no passableNeighbors) still work");
+});
+
+test("contiguity: passableNeighbors preserves traversability for non-river edges", () => {
+  // P0 — P1 — P2 chain. River blocks only P1-P2 edge; P0-P1 stays passable.
+  // All three in district 1: P0-P1 connected via passable; P2 isolated → not contiguous overall.
+  const p0 = makePrecinctWithBlocked(0, [1, null, null, null, null, null], [1, null, null, null, null, null]);
+  const p1 = makePrecinctWithBlocked(
+    1,
+    [2, null, null, 0, null, null],
+    [null, null, null, 0, null, null], // edge to 2 blocked; edge to 0 passable
+  );
+  const p2 = makePrecinctWithBlocked(2, [null, null, null, 1, null, null], [null, null, null, null, null, null]);
+  const precincts = [p0, p1, p2];
+  const assignments = new Map([[0, 1], [1, 1], [2, 1]]);
+  const stats = computeValidityStats(precincts, assignments, 1, RULES_REQUIRED);
+  assertNotNull(stats.contiguity, "contiguity map should exist");
+  assertEqual(stats.contiguity!.get(1), false, "river splits district into two components");
+});
+
 summarize();


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #241
- [x] Parent PR merged: #242

## Summary
- GAME-075 PR3 of 4: contiguity BFS now reads `passableNeighbors` instead of `neighbors`. This activates the river-blocking behavior wired in by PR1 (#241) when a scenario sets `river_blocks_contiguity: true`.
- Single line change: `validity.ts:isContiguous` substitutes `p.passableNeighbors ?? p.neighbors` for the unconditional `p.neighbors` traversal. The `??` fallback preserves behavior for legacy/test precincts constructed without `passableNeighbors`.
- 3 new unit tests:
  - `river-blocked edge (passableNeighbors null) breaks BFS traversal` — two adjacent precincts with the shared edge nulled in `passableNeighbors` are reported non-contiguous.
  - `passableNeighbors absent falls back to neighbors` — legacy precincts still work.
  - `passableNeighbors preserves traversability for non-river edges` — a 3-precinct chain with only the middle edge blocked correctly splits into two components.

## Validation performed
- [x] `bazel test //game/web/src/simulation:validity_test` — all 14 tests pass (11 existing + 3 new)
- [x] `bazel build //game/web:app` — compiles cleanly
- [x] `bazel test //game/web/src/...` — all unit test targets pass
- [x] `bazel test //game/web:e2e_test` — 140 e2e tests pass (no regression on existing scenarios; they don't set `river_blocks_contiguity`, and the existing scenarios have no river_edges to populate `passableNeighbors` differently from `neighbors`)

## Affected machines / services
- Static browser game only; no server, no database, no infra changes

## Deployment steps
- POST-MERGE: no deploy needed; PR4 will ship a scenario that demonstrates river blocking. Until then, the behavior change is dormant.

## Tickets addressed
- see GAME-075 (PR3 of 4 — contiguity BFS; PR4=demo scenario)

## Rollback
- Revert this PR; BFS reverts to reading `neighbors` and river-blocking becomes dormant. Schema/loader/renderer remain intact.
