### PR TITLE
feat(GAME-082): smooth river curves via chain-building + d3.curveBasis (PR2)

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -1100,9 +1100,18 @@ test("scenario-010 terrain: 5 terrain tiles rendered (2 mountain + 3 sea)", asyn
   await expect(page.locator("g.terrain-tile[data-terrain-type='sea']")).toHaveCount(3);
 });
 
-test("scenario-010 terrain: 7 river edges rendered along the bank boundary", async ({ page }) => {
+test("scenario-010 terrain: river rendered as a single smoothed chain", async ({ page }) => {
   await page.goto("/?s=scenario-010&debug");
-  await expect(page.locator("line.river-edge")).toHaveCount(7);
+  // GAME-082: 7 connected river edges → 1 smoothed <path> via d3.curveBasis.
+  // Branch-free river ⇒ exactly 1 chain. Path's "d" attribute starts with "M".
+  await expect(page.locator("path.river-chain")).toHaveCount(1);
+  const d = await page.locator("path.river-chain").getAttribute("d");
+  expect(d).toBeTruthy();
+  expect(d!.startsWith("M")).toBe(true);
+  // curveBasis on 3+ points emits cubic bezier (C). Scenario-010 has 7 edges → 8 points
+  // → C-rich path. Future scenarios with 1-edge rivers (2 points) emit only "L", so the
+  // `includes("C")` assertion is scenario-010-specific and intentional.
+  expect(d!.includes("C")).toBe(true);
 });
 
 test("scenario-010 terrain: terrain tiles are non-interactive (pointer-events: none)", async ({ page }) => {

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -54,6 +54,80 @@ type SVGSel = d3.Selection<SVGSVGElement, unknown, null, undefined>;
 // D3's append returns a Selection with parent type null when chained from select(element)
 type GSel = d3.Selection<SVGGElement, unknown, null, undefined>;
 type Segment = { x1: number; y1: number; x2: number; y2: number };
+type Point2D = [number, number];
+
+// ─── River chain building (GAME-082) ─────────────────────────────────────────
+
+/**
+ * Group river-edge corner-pair segments into connected chains so each chain
+ * can be rendered as a single smoothed SVG path rather than N separate lines.
+ *
+ * Two segments are considered connected when they share a corner (same pixel
+ * coordinates). Corners that appear in exactly 2 segments are interior to a
+ * chain; corners that appear in 1 segment are chain endpoints; corners with
+ * degree >= 3 are Y/T junctions where chains terminate (each branch becomes
+ * its own chain — visually they meet at the junction).
+ *
+ * Walking strategy: start from each endpoint (degree-1 corner) and follow
+ * unvisited segments through degree-2 corners. After all endpoint-rooted walks
+ * complete, any remaining unvisited segments form closed loops or branches at
+ * junctions — emit those as their own chains from an arbitrary starting point.
+ */
+function buildRiverChains(segs: [Point2D, Point2D][]): Point2D[][] {
+	// Quantize corner coordinates to handle hexCorners() float drift.
+	// 2 decimals = 0.01 px precision — well below any real edge mismatch.
+	const key = (p: Point2D): string => `${p[0].toFixed(2)},${p[1].toFixed(2)}`;
+
+	// corner-key → indices of segments touching that corner
+	const cornerToSegs = new Map<string, number[]>();
+	segs.forEach((seg, i) => {
+		for (const c of seg) {
+			const k = key(c);
+			if (!cornerToSegs.has(k)) cornerToSegs.set(k, []);
+			cornerToSegs.get(k)!.push(i);
+		}
+	});
+
+	const visited = new Set<number>();
+	const chains: Point2D[][] = [];
+
+	const walk = (startSeg: number, startCorner: Point2D): Point2D[] => {
+		const points: Point2D[] = [startCorner];
+		let segIdx = startSeg;
+		let corner = startCorner;
+		while (!visited.has(segIdx)) {
+			visited.add(segIdx);
+			const seg = segs[segIdx];
+			if (seg === undefined) break;
+			const other = key(seg[0]) === key(corner) ? seg[1] : seg[0];
+			points.push(other);
+			const candidates = (cornerToSegs.get(key(other)) ?? []).filter((s) => !visited.has(s));
+			if (candidates.length !== 1) break; // endpoint, junction, or dead end
+			segIdx = candidates[0]!;
+			corner = other;
+		}
+		return points;
+	};
+
+	// Pass 1: start from endpoints (degree-1 corners) — these are the natural
+	// chain heads and produce the longest/cleanest chains.
+	for (const [k, ss] of cornerToSegs) {
+		if (ss.length !== 1) continue;
+		const segIdx = ss[0]!;
+		if (visited.has(segIdx)) continue;
+		const seg = segs[segIdx]!;
+		const startCorner = key(seg[0]) === k ? seg[0] : seg[1];
+		chains.push(walk(segIdx, startCorner));
+	}
+	// Pass 2: any remaining unvisited segments belong to closed loops or live
+	// past a junction. Emit each as its own chain from an arbitrary start.
+	segs.forEach((seg, i) => {
+		if (visited.has(i)) return;
+		chains.push(walk(i, seg[0]));
+	});
+
+	return chains;
+}
 
 // ─── Polygon path helper ─────────────────────────────────────────────────────
 
@@ -378,7 +452,8 @@ export class SvgMapRenderer implements MapRenderer {
 		const { precincts, riverEdges } = this.getState();
 		if (!riverEdges || riverEdges.length === 0) return;
 
-		const segments: Segment[] = [];
+		// 1. Convert each river edge to its corner pair.
+		const segs: [Point2D, Point2D][] = [];
 		for (const [aIdx, bIdx] of riverEdges) {
 			const a = precincts[aIdx];
 			if (a === undefined) {
@@ -387,8 +462,6 @@ export class SvgMapRenderer implements MapRenderer {
 			}
 			const edge = a.neighbors.findIndex((n) => n === bIdx);
 			if (edge < 0) {
-				// Loader validates geometric adjacency, so this branch is unreachable for
-				// validated scenarios. Warn defensively in case data bypasses the loader.
 				console.warn(`renderRivers: precinct ${aIdx} is not a geometric neighbor of ${bIdx}`);
 				continue;
 			}
@@ -396,21 +469,28 @@ export class SvgMapRenderer implements MapRenderer {
 			const c0 = corners[edge];
 			const c1 = corners[(edge + 1) % 6];
 			if (c0 === undefined || c1 === undefined) continue;
-			segments.push({ x1: c0[0], y1: c0[1], x2: c1[0], y2: c1[1] });
+			segs.push([c0, c1]);
 		}
 
+		// 2. Build chains of connected segments by walking the corner graph.
+		const chains = buildRiverChains(segs);
+
+		// 3. Render each chain as a smoothed SVG path. d3.curveBasis approximates
+		//    the corner points without strictly passing through them, producing a
+		//    gentle meander rather than the raw hex-edge zigzag.
+		const lineGen = d3.line<Point2D>().x((p) => p[0]).y((p) => p[1]).curve(d3.curveBasis);
+
 		this.riverGroup
-			.selectAll<SVGLineElement, Segment>("line.river-edge")
-			.data(segments)
-			.join("line")
-			.attr("class", "river-edge")
-			.attr("x1", (d) => d.x1)
-			.attr("y1", (d) => d.y1)
-			.attr("x2", (d) => d.x2)
-			.attr("y2", (d) => d.y2)
+			.selectAll<SVGPathElement, Point2D[]>("path.river-chain")
+			.data(chains)
+			.join("path")
+			.attr("class", "river-chain")
+			.attr("d", (d) => lineGen(d) ?? "")
+			.attr("fill", "none")
 			.attr("stroke", SvgMapRenderer.RIVER_STROKE)
 			.attr("stroke-width", SvgMapRenderer.RIVER_BASE_WIDTH / this.currentK)
 			.attr("stroke-linecap", "round")
+			.attr("stroke-linejoin", "round")
 			.attr("opacity", SvgMapRenderer.RIVER_OPACITY)
 			.style("pointer-events", "none");
 	}
@@ -539,7 +619,7 @@ export class SvgMapRenderer implements MapRenderer {
 					.attr("stroke-width", pw);
 				// Terrain feature stroke widths also scale inversely.
 				this.riverGroup
-					.selectAll<SVGLineElement, Segment>("line.river-edge")
+					.selectAll<SVGPathElement, Point2D[]>("path.river-chain")
 					.attr("stroke-width", SvgMapRenderer.RIVER_BASE_WIDTH / this.currentK);
 				this.terrainOverlayGroup
 					.selectAll<SVGLineElement, Segment>("line.terrain-edge")


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #248

## Summary
- GAME-082 PR2: rivers now render as smooth meandering curves instead of straight hex-edge zigzags.
- Algorithm — `buildRiverChains(segs)` in `mapRenderer.ts`:
  1. Convert each river-edge precinct pair into its corner-pair pixel coordinates (via `hexCorners()`).
  2. Build a corner-key→segment-indices map. Corner keys are quantized to 2 decimals (`toFixed(2)`) to absorb any `Math.cos`/`Math.sin` float drift; adjacent edges share corner coordinates exactly because `hexCorners()` computes them identically from either side.
  3. Walk chains starting from degree-1 corners (natural chain endpoints). At any corner with degree ≠ 2 the walk terminates — this gracefully handles Y/T junctions where multiple river edges meet (each branch becomes its own chain, all meeting visually at the junction).
  4. Pass 2 emits any remaining unvisited segments as their own chains — covers closed-loop rivers and branches past a junction.
- Render — each chain becomes one `<path class="river-chain">` rendered via `d3.line().curve(d3.curveBasis)`. `curveBasis` approximates corner points without strictly passing through them, so the river meanders gently through the hex zigzag rather than tracing it.
- Side effect: scenario-010's 7 connected river edges now render as **1 path** instead of 7 separate lines.

## Junction handling
- Y/T-junction is split into multiple chains, each from an endpoint to the junction. They share a corner point so visually they meet at one place. Not optimal (the curves don't blend across the junction) but acceptable for v1 per the GAME-082 ticket. Future polish: emit a single multi-segment path with explicit M/L commands or sub-paths.
- Closed loop: walk passes through every segment and terminates back at the start when no unvisited candidate remains. Pass-2 emit picks it up.

## E2e test changes
- Updated `scenario-010 terrain: 7 river edges rendered along the bank boundary` → `scenario-010 terrain: river rendered as a single smoothed chain`. Asserts:
  - `path.river-chain` count = 1
  - `d` attribute starts with `M` (path move-to)
  - `d` attribute contains `C` (cubic bezier — confirms curveBasis output, not a fallback to straight lines)

## Validation performed
- [x] `bazel build //game/web:app` — compiles cleanly
- [x] `bazel test //game/web:e2e_test` — 146 e2e tests pass (the updated scenario-010 river test passes against the new path-based rendering)
- [ ] N/A — `buildRiverChains` has no dedicated unit test; the render/ directory has no test target. The function is exercised end-to-end by the scenario-010 path assertion + manual eyeball after dev deploy. Adding a unit test would require either splitting the helper into a separate library file with its own BUILD entry or wiring up a new render-test target — out of scope for this PR.

## Affected machines / services
- Static browser game only

## Deployment steps
- POST-MERGE: deploy to dev via `./game/release.main.kts -- prepare && ./game/release.main.kts -- deploy --env dev` to eyeball the new curved river rendering on scenario-010

## Tickets addressed
- see #247

## Rollback
- Revert this PR; rivers return to straight-line rendering. No data migration.
