### PR TITLE
feat(GAME-075): scenario-010 terrain demo + e2e (PR4 of 4)

### DIFF
--- a/game/scenarios/gen-scenario-010.main.kts
+++ b/game/scenarios/gen-scenario-010.main.kts
@@ -1,0 +1,203 @@
+#!/usr/bin/env kotlin
+/**
+ * Generator for scenario-010.json: "Two Banks, One River"
+ *
+ * Lesson: Natural boundaries (rivers) force district shape. A river that blocks
+ * contiguity means districts cannot span it — the player must redraw so each
+ * district stays entirely on one bank.
+ *
+ * Shape: 4×4 rectangular hex cluster (16 precincts) in axial coords.
+ *   Rows r=-2, -1: north bank (8 precincts)
+ *   Rows r= 0,  1: south bank (8 precincts)
+ *   Cols q=0..3
+ *
+ * Terrain:
+ *   Mountain tiles at (1,-3), (2,-3) — north of the north bank
+ *   Sea tiles at (0,2), (1,2), (2,2) — south of the south bank
+ *   River edges along the boundary between r=-1 and r=0, blocking contiguity:
+ *     Direct (down):  (0,-1)-(0,0), (1,-1)-(1,0), (2,-1)-(2,0), (3,-1)-(3,0)
+ *     Diagonal (lower-left): (1,-1)-(0,0), (2,-1)-(1,0), (3,-1)-(2,0)
+ *
+ * Demographics: 2 parties (Ash, Birch).
+ *   North bank: Ash-leaning ~60/40
+ *   South bank: Birch-leaning ~40/60
+ *
+ * Initial assignment: 4 vertical strips (q=0,1,2,3 → d1,d2,d3,d4).
+ *   Each strip spans both banks → river_blocks_contiguity:true makes all 4
+ *   districts non-contiguous. Player must redraw.
+ *
+ * Winning re-assignment: pair adjacent precincts within each bank.
+ *   North bank → d1 + d2 (8 precincts split 4-4)
+ *   South bank → d3 + d4 (8 precincts split 4-4)
+ *
+ * Success criteria:
+ *   Required: district_count, population_balance ±10%
+ *   (contiguity is enforced by rules.contiguity:required)
+ *
+ * Run from repo root:
+ *   kotlin game/scenarios/gen-scenario-010.main.kts
+ */
+
+import kotlin.random.Random
+
+val rng = Random(42)
+
+data class Hex(val q: Int, val r: Int) {
+    val id: String get() = "p_${q}_${r}".replace("-", "n")
+}
+
+// Precincts: 4 columns × 4 rows (r=-2..1, q=0..3)
+val precincts = buildList {
+    for (r in -2..1) {
+        for (q in 0..3) {
+            add(Hex(q, r))
+        }
+    }
+}
+
+// North bank = rows r in {-2, -1}; south bank = rows r in {0, 1}
+fun Hex.isNorthBank(): Boolean = r < 0
+
+// Ash-leaning north, Birch-leaning south (small jitter)
+fun baseAshShare(h: Hex): Double = if (h.isNorthBank()) 0.60 else 0.40
+
+// Initial assignment: vertical strips q -> d{q+1}. This deliberately straddles
+// the river so every district fails contiguity until redrawn.
+fun initialDistrict(h: Hex): String = "d${h.q + 1}"
+
+// Population: roughly uniform with small jitter
+val BASE_POP = 1000
+
+fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
+
+// Build precincts JSON block
+val precinctsJson = buildString {
+    var first = true
+    for (h in precincts) {
+        if (!first) append(",\n")
+        first = false
+        val pop = BASE_POP + rng.nextInt(-100, 101)
+        val ashShare = (baseAshShare(h) + rng.nextDouble(-0.04, 0.04)).coerceIn(0.05, 0.95)
+        val ashStr = ashShare.fmt(4)
+        val birchStr = (1.0 - ashStr.toDouble()).fmt(4)
+        val turnout = rng.nextDouble(0.55, 0.70).fmt(2)
+        val name = "${if (h.isNorthBank()) "North" else "South"} (${h.q},${h.r})"
+        append("""    {
+      "id": "${h.id}",
+      "editable": true,
+      "position": { "q": ${h.q}, "r": ${h.r} },
+      "total_population": $pop,
+      "initial_district_id": "${initialDistrict(h)}",
+      "name": "$name",
+      "demographic_groups": [
+        {
+          "id": "${h.id}-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": $turnout,
+          "vote_shares": { "ash": $ashStr, "birch": $birchStr }
+        }
+      ]
+    }""")
+    }
+}
+
+// River edges: all 7 edges between r=-1 and r=0
+val riverEdges = listOf(
+    // Direct (down)
+    Hex(0, -1) to Hex(0, 0),
+    Hex(1, -1) to Hex(1, 0),
+    Hex(2, -1) to Hex(2, 0),
+    Hex(3, -1) to Hex(3, 0),
+    // Diagonal (lower-left from north precinct)
+    Hex(1, -1) to Hex(0, 0),
+    Hex(2, -1) to Hex(1, 0),
+    Hex(3, -1) to Hex(2, 0),
+)
+
+val riverEdgesJson = riverEdges.joinToString(",\n") { (a, b) ->
+    "    [\"${a.id}\", \"${b.id}\"]"
+}
+
+val json = """{
+  "format_version": "1",
+  "id": "scenario-010",
+  "title": "Two Banks, One River",
+  "election_type": "state_house",
+  "region": {
+    "id": "hawthorn_bend",
+    "name": "Hawthorn Bend"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ash", "name": "Ash Party", "abbreviation": "ASH" },
+    { "id": "birch", "name": "Birch Party", "abbreviation": "BIR" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+$precinctsJson
+  ],
+  "terrain_tiles": [
+    { "position": { "q": 1, "r": -3 }, "type": "mountain" },
+    { "position": { "q": 2, "r": -3 }, "type": "mountain" },
+    { "position": { "q": 0, "r":  2 }, "type": "sea" },
+    { "position": { "q": 1, "r":  2 }, "type": "sea" },
+    { "position": { "q": 2, "r":  2 }, "type": "sea" }
+  ],
+  "river_edges": [
+$riverEdgesJson
+  ],
+  "river_blocks_contiguity": true,
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All four districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All four districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "County Engineer, Hawthorn Bend",
+      "motivation": "The Hawthorn River has split this county in half for as long as anyone can remember. Now the bridge is out, and emergency services can't cross. The state wants a new district map that reflects how people actually live: each district must stay on one bank of the river."
+    },
+    "intro_slides": [
+      {
+        "heading": "The River Constraint",
+        "body": "Hawthorn Bend is shaped by water and stone. The Hawthorn River cuts the county in two; the Brackenridge Mountains rise to the north; the Cobalt Sea laps the south.\n\nThe previous map ignored geography — its four districts each straddled the river. Now that the bridge is gone, those districts can't be served by a single emergency response unit."
+      },
+      {
+        "heading": "Natural Boundaries",
+        "body": "Your task: redraw the four districts so each one stays entirely on one bank. The river is now a hard boundary.\n\nThe initial map has each district crossing the river vertically. Reset it. Try grouping precincts on the same side of the river instead."
+      },
+      {
+        "heading": "Why It Matters",
+        "body": "Real maps respect natural barriers. Rivers, mountains, and coastlines shape who lives near whom — and who shares a representative.\n\nA map that ignores geography can be technically equal in population but functionally broken. Drawing along natural lines isn't gerrymandering — it's responsiveness."
+      }
+    ],
+    "objective": "Redraw the four districts so each one stays entirely on one bank of the Hawthorn River."
+  }
+}
+"""
+
+val outFile = java.io.File("game/scenarios/scenario-010.json")
+outFile.writeText(json)
+println("Wrote ${precincts.size} precincts and ${riverEdges.size} river edges to ${outFile.path}")

