### PR TITLE
feat(GAME-082): thicker rivers + bolder coast/lakeside edges (PR1)

### DIFF
--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -208,16 +208,16 @@ export class SvgMapRenderer implements MapRenderer {
 	private static readonly TERRAIN_GLYPH_COLOR = "rgba(255,255,255,0.45)";
 	private static readonly TERRAIN_GLYPH_FONT_SIZE = 22; // pixel size at 1× zoom
 	private static readonly RIVER_STROKE = "#38bdf8";
-	private static readonly RIVER_BASE_WIDTH = 2.5;
-	private static readonly RIVER_OPACITY = 0.7;
+	private static readonly RIVER_BASE_WIDTH = 9;
+	private static readonly RIVER_OPACITY = 0.9;
 	private static readonly INTERNAL_LAKE_FILL = "#4dd0e1";
 	private static readonly INTERNAL_LAKE_OPACITY = 0.55;
 	private static readonly INTERNAL_LAKE_RX_FACTOR = 0.55; // hex_size × factor = ellipse radius
 	private static readonly INTERNAL_LAKE_RY_FACTOR = 0.45;
 	private static readonly COAST_STROKE = "#3a7fc1";
 	private static readonly LAKESIDE_STROKE = "#4dd0e1";
-	private static readonly TERRAIN_EDGE_BASE_WIDTH = 3;
-	private static readonly TERRAIN_EDGE_OPACITY = 0.9;
+	private static readonly TERRAIN_EDGE_BASE_WIDTH = 5;
+	private static readonly TERRAIN_EDGE_OPACITY = 0.95;
 
 	// Keyboard precinct navigation state
 	private focusedPrecinctId: number | null = null;

--- a/thoughts/shared/tickets/GAME-082-terrain-visual-treatment-refinement.md
+++ b/thoughts/shared/tickets/GAME-082-terrain-visual-treatment-refinement.md
@@ -4,6 +4,7 @@ title: Terrain visual treatment refinement — thicker rivers, prominent coast/l
 area: game, rendering, UX
 status: open
 created: 2026-05-19
+github_issue: 247
 ---
 
 ## Summary


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- GAME-082 PR1: visual-tuning bump for river and coast/lakeside stroke widths after manual playthrough of scenario-010 showed the prior values read as hairlines.
- `mapRenderer.ts` constants only — no schema, simulation, or layer-order changes:
  - `RIVER_BASE_WIDTH`: 2.5 → 9 (river was thread-thin against a 36 px hex radius; now visibly geographic)
  - `RIVER_OPACITY`: 0.7 → 0.9
  - `TERRAIN_EDGE_BASE_WIDTH`: 3 → 5 (coast/lakeside edge strokes now read as shorelines)
  - `TERRAIN_EDGE_OPACITY`: 0.9 → 0.95
- Stroke widths still scale inversely with zoom; the bump applies to the base constants only.
- River still renders as straight lines along hex edges — curving (chain-building + d3.curveBasis smoothing) is PR2 of GAME-082.
- Ticket frontmatter patched by `gh-ticket.main.kts create` (added `github_issue: 247`); folded into this PR rather than spinning a bookkeeping-only PR.

## Validation performed
- [x] `bazel build //game/web:app` — compiles cleanly
- [x] `bazel test //game/web:e2e_test` — 146 e2e tests pass (existing scenario-010 tests check `line.river-edge` and `line.terrain-edge-sea` counts, not stroke widths, so they pass unchanged)
- [ ] N/A — no unit tests touched (the change is pure visual constants)

## Affected machines / services
- Static browser game only; no server, no database, no infra changes

## Deployment steps
- POST-MERGE: deploy to dev via `./game/release.main.kts -- prepare && ./game/release.main.kts -- deploy --env dev` to eyeball the new river thickness on scenario-010 before continuing with PR2 (curves)

## Tickets addressed
- see #247

## Rollback
- Revert this PR; constants return to the prior values. No data migration needed.
