### PR TITLE
feat(GAME-082): scenario-010 geographic-features intro + river bend + curveCardinal (PR3)

### DIFF
--- a/game/scenarios/gen-scenario-010.main.kts
+++ b/game/scenarios/gen-scenario-010.main.kts
@@ -102,17 +102,21 @@ val precinctsJson = buildString {
     }
 }
 
-// River edges: all 7 edges between r=-1 and r=0
+// River edges form a single connected chain along the boundary between rows
+// r=-1 and r=0, ending with a hook that wraps over the top of (3,-1) into row
+// r=-2. The hook tests how the chain-walker + curveCardinal smoothing handle a
+// direction change. Edges 6 and 7 (originally going south at (3,-1)) are replaced
+// with edges 3 and 4 of (3,-1) — corners 3→4→5 traversing the top of (3,-1).
 val riverEdges = listOf(
-    // Direct (down)
-    Hex(0, -1) to Hex(0, 0),
-    Hex(1, -1) to Hex(1, 0),
-    Hex(2, -1) to Hex(2, 0),
-    Hex(3, -1) to Hex(3, 0),
-    // Diagonal (lower-left from north precinct)
-    Hex(1, -1) to Hex(0, 0),
-    Hex(2, -1) to Hex(1, 0),
-    Hex(3, -1) to Hex(2, 0),
+    // Western zigzag along the r=-1 / r=0 boundary
+    Hex(0, -1) to Hex(0, 0),     // down across (0,-1)
+    Hex(1, -1) to Hex(0, 0),     // lower-left from (1,-1)
+    Hex(1, -1) to Hex(1, 0),     // down across (1,-1)
+    Hex(2, -1) to Hex(1, 0),     // lower-left from (2,-1)
+    Hex(2, -1) to Hex(2, 0),     // down across (2,-1)
+    // Bend: wraps over the top of (3,-1) via corners 3 → 4 → 5
+    Hex(3, -1) to Hex(2, -1),    // upper-left edge of (3,-1) (corner 3→4)
+    Hex(3, -1) to Hex(3, -2),    // top (up) edge of (3,-1) (corner 4→5)
 )
 
 val riverEdgesJson = riverEdges.joinToString(",\n") { (a, b) ->
@@ -153,7 +157,7 @@ $precinctsJson
   "river_edges": [
 $riverEdgesJson
   ],
-  "river_blocks_contiguity": true,
+  "river_blocks_contiguity": false,
   "events": [],
   "rules": {
     "population_tolerance": 0.10,
@@ -175,25 +179,25 @@ $riverEdgesJson
   ],
   "narrative": {
     "character": {
-      "name": "You",
-      "role": "County Engineer, Hawthorn Bend",
-      "motivation": "The Hawthorn River has split this county in half for as long as anyone can remember. Now the bridge is out, and emergency services can't cross. The state wants a new district map that reflects how people actually live: each district must stay on one bank of the river."
+      "name": "Tutorial Guide",
+      "role": "Tour Guide",
+      "motivation": "Welcome to Hawthorn Bend — a small region with three kinds of terrain you'll see throughout the game: a sea coast, a mountain ridge, and a river."
     },
     "intro_slides": [
       {
-        "heading": "The River Constraint",
-        "body": "Hawthorn Bend is shaped by water and stone. The Hawthorn River cuts the county in two; the Brackenridge Mountains rise to the north; the Cobalt Sea laps the south.\n\nThe previous map ignored geography — its four districts each straddled the river. Now that the bridge is gone, those districts can't be served by a single emergency response unit."
+        "heading": "Reading the Map",
+        "body": "Maps in this game can include geographic features alongside the precincts you'll draw districts from.\n\n- The blue ribbon is a **river** — it flows along the edges between hexes.\n- The grey hexes at the top are **mountains**.\n- The blue hexes at the bottom are **sea**.\n\nMountains and sea are not assignable — you can't put a district there. Rivers run between hexes, not on them."
       },
       {
-        "heading": "Natural Boundaries",
-        "body": "Your task: redraw the four districts so each one stays entirely on one bank. The river is now a hard boundary.\n\nThe initial map has each district crossing the river vertically. Reset it. Try grouping precincts on the same side of the river instead."
+        "heading": "Geography is Cosmetic",
+        "body": "In this game, geographic features are visual: they show you what the region looks like, but they don't constrain district-drawing.\n\nReal redistricting often uses rivers as district boundaries, but that's because of political choices — state lines, county lines, historical municipal limits — not because rivers are physical barriers. A district can cross a river if the people on both sides share a community.\n\nThe initial map here is already a working district plan. Try submitting it."
       },
       {
-        "heading": "Why It Matters",
-        "body": "Real maps respect natural barriers. Rivers, mountains, and coastlines shape who lives near whom — and who shares a representative.\n\nA map that ignores geography can be technically equal in population but functionally broken. Drawing along natural lines isn't gerrymandering — it's responsiveness."
+        "heading": "Try It Out",
+        "body": "Click **Submit Map** to evaluate the starting districts. You can also repaint districts to experiment — drag across hexes to assign them, click district buttons to switch which district you're drawing.\n\nWhen you're ready, move on to the rest of the campaign."
       }
     ],
-    "objective": "Redraw the four districts so each one stays entirely on one bank of the Hawthorn River."
+    "objective": "Get familiar with how rivers, mountains, and coastlines look on the map. Submit the initial map, or repaint to experiment."
   }
 }
 """

--- a/game/scenarios/scenario-010.json
+++ b/game/scenarios/scenario-010.json
@@ -302,14 +302,14 @@
   ],
   "river_edges": [
     ["p_0_n1", "p_0_0"],
-    ["p_1_n1", "p_1_0"],
-    ["p_2_n1", "p_2_0"],
-    ["p_3_n1", "p_3_0"],
     ["p_1_n1", "p_0_0"],
+    ["p_1_n1", "p_1_0"],
     ["p_2_n1", "p_1_0"],
-    ["p_3_n1", "p_2_0"]
+    ["p_2_n1", "p_2_0"],
+    ["p_3_n1", "p_2_n1"],
+    ["p_3_n1", "p_3_n2"]
   ],
-  "river_blocks_contiguity": true,
+  "river_blocks_contiguity": false,
   "events": [],
   "rules": {
     "population_tolerance": 0.10,
@@ -331,24 +331,24 @@
   ],
   "narrative": {
     "character": {
-      "name": "You",
-      "role": "County Engineer, Hawthorn Bend",
-      "motivation": "The Hawthorn River has split this county in half for as long as anyone can remember. Now the bridge is out, and emergency services can't cross. The state wants a new district map that reflects how people actually live: each district must stay on one bank of the river."
+      "name": "Tutorial Guide",
+      "role": "Tour Guide",
+      "motivation": "Welcome to Hawthorn Bend — a small region with three kinds of terrain you'll see throughout the game: a sea coast, a mountain ridge, and a river."
     },
     "intro_slides": [
       {
-        "heading": "The River Constraint",
-        "body": "Hawthorn Bend is shaped by water and stone. The Hawthorn River cuts the county in two; the Brackenridge Mountains rise to the north; the Cobalt Sea laps the south.\n\nThe previous map ignored geography — its four districts each straddled the river. Now that the bridge is gone, those districts can't be served by a single emergency response unit."
+        "heading": "Reading the Map",
+        "body": "Maps in this game can include geographic features alongside the precincts you'll draw districts from.\n\n- The blue ribbon is a **river** — it flows along the edges between hexes.\n- The grey hexes at the top are **mountains**.\n- The blue hexes at the bottom are **sea**.\n\nMountains and sea are not assignable — you can't put a district there. Rivers run between hexes, not on them."
       },
       {
-        "heading": "Natural Boundaries",
-        "body": "Your task: redraw the four districts so each one stays entirely on one bank. The river is now a hard boundary.\n\nThe initial map has each district crossing the river vertically. Reset it. Try grouping precincts on the same side of the river instead."
+        "heading": "Geography is Cosmetic",
+        "body": "In this game, geographic features are visual: they show you what the region looks like, but they don't constrain district-drawing.\n\nReal redistricting often uses rivers as district boundaries, but that's because of political choices — state lines, county lines, historical municipal limits — not because rivers are physical barriers. A district can cross a river if the people on both sides share a community.\n\nThe initial map here is already a working district plan. Try submitting it."
       },
       {
-        "heading": "Why It Matters",
-        "body": "Real maps respect natural barriers. Rivers, mountains, and coastlines shape who lives near whom — and who shares a representative.\n\nA map that ignores geography can be technically equal in population but functionally broken. Drawing along natural lines isn't gerrymandering — it's responsiveness."
+        "heading": "Try It Out",
+        "body": "Click **Submit Map** to evaluate the starting districts. You can also repaint districts to experiment — drag across hexes to assign them, click district buttons to switch which district you're drawing.\n\nWhen you're ready, move on to the rest of the campaign."
       }
     ],
-    "objective": "Redraw the four districts so each one stays entirely on one bank of the Hawthorn River."
+    "objective": "Get familiar with how rivers, mountains, and coastlines look on the map. Submit the initial map, or repaint to experiment."
   }
 }

--- a/game/web/e2e/campaign-select.spec.ts
+++ b/game/web/e2e/campaign-select.spec.ts
@@ -27,12 +27,13 @@ test("campaign select: clicking Educational Campaign navigates to ?campaign=educ
   await expect(page).toHaveURL(/campaign=educational/);
 });
 
-test("campaign select: progress shows 0 / 2 for Tutorial with fresh localStorage", async ({ page }) => {
+test("campaign select: progress shows 0 / 3 for Tutorial with fresh localStorage", async ({ page }) => {
   await page.goto("/?view=campaigns");
   await page.evaluate((key) => localStorage.removeItem(key), PROGRESS_KEY);
   await page.reload();
   await expect(page.locator("#campaign-select")).toBeVisible({ timeout: 10_000 });
-  await expect(page.locator(".campaign-card").first()).toContainText("0 / 2 scenarios complete");
+  // GAME-082: scenario-010 moved from educational to tutorial as a geographic-features intro.
+  await expect(page.locator(".campaign-card").first()).toContainText("0 / 3 scenarios complete");
 });
 
 test("campaign select: Back button is present", async ({ page }) => {

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -904,13 +904,15 @@ test("about page: accessible from main menu and shows educational content", asyn
 
 // ─── GAME-048: Campaign-driven scenario select ──────────────────────────────
 
-test("campaign select: ?campaign=tutorial shows only tutorial-001 and tutorial-002", async ({ page }) => {
+test("campaign select: ?campaign=tutorial shows tutorial-001, tutorial-002, and scenario-010", async ({ page }) => {
   await page.goto("/?campaign=tutorial");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   const cards = page.locator(".scenario-card");
-  await expect(cards).toHaveCount(2);
+  // GAME-082: scenario-010 is now part of the tutorial campaign as a geographic-features intro.
+  await expect(cards).toHaveCount(3);
   await expect(cards.nth(0)).toContainText("Welcome to Redistricting");
   await expect(cards.nth(1)).toContainText("Three-District Challenge");
+  await expect(cards.nth(2)).toContainText("Two Banks, One River");
 });
 
 test("campaign select: ?campaign=tutorial Back button is visible", async ({ page }) => {
@@ -1100,17 +1102,18 @@ test("scenario-010 terrain: 5 terrain tiles rendered (2 mountain + 3 sea)", asyn
   await expect(page.locator("g.terrain-tile[data-terrain-type='sea']")).toHaveCount(3);
 });
 
-test("scenario-010 terrain: river rendered as a single smoothed chain", async ({ page }) => {
+test("scenario-010 terrain: river rendered as a single smoothed chain with bend", async ({ page }) => {
   await page.goto("/?s=scenario-010&debug");
-  // GAME-082: 7 connected river edges → 1 smoothed <path> via d3.curveBasis.
-  // Branch-free river ⇒ exactly 1 chain. Path's "d" attribute starts with "M".
+  // GAME-082: 7 connected river edges form a single chain.
+  // The chain runs west-east along the r=-1/r=0 boundary, then bends up over the
+  // top of (3,-1) via corners 3→4→5. Smoothing uses d3.curveCardinal.tension(0.4).
+  // Single chain ⇒ exactly 1 <path.river-chain>.
   await expect(page.locator("path.river-chain")).toHaveCount(1);
   const d = await page.locator("path.river-chain").getAttribute("d");
   expect(d).toBeTruthy();
   expect(d!.startsWith("M")).toBe(true);
-  // curveBasis on 3+ points emits cubic bezier (C). Scenario-010 has 7 edges → 8 points
-  // → C-rich path. Future scenarios with 1-edge rivers (2 points) emit only "L", so the
-  // `includes("C")` assertion is scenario-010-specific and intentional.
+  // curveCardinal on 3+ points emits cubic bezier (C). Scenario-010 has 7 edges → 8
+  // corners → C-rich path. The assertion is scenario-010-specific and intentional.
   expect(d!.includes("C")).toBe(true);
 });
 
@@ -1131,12 +1134,12 @@ test("scenario-010 terrain: coast edge strokes on precincts adjacent to sea", as
   await expect(page.locator("line.terrain-edge-sea")).toHaveCount(6);
 });
 
-test("scenario-010 contiguity: initial vertical-strip districts fail river-blocked BFS", async ({ page }) => {
+test("scenario-010 contiguity: river is cosmetic, initial districts are contiguous", async ({ page }) => {
   await loadScenario(page, "scenario-010");
-  // Initial assignment: 4 vertical strips spanning both banks.
-  // With river_blocks_contiguity:true, every district straddles the river → all non-contiguous.
+  // GAME-082: rivers are visual only — `river_blocks_contiguity: false` in scenario JSON.
+  // The initial vertical-strip assignment is contiguous (column hexes are adjacent).
   await expect(page.locator("#validity-container")).toBeVisible();
   const validityText = await page.locator("#validity-container").innerText();
-  // At least one "Non-contiguous" badge in the validity panel.
-  expect(validityText).toMatch(/Non-contiguous/);
+  expect(validityText).toMatch(/Connected/);
+  expect(validityText).not.toMatch(/Non-contiguous/);
 });

--- a/game/web/src/model/campaigns.ts
+++ b/game/web/src/model/campaigns.ts
@@ -12,14 +12,14 @@ export const CAMPAIGN_REGISTRY: Campaign[] = [
 		id: "tutorial",
 		title: "Tutorial",
 		description:
-			"Learn the basics of district drawing with two introductory maps.",
-		scenarioIds: ["tutorial-001", "tutorial-002"],
+			"Learn the basics of district drawing and the map's geographic features.",
+		scenarioIds: ["tutorial-001", "tutorial-002", "scenario-010"],
 	},
 	{
 		id: "educational",
 		title: "Educational Campaign",
 		description:
-			"Explore nine scenarios that illustrate real gerrymandering techniques and their effects on elections.",
+			"Explore eight scenarios that illustrate real gerrymandering techniques and their effects on elections.",
 		scenarioIds: [
 			"scenario-002",
 			"scenario-003",
@@ -29,7 +29,6 @@ export const CAMPAIGN_REGISTRY: Campaign[] = [
 			"scenario-007",
 			"scenario-008",
 			"scenario-009",
-			"scenario-010",
 		],
 	},
 ];

--- a/game/web/src/model/campaigns_test.ts
+++ b/game/web/src/model/campaigns_test.ts
@@ -56,23 +56,24 @@ test("CAMPAIGN_REGISTRY: first campaign is tutorial", () => {
 	assertEqual(CAMPAIGN_REGISTRY[0]?.id, "tutorial", "first id");
 });
 
-test("tutorial campaign has exactly 2 scenario IDs", () => {
+test("tutorial campaign has exactly 3 scenario IDs", () => {
 	const tutorial = getCampaign("tutorial");
 	assertNotNull(tutorial, "tutorial exists");
-	assertEqual(tutorial!.scenarioIds.length, 2, "tutorial scenarioIds length");
+	assertEqual(tutorial!.scenarioIds.length, 3, "tutorial scenarioIds length");
 });
 
-test("tutorial campaign scenarioIds are tutorial-001 and tutorial-002", () => {
+test("tutorial campaign scenarioIds are tutorial-001, tutorial-002, scenario-010", () => {
 	const tutorial = getCampaign("tutorial");
 	assertNotNull(tutorial, "tutorial exists");
 	assertEqual(tutorial!.scenarioIds[0], "tutorial-001", "first scenario");
 	assertEqual(tutorial!.scenarioIds[1], "tutorial-002", "second scenario");
+	assertEqual(tutorial!.scenarioIds[2], "scenario-010", "third scenario (geographic-features intro)");
 });
 
-test("educational campaign has exactly 9 scenario IDs", () => {
+test("educational campaign has exactly 8 scenario IDs", () => {
 	const edu = getCampaign("educational");
 	assertNotNull(edu, "educational exists");
-	assertEqual(edu!.scenarioIds.length, 9, "educational scenarioIds length");
+	assertEqual(edu!.scenarioIds.length, 8, "educational scenarioIds length");
 });
 
 test("educational campaign starts with scenario-002", () => {
@@ -81,10 +82,10 @@ test("educational campaign starts with scenario-002", () => {
 	assertEqual(edu!.scenarioIds[0], "scenario-002", "first scenario");
 });
 
-test("educational campaign ends with scenario-010", () => {
+test("educational campaign ends with scenario-009", () => {
 	const edu = getCampaign("educational");
 	assertNotNull(edu, "educational exists");
-	assertEqual(edu!.scenarioIds[edu!.scenarioIds.length - 1], "scenario-010", "last scenario");
+	assertEqual(edu!.scenarioIds[edu!.scenarioIds.length - 1], "scenario-009", "last scenario");
 });
 
 // ─── getCampaign ──────────────────────────────────────────────────────────────

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -475,10 +475,12 @@ export class SvgMapRenderer implements MapRenderer {
 		// 2. Build chains of connected segments by walking the corner graph.
 		const chains = buildRiverChains(segs);
 
-		// 3. Render each chain as a smoothed SVG path. d3.curveBasis approximates
-		//    the corner points without strictly passing through them, producing a
-		//    gentle meander rather than the raw hex-edge zigzag.
-		const lineGen = d3.line<Point2D>().x((p) => p[0]).y((p) => p[1]).curve(d3.curveBasis);
+		// 3. Render each chain as a smoothed SVG path. d3.curveCardinal with
+		//    tension 0.4 passes through every corner with moderate swing — more
+		//    visible meander through hex vertices than curveBasis's tighter
+		//    approximation, while still avoiding the sharp Catmull-Rom overshoot
+		//    at sharp turns.
+		const lineGen = d3.line<Point2D>().x((p) => p[0]).y((p) => p[1]).curve(d3.curveCardinal.tension(0.4));
 
 		this.riverGroup
 			.selectAll<SVGPathElement, Point2D[]>("path.river-chain")


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #249

## Summary
- GAME-082 PR3: reworks scenario-010 to align with the project-level principle that **geography is cosmetic by default**. Adds a river bend (per the "test the curve wrapping more" request) and bumps curve expressiveness to `curveCardinal.tension(0.4)`.

## Changes

### Scenario-010 design pivot — geographic-features intro, not a puzzle
- `river_blocks_contiguity: true` → `false`. Rivers no longer hard-block districts. Real redistricting doesn't treat rivers as physical barriers; they're often *aligned with* district boundaries due to higher-order political features (state lines, county lines), but that alignment is a separate concept and shouldn't be baked into the BFS.
- Narrative completely rewritten. The old "redraw to respect the river" framing is gone. The new framing is a tutorial-style introduction to how rivers, mountains, and sea tiles look on the map — explicitly tells the player that geography is cosmetic.
- Character changed from "County Engineer, Hawthorn Bend" to "Tutorial Guide / Tour Guide" to match the new framing.
- Objective changed from "redraw so each district stays on one bank" to "get familiar with how geographic features look; submit the initial map or repaint to experiment."

### Campaign placement: educational → tutorial
- Removed from educational campaign (was 9th/last). Educational is back to 8 scenarios ending with scenario-009.
- Added to tutorial campaign (now 3 scenarios: tutorial-001, tutorial-002, scenario-010).
- Tutorial campaign description updated to mention geographic features.
- Note: scenario-010 keeps its ID for now. Rename to tutorial-003 is a possible follow-up.

### River bend (the "wrapping" test the user asked for)
- River edges 6–7 replaced:
  - **Drop** `(3,-1)-(2,0)` (the last "lower-left" diagonal — corners 2→3 of (3,-1))
  - **Drop** `(3,-1)-(3,0)` (the easternmost "down" edge — corners 1→2 of (3,-1))
  - **Add** `(3,-1)-(2,-1)` (upper-left edge of (3,-1) — corners 3→4)
  - **Add** `(3,-1)-(3,-2)` (top edge of (3,-1) — corners 4→5)
- Net 7 river edges (same count as before). Forms a single connected chain that runs west→east along the r=-1/r=0 boundary, then bends up over the top of (3,-1) at the east end. Chain-walker emits one `<path>`.
- The bend tests how the chain-walker + curve smoothing handle a directional change in the chain — confirming that the curve handles "the river going back north before continuing" as the user requested.

### Curve smoothing: `d3.curveBasis` → `d3.curveCardinal.tension(0.4)`
- curveBasis approximates corner points (cuts inside the hex-edge zigzag) — visually subtle.
- curveCardinal passes through every corner. Tension 0.4 gives moderate swing — more visible meander while avoiding the sharp Catmull-Rom overshoot at sharp turns.

### Test updates
- `campaigns_test.ts`: tutorial campaign now 3 scenarios; educational now 8 ending with scenario-009.
- `campaign-select.spec.ts`: progress display "0 / 3 scenarios complete" for fresh Tutorial localStorage.
- `scenarios.spec.ts`:
  - `?campaign=tutorial` expects 3 scenario cards (was 2).
  - River-rendered-as-single-chain test updated to reflect curveCardinal output + bend description.
  - Contiguity test inverted: river is cosmetic → initial vertical-strip assignment shows "Connected" for all districts (no "Non-contiguous" badges).

## Validation performed
- [x] `./game/scenarios/gen-scenario-010.main.kts` regenerates JSON with new river_edges + flag flip
- [x] `jq` check confirms `river_blocks_contiguity: false`, 7 river edges, "Tour Guide" narrative
- [x] `bazel build //game/web:app` — compiles cleanly
- [x] `bazel test //game/web/src/...` — all 16 unit test targets pass
- [x] `bazel test //game/web:e2e_test` — 146 e2e tests pass (2 fixed in this PR + the new contiguity inversion)

## Affected machines / services
- Static browser game only; no server, database, or infra changes

## Deployment steps
- POST-MERGE: deploy to dev via `./game/release.main.kts -- prepare && ./game/release.main.kts -- deploy --env dev` to eyeball the bend + tension change on scenario-010

## Tickets addressed
- see #247

## Rollback
- Revert this PR; scenario-010 returns to "respect the river" framing, educational campaign regains scenario-010 as last, tutorial campaign returns to 2 scenarios. Curve type returns to curveBasis.