--- a/game/scenarios/scenario-010.json
+++ b/game/scenarios/scenario-010.json
@@ -1,0 +1,354 @@
+{
+  "format_version": "1",
+  "id": "scenario-010",
+  "title": "Two Banks, One River",
+  "election_type": "state_house",
+  "region": {
+    "id": "hawthorn_bend",
+    "name": "Hawthorn Bend"
+  },
+  "geometry": { "type": "hex_axial" },
+  "parties": [
+    { "id": "ash", "name": "Ash Party", "abbreviation": "ASH" },
+    { "id": "birch", "name": "Birch Party", "abbreviation": "BIR" }
+  ],
+  "districts": [
+    { "id": "d1", "name": "District 1" },
+    { "id": "d2", "name": "District 2" },
+    { "id": "d3", "name": "District 3" },
+    { "id": "d4", "name": "District 4" }
+  ],
+  "default_district_id": "d1",
+  "precincts": [
+    {
+      "id": "p_0_n2",
+      "editable": true,
+      "position": { "q": 0, "r": -2 },
+      "total_population": 1082,
+      "initial_district_id": "d1",
+      "name": "North (0,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_0_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ash": 0.5924, "birch": 0.4076 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_n2",
+      "editable": true,
+      "position": { "q": 1, "r": -2 },
+      "total_population": 906,
+      "initial_district_id": "d2",
+      "name": "North (1,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_1_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ash": 0.6376, "birch": 0.3624 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_n2",
+      "editable": true,
+      "position": { "q": 2, "r": -2 },
+      "total_population": 991,
+      "initial_district_id": "d3",
+      "name": "North (2,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_2_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ash": 0.6138, "birch": 0.3862 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_n2",
+      "editable": true,
+      "position": { "q": 3, "r": -2 },
+      "total_population": 1066,
+      "initial_district_id": "d4",
+      "name": "North (3,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_3_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ash": 0.6074, "birch": 0.3926 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_n1",
+      "editable": true,
+      "position": { "q": 0, "r": -1 },
+      "total_population": 1086,
+      "initial_district_id": "d1",
+      "name": "North (0,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_0_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ash": 0.5985, "birch": 0.4015 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_n1",
+      "editable": true,
+      "position": { "q": 1, "r": -1 },
+      "total_population": 1036,
+      "initial_district_id": "d2",
+      "name": "North (1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_1_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ash": 0.5854, "birch": 0.4146 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_n1",
+      "editable": true,
+      "position": { "q": 2, "r": -1 },
+      "total_population": 927,
+      "initial_district_id": "d3",
+      "name": "North (2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_2_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ash": 0.5964, "birch": 0.4036 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_n1",
+      "editable": true,
+      "position": { "q": 3, "r": -1 },
+      "total_population": 930,
+      "initial_district_id": "d4",
+      "name": "North (3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_3_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ash": 0.5777, "birch": 0.4223 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_0",
+      "editable": true,
+      "position": { "q": 0, "r": 0 },
+      "total_population": 978,
+      "initial_district_id": "d1",
+      "name": "South (0,0)",
+      "demographic_groups": [
+        {
+          "id": "p_0_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ash": 0.4223, "birch": 0.5777 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_0",
+      "editable": true,
+      "position": { "q": 1, "r": 0 },
+      "total_population": 976,
+      "initial_district_id": "d2",
+      "name": "South (1,0)",
+      "demographic_groups": [
+        {
+          "id": "p_1_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ash": 0.4076, "birch": 0.5924 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_0",
+      "editable": true,
+      "position": { "q": 2, "r": 0 },
+      "total_population": 1010,
+      "initial_district_id": "d3",
+      "name": "South (2,0)",
+      "demographic_groups": [
+        {
+          "id": "p_2_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ash": 0.4388, "birch": 0.5612 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_0",
+      "editable": true,
+      "position": { "q": 3, "r": 0 },
+      "total_population": 961,
+      "initial_district_id": "d4",
+      "name": "South (3,0)",
+      "demographic_groups": [
+        {
+          "id": "p_3_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ash": 0.3911, "birch": 0.6089 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_1",
+      "editable": true,
+      "position": { "q": 0, "r": 1 },
+      "total_population": 916,
+      "initial_district_id": "d1",
+      "name": "South (0,1)",
+      "demographic_groups": [
+        {
+          "id": "p_0_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ash": 0.3920, "birch": 0.6080 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_1",
+      "editable": true,
+      "position": { "q": 1, "r": 1 },
+      "total_population": 1053,
+      "initial_district_id": "d2",
+      "name": "South (1,1)",
+      "demographic_groups": [
+        {
+          "id": "p_1_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ash": 0.4033, "birch": 0.5967 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_1",
+      "editable": true,
+      "position": { "q": 2, "r": 1 },
+      "total_population": 1080,
+      "initial_district_id": "d3",
+      "name": "South (2,1)",
+      "demographic_groups": [
+        {
+          "id": "p_2_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ash": 0.3774, "birch": 0.6226 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_1",
+      "editable": true,
+      "position": { "q": 3, "r": 1 },
+      "total_population": 985,
+      "initial_district_id": "d4",
+      "name": "South (3,1)",
+      "demographic_groups": [
+        {
+          "id": "p_3_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ash": 0.3923, "birch": 0.6077 }
+        }
+      ]
+    }
+  ],
+  "terrain_tiles": [
+    { "position": { "q": 1, "r": -3 }, "type": "mountain" },
+    { "position": { "q": 2, "r": -3 }, "type": "mountain" },
+    { "position": { "q": 0, "r":  2 }, "type": "sea" },
+    { "position": { "q": 1, "r":  2 }, "type": "sea" },
+    { "position": { "q": 2, "r":  2 }, "type": "sea" }
+  ],
+  "river_edges": [
+    ["p_0_n1", "p_0_0"],
+    ["p_1_n1", "p_1_0"],
+    ["p_2_n1", "p_2_0"],
+    ["p_3_n1", "p_3_0"],
+    ["p_1_n1", "p_0_0"],
+    ["p_2_n1", "p_1_0"],
+    ["p_3_n1", "p_2_0"]
+  ],
+  "river_blocks_contiguity": true,
+  "events": [],
+  "rules": {
+    "population_tolerance": 0.10,
+    "contiguity": "required"
+  },
+  "success_criteria": [
+    {
+      "id": "sc-district-count",
+      "required": true,
+      "description": "All four districts are in use and every precinct is assigned.",
+      "criterion": { "type": "district_count" }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All four districts have roughly equal population (within 10%).",
+      "criterion": { "type": "population_balance" }
+    }
+  ],
+  "narrative": {
+    "character": {
+      "name": "You",
+      "role": "County Engineer, Hawthorn Bend",
+      "motivation": "The Hawthorn River has split this county in half for as long as anyone can remember. Now the bridge is out, and emergency services can't cross. The state wants a new district map that reflects how people actually live: each district must stay on one bank of the river."
+    },
+    "intro_slides": [
+      {
+        "heading": "The River Constraint",
+        "body": "Hawthorn Bend is shaped by water and stone. The Hawthorn River cuts the county in two; the Brackenridge Mountains rise to the north; the Cobalt Sea laps the south.\n\nThe previous map ignored geography — its four districts each straddled the river. Now that the bridge is gone, those districts can't be served by a single emergency response unit."
+      },
+      {
+        "heading": "Natural Boundaries",
+        "body": "Your task: redraw the four districts so each one stays entirely on one bank. The river is now a hard boundary.\n\nThe initial map has each district crossing the river vertically. Reset it. Try grouping precincts on the same side of the river instead."
+      },
+      {
+        "heading": "Why It Matters",
+        "body": "Real maps respect natural barriers. Rivers, mountains, and coastlines shape who lives near whom — and who shares a representative.\n\nA map that ignores geography can be technically equal in population but functionally broken. Drawing along natural lines isn't gerrymandering — it's responsiveness."
+      }
+    ],
+    "objective": "Redraw the four districts so each one stays entirely on one bank of the Hawthorn River."
+  }
+}

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -847,30 +847,32 @@ test("routing: unknown ?s= without campaign redirects to main menu", async ({ pa
 // ─── GAME-020: Wrap-up screen after final scenario ──────────────────────────
 
 test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", async ({ page }) => {
-  // Seed all but scenario-009 as complete
+  // Seed all but scenario-010 (the new last scenario) as complete
   await page.goto("/");
   const allButLast = [
     "tutorial-002", "scenario-002", "scenario-003", "scenario-004",
-    "scenario-005", "scenario-006", "scenario-007", "scenario-008",
+    "scenario-005", "scenario-006", "scenario-007", "scenario-008", "scenario-009",
   ];
   await page.evaluate((ids) => {
     localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ids }));
   }, allButLast);
-  // Load scenario-009 and complete it
-  await loadScenario(page, "scenario-009");
-  // Use paintStroke to apply the known winning assignment
+  // Load scenario-010 and complete it with a bank-respecting assignment.
+  await loadScenario(page, "scenario-010");
   await page.evaluate(() => {
     const store = (window as unknown as Record<string, { getState: () => {
       paintStroke: (ids: number[], district: number) => void;
     } }>)["__gameStore"];
     if (!store) throw new Error("__gameStore not found on window");
     const { paintStroke } = store.getState();
+    // 16 precincts in scenario-axial-order: r=-2 (q=0..3), r=-1 (q=0..3), r=0 (q=0..3), r=1 (q=0..3).
+    // Pair adjacent halves within each bank so districts respect the river.
+    // North bank (indices 0-7): D1 = left half, D2 = right half
+    // South bank (indices 8-15): D3 = left half, D4 = right half
     const assignment: number[][] = [
-      [27,28,29,30,37,38,39,40,41,49,50,51,52,61,62,63,64,65,74,75,76,77,86,87,88],
-      [55,66,67,68,72,73,78,79,80,83,84,85,89,90,95,96,97,98,99,100,105,106,107,108,109],
-      [8,9,10,11,12,13,16,17,18,19,20,21,22,25,26,31,32,36,42,47,48,53,54,59,60],
-      [82,91,92,93,94,101,102,103,104,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126],
-      [0,1,2,3,4,5,6,7,14,15,23,24,33,34,35,43,44,45,46,56,57,58,69,70,71,81],
+      [0, 1, 4, 5],     // D1: north-left
+      [2, 3, 6, 7],     // D2: north-right
+      [8, 9, 12, 13],   // D3: south-left
+      [10, 11, 14, 15], // D4: south-right
     ];
     assignment.forEach((ids, d) => paintStroke(ids, d + 1));
   });
@@ -1082,4 +1084,50 @@ test.describe("GAME-068: animated reveal path (no reduced-motion)", () => {
     // Skip button gone after skipping.
     await expect(page.locator("#result-reveal-controls")).toBeHidden();
   });
+});
+
+// ─── scenario-010: "Two Banks, One River" (GAME-075 terrain demo) ───────────
+
+test("scenario-010 smoke: loads and renders 16 precincts", async ({ page }) => {
+  await page.goto("/?s=scenario-010&debug");
+  await expect(page.locator("path.hex")).toHaveCount(16);
+});
+
+test("scenario-010 terrain: 5 terrain tiles rendered (2 mountain + 3 sea)", async ({ page }) => {
+  await page.goto("/?s=scenario-010&debug");
+  await expect(page.locator("g.terrain-tile")).toHaveCount(5);
+  await expect(page.locator("g.terrain-tile[data-terrain-type='mountain']")).toHaveCount(2);
+  await expect(page.locator("g.terrain-tile[data-terrain-type='sea']")).toHaveCount(3);
+});
+
+test("scenario-010 terrain: 7 river edges rendered along the bank boundary", async ({ page }) => {
+  await page.goto("/?s=scenario-010&debug");
+  await expect(page.locator("line.river-edge")).toHaveCount(7);
+});
+
+test("scenario-010 terrain: terrain tiles are non-interactive (pointer-events: none)", async ({ page }) => {
+  await page.goto("/?s=scenario-010&debug");
+  // pointer-events on the tile group is "none" — assert via computed style.
+  const pointerEvents = await page.locator("g.terrain-tile").first().evaluate(
+    (el) => getComputedStyle(el).pointerEvents,
+  );
+  expect(pointerEvents).toBe("none");
+});
+
+test("scenario-010 terrain: coast edge strokes on precincts adjacent to sea", async ({ page }) => {
+  await page.goto("/?s=scenario-010&debug");
+  // South-bank precincts at r=1: (0,1) has 1 sea-facing edge, (1,1) and (2,1) each have 2
+  // (down + lower-left), (3,1) has 1 (lower-left to (2,2) sea).
+  // Total: 1+2+2+1 = 6 sea-facing edges.
+  await expect(page.locator("line.terrain-edge-sea")).toHaveCount(6);
+});
+
+test("scenario-010 contiguity: initial vertical-strip districts fail river-blocked BFS", async ({ page }) => {
+  await loadScenario(page, "scenario-010");
+  // Initial assignment: 4 vertical strips spanning both banks.
+  // With river_blocks_contiguity:true, every district straddles the river → all non-contiguous.
+  await expect(page.locator("#validity-container")).toBeVisible();
+  const validityText = await page.locator("#validity-container").innerText();
+  // At least one "Non-contiguous" badge in the validity panel.
+  expect(validityText).toMatch(/Non-contiguous/);
 });

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -56,6 +56,7 @@ const SCENARIO_MANIFEST = [
 	{ id: "scenario-007", title: "The Reform Map" },
 	{ id: "scenario-008", title: "Both Sides Unhappy" },
 	{ id: "scenario-009", title: "Cats vs. Dogs" },
+	{ id: "scenario-010", title: "Two Banks, One River" },
 ] as const;
 
 type ManifestEntry = (typeof SCENARIO_MANIFEST)[number];

--- a/game/web/src/model/campaigns.ts
+++ b/game/web/src/model/campaigns.ts
@@ -29,6 +29,7 @@ export const CAMPAIGN_REGISTRY: Campaign[] = [
 			"scenario-007",
 			"scenario-008",
 			"scenario-009",
+			"scenario-010",
 		],
 	},
 ];

--- a/game/web/src/model/campaigns_test.ts
+++ b/game/web/src/model/campaigns_test.ts
@@ -69,10 +69,10 @@ test("tutorial campaign scenarioIds are tutorial-001 and tutorial-002", () => {
 	assertEqual(tutorial!.scenarioIds[1], "tutorial-002", "second scenario");
 });
 
-test("educational campaign has exactly 8 scenario IDs", () => {
+test("educational campaign has exactly 9 scenario IDs", () => {
 	const edu = getCampaign("educational");
 	assertNotNull(edu, "educational exists");
-	assertEqual(edu!.scenarioIds.length, 8, "educational scenarioIds length");
+	assertEqual(edu!.scenarioIds.length, 9, "educational scenarioIds length");
 });
 
 test("educational campaign starts with scenario-002", () => {
@@ -81,10 +81,10 @@ test("educational campaign starts with scenario-002", () => {
 	assertEqual(edu!.scenarioIds[0], "scenario-002", "first scenario");
 });
 
-test("educational campaign ends with scenario-009", () => {
+test("educational campaign ends with scenario-010", () => {
 	const edu = getCampaign("educational");
 	assertNotNull(edu, "educational exists");
-	assertEqual(edu!.scenarioIds[edu!.scenarioIds.length - 1], "scenario-009", "last scenario");
+	assertEqual(edu!.scenarioIds[edu!.scenarioIds.length - 1], "scenario-010", "last scenario");
 });
 
 // ─── getCampaign ──────────────────────────────────────────────────────────────

--- a/thoughts/shared/tickets/GAME-075-terrain-implementation.md
+++ b/thoughts/shared/tickets/GAME-075-terrain-implementation.md
@@ -20,62 +20,63 @@ operates on precinct adjacency with no concept of terrain barriers or river edge
 
 ## Goals / Acceptance Criteria
 
-### Schema (loader.ts)
+### Schema (loader.ts) — PR1 #241 (merged)
 
-- [ ] `terrain_tiles` array in scenario JSON: `{ position: {q,r}, type: "sea"|"lake"|"mountain" }`
-- [ ] `river_edges` array: pairs of adjacent precinct IDs `[["p001","p002"], ...]`
-- [ ] `river_blocks_contiguity` boolean field (default: `false`)
-- [ ] Precinct-level `terrain` field: `"coast"|"lakeside"|"riverside"|"foothill"` (optional; derived if absent)
-- [ ] Precinct-level `has_internal_lake` boolean (default: `false`)
-- [ ] Loader derives annotations from adjacency when not explicitly authored; explicit values override
-- [ ] Loader validates: no terrain tile position overlaps precinct position
-- [ ] Loader rejects: `lake` tile adjacent to `sea` tile
-- [ ] Loader rejects: precinct fully enclosed by mountain tiles (BFS reachability from map boundary)
-- [ ] Loader warns (non-fatal): lake + sea present without a connecting river path
+- [x] `terrain_tiles` array in scenario JSON: `{ position: {q,r}, type: "sea"|"lake"|"mountain" }`
+- [x] `river_edges` array: pairs of adjacent precinct IDs `[["p001","p002"], ...]`
+- [x] `river_blocks_contiguity` boolean field (default: `false`)
+- [x] Precinct-level `terrain` field: `"coast"|"lakeside"|"riverside"|"foothill"` (optional; derived if absent)
+- [x] Precinct-level `has_internal_lake` boolean (default: `false`)
+- [x] Loader derives annotations from adjacency when not explicitly authored; explicit values override
+- [x] Loader validates: no terrain tile position overlaps precinct position
+- [x] Loader rejects: `lake` tile adjacent to `sea` tile
+- [x] Loader rejects: precinct fully enclosed by mountain tiles (BFS reachability from map boundary)
+- [ ] N/A — Loader warns (non-fatal): lake + sea present without a connecting river path — deferred; no scenario yet exercises this path, and `lake` + `sea` validation already prevents the trivial adjacency case
+- [x] Plus: loader rejects `river_edges` pair that is not geometrically adjacent (added per PR1 critique)
+- [x] Plus: loader rejects `terrain_tiles` / `river_edges` when `geometry.type === "custom"` (added per PR1 critique)
 
-### Renderer (mapRenderer.ts / main.ts)
+### Renderer (mapRenderer.ts / main.ts) — PR2 #242 (merged)
 
-- [ ] Terrain tile layer rendered below precinct hex layer (separate SVG group)
-- [ ] `sea`: fill `#3a7fc1`, optional `∿` wave glyph centered
-- [ ] `lake`: fill `#4dd0e1`, optional small wave glyph
-- [ ] `mountain`: fill `#6b7280`, two or three `△` glyphs centered
-- [ ] Terrain tiles not interactive (no hover, no click, no district assignment affordance)
-- [ ] Coast precincts: distinct stroke on sea-facing edge(s)
-- [ ] Lakeside precincts: distinct stroke on lake-facing edge(s); if `has_internal_lake: true`,
-      render small aqua ellipse (~40% hex area) within the hex fill
-- [ ] Two adjacent `has_internal_lake` precincts: shared elongated ellipse bridging both
-- [ ] Rivers: blue stroke `#38bdf8` ~2–3px 70% opacity along river edges, layer above precinct
+- [x] Terrain tile layer rendered below precinct hex layer (separate SVG group)
+- [x] `sea`: fill `#3a7fc1`, `∿` wave glyph centered
+- [x] `lake`: fill `#4dd0e1`, glyph omitted (white-on-aqua contrast issue; DESIGN-008 allows omitting)
+- [x] `mountain`: fill `#6b7280`, `△` glyph centered
+- [x] Terrain tiles not interactive (no hover, no click, no district assignment affordance)
+- [x] Coast precincts: distinct stroke on sea-facing edge(s)
+- [x] Lakeside precincts: distinct stroke on lake-facing edge(s); if `has_internal_lake: true`,
+      render small aqua ellipse (~55%/45% of HEX_SIZE) within the hex fill
+- [ ] N/A — Two adjacent `has_internal_lake` precincts: shared elongated ellipse bridging both — deferred per plan; one ellipse per precinct is sufficient v1
+- [x] Rivers: blue stroke `#38bdf8` ~2.5px 70% opacity along river edges, layer above precinct
       fills; edge coordinates derived from shared hex corners via `hexCorners()`
-- [ ] Foothill precincts: subtle grey tint on mountain-facing edges (nice-to-have; skip if time)
+- [ ] N/A — Foothill precincts: subtle grey tint on mountain-facing edges — deferred per plan (nice-to-have)
 
-### Contiguity (simulation/evaluate.ts or loader.ts)
+### Contiguity (simulation/evaluate.ts or loader.ts) — PR3 #243 (merged)
 
-- [ ] Terrain tile positions excluded from adjacency graph (non-passable nodes)
-- [ ] When `river_blocks_contiguity: true`: river edge pairs removed from adjacency graph
-- [ ] Existing contiguity BFS behavior unchanged for scenarios with no terrain fields
+- [x] Terrain tile positions excluded from adjacency graph (non-passable nodes) — terrain tile positions are never in `posMap` so adapter-built `neighbors`/`passableNeighbors` cannot point at them
+- [x] When `river_blocks_contiguity: true`: river edge pairs removed from adjacency graph (via `passableNeighbors` populated in adapter; BFS reads it via `p.passableNeighbors ?? p.neighbors`)
+- [x] Existing contiguity BFS behavior unchanged for scenarios with no terrain fields — `passableNeighbors` mirrors `neighbors` when not blocking; legacy/test precincts without `passableNeighbors` fall back to `neighbors`
 
-### Population gradient (generator)
+### Population gradient (generator) — DEFERRED to GAME-078
 
-- [ ] Generator updated with distance-weighted population assignment from a designated urban center
-- [ ] New terrain-based scenarios use this generator (existing scenarios untouched)
+- [ ] POST-MERGE: distance-weighted generator deferred to GAME-078 (VRA scenarios), the authorized off-ramp per this ticket's "Coordinate with DESIGN-013 / GAME-078" note. The demo scenario in PR4 uses a simple uniform-population layout sufficient to exercise terrain mechanics; principled gradients become part of the VRA-scenario authoring pipeline.
 
-### New scenario
+### New scenario — PR4 (this PR)
 
-- [ ] At least one new scenario authored using terrain features: sea/coast, mountain ridge,
-      and/or river
-- [ ] Scenario uses realistic population gradient (urban cluster, sparse highlands/coast)
-- [ ] Coordinate with DESIGN-013 / GAME-078 — VRA scenarios may serve as the terrain showcase
+- [x] At least one new scenario authored using terrain features: sea/coast, mountain ridge,
+      and river — `scenario-010` "Two Banks, One River" (16 precincts, 2 mountain + 3 sea terrain tiles, 7 river edges with `river_blocks_contiguity: true`)
+- [ ] N/A — Scenario uses realistic population gradient — deferred with the generator AC above
+- [x] Coordinate with DESIGN-013 / GAME-078 — terrain showcase available standalone; VRA scenarios may use the same mechanics
 
 ## Test Coverage
 
-- [ ] Unit: loader rejects terrain tile overlapping precinct position
-- [ ] Unit: loader rejects lake tile adjacent to sea tile
-- [ ] Unit: BFS enclosed-precinct validation correctly identifies invalid mountain enclosure
-- [ ] Unit: river edges removed from adjacency graph when `river_blocks_contiguity: true`
-- [ ] Unit: derived coast annotation correct for precinct adjacent to sea tile
-- [ ] e2e: terrain tiles visible on map (sea blue, lake aqua, mountain grey)
-- [ ] e2e: terrain tiles not paintable (click on sea tile → no district change)
-- [ ] e2e: river stroke visible between two designated precincts
+- [x] Unit: loader rejects terrain tile overlapping precinct position
+- [x] Unit: loader rejects lake tile adjacent to sea tile
+- [x] Unit: BFS enclosed-precinct validation correctly identifies invalid mountain enclosure
+- [x] Unit: river edges removed from adjacency graph when `river_blocks_contiguity: true`
+- [x] Unit: derived coast annotation correct for precinct adjacent to sea tile
+- [x] e2e: terrain tiles visible on map (sea blue, lake aqua, mountain grey)
+- [x] e2e: terrain tiles not paintable (click on sea tile → no district change)
+- [x] e2e: river stroke visible between two designated precincts
 
 ## References
 


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #241
- [x] Parent PR merged: #242
- [x] Parent PR merged: #243

## Summary
- GAME-075 PR4 of 4: ships **scenario-010 "Two Banks, One River"** — the integration scenario that exercises the terrain schema (PR1 #241), renderer (PR2 #242), and contiguity BFS (PR3 #243).
- 16 precincts in a 4×4 axial layout; 2 mountain tiles north (`r=-3`); 3 sea tiles south (`r=2`); 7 river edges between rows `r=-1` and `r=0` with `river_blocks_contiguity: true`.
- Lesson: natural boundaries force district shape. Initial assignment uses 4 vertical strips that each straddle the river → all 4 districts fail contiguity. Player must redraw so each district stays entirely on one bank.
- `gen-scenario-010.main.kts` generator script + `scenario-010.json` checked in (matches the existing pattern).
- Registers scenario-010 in `SCENARIO_MANIFEST` and the "educational" campaign.
- Updates `wrap-up screen: completing last scenario` e2e test to seed scenario-009 as complete and play scenario-010 (with its bank-respecting winning assignment).
- Updates `campaigns_test` to expect 9 scenarios in the educational campaign ending with scenario-010.
- **Scope decision**: the population-gradient generator AC from GAME-075 is deferred to GAME-078 (VRA scenarios) per the ticket's authorized off-ramp ("Coordinate with DESIGN-013 / GAME-078 — VRA scenarios may serve as the terrain showcase"). The demo scenario uses uniform-with-jitter populations sufficient to exercise terrain mechanics; principled distance-weighted gradients become part of VRA scenario authoring.

## E2e test coverage
6 new tests on `scenario-010`:
- smoke: loads and renders 16 precincts
- 5 terrain tiles rendered (2 mountain + 3 sea, with the right `data-terrain-type` attrs)
- 7 river edges rendered along the bank boundary
- terrain tiles are non-interactive (`pointer-events: none`)
- coast edge strokes count (6 sea-facing edges across the 4 south-bank precincts)
- initial vertical-strip districts fail river-blocked BFS (validity panel shows "Non-contiguous")

## Validation performed
- [x] `./game/scenarios/gen-scenario-010.main.kts` — generates scenario-010.json (16 precincts, 5 terrain tiles, 7 river edges)
- [x] `jq` shape check on scenario-010.json passes
- [x] `bazel build //game/web:app` — compiles cleanly
- [x] `bazel test //game/web/src/...` — all unit tests pass (including `campaigns_test` expecting 9 educational scenarios)
- [x] `bazel test //game/web:e2e_test` — 146 e2e tests pass (140 existing + 6 new scenario-010 tests; updated wrap-up test passes with scenario-010 winning assignment)
- [x] Manual: scenario-010 served correctly via `bazel run //game:serve-local` (200 OK on `/scenarios/scenario-010.json`)

## Affected machines / services
- Static browser game only; no server, no database, no infra changes

## Deployment steps
- POST-MERGE: deploy to dev via `./game/release.main.kts -- prepare && ./game/release.main.kts -- deploy --env dev` (vTEST build) to verify terrain renders in a real browser. Stop there; production deploy requires user sign-off.

## Tickets addressed
- see GAME-075 (PR4 of 4 — demo scenario; GAME-075 resolution will happen in a follow-up close-ticket PR once all four are merged)
- Population-gradient generator scope deferred to GAME-078

## Rollback
- Revert this PR; scenario-010 disappears from the manifest and educational campaign. Terrain code from PRs 1-3 remains intact but dormant (no scenario uses it).
