### PR TITLE
feat(GAME-086): lake rendering — lakeside intrusion + river/lake color unify + geo repositioning

### DIFF
--- a/game/scenarios/gen-tutorial-003.main.kts
+++ b/game/scenarios/gen-tutorial-003.main.kts
@@ -2,119 +2,134 @@
 /**
  * Generator for tutorial-003.json: "Hawthorn Bend — A Tour of the Map"
  *
- * Tutorial-campaign scenario that introduces all four terrain annotations in one map:
- *   - foothill   (precincts adjacent to mountain tiles)
- *   - lakeside   (precincts adjacent to lake tiles, plus one explicit + internal lake)
- *   - riverside  (precincts on river edges)
- *   - coast      (precincts adjacent to sea tiles)
+ * Shape: R=6 hex circle centred at (0,0), minus terrain tile positions (124 precincts).
+ * Terrain tiles at hexDist ≤ R are excluded from precincts — tile-type wins over radius.
  *
- * Geography is cosmetic — `river_blocks_contiguity: false`. The initial quadrant
- * assignment is already contiguous and population-balanced, so the player can submit
- * immediately or repaint to experiment.
+ * Terrain:
+ *   Mountains  (-3,-3), (-2,-4), (-1,-5)  → inside R=6, excluded from precincts;
+ *                                            foothills on their inner neighbours
+ *   Sea        (-3,6), (-2,6), (-1,6), (0,6) → outside R=6 (hexDist=6 edge), coast on r=5 neighbours
+ *   Lake tile  (-1,1)                       → inside R=6, renders as aqua tile; lakeside on 6 neighbours
  *
- * Shape: 6 × 6 rectangular hex cluster (36 precincts), q=0..5, r=-3..2.
+ * River: 19 edges from NW foothill (-1,-4) through centre to S coast.
  *
- * Terrain placement:
- *   Mountain tiles at (1,-4), (2,-4), (3,-4) — row r=-3 precincts (0..4,-3) become foothill.
- *   Lake tile at (6,-2) — precincts (5,-2) and (5,-1) become lakeside.
- *   Sea tiles at (1,3), (2,3), (3,3) — precincts (1..4, 2) become coast.
- *   River: 5 edges along the r=-1/r=0 boundary, q=0..2 — (0..2, -1) and (0..2, 0) become riverside.
- *   Internal lake: (0,2) explicitly authored with terrain:"lakeside" + has_internal_lake:true
- *                  to showcase the ellipse rendering on a precinct without a neighboring lake tile.
- *
- * Initial assignment: 4 quadrants of 9 precincts each:
- *   d1 top-left  (q=0..2, r=-3..-1), d2 top-right (q=3..5, r=-3..-1),
- *   d3 bottom-left (q=0..2, r=0..2), d4 bottom-right (q=3..5, r=0..2).
- *
- * Demographics: 2 parties (Ash, Birch), small jitter, no strong partisan story.
+ * Districts: 4, angular split from centre (~31 precincts each).
  *
  * Run from repo root:
  *   ./game/scenarios/gen-tutorial-003.main.kts
  */
 
+import kotlin.math.*
 import kotlin.random.Random
 
 val rng = Random(42)
+
+fun hexDist(q: Int, r: Int) = (abs(q) + abs(r) + abs(q + r)) / 2
 
 data class Hex(val q: Int, val r: Int) {
     val id: String get() = "p_${q}_${r}".replace("-", "n")
 }
 
-// Precincts: 6 columns × 6 rows (r=-3..2, q=0..5)
-val precincts = buildList {
-    for (r in -3..2) {
-        for (q in 0..5) {
-            add(Hex(q, r))
+val R = 6
+
+// Declare terrain tiles first — positions at hexDist ≤ R are excluded from precincts.
+val mountainTiles = listOf(Hex(-3,-3), Hex(-2,-4), Hex(-1,-5))
+val seaTiles      = listOf(Hex(-3,6), Hex(-2,6), Hex(-1,6), Hex(0,6))
+val lakeTile      = Hex(-1, 1)
+val terrainPositions: Set<Hex> = (mountainTiles + seaTiles + listOf(lakeTile)).toSet()
+
+val hexes = buildList {
+    for (q in -R..R) {
+        val rMin = maxOf(-R, -q - R)
+        val rMax = minOf(R, -q + R)
+        for (r in rMin..rMax) {
+            val h = Hex(q, r)
+            if (h !in terrainPositions) add(h)
         }
+    }
+}.sortedWith(compareBy({ it.r }, { it.q }))
+
+// Angular 4-way split — gives ~32 precincts per district.
+fun initialDistrict(q: Int, r: Int): String {
+    if (q == 0 && r == 0) return "d1"
+    val x = q + r * 0.5
+    val y = r * sqrt(3.0) / 2.0
+    val a = atan2(y, x)
+    return when {
+        a >= -PI / 4 && a < PI / 4     -> "d1"  // east
+        a >= PI / 4  && a < 3 * PI / 4 -> "d2"  // north
+        a >= -3 * PI / 4 && a < -PI / 4 -> "d4" // south
+        else                            -> "d3"  // west
     }
 }
 
-// Initial quadrant assignment.
-fun initialDistrict(h: Hex): String = when {
-    h.q < 3 && h.r < 0 -> "d1"   // top-left
-    h.q >= 3 && h.r < 0 -> "d2"  // top-right
-    h.q < 3 && h.r >= 0 -> "d3"  // bottom-left
-    else -> "d4"                  // bottom-right
-}
-
-// Mild partisan jitter — no specific lesson, just realistic variation.
-fun baseAshShare(h: Hex): Double = 0.50
-
 val BASE_POP = 1000
-
-fun Double.fmt(decimals: Int = 4) = "%.${decimals}f".format(this)
-
-// Precinct (0,2) gets explicit lakeside + has_internal_lake to showcase the ellipse on
-// a precinct that isn't adjacent to a lake tile.
-val internalLakePrecincts = setOf(Hex(0, 2))
+fun Double.fmt(d: Int = 4) = "%.${d}f".format(this)
 
 val precinctsJson = buildString {
     var first = true
-    for (h in precincts) {
+    for (h in hexes) {
         if (!first) append(",\n")
         first = false
         val pop = BASE_POP + rng.nextInt(-100, 101)
-        val ashShare = (baseAshShare(h) + rng.nextDouble(-0.06, 0.06)).coerceIn(0.05, 0.95)
-        val ashStr = ashShare.fmt(4)
-        val birchStr = (1.0 - ashStr.toDouble()).fmt(4)
-        val turnout = rng.nextDouble(0.55, 0.70).fmt(2)
-        val name = "(${h.q},${h.r})"
-        val hasInternalLake = h in internalLakePrecincts
-        val extraFields = if (hasInternalLake) {
-            ",\n      \"terrain\": \"lakeside\",\n      \"has_internal_lake\": true"
-        } else ""
+        val ash = (0.50 + rng.nextDouble(-0.06, 0.06)).coerceIn(0.05, 0.95)
+        val birch = 1.0 - ash
+        val turnout = rng.nextDouble(0.55, 0.70)
         append("""    {
       "id": "${h.id}",
       "editable": true,
       "position": { "q": ${h.q}, "r": ${h.r} },
       "total_population": $pop,
-      "initial_district_id": "${initialDistrict(h)}",
-      "name": "$name"$extraFields,
+      "initial_district_id": "${initialDistrict(h.q, h.r)}",
+      "name": "(${h.q},${h.r})",
       "demographic_groups": [
         {
           "id": "${h.id}-all",
           "name": "All voters",
           "population_share": 1.0,
-          "turnout_rate": $turnout,
-          "vote_shares": { "ash": $ashStr, "birch": $birchStr }
+          "turnout_rate": ${turnout.fmt(2)},
+          "vote_shares": { "ash": ${ash.fmt(4)}, "birch": ${birch.fmt(4)} }
         }
       ]
     }""")
     }
 }
 
-// River: 5 edges along the r=-1 / r=0 boundary, western half (q=0..2).
+// River: two chains — NW foothill to lake, and lake to S coast.
+// Lake tile at (-1,1) splits the river; two reaches rendered as separate chains.
+// Starts at (-1,-4) rather than (-2,-4): the latter is now a mountain tile.
 val riverEdges = listOf(
-    Hex(0, -1) to Hex(0, 0),     // down across (0,-1)
-    Hex(1, -1) to Hex(0, 0),     // lower-left from (1,-1)
-    Hex(1, -1) to Hex(1, 0),     // down across (1,-1)
-    Hex(2, -1) to Hex(1, 0),     // lower-left from (2,-1)
-    Hex(2, -1) to Hex(2, 0),     // down across (2,-1)
+    Hex(-1,-4) to Hex(-2,-3),   // SW — start at foothill
+    Hex(-2,-3) to Hex(-1,-3),   // E
+    Hex(-1,-3) to Hex(-2,-2),   // SW
+    Hex(-2,-2) to Hex(-1,-2),   // E
+    Hex(-1,-2) to Hex(-2,-1),   // SW
+    Hex(-2,-1) to Hex(-1,-1),   // E
+    Hex(-1,-1) to Hex(-2, 0),   // SW
+    Hex(-2, 0) to Hex(-1, 0),   // E
+    Hex(-1, 0) to Hex(-2, 1),   // SW — upstream reach ends here (lake at (-1,1))
+    // gap: (-2,1)→(-1,1) and (-1,1)→(-2,2) removed — lake tile occupies (-1,1)
+    Hex(-2, 2) to Hex(-1, 2),   // E — downstream reach begins here
+    Hex(-1, 2) to Hex(-2, 3),   // SW
+    Hex(-2, 3) to Hex(-1, 3),   // E
+    Hex(-1, 3) to Hex(-2, 4),   // SW
+    Hex(-2, 4) to Hex(-1, 4),   // E
+    Hex(-1, 4) to Hex(-2, 5),   // SW
+    Hex(-2, 5) to Hex(-1, 5),   // E — reaches coast area (sea now at r=6)
 )
 
-val riverEdgesJson = riverEdges.joinToString(",\n") { (a, b) ->
+val riverJson = riverEdges.joinToString(",\n") { (a, b) ->
     "    [\"${a.id}\", \"${b.id}\"]"
 }
+
+
+val terrainJson = buildString {
+    for (t in mountainTiles) append("    { \"position\": { \"q\": ${t.q}, \"r\": ${t.r} }, \"type\": \"mountain\" },\n")
+    for (t in seaTiles)      append("    { \"position\": { \"q\": ${t.q}, \"r\": ${t.r} }, \"type\": \"sea\" },\n")
+    append("    { \"position\": { \"q\": ${lakeTile.q}, \"r\": ${lakeTile.r} }, \"type\": \"lake\" }")
+}
+
+val distCounts = hexes.groupBy { initialDistrict(it.q, it.r) }.mapValues { it.value.size }
 
 val json = """{
   "format_version": "1",
@@ -141,16 +156,10 @@ val json = """{
 $precinctsJson
   ],
   "terrain_tiles": [
-    { "position": { "q": 1, "r": -4 }, "type": "mountain" },
-    { "position": { "q": 2, "r": -4 }, "type": "mountain" },
-    { "position": { "q": 3, "r": -4 }, "type": "mountain" },
-    { "position": { "q": 6, "r": -2 }, "type": "lake" },
-    { "position": { "q": 1, "r":  3 }, "type": "sea" },
-    { "position": { "q": 2, "r":  3 }, "type": "sea" },
-    { "position": { "q": 3, "r":  3 }, "type": "sea" }
+$terrainJson
   ],
   "river_edges": [
-$riverEdgesJson
+$riverJson
   ],
   "river_blocks_contiguity": false,
   "events": [],
@@ -176,27 +185,28 @@ $riverEdgesJson
     "character": {
       "name": "Tutorial Guide",
       "role": "Tour Guide",
-      "motivation": "Welcome to Hawthorn Bend. This map shows every kind of terrain you'll see in the game — take a moment to look around before you start drawing districts."
+      "motivation": "Welcome to Hawthorn Bend. This map shows every kind of terrain feature that you will see in the game."
     },
     "intro_slides": [
       {
         "heading": "Reading the Map",
-        "body": "Maps in this game can include geographic features alongside the precincts you draw districts from.\n\n- **Mountains** (grey tiles, top of map) — not assignable. Precincts beside them are foothills, marked with a subtle grey edge.\n- **Sea** (dark blue tiles, bottom of map) — not assignable. Precincts beside them are coast, marked with a blue shoreline.\n- **Lake** (aqua tile, right side) — not assignable. Precincts beside it are lakeside, marked with an aqua edge.\n- **River** (blue line through the middle-left) — flows along hex edges, not on them. Precincts on a river are riverside.\n\nThere's also a small lake within one precinct on the south-west — an inland pond, drawn as an aqua oval inside the hex."
+        "body": "Maps can include geographic features alongside the precincts you draw districts from.\n\n- **Mountains** (grey tiles, northwest) — not assignable. Adjacent precincts are foothills with a soft grey fringe.\n- **Sea** (dark blue tiles, south) — not assignable. Adjacent precincts are coast with a blue shoreline.\n- **Lake** (aqua tile, centre) — not assignable. Adjacent precincts show a teal lakeside fringe.\n- **River** (teal line) — flows from the mountain area, through the lake, and down to the sea."
       },
       {
         "heading": "Geography is Cosmetic",
-        "body": "These features are visual: they show what the region looks like, but **they do not constrain district-drawing**.\n\nReal redistricting often uses rivers and mountains as district boundaries — but that's because of political choices (state lines, county lines, historical municipal limits) that *happen* to follow geography, not because geography is a physical barrier. A district can cross a river if the people on both sides share a community.\n\nThe initial map here divides the region into four quadrants. It's already a valid plan."
+        "body": "These features are visual: they show what the region looks like, but **they do not constrain district-drawing**.\n\nReal redistricting often uses rivers and mountains as district boundaries — but that is because of political choices (state lines, county lines, historical municipal limits) that happen to follow geography, not because geography is a physical barrier. A district can cross a river or lake if the people on both sides share a community.\n\nThe initial map divides the region into four sectors. It is already a valid plan."
       },
       {
         "heading": "Try It Out",
-        "body": "Click **Submit Map** to evaluate the starting districts. You can also repaint districts to experiment — drag across hexes to assign them, click district buttons to switch which district you're drawing.\n\nWhen you're done exploring, move on to the educational campaign."
+        "body": "Click **Submit Map** to evaluate the starting districts. You can also repaint districts to experiment — drag across hexes to assign them, click district buttons to switch which district you are drawing.\n\nWhen you are done exploring, move on to the educational campaign."
       }
     ],
-    "objective": "Look around the map at the four kinds of terrain. Submit the initial four-quadrant map, or repaint to experiment."
+    "objective": "Look around the map at the terrain features. Submit the initial four-district map, or repaint to experiment."
   }
 }
 """
 
 val outFile = java.io.File("game/scenarios/tutorial-003.json")
 outFile.writeText(json)
-println("Wrote ${precincts.size} precincts and ${riverEdges.size} river edges to ${outFile.path}")
+println("Wrote ${hexes.size} precincts, ${riverEdges.size} river edges → ${outFile.path}")
+println("District counts: $distCounts")

--- a/game/scenarios/tutorial-003.json
+++ b/game/scenarios/tutorial-003.json
@@ -21,15 +21,15 @@
   "default_district_id": "d1",
   "precincts": [
     {
-      "id": "p_0_n3",
+      "id": "p_0_n6",
       "editable": true,
-      "position": { "q": 0, "r": -3 },
+      "position": { "q": 0, "r": -6 },
       "total_population": 1082,
-      "initial_district_id": "d1",
-      "name": "(0,-3)",
+      "initial_district_id": "d4",
+      "name": "(0,-6)",
       "demographic_groups": [
         {
-          "id": "p_0_n3-all",
+          "id": "p_0_n6-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.70,
@@ -38,15 +38,15 @@
       ]
     },
     {
-      "id": "p_1_n3",
+      "id": "p_1_n6",
       "editable": true,
-      "position": { "q": 1, "r": -3 },
+      "position": { "q": 1, "r": -6 },
       "total_population": 906,
-      "initial_district_id": "d1",
-      "name": "(1,-3)",
+      "initial_district_id": "d4",
+      "name": "(1,-6)",
       "demographic_groups": [
         {
-          "id": "p_1_n3-all",
+          "id": "p_1_n6-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
@@ -55,15 +55,15 @@
       ]
     },
     {
-      "id": "p_2_n3",
+      "id": "p_2_n6",
       "editable": true,
-      "position": { "q": 2, "r": -3 },
+      "position": { "q": 2, "r": -6 },
       "total_population": 991,
-      "initial_district_id": "d1",
-      "name": "(2,-3)",
+      "initial_district_id": "d4",
+      "name": "(2,-6)",
       "demographic_groups": [
         {
-          "id": "p_2_n3-all",
+          "id": "p_2_n6-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
@@ -72,15 +72,15 @@
       ]
     },
     {
-      "id": "p_3_n3",
+      "id": "p_3_n6",
       "editable": true,
-      "position": { "q": 3, "r": -3 },
+      "position": { "q": 3, "r": -6 },
       "total_population": 1066,
-      "initial_district_id": "d2",
-      "name": "(3,-3)",
+      "initial_district_id": "d4",
+      "name": "(3,-6)",
       "demographic_groups": [
         {
-          "id": "p_3_n3-all",
+          "id": "p_3_n6-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.56,
@@ -89,15 +89,15 @@
       ]
     },
     {
-      "id": "p_4_n3",
+      "id": "p_4_n6",
       "editable": true,
-      "position": { "q": 4, "r": -3 },
+      "position": { "q": 4, "r": -6 },
       "total_population": 1086,
-      "initial_district_id": "d2",
-      "name": "(4,-3)",
+      "initial_district_id": "d4",
+      "name": "(4,-6)",
       "demographic_groups": [
         {
-          "id": "p_4_n3-all",
+          "id": "p_4_n6-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
@@ -106,15 +106,15 @@
       ]
     },
     {
-      "id": "p_5_n3",
+      "id": "p_5_n6",
       "editable": true,
-      "position": { "q": 5, "r": -3 },
+      "position": { "q": 5, "r": -6 },
       "total_population": 1036,
-      "initial_district_id": "d2",
-      "name": "(5,-3)",
+      "initial_district_id": "d4",
+      "name": "(5,-6)",
       "demographic_groups": [
         {
-          "id": "p_5_n3-all",
+          "id": "p_5_n6-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
@@ -123,15 +123,15 @@
       ]
     },
     {
-      "id": "p_0_n2",
+      "id": "p_6_n6",
       "editable": true,
-      "position": { "q": 0, "r": -2 },
+      "position": { "q": 6, "r": -6 },
       "total_population": 927,
-      "initial_district_id": "d1",
-      "name": "(0,-2)",
+      "initial_district_id": "d4",
+      "name": "(6,-6)",
       "demographic_groups": [
         {
-          "id": "p_0_n2-all",
+          "id": "p_6_n6-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.55,
@@ -140,15 +140,15 @@
       ]
     },
     {
-      "id": "p_1_n2",
+      "id": "p_0_n5",
       "editable": true,
-      "position": { "q": 1, "r": -2 },
+      "position": { "q": 0, "r": -5 },
       "total_population": 930,
-      "initial_district_id": "d1",
-      "name": "(1,-2)",
+      "initial_district_id": "d4",
+      "name": "(0,-5)",
       "demographic_groups": [
         {
-          "id": "p_1_n2-all",
+          "id": "p_0_n5-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
@@ -157,15 +157,15 @@
       ]
     },
     {
-      "id": "p_2_n2",
+      "id": "p_1_n5",
       "editable": true,
-      "position": { "q": 2, "r": -2 },
+      "position": { "q": 1, "r": -5 },
       "total_population": 978,
-      "initial_district_id": "d1",
-      "name": "(2,-2)",
+      "initial_district_id": "d4",
+      "name": "(1,-5)",
       "demographic_groups": [
         {
-          "id": "p_2_n2-all",
+          "id": "p_1_n5-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
@@ -174,15 +174,15 @@
       ]
     },
     {
-      "id": "p_3_n2",
+      "id": "p_2_n5",
       "editable": true,
-      "position": { "q": 3, "r": -2 },
+      "position": { "q": 2, "r": -5 },
       "total_population": 976,
-      "initial_district_id": "d2",
-      "name": "(3,-2)",
+      "initial_district_id": "d4",
+      "name": "(2,-5)",
       "demographic_groups": [
         {
-          "id": "p_3_n2-all",
+          "id": "p_2_n5-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
@@ -191,15 +191,15 @@
       ]
     },
     {
-      "id": "p_4_n2",
+      "id": "p_3_n5",
       "editable": true,
-      "position": { "q": 4, "r": -2 },
+      "position": { "q": 3, "r": -5 },
       "total_population": 1010,
-      "initial_district_id": "d2",
-      "name": "(4,-2)",
+      "initial_district_id": "d4",
+      "name": "(3,-5)",
       "demographic_groups": [
         {
-          "id": "p_4_n2-all",
+          "id": "p_3_n5-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
@@ -208,15 +208,15 @@
       ]
     },
     {
-      "id": "p_5_n2",
+      "id": "p_4_n5",
       "editable": true,
-      "position": { "q": 5, "r": -2 },
+      "position": { "q": 4, "r": -5 },
       "total_population": 961,
-      "initial_district_id": "d2",
-      "name": "(5,-2)",
+      "initial_district_id": "d4",
+      "name": "(4,-5)",
       "demographic_groups": [
         {
-          "id": "p_5_n2-all",
+          "id": "p_4_n5-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
@@ -225,15 +225,15 @@
       ]
     },
     {
-      "id": "p_0_n1",
+      "id": "p_5_n5",
       "editable": true,
-      "position": { "q": 0, "r": -1 },
+      "position": { "q": 5, "r": -5 },
       "total_population": 916,
-      "initial_district_id": "d1",
-      "name": "(0,-1)",
+      "initial_district_id": "d4",
+      "name": "(5,-5)",
       "demographic_groups": [
         {
-          "id": "p_0_n1-all",
+          "id": "p_5_n5-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
@@ -242,15 +242,15 @@
       ]
     },
     {
-      "id": "p_1_n1",
+      "id": "p_6_n5",
       "editable": true,
-      "position": { "q": 1, "r": -1 },
+      "position": { "q": 6, "r": -5 },
       "total_population": 1053,
-      "initial_district_id": "d1",
-      "name": "(1,-1)",
+      "initial_district_id": "d4",
+      "name": "(6,-5)",
       "demographic_groups": [
         {
-          "id": "p_1_n1-all",
+          "id": "p_6_n5-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
@@ -259,15 +259,15 @@
       ]
     },
     {
-      "id": "p_2_n1",
+      "id": "p_n1_n4",
       "editable": true,
-      "position": { "q": 2, "r": -1 },
+      "position": { "q": -1, "r": -4 },
       "total_population": 1080,
-      "initial_district_id": "d1",
-      "name": "(2,-1)",
+      "initial_district_id": "d4",
+      "name": "(-1,-4)",
       "demographic_groups": [
         {
-          "id": "p_2_n1-all",
+          "id": "p_n1_n4-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
@@ -276,15 +276,15 @@
       ]
     },
     {
-      "id": "p_3_n1",
+      "id": "p_0_n4",
       "editable": true,
-      "position": { "q": 3, "r": -1 },
+      "position": { "q": 0, "r": -4 },
       "total_population": 985,
-      "initial_district_id": "d2",
-      "name": "(3,-1)",
+      "initial_district_id": "d4",
+      "name": "(0,-4)",
       "demographic_groups": [
         {
-          "id": "p_3_n1-all",
+          "id": "p_0_n4-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
@@ -293,15 +293,15 @@
       ]
     },
     {
-      "id": "p_4_n1",
+      "id": "p_1_n4",
       "editable": true,
-      "position": { "q": 4, "r": -1 },
+      "position": { "q": 1, "r": -4 },
       "total_population": 917,
-      "initial_district_id": "d2",
-      "name": "(4,-1)",
+      "initial_district_id": "d4",
+      "name": "(1,-4)",
       "demographic_groups": [
         {
-          "id": "p_4_n1-all",
+          "id": "p_1_n4-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.66,
@@ -310,15 +310,15 @@
       ]
     },
     {
-      "id": "p_5_n1",
+      "id": "p_2_n4",
       "editable": true,
-      "position": { "q": 5, "r": -1 },
+      "position": { "q": 2, "r": -4 },
       "total_population": 1002,
-      "initial_district_id": "d2",
-      "name": "(5,-1)",
+      "initial_district_id": "d4",
+      "name": "(2,-4)",
       "demographic_groups": [
         {
-          "id": "p_5_n1-all",
+          "id": "p_2_n4-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
@@ -327,15 +327,15 @@
       ]
     },
     {
-      "id": "p_0_0",
+      "id": "p_3_n4",
       "editable": true,
-      "position": { "q": 0, "r": 0 },
+      "position": { "q": 3, "r": -4 },
       "total_population": 1052,
-      "initial_district_id": "d3",
-      "name": "(0,0)",
+      "initial_district_id": "d4",
+      "name": "(3,-4)",
       "demographic_groups": [
         {
-          "id": "p_0_0-all",
+          "id": "p_3_n4-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
@@ -344,15 +344,15 @@
       ]
     },
     {
-      "id": "p_1_0",
+      "id": "p_4_n4",
       "editable": true,
-      "position": { "q": 1, "r": 0 },
+      "position": { "q": 4, "r": -4 },
       "total_population": 1096,
-      "initial_district_id": "d3",
-      "name": "(1,0)",
+      "initial_district_id": "d4",
+      "name": "(4,-4)",
       "demographic_groups": [
         {
-          "id": "p_1_0-all",
+          "id": "p_4_n4-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
@@ -361,15 +361,15 @@
       ]
     },
     {
-      "id": "p_2_0",
+      "id": "p_5_n4",
       "editable": true,
-      "position": { "q": 2, "r": 0 },
+      "position": { "q": 5, "r": -4 },
       "total_population": 1093,
-      "initial_district_id": "d3",
-      "name": "(2,0)",
+      "initial_district_id": "d4",
+      "name": "(5,-4)",
       "demographic_groups": [
         {
-          "id": "p_2_0-all",
+          "id": "p_5_n4-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
@@ -378,15 +378,15 @@
       ]
     },
     {
-      "id": "p_3_0",
+      "id": "p_6_n4",
       "editable": true,
-      "position": { "q": 3, "r": 0 },
+      "position": { "q": 6, "r": -4 },
       "total_population": 1065,
-      "initial_district_id": "d4",
-      "name": "(3,0)",
+      "initial_district_id": "d1",
+      "name": "(6,-4)",
       "demographic_groups": [
         {
-          "id": "p_3_0-all",
+          "id": "p_6_n4-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.62,
@@ -395,15 +395,15 @@
       ]
     },
     {
-      "id": "p_4_0",
+      "id": "p_n2_n3",
       "editable": true,
-      "position": { "q": 4, "r": 0 },
+      "position": { "q": -2, "r": -3 },
       "total_population": 965,
-      "initial_district_id": "d4",
-      "name": "(4,0)",
+      "initial_district_id": "d3",
+      "name": "(-2,-3)",
       "demographic_groups": [
         {
-          "id": "p_4_0-all",
+          "id": "p_n2_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
@@ -412,15 +412,15 @@
       ]
     },
     {
-      "id": "p_5_0",
+      "id": "p_n1_n3",
       "editable": true,
-      "position": { "q": 5, "r": 0 },
+      "position": { "q": -1, "r": -3 },
       "total_population": 942,
       "initial_district_id": "d4",
-      "name": "(5,0)",
+      "name": "(-1,-3)",
       "demographic_groups": [
         {
-          "id": "p_5_0-all",
+          "id": "p_n1_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.69,
@@ -429,15 +429,15 @@
       ]
     },
     {
-      "id": "p_0_1",
+      "id": "p_0_n3",
       "editable": true,
-      "position": { "q": 0, "r": 1 },
+      "position": { "q": 0, "r": -3 },
       "total_population": 1014,
-      "initial_district_id": "d3",
-      "name": "(0,1)",
+      "initial_district_id": "d4",
+      "name": "(0,-3)",
       "demographic_groups": [
         {
-          "id": "p_0_1-all",
+          "id": "p_0_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
@@ -446,15 +446,15 @@
       ]
     },
     {
-      "id": "p_1_1",
+      "id": "p_1_n3",
       "editable": true,
-      "position": { "q": 1, "r": 1 },
+      "position": { "q": 1, "r": -3 },
       "total_population": 1089,
-      "initial_district_id": "d3",
-      "name": "(1,1)",
+      "initial_district_id": "d4",
+      "name": "(1,-3)",
       "demographic_groups": [
         {
-          "id": "p_1_1-all",
+          "id": "p_1_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.65,
@@ -463,15 +463,15 @@
       ]
     },
     {
-      "id": "p_2_1",
+      "id": "p_2_n3",
       "editable": true,
-      "position": { "q": 2, "r": 1 },
+      "position": { "q": 2, "r": -3 },
       "total_population": 958,
-      "initial_district_id": "d3",
-      "name": "(2,1)",
+      "initial_district_id": "d4",
+      "name": "(2,-3)",
       "demographic_groups": [
         {
-          "id": "p_2_1-all",
+          "id": "p_2_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.60,
@@ -480,15 +480,15 @@
       ]
     },
     {
-      "id": "p_3_1",
+      "id": "p_3_n3",
       "editable": true,
-      "position": { "q": 3, "r": 1 },
+      "position": { "q": 3, "r": -3 },
       "total_population": 1050,
       "initial_district_id": "d4",
-      "name": "(3,1)",
+      "name": "(3,-3)",
       "demographic_groups": [
         {
-          "id": "p_3_1-all",
+          "id": "p_3_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.67,
@@ -497,15 +497,15 @@
       ]
     },
     {
-      "id": "p_4_1",
+      "id": "p_4_n3",
       "editable": true,
-      "position": { "q": 4, "r": 1 },
+      "position": { "q": 4, "r": -3 },
       "total_population": 1048,
       "initial_district_id": "d4",
-      "name": "(4,1)",
+      "name": "(4,-3)",
       "demographic_groups": [
         {
-          "id": "p_4_1-all",
+          "id": "p_4_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.63,
@@ -514,15 +514,15 @@
       ]
     },
     {
-      "id": "p_5_1",
+      "id": "p_5_n3",
       "editable": true,
-      "position": { "q": 5, "r": 1 },
+      "position": { "q": 5, "r": -3 },
       "total_population": 1025,
-      "initial_district_id": "d4",
-      "name": "(5,1)",
+      "initial_district_id": "d1",
+      "name": "(5,-3)",
       "demographic_groups": [
         {
-          "id": "p_5_1-all",
+          "id": "p_5_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.64,
@@ -531,17 +531,15 @@
       ]
     },
     {
-      "id": "p_0_2",
+      "id": "p_6_n3",
       "editable": true,
-      "position": { "q": 0, "r": 2 },
+      "position": { "q": 6, "r": -3 },
       "total_population": 1042,
-      "initial_district_id": "d3",
-      "name": "(0,2)",
-      "terrain": "lakeside",
-      "has_internal_lake": true,
+      "initial_district_id": "d1",
+      "name": "(6,-3)",
       "demographic_groups": [
         {
-          "id": "p_0_2-all",
+          "id": "p_6_n3-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.57,
@@ -550,15 +548,15 @@
       ]
     },
     {
-      "id": "p_1_2",
+      "id": "p_n4_n2",
       "editable": true,
-      "position": { "q": 1, "r": 2 },
+      "position": { "q": -4, "r": -2 },
       "total_population": 984,
       "initial_district_id": "d3",
-      "name": "(1,2)",
+      "name": "(-4,-2)",
       "demographic_groups": [
         {
-          "id": "p_1_2-all",
+          "id": "p_n4_n2-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.61,
@@ -567,15 +565,15 @@
       ]
     },
     {
-      "id": "p_2_2",
+      "id": "p_n3_n2",
       "editable": true,
-      "position": { "q": 2, "r": 2 },
+      "position": { "q": -3, "r": -2 },
       "total_population": 1085,
       "initial_district_id": "d3",
-      "name": "(2,2)",
+      "name": "(-3,-2)",
       "demographic_groups": [
         {
-          "id": "p_2_2-all",
+          "id": "p_n3_n2-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.58,
@@ -584,15 +582,15 @@
       ]
     },
     {
-      "id": "p_3_2",
+      "id": "p_n2_n2",
       "editable": true,
-      "position": { "q": 3, "r": 2 },
+      "position": { "q": -2, "r": -2 },
       "total_population": 1004,
-      "initial_district_id": "d4",
-      "name": "(3,2)",
+      "initial_district_id": "d3",
+      "name": "(-2,-2)",
       "demographic_groups": [
         {
-          "id": "p_3_2-all",
+          "id": "p_n2_n2-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.70,
@@ -601,15 +599,15 @@
       ]
     },
     {
-      "id": "p_4_2",
+      "id": "p_n1_n2",
       "editable": true,
-      "position": { "q": 4, "r": 2 },
+      "position": { "q": -1, "r": -2 },
       "total_population": 901,
-      "initial_district_id": "d4",
-      "name": "(4,2)",
+      "initial_district_id": "d3",
+      "name": "(-1,-2)",
       "demographic_groups": [
         {
-          "id": "p_4_2-all",
+          "id": "p_n1_n2-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.59,
@@ -618,38 +616,1461 @@
       ]
     },
     {
-      "id": "p_5_2",
+      "id": "p_0_n2",
       "editable": true,
-      "position": { "q": 5, "r": 2 },
+      "position": { "q": 0, "r": -2 },
       "total_population": 1087,
       "initial_district_id": "d4",
-      "name": "(5,2)",
+      "name": "(0,-2)",
       "demographic_groups": [
         {
-          "id": "p_5_2-all",
+          "id": "p_0_n2-all",
           "name": "All voters",
           "population_share": 1.0,
           "turnout_rate": 0.68,
           "vote_shares": { "ash": 0.4853, "birch": 0.5147 }
         }
       ]
+    },
+    {
+      "id": "p_1_n2",
+      "editable": true,
+      "position": { "q": 1, "r": -2 },
+      "total_population": 1022,
+      "initial_district_id": "d4",
+      "name": "(1,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_1_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ash": 0.4719, "birch": 0.5281 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_n2",
+      "editable": true,
+      "position": { "q": 2, "r": -2 },
+      "total_population": 940,
+      "initial_district_id": "d4",
+      "name": "(2,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_2_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.5294, "birch": 0.4706 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_n2",
+      "editable": true,
+      "position": { "q": 3, "r": -2 },
+      "total_population": 911,
+      "initial_district_id": "d1",
+      "name": "(3,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_3_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ash": 0.5275, "birch": 0.4725 }
+        }
+      ]
+    },
+    {
+      "id": "p_4_n2",
+      "editable": true,
+      "position": { "q": 4, "r": -2 },
+      "total_population": 1034,
+      "initial_district_id": "d1",
+      "name": "(4,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_4_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.4513, "birch": 0.5487 }
+        }
+      ]
+    },
+    {
+      "id": "p_5_n2",
+      "editable": true,
+      "position": { "q": 5, "r": -2 },
+      "total_population": 965,
+      "initial_district_id": "d1",
+      "name": "(5,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_5_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ash": 0.5429, "birch": 0.4571 }
+        }
+      ]
+    },
+    {
+      "id": "p_6_n2",
+      "editable": true,
+      "position": { "q": 6, "r": -2 },
+      "total_population": 998,
+      "initial_district_id": "d1",
+      "name": "(6,-2)",
+      "demographic_groups": [
+        {
+          "id": "p_6_n2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.5276, "birch": 0.4724 }
+        }
+      ]
+    },
+    {
+      "id": "p_n5_n1",
+      "editable": true,
+      "position": { "q": -5, "r": -1 },
+      "total_population": 912,
+      "initial_district_id": "d3",
+      "name": "(-5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_n5_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ash": 0.4934, "birch": 0.5066 }
+        }
+      ]
+    },
+    {
+      "id": "p_n4_n1",
+      "editable": true,
+      "position": { "q": -4, "r": -1 },
+      "total_population": 969,
+      "initial_district_id": "d3",
+      "name": "(-4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_n4_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ash": 0.4442, "birch": 0.5558 }
+        }
+      ]
+    },
+    {
+      "id": "p_n3_n1",
+      "editable": true,
+      "position": { "q": -3, "r": -1 },
+      "total_population": 904,
+      "initial_district_id": "d3",
+      "name": "(-3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_n3_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.4830, "birch": 0.5170 }
+        }
+      ]
+    },
+    {
+      "id": "p_n2_n1",
+      "editable": true,
+      "position": { "q": -2, "r": -1 },
+      "total_population": 917,
+      "initial_district_id": "d3",
+      "name": "(-2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_n2_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ash": 0.5059, "birch": 0.4941 }
+        }
+      ]
+    },
+    {
+      "id": "p_n1_n1",
+      "editable": true,
+      "position": { "q": -1, "r": -1 },
+      "total_population": 974,
+      "initial_district_id": "d3",
+      "name": "(-1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_n1_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ash": 0.4923, "birch": 0.5077 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_n1",
+      "editable": true,
+      "position": { "q": 0, "r": -1 },
+      "total_population": 1051,
+      "initial_district_id": "d4",
+      "name": "(0,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_0_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.4714, "birch": 0.5286 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_n1",
+      "editable": true,
+      "position": { "q": 1, "r": -1 },
+      "total_population": 951,
+      "initial_district_id": "d4",
+      "name": "(1,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_1_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.4780, "birch": 0.5220 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_n1",
+      "editable": true,
+      "position": { "q": 2, "r": -1 },
+      "total_population": 1076,
+      "initial_district_id": "d1",
+      "name": "(2,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_2_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ash": 0.5390, "birch": 0.4610 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_n1",
+      "editable": true,
+      "position": { "q": 3, "r": -1 },
+      "total_population": 1037,
+      "initial_district_id": "d1",
+      "name": "(3,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_3_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ash": 0.5106, "birch": 0.4894 }
+        }
+      ]
+    },
+    {
+      "id": "p_4_n1",
+      "editable": true,
+      "position": { "q": 4, "r": -1 },
+      "total_population": 1043,
+      "initial_district_id": "d1",
+      "name": "(4,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_4_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ash": 0.5029, "birch": 0.4971 }
+        }
+      ]
+    },
+    {
+      "id": "p_5_n1",
+      "editable": true,
+      "position": { "q": 5, "r": -1 },
+      "total_population": 969,
+      "initial_district_id": "d1",
+      "name": "(5,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_5_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ash": 0.4816, "birch": 0.5184 }
+        }
+      ]
+    },
+    {
+      "id": "p_6_n1",
+      "editable": true,
+      "position": { "q": 6, "r": -1 },
+      "total_population": 1096,
+      "initial_district_id": "d1",
+      "name": "(6,-1)",
+      "demographic_groups": [
+        {
+          "id": "p_6_n1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ash": 0.5096, "birch": 0.4904 }
+        }
+      ]
+    },
+    {
+      "id": "p_n6_0",
+      "editable": true,
+      "position": { "q": -6, "r": 0 },
+      "total_population": 1096,
+      "initial_district_id": "d3",
+      "name": "(-6,0)",
+      "demographic_groups": [
+        {
+          "id": "p_n6_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ash": 0.5432, "birch": 0.4568 }
+        }
+      ]
+    },
+    {
+      "id": "p_n5_0",
+      "editable": true,
+      "position": { "q": -5, "r": 0 },
+      "total_population": 943,
+      "initial_district_id": "d3",
+      "name": "(-5,0)",
+      "demographic_groups": [
+        {
+          "id": "p_n5_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.4607, "birch": 0.5393 }
+        }
+      ]
+    },
+    {
+      "id": "p_n4_0",
+      "editable": true,
+      "position": { "q": -4, "r": 0 },
+      "total_population": 1032,
+      "initial_district_id": "d3",
+      "name": "(-4,0)",
+      "demographic_groups": [
+        {
+          "id": "p_n4_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ash": 0.5433, "birch": 0.4567 }
+        }
+      ]
+    },
+    {
+      "id": "p_n3_0",
+      "editable": true,
+      "position": { "q": -3, "r": 0 },
+      "total_population": 987,
+      "initial_district_id": "d3",
+      "name": "(-3,0)",
+      "demographic_groups": [
+        {
+          "id": "p_n3_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.5094, "birch": 0.4906 }
+        }
+      ]
+    },
+    {
+      "id": "p_n2_0",
+      "editable": true,
+      "position": { "q": -2, "r": 0 },
+      "total_population": 1031,
+      "initial_district_id": "d3",
+      "name": "(-2,0)",
+      "demographic_groups": [
+        {
+          "id": "p_n2_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ash": 0.5479, "birch": 0.4521 }
+        }
+      ]
+    },
+    {
+      "id": "p_n1_0",
+      "editable": true,
+      "position": { "q": -1, "r": 0 },
+      "total_population": 903,
+      "initial_district_id": "d3",
+      "name": "(-1,0)",
+      "demographic_groups": [
+        {
+          "id": "p_n1_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.5151, "birch": 0.4849 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_0",
+      "editable": true,
+      "position": { "q": 0, "r": 0 },
+      "total_population": 1044,
+      "initial_district_id": "d1",
+      "name": "(0,0)",
+      "demographic_groups": [
+        {
+          "id": "p_0_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ash": 0.4563, "birch": 0.5437 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_0",
+      "editable": true,
+      "position": { "q": 1, "r": 0 },
+      "total_population": 1076,
+      "initial_district_id": "d1",
+      "name": "(1,0)",
+      "demographic_groups": [
+        {
+          "id": "p_1_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ash": 0.5025, "birch": 0.4975 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_0",
+      "editable": true,
+      "position": { "q": 2, "r": 0 },
+      "total_population": 980,
+      "initial_district_id": "d1",
+      "name": "(2,0)",
+      "demographic_groups": [
+        {
+          "id": "p_2_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ash": 0.5371, "birch": 0.4629 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_0",
+      "editable": true,
+      "position": { "q": 3, "r": 0 },
+      "total_population": 1006,
+      "initial_district_id": "d1",
+      "name": "(3,0)",
+      "demographic_groups": [
+        {
+          "id": "p_3_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ash": 0.5361, "birch": 0.4639 }
+        }
+      ]
+    },
+    {
+      "id": "p_4_0",
+      "editable": true,
+      "position": { "q": 4, "r": 0 },
+      "total_population": 989,
+      "initial_district_id": "d1",
+      "name": "(4,0)",
+      "demographic_groups": [
+        {
+          "id": "p_4_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.4436, "birch": 0.5564 }
+        }
+      ]
+    },
+    {
+      "id": "p_5_0",
+      "editable": true,
+      "position": { "q": 5, "r": 0 },
+      "total_population": 980,
+      "initial_district_id": "d1",
+      "name": "(5,0)",
+      "demographic_groups": [
+        {
+          "id": "p_5_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.4860, "birch": 0.5140 }
+        }
+      ]
+    },
+    {
+      "id": "p_6_0",
+      "editable": true,
+      "position": { "q": 6, "r": 0 },
+      "total_population": 1092,
+      "initial_district_id": "d1",
+      "name": "(6,0)",
+      "demographic_groups": [
+        {
+          "id": "p_6_0-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.5088, "birch": 0.4912 }
+        }
+      ]
+    },
+    {
+      "id": "p_n6_1",
+      "editable": true,
+      "position": { "q": -6, "r": 1 },
+      "total_population": 989,
+      "initial_district_id": "d3",
+      "name": "(-6,1)",
+      "demographic_groups": [
+        {
+          "id": "p_n6_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ash": 0.5439, "birch": 0.4561 }
+        }
+      ]
+    },
+    {
+      "id": "p_n5_1",
+      "editable": true,
+      "position": { "q": -5, "r": 1 },
+      "total_population": 1068,
+      "initial_district_id": "d3",
+      "name": "(-5,1)",
+      "demographic_groups": [
+        {
+          "id": "p_n5_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ash": 0.5447, "birch": 0.4553 }
+        }
+      ]
+    },
+    {
+      "id": "p_n4_1",
+      "editable": true,
+      "position": { "q": -4, "r": 1 },
+      "total_population": 1021,
+      "initial_district_id": "d3",
+      "name": "(-4,1)",
+      "demographic_groups": [
+        {
+          "id": "p_n4_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ash": 0.5423, "birch": 0.4577 }
+        }
+      ]
+    },
+    {
+      "id": "p_n3_1",
+      "editable": true,
+      "position": { "q": -3, "r": 1 },
+      "total_population": 945,
+      "initial_district_id": "d3",
+      "name": "(-3,1)",
+      "demographic_groups": [
+        {
+          "id": "p_n3_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ash": 0.5420, "birch": 0.4580 }
+        }
+      ]
+    },
+    {
+      "id": "p_n2_1",
+      "editable": true,
+      "position": { "q": -2, "r": 1 },
+      "total_population": 928,
+      "initial_district_id": "d3",
+      "name": "(-2,1)",
+      "demographic_groups": [
+        {
+          "id": "p_n2_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.4737, "birch": 0.5263 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_1",
+      "editable": true,
+      "position": { "q": 0, "r": 1 },
+      "total_population": 958,
+      "initial_district_id": "d2",
+      "name": "(0,1)",
+      "demographic_groups": [
+        {
+          "id": "p_0_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ash": 0.4734, "birch": 0.5266 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_1",
+      "editable": true,
+      "position": { "q": 1, "r": 1 },
+      "total_population": 923,
+      "initial_district_id": "d1",
+      "name": "(1,1)",
+      "demographic_groups": [
+        {
+          "id": "p_1_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.5292, "birch": 0.4708 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_1",
+      "editable": true,
+      "position": { "q": 2, "r": 1 },
+      "total_population": 904,
+      "initial_district_id": "d1",
+      "name": "(2,1)",
+      "demographic_groups": [
+        {
+          "id": "p_2_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ash": 0.5340, "birch": 0.4660 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_1",
+      "editable": true,
+      "position": { "q": 3, "r": 1 },
+      "total_population": 977,
+      "initial_district_id": "d1",
+      "name": "(3,1)",
+      "demographic_groups": [
+        {
+          "id": "p_3_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.5390, "birch": 0.4610 }
+        }
+      ]
+    },
+    {
+      "id": "p_4_1",
+      "editable": true,
+      "position": { "q": 4, "r": 1 },
+      "total_population": 1055,
+      "initial_district_id": "d1",
+      "name": "(4,1)",
+      "demographic_groups": [
+        {
+          "id": "p_4_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ash": 0.5415, "birch": 0.4585 }
+        }
+      ]
+    },
+    {
+      "id": "p_5_1",
+      "editable": true,
+      "position": { "q": 5, "r": 1 },
+      "total_population": 1052,
+      "initial_district_id": "d1",
+      "name": "(5,1)",
+      "demographic_groups": [
+        {
+          "id": "p_5_1-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ash": 0.4446, "birch": 0.5554 }
+        }
+      ]
+    },
+    {
+      "id": "p_n6_2",
+      "editable": true,
+      "position": { "q": -6, "r": 2 },
+      "total_population": 940,
+      "initial_district_id": "d3",
+      "name": "(-6,2)",
+      "demographic_groups": [
+        {
+          "id": "p_n6_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ash": 0.5499, "birch": 0.4501 }
+        }
+      ]
+    },
+    {
+      "id": "p_n5_2",
+      "editable": true,
+      "position": { "q": -5, "r": 2 },
+      "total_population": 958,
+      "initial_district_id": "d3",
+      "name": "(-5,2)",
+      "demographic_groups": [
+        {
+          "id": "p_n5_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ash": 0.5293, "birch": 0.4707 }
+        }
+      ]
+    },
+    {
+      "id": "p_n4_2",
+      "editable": true,
+      "position": { "q": -4, "r": 2 },
+      "total_population": 906,
+      "initial_district_id": "d3",
+      "name": "(-4,2)",
+      "demographic_groups": [
+        {
+          "id": "p_n4_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.4501, "birch": 0.5499 }
+        }
+      ]
+    },
+    {
+      "id": "p_n3_2",
+      "editable": true,
+      "position": { "q": -3, "r": 2 },
+      "total_population": 1042,
+      "initial_district_id": "d3",
+      "name": "(-3,2)",
+      "demographic_groups": [
+        {
+          "id": "p_n3_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ash": 0.4760, "birch": 0.5240 }
+        }
+      ]
+    },
+    {
+      "id": "p_n2_2",
+      "editable": true,
+      "position": { "q": -2, "r": 2 },
+      "total_population": 939,
+      "initial_district_id": "d2",
+      "name": "(-2,2)",
+      "demographic_groups": [
+        {
+          "id": "p_n2_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ash": 0.4952, "birch": 0.5048 }
+        }
+      ]
+    },
+    {
+      "id": "p_n1_2",
+      "editable": true,
+      "position": { "q": -1, "r": 2 },
+      "total_population": 1054,
+      "initial_district_id": "d2",
+      "name": "(-1,2)",
+      "demographic_groups": [
+        {
+          "id": "p_n1_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ash": 0.5259, "birch": 0.4741 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_2",
+      "editable": true,
+      "position": { "q": 0, "r": 2 },
+      "total_population": 1084,
+      "initial_district_id": "d2",
+      "name": "(0,2)",
+      "demographic_groups": [
+        {
+          "id": "p_0_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ash": 0.4769, "birch": 0.5231 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_2",
+      "editable": true,
+      "position": { "q": 1, "r": 2 },
+      "total_population": 1012,
+      "initial_district_id": "d1",
+      "name": "(1,2)",
+      "demographic_groups": [
+        {
+          "id": "p_1_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.4573, "birch": 0.5427 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_2",
+      "editable": true,
+      "position": { "q": 2, "r": 2 },
+      "total_population": 1018,
+      "initial_district_id": "d1",
+      "name": "(2,2)",
+      "demographic_groups": [
+        {
+          "id": "p_2_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.67,
+          "vote_shares": { "ash": 0.4955, "birch": 0.5045 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_2",
+      "editable": true,
+      "position": { "q": 3, "r": 2 },
+      "total_population": 1046,
+      "initial_district_id": "d1",
+      "name": "(3,2)",
+      "demographic_groups": [
+        {
+          "id": "p_3_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ash": 0.5236, "birch": 0.4764 }
+        }
+      ]
+    },
+    {
+      "id": "p_4_2",
+      "editable": true,
+      "position": { "q": 4, "r": 2 },
+      "total_population": 1069,
+      "initial_district_id": "d1",
+      "name": "(4,2)",
+      "demographic_groups": [
+        {
+          "id": "p_4_2-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ash": 0.5402, "birch": 0.4598 }
+        }
+      ]
+    },
+    {
+      "id": "p_n6_3",
+      "editable": true,
+      "position": { "q": -6, "r": 3 },
+      "total_population": 926,
+      "initial_district_id": "d3",
+      "name": "(-6,3)",
+      "demographic_groups": [
+        {
+          "id": "p_n6_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ash": 0.5157, "birch": 0.4843 }
+        }
+      ]
+    },
+    {
+      "id": "p_n5_3",
+      "editable": true,
+      "position": { "q": -5, "r": 3 },
+      "total_population": 1092,
+      "initial_district_id": "d3",
+      "name": "(-5,3)",
+      "demographic_groups": [
+        {
+          "id": "p_n5_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.5185, "birch": 0.4815 }
+        }
+      ]
+    },
+    {
+      "id": "p_n4_3",
+      "editable": true,
+      "position": { "q": -4, "r": 3 },
+      "total_population": 911,
+      "initial_district_id": "d2",
+      "name": "(-4,3)",
+      "demographic_groups": [
+        {
+          "id": "p_n4_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ash": 0.5244, "birch": 0.4756 }
+        }
+      ]
+    },
+    {
+      "id": "p_n3_3",
+      "editable": true,
+      "position": { "q": -3, "r": 3 },
+      "total_population": 957,
+      "initial_district_id": "d2",
+      "name": "(-3,3)",
+      "demographic_groups": [
+        {
+          "id": "p_n3_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.5398, "birch": 0.4602 }
+        }
+      ]
+    },
+    {
+      "id": "p_n2_3",
+      "editable": true,
+      "position": { "q": -2, "r": 3 },
+      "total_population": 1004,
+      "initial_district_id": "d2",
+      "name": "(-2,3)",
+      "demographic_groups": [
+        {
+          "id": "p_n2_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ash": 0.5089, "birch": 0.4911 }
+        }
+      ]
+    },
+    {
+      "id": "p_n1_3",
+      "editable": true,
+      "position": { "q": -1, "r": 3 },
+      "total_population": 975,
+      "initial_district_id": "d2",
+      "name": "(-1,3)",
+      "demographic_groups": [
+        {
+          "id": "p_n1_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.64,
+          "vote_shares": { "ash": 0.5557, "birch": 0.4443 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_3",
+      "editable": true,
+      "position": { "q": 0, "r": 3 },
+      "total_population": 1083,
+      "initial_district_id": "d2",
+      "name": "(0,3)",
+      "demographic_groups": [
+        {
+          "id": "p_0_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ash": 0.5430, "birch": 0.4570 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_3",
+      "editable": true,
+      "position": { "q": 1, "r": 3 },
+      "total_population": 908,
+      "initial_district_id": "d2",
+      "name": "(1,3)",
+      "demographic_groups": [
+        {
+          "id": "p_1_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.4707, "birch": 0.5293 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_3",
+      "editable": true,
+      "position": { "q": 2, "r": 3 },
+      "total_population": 1020,
+      "initial_district_id": "d1",
+      "name": "(2,3)",
+      "demographic_groups": [
+        {
+          "id": "p_2_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ash": 0.4717, "birch": 0.5283 }
+        }
+      ]
+    },
+    {
+      "id": "p_3_3",
+      "editable": true,
+      "position": { "q": 3, "r": 3 },
+      "total_population": 1054,
+      "initial_district_id": "d1",
+      "name": "(3,3)",
+      "demographic_groups": [
+        {
+          "id": "p_3_3-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.55,
+          "vote_shares": { "ash": 0.5417, "birch": 0.4583 }
+        }
+      ]
+    },
+    {
+      "id": "p_n6_4",
+      "editable": true,
+      "position": { "q": -6, "r": 4 },
+      "total_population": 925,
+      "initial_district_id": "d3",
+      "name": "(-6,4)",
+      "demographic_groups": [
+        {
+          "id": "p_n6_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ash": 0.5151, "birch": 0.4849 }
+        }
+      ]
+    },
+    {
+      "id": "p_n5_4",
+      "editable": true,
+      "position": { "q": -5, "r": 4 },
+      "total_population": 981,
+      "initial_district_id": "d2",
+      "name": "(-5,4)",
+      "demographic_groups": [
+        {
+          "id": "p_n5_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.57,
+          "vote_shares": { "ash": 0.5025, "birch": 0.4975 }
+        }
+      ]
+    },
+    {
+      "id": "p_n4_4",
+      "editable": true,
+      "position": { "q": -4, "r": 4 },
+      "total_population": 967,
+      "initial_district_id": "d2",
+      "name": "(-4,4)",
+      "demographic_groups": [
+        {
+          "id": "p_n4_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ash": 0.4422, "birch": 0.5578 }
+        }
+      ]
+    },
+    {
+      "id": "p_n3_4",
+      "editable": true,
+      "position": { "q": -3, "r": 4 },
+      "total_population": 956,
+      "initial_district_id": "d2",
+      "name": "(-3,4)",
+      "demographic_groups": [
+        {
+          "id": "p_n3_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.5303, "birch": 0.4697 }
+        }
+      ]
+    },
+    {
+      "id": "p_n2_4",
+      "editable": true,
+      "position": { "q": -2, "r": 4 },
+      "total_population": 1048,
+      "initial_district_id": "d2",
+      "name": "(-2,4)",
+      "demographic_groups": [
+        {
+          "id": "p_n2_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.60,
+          "vote_shares": { "ash": 0.4572, "birch": 0.5428 }
+        }
+      ]
+    },
+    {
+      "id": "p_n1_4",
+      "editable": true,
+      "position": { "q": -1, "r": 4 },
+      "total_population": 1088,
+      "initial_district_id": "d2",
+      "name": "(-1,4)",
+      "demographic_groups": [
+        {
+          "id": "p_n1_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.61,
+          "vote_shares": { "ash": 0.4519, "birch": 0.5481 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_4",
+      "editable": true,
+      "position": { "q": 0, "r": 4 },
+      "total_population": 979,
+      "initial_district_id": "d2",
+      "name": "(0,4)",
+      "demographic_groups": [
+        {
+          "id": "p_0_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ash": 0.5203, "birch": 0.4797 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_4",
+      "editable": true,
+      "position": { "q": 1, "r": 4 },
+      "total_population": 958,
+      "initial_district_id": "d2",
+      "name": "(1,4)",
+      "demographic_groups": [
+        {
+          "id": "p_1_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ash": 0.5237, "birch": 0.4763 }
+        }
+      ]
+    },
+    {
+      "id": "p_2_4",
+      "editable": true,
+      "position": { "q": 2, "r": 4 },
+      "total_population": 1056,
+      "initial_district_id": "d1",
+      "name": "(2,4)",
+      "demographic_groups": [
+        {
+          "id": "p_2_4-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.66,
+          "vote_shares": { "ash": 0.5426, "birch": 0.4574 }
+        }
+      ]
+    },
+    {
+      "id": "p_n6_5",
+      "editable": true,
+      "position": { "q": -6, "r": 5 },
+      "total_population": 912,
+      "initial_district_id": "d2",
+      "name": "(-6,5)",
+      "demographic_groups": [
+        {
+          "id": "p_n6_5-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.58,
+          "vote_shares": { "ash": 0.4952, "birch": 0.5048 }
+        }
+      ]
+    },
+    {
+      "id": "p_n5_5",
+      "editable": true,
+      "position": { "q": -5, "r": 5 },
+      "total_population": 951,
+      "initial_district_id": "d2",
+      "name": "(-5,5)",
+      "demographic_groups": [
+        {
+          "id": "p_n5_5-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.63,
+          "vote_shares": { "ash": 0.5047, "birch": 0.4953 }
+        }
+      ]
+    },
+    {
+      "id": "p_n4_5",
+      "editable": true,
+      "position": { "q": -4, "r": 5 },
+      "total_population": 1004,
+      "initial_district_id": "d2",
+      "name": "(-4,5)",
+      "demographic_groups": [
+        {
+          "id": "p_n4_5-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.65,
+          "vote_shares": { "ash": 0.5420, "birch": 0.4580 }
+        }
+      ]
+    },
+    {
+      "id": "p_n3_5",
+      "editable": true,
+      "position": { "q": -3, "r": 5 },
+      "total_population": 919,
+      "initial_district_id": "d2",
+      "name": "(-3,5)",
+      "demographic_groups": [
+        {
+          "id": "p_n3_5-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ash": 0.5374, "birch": 0.4626 }
+        }
+      ]
+    },
+    {
+      "id": "p_n2_5",
+      "editable": true,
+      "position": { "q": -2, "r": 5 },
+      "total_population": 927,
+      "initial_district_id": "d2",
+      "name": "(-2,5)",
+      "demographic_groups": [
+        {
+          "id": "p_n2_5-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.70,
+          "vote_shares": { "ash": 0.5491, "birch": 0.4509 }
+        }
+      ]
+    },
+    {
+      "id": "p_n1_5",
+      "editable": true,
+      "position": { "q": -1, "r": 5 },
+      "total_population": 998,
+      "initial_district_id": "d2",
+      "name": "(-1,5)",
+      "demographic_groups": [
+        {
+          "id": "p_n1_5-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.56,
+          "vote_shares": { "ash": 0.4507, "birch": 0.5493 }
+        }
+      ]
+    },
+    {
+      "id": "p_0_5",
+      "editable": true,
+      "position": { "q": 0, "r": 5 },
+      "total_population": 995,
+      "initial_district_id": "d2",
+      "name": "(0,5)",
+      "demographic_groups": [
+        {
+          "id": "p_0_5-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.69,
+          "vote_shares": { "ash": 0.5377, "birch": 0.4623 }
+        }
+      ]
+    },
+    {
+      "id": "p_1_5",
+      "editable": true,
+      "position": { "q": 1, "r": 5 },
+      "total_population": 1054,
+      "initial_district_id": "d2",
+      "name": "(1,5)",
+      "demographic_groups": [
+        {
+          "id": "p_1_5-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.68,
+          "vote_shares": { "ash": 0.4991, "birch": 0.5009 }
+        }
+      ]
+    },
+    {
+      "id": "p_n6_6",
+      "editable": true,
+      "position": { "q": -6, "r": 6 },
+      "total_population": 921,
+      "initial_district_id": "d2",
+      "name": "(-6,6)",
+      "demographic_groups": [
+        {
+          "id": "p_n6_6-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.62,
+          "vote_shares": { "ash": 0.5355, "birch": 0.4645 }
+        }
+      ]
+    },
+    {
+      "id": "p_n5_6",
+      "editable": true,
+      "position": { "q": -5, "r": 6 },
+      "total_population": 1086,
+      "initial_district_id": "d2",
+      "name": "(-5,6)",
+      "demographic_groups": [
+        {
+          "id": "p_n5_6-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ash": 0.5440, "birch": 0.4560 }
+        }
+      ]
+    },
+    {
+      "id": "p_n4_6",
+      "editable": true,
+      "position": { "q": -4, "r": 6 },
+      "total_population": 943,
+      "initial_district_id": "d2",
+      "name": "(-4,6)",
+      "demographic_groups": [
+        {
+          "id": "p_n4_6-all",
+          "name": "All voters",
+          "population_share": 1.0,
+          "turnout_rate": 0.59,
+          "vote_shares": { "ash": 0.4578, "birch": 0.5422 }
+        }
+      ]
     }
   ],
   "terrain_tiles": [
-    { "position": { "q": 1, "r": -4 }, "type": "mountain" },
-    { "position": { "q": 2, "r": -4 }, "type": "mountain" },
-    { "position": { "q": 3, "r": -4 }, "type": "mountain" },
-    { "position": { "q": 6, "r": -2 }, "type": "lake" },
-    { "position": { "q": 1, "r":  3 }, "type": "sea" },
-    { "position": { "q": 2, "r":  3 }, "type": "sea" },
-    { "position": { "q": 3, "r":  3 }, "type": "sea" }
+    { "position": { "q": -3, "r": -3 }, "type": "mountain" },
+    { "position": { "q": -2, "r": -4 }, "type": "mountain" },
+    { "position": { "q": -1, "r": -5 }, "type": "mountain" },
+    { "position": { "q": -3, "r": 6 }, "type": "sea" },
+    { "position": { "q": -2, "r": 6 }, "type": "sea" },
+    { "position": { "q": -1, "r": 6 }, "type": "sea" },
+    { "position": { "q": 0, "r": 6 }, "type": "sea" },
+    { "position": { "q": -1, "r": 1 }, "type": "lake" }
   ],
   "river_edges": [
-    ["p_0_n1", "p_0_0"],
-    ["p_1_n1", "p_0_0"],
-    ["p_1_n1", "p_1_0"],
-    ["p_2_n1", "p_1_0"],
-    ["p_2_n1", "p_2_0"]
+    ["p_n1_n4", "p_n2_n3"],
+    ["p_n2_n3", "p_n1_n3"],
+    ["p_n1_n3", "p_n2_n2"],
+    ["p_n2_n2", "p_n1_n2"],
+    ["p_n1_n2", "p_n2_n1"],
+    ["p_n2_n1", "p_n1_n1"],
+    ["p_n1_n1", "p_n2_0"],
+    ["p_n2_0", "p_n1_0"],
+    ["p_n1_0", "p_n2_1"],
+    ["p_n2_2", "p_n1_2"],
+    ["p_n1_2", "p_n2_3"],
+    ["p_n2_3", "p_n1_3"],
+    ["p_n1_3", "p_n2_4"],
+    ["p_n2_4", "p_n1_4"],
+    ["p_n1_4", "p_n2_5"],
+    ["p_n2_5", "p_n1_5"]
   ],
   "river_blocks_contiguity": false,
   "events": [],
@@ -675,22 +2096,22 @@
     "character": {
       "name": "Tutorial Guide",
       "role": "Tour Guide",
-      "motivation": "Welcome to Hawthorn Bend. This map shows every kind of terrain you'll see in the game — take a moment to look around before you start drawing districts."
+      "motivation": "Welcome to Hawthorn Bend. This map shows every kind of terrain feature that you will see in the game."
     },
     "intro_slides": [
       {
         "heading": "Reading the Map",
-        "body": "Maps in this game can include geographic features alongside the precincts you draw districts from.\n\n- **Mountains** (grey tiles, top of map) — not assignable. Precincts beside them are foothills, marked with a subtle grey edge.\n- **Sea** (dark blue tiles, bottom of map) — not assignable. Precincts beside them are coast, marked with a blue shoreline.\n- **Lake** (aqua tile, right side) — not assignable. Precincts beside it are lakeside, marked with an aqua edge.\n- **River** (blue line through the middle-left) — flows along hex edges, not on them. Precincts on a river are riverside.\n\nThere's also a small lake within one precinct on the south-west — an inland pond, drawn as an aqua oval inside the hex."
+        "body": "Maps can include geographic features alongside the precincts you draw districts from.\n\n- **Mountains** (grey tiles, northwest) — not assignable. Adjacent precincts are foothills with a soft grey fringe.\n- **Sea** (dark blue tiles, south) — not assignable. Adjacent precincts are coast with a blue shoreline.\n- **Lake** (aqua tile, centre) — not assignable. Adjacent precincts show a teal lakeside fringe.\n- **River** (teal line) — flows from the mountain area, through the lake, and down to the sea."
       },
       {
         "heading": "Geography is Cosmetic",
-        "body": "These features are visual: they show what the region looks like, but **they do not constrain district-drawing**.\n\nReal redistricting often uses rivers and mountains as district boundaries — but that's because of political choices (state lines, county lines, historical municipal limits) that *happen* to follow geography, not because geography is a physical barrier. A district can cross a river if the people on both sides share a community.\n\nThe initial map here divides the region into four quadrants. It's already a valid plan."
+        "body": "These features are visual: they show what the region looks like, but **they do not constrain district-drawing**.\n\nReal redistricting often uses rivers and mountains as district boundaries — but that is because of political choices (state lines, county lines, historical municipal limits) that happen to follow geography, not because geography is a physical barrier. A district can cross a river or lake if the people on both sides share a community.\n\nThe initial map divides the region into four sectors. It is already a valid plan."
       },
       {
         "heading": "Try It Out",
-        "body": "Click **Submit Map** to evaluate the starting districts. You can also repaint districts to experiment — drag across hexes to assign them, click district buttons to switch which district you're drawing.\n\nWhen you're done exploring, move on to the educational campaign."
+        "body": "Click **Submit Map** to evaluate the starting districts. You can also repaint districts to experiment — drag across hexes to assign them, click district buttons to switch which district you are drawing.\n\nWhen you are done exploring, move on to the educational campaign."
       }
     ],
-    "objective": "Look around the map at the four kinds of terrain. Submit the initial four-quadrant map, or repaint to experiment."
+    "objective": "Look around the map at the terrain features. Submit the initial four-district map, or repaint to experiment."
   }
 }

--- a/game/web/e2e/main-menu.spec.ts
+++ b/game/web/e2e/main-menu.spec.ts
@@ -66,7 +66,9 @@ test("main menu: Continue navigates directly to last played scenario", async ({ 
   await page.reload();
   await expect(page.locator("#btn-main-continue")).toBeVisible({ timeout: 10_000 });
   await page.locator("#btn-main-continue").click();
+  // Must include campaign param — without it the app redirects to the main menu (bug: GAME-082).
   await expect(page).toHaveURL(/s=tutorial-002/);
+  await expect(page).toHaveURL(/campaign=tutorial/);
 });
 
 test("main menu: Load is visible but disabled", async ({ page }) => {

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -1073,28 +1073,32 @@ test.describe("GAME-068: animated reveal path (no reduced-motion)", () => {
 
 // ─── tutorial-003: "Hawthorn Bend — A Tour of the Map" (GAME-082 geo features tour) ───
 
-test("tutorial-003 smoke: loads and renders 36 precincts", async ({ page }) => {
+test("tutorial-003 smoke: loads and renders 119 precincts", async ({ page }) => {
   await page.goto("/?s=tutorial-003&debug");
-  await expect(page.locator("path.hex")).toHaveCount(36);
+  // 127 R=6 circle hexes minus 3 mountain tiles minus 4 sea tiles (now at r=6) minus 1 lake tile = 119.
+  await expect(page.locator("path.hex")).toHaveCount(119);
 });
 
-test("tutorial-003 terrain: 7 terrain tiles rendered (3 mountain + 3 sea + 1 lake)", async ({ page }) => {
+test("tutorial-003 terrain: 8 terrain tiles rendered (3 mountain + 4 sea + 1 lake)", async ({ page }) => {
   await page.goto("/?s=tutorial-003&debug");
-  await expect(page.locator("g.terrain-tile")).toHaveCount(7);
+  // Mountain tiles now at (-3,-3), (-2,-4), (-1,-5) — hexDist=6 boundary positions.
+  await expect(page.locator("g.terrain-tile")).toHaveCount(8);
   await expect(page.locator("g.terrain-tile[data-terrain-type='mountain']")).toHaveCount(3);
-  await expect(page.locator("g.terrain-tile[data-terrain-type='sea']")).toHaveCount(3);
+  await expect(page.locator("g.terrain-tile[data-terrain-type='sea']")).toHaveCount(4);
   await expect(page.locator("g.terrain-tile[data-terrain-type='lake']")).toHaveCount(1);
 });
 
-test("tutorial-003 terrain: river rendered as a single smoothed chain", async ({ page }) => {
+test("tutorial-003 terrain: river rendered as two smoothed chains (split at lake tile)", async ({ page }) => {
   await page.goto("/?s=tutorial-003&debug");
-  // 5 connected river edges form a single chain along the r=-1/r=0 boundary (q=0..2).
+  // 16 river edges split into two chains by the lake tile at (-1,1):
+  //   chain 1: NW foothill (-1,-4) → (-2,1)  [9 edges]
+  //   chain 2: (-2,2) → (-1,5) [7 edges] — downstream reach to coast area
   // Smoothing uses d3.curveCardinal.tension(0.4).
-  await expect(page.locator("path.river-chain")).toHaveCount(1);
-  const d = await page.locator("path.river-chain").getAttribute("d");
+  await expect(page.locator("path.river-chain")).toHaveCount(2);
+  const d = await page.locator("path.river-chain").first().getAttribute("d");
   expect(d).toBeTruthy();
   expect(d!.startsWith("M")).toBe(true);
-  // curveCardinal on 3+ points emits cubic bezier (C). 5 edges → 6 corners → C-rich path.
+  // curveCardinal on 3+ points emits cubic bezier (C).
   expect(d!.includes("C")).toBe(true);
 });
 
@@ -1108,38 +1112,36 @@ test("tutorial-003 terrain: terrain tiles are non-interactive (pointer-events: n
 
 test("tutorial-003 terrain: coast edge strokes on precincts adjacent to sea", async ({ page }) => {
   await page.goto("/?s=tutorial-003&debug");
-  // Coast precincts at r=2: (1,2) has 1 sea-facing edge, (2,2) and (3,2) each have 2
-  // (down + lower-left), (4,2) has 1 (lower-left to (3,3) sea).
-  // Total: 1+2+2+1 = 6 sea-facing edges, each rendered as a curved <path> (GAME-082).
-  await expect(page.locator("path.terrain-edge-sea")).toHaveCount(6);
+  // Sea tiles moved to r=6: (-3,6), (-2,6), (-1,6), (0,6). Coast precincts at r=5 / edge of map:
+  //   (-3,6): 3 precinct-facing edges → (-4,6), (-3,5), (-2,5)
+  //   (-2,6): 2 precinct-facing edges → (-2,5), (-1,5)
+  //   (-1,6): 2 precinct-facing edges → (-1,5), (0,5)
+  //   (0,6):  2 precinct-facing edges → (0,5), (1,5)
+  // Total: 3+2+2+2 = 9 sea-facing edges, each rendered as a curved <path> (GAME-082).
+  await expect(page.locator("path.terrain-edge-sea")).toHaveCount(9);
 });
 
-test("tutorial-003 terrain: lakeside edge strokes on precincts adjacent to lake", async ({ page }) => {
+test("tutorial-003 terrain: lake edge strokes on precincts adjacent to lake tile", async ({ page }) => {
   await page.goto("/?s=tutorial-003&debug");
-  // Lakeside precincts adjacent to lake at (6,-2): (5,-2) via lower-right, (5,-1) via upper-right.
-  // 2 lake-facing edges total. Lakeside still uses straight <line> (the lake fill provides weight).
-  await expect(page.locator("line.terrain-edge-lake")).toHaveCount(2);
+  // Lake tile at (-1,1). All 6 neighbours are valid precincts, each with 1 lake-facing edge:
+  //   (0,1), (-1,2), (-2,2), (-2,1), (-1,0), (0,0)
+  // Total: 6 lake-facing edges, each rendered as a curved <path>.
+  await expect(page.locator("path.terrain-edge-lake")).toHaveCount(6);
 });
 
 test("tutorial-003 terrain: foothill edge strokes on precincts adjacent to mountains", async ({ page }) => {
   await page.goto("/?s=tutorial-003&debug");
-  // Foothill precincts at r=-3 facing mountain tiles at (1,-4), (2,-4), (3,-4).
-  // In flat-top axial hex, a hex at (q, r-1) is the "up" neighbor and (q+1, r-1) is the
-  // "upper-right" neighbor — but (q-1, r-1) is NOT a neighbor (no hex direction with both
-  // q and r decreasing). So mountain edges per foothill:
-  //   (0,-3): 1 (upper-right to (1,-4))
-  //   (1,-3): 2 (up to (1,-4), upper-right to (2,-4))
-  //   (2,-3): 2 (up to (2,-4), upper-right to (3,-4))
-  //   (3,-3): 1 (up to (3,-4))
-  //   (4,-3): 0 — NOT a foothill
-  // Total: 1+2+2+1 = 6 mountain-facing edges, rendered as curved <path> (GAME-082).
-  await expect(page.locator("path.terrain-edge-mountain")).toHaveCount(6);
-});
-
-test("tutorial-003 terrain: internal lake ellipse renders for has_internal_lake precincts", async ({ page }) => {
-  await page.goto("/?s=tutorial-003&debug");
-  // (0,2) has has_internal_lake: true; exactly one aqua ellipse renders.
-  await expect(page.locator("ellipse.internal-lake")).toHaveCount(1);
+  // Mountain tiles at (-3,-3), (-2,-4), (-1,-5) are NOT precincts (terrain-position exclusion).
+  // Only positions with hexDist ≤ 6 are valid precincts. Foothill precincts are:
+  //   (-2,-3): 2 edges facing (-3,-3) and (-2,-4) [hexDist=5]
+  //   (-3,-2): 1 edge facing (-3,-3)              [hexDist=3]
+  //   (-4,-2): 1 edge facing (-3,-3)              [hexDist=4]
+  //   (-1,-4): 2 edges facing (-2,-4) and (-1,-5) [hexDist=5]
+  //   (0,-5):  1 edge facing (-1,-5)              [hexDist=5]
+  //   (0,-6):  1 edge facing (-1,-5)              [hexDist=6]
+  // Positions (-4,-3), (-3,-4), (-2,-5), (-1,-6) are hexDist=7 — outside the grid.
+  // Total: 2+1+1+2+1+1 = 8 mountain-facing edges, rendered as curved <path> (GAME-082).
+  await expect(page.locator("path.terrain-edge-mountain")).toHaveCount(8);
 });
 
 test("tutorial-003 contiguity: river is cosmetic, initial quadrant districts are contiguous", async ({ page }) => {

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -144,6 +144,7 @@
         <button id="btn-county-toggle" aria-label="Toggle county borders display">Show County Borders</button>
         <button id="btn-submit" disabled aria-label="Submit map for evaluation">Submit Map</button>
         <button id="btn-debug-win" style="display:none;background:#8b4513;color:#ffa;">⚡ Force Win (debug)</button>
+        <button id="btn-debug-coords" style="display:none;background:#1e3a5f;color:#9ef;">⌖ Coords [C]</button>
         <button id="btn-reset" aria-label="Reset map to initial state">Reset</button>
         <span id="reset-confirm">
           Reset to start?

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -267,9 +267,6 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	}
 
 	function buildContinueUrl(scenarioId: string): string {
-		if (SCENARIO_MANIFEST.some((e) => e.id === scenarioId)) {
-			return `./?s=${scenarioId}`;
-		}
 		for (const campaign of CAMPAIGN_REGISTRY) {
 			if (campaign.scenarioIds.includes(scenarioId)) {
 				return `./?s=${scenarioId}&campaign=${campaign.id}`;
@@ -679,6 +676,9 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		} else if (isCtrlOrCmd && (e.key === "y" || (isMac && e.shiftKey && e.key === "z"))) {
 			e.preventDefault();
 			temporalStore.getState().redo();
+		} else if (IS_DEBUG && e.key === "c" && !isCtrlOrCmd && !e.shiftKey && !e.altKey) {
+			const tag = (e.target as Element | null)?.tagName ?? "";
+			if (tag !== "INPUT" && tag !== "TEXTAREA") toggleCoordLabels();
 		}
 	});
 
@@ -1379,6 +1379,18 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		btnDebugWin.addEventListener("click", () => {
 			showResultScreen(/*debugForcePass=*/ true);
 		});
+	}
+
+	const btnDebugCoords = document.getElementById("btn-debug-coords") as HTMLButtonElement | null;
+	let coordLabelsOn = false;
+	const toggleCoordLabels = () => {
+		coordLabelsOn = !coordLabelsOn;
+		renderer.setCoordLabelsVisible(coordLabelsOn);
+		if (btnDebugCoords) btnDebugCoords.textContent = coordLabelsOn ? "⌖ Coords ON [C]" : "⌖ Coords [C]";
+	};
+	if (btnDebugCoords && IS_DEBUG) {
+		btnDebugCoords.style.display = "";
+		btnDebugCoords.addEventListener("click", toggleCoordLabels);
 	}
 
 	btnKeepDrawing!.addEventListener("click", () => {

--- a/game/web/src/model/adapter.ts
+++ b/game/web/src/model/adapter.ts
@@ -14,7 +14,7 @@
  */
 
 import type { Scenario } from "./scenario.js";
-import type { AssignmentMap, DistrictId, Precinct, TerrainTileRuntime } from "./types.js";
+import type { AssignmentMap, DistrictId, Precinct, TerrainAnnotation, TerrainTileRuntime } from "./types.js";
 import { HEX_DIRECTIONS, hexToPixel } from "./hex-geometry.js";
 
 // vote_shares is Record<PartyId, number> with branded keys; cast to plain string map at runtime
@@ -84,26 +84,24 @@ export function scenarioToSpike(scenario: Scenario): {
 			return riverEdgeSet.has(`${i},${nbIdx}`) ? null : nbIdx;
 		});
 
-		// Derive terrain annotation from adjacency (explicit value overrides derivation).
-		// Priority: explicit > coast (sea) > lakeside (lake) > foothill (mountain) > riverside (river edge).
-		// Terrain tiles are dominant features; rivers are edge features, so tiles take priority.
-		let terrain: Precinct["terrain"] = pc.terrain as Precinct["terrain"] | undefined;
-		if (terrain === undefined) {
-			let hasSea = false;
-			let hasLake = false;
-			let hasMountain = false;
-			for (const [dq, dr] of HEX_DIRECTIONS) {
-				const tileType = terrainPosMap.get(`${q + dq},${r + dr}`);
-				if (tileType === "sea") hasSea = true;
-				else if (tileType === "lake") hasLake = true;
-				else if (tileType === "mountain") hasMountain = true;
-			}
-			const isRiverside = riverPairs.some(([a, b]) => a === i || b === i);
-			if (hasSea) terrain = "coast";
-			else if (hasLake) terrain = "lakeside";
-			else if (hasMountain) terrain = "foothill";
-			else if (isRiverside) terrain = "riverside";
+		// Derive composable terrain annotations — all independent, any combination valid.
+		// coast/foothill/lakeside/riverside: purely derived from adjacency (never authored in JSON).
+		let hasSea = false;
+		let hasMountain = false;
+		let hasLakeAdj = false;
+		for (const [dq, dr] of HEX_DIRECTIONS) {
+			const tileType = terrainPosMap.get(`${q + dq},${r + dr}`);
+			if (tileType === "sea") hasSea = true;
+			else if (tileType === "mountain") hasMountain = true;
+			else if (tileType === "lake") hasLakeAdj = true;
 		}
+		const isRiverside = riverPairs.some(([a, b]) => a === i || b === i);
+		const terrainAnnotation: TerrainAnnotation = {
+			coast: hasSea,
+			foothill: hasMountain,
+			lakeside: hasLakeAdj,
+			riverside: isRiverside && !hasSea && !hasMountain && !hasLakeAdj,
+		};
 
 		// Population-weighted vote shares (turnout ignored until Sprint 3)
 		// Map first scenario party → R, second → D (matches partyIdToKey in main.ts)
@@ -141,8 +139,10 @@ export function scenarioToSpike(scenario: Scenario): {
 		};
 		if (pc.name !== undefined) spikePrecinct.name = pc.name;
 		if (pc.county_id !== undefined) spikePrecinct.county_id = pc.county_id;
-		if (terrain !== undefined) spikePrecinct.terrain = terrain;
-		if (pc.has_internal_lake) spikePrecinct.has_internal_lake = true;
+		// Only store annotation when at least one flag is true (avoids polluting all precincts)
+		if (hasSea || hasMountain || isRiverside || hasLakeAdj) {
+			spikePrecinct.terrainAnnotation = terrainAnnotation;
+		}
 		if (pc.demographic_groups.length > 1) {
 			spikePrecinct.groupShares = pc.demographic_groups.map((g) => {
 				const entry: { name: string; share: number; dimensions?: Record<string, string> } = {
@@ -165,7 +165,7 @@ export function scenarioToSpike(scenario: Scenario): {
 		assignments.set(i, spikeDistId);
 	});
 
-	// Build runtime terrain tiles with axial coord + pixel center
+	// Build initial runtime terrain tiles with axial coord + pixel center
 	const terrainTiles: TerrainTileRuntime[] = (scenario.terrain_tiles ?? []).map((tile) => ({
 		coord: { q: tile.position.q, r: tile.position.r },
 		center: hexToPixel(tile.position.q, tile.position.r),

--- a/game/web/src/model/adapter_test.ts
+++ b/game/web/src/model/adapter_test.ts
@@ -272,22 +272,7 @@ test("scenarioToSpike: coast annotation derived from adjacency to sea tile", () 
 		terrain_tiles: [{ position: { q: 1, r: 0 }, type: "sea" }],
 	});
 	const { precincts } = scenarioToSpike(scenario);
-	assertEqual(precincts[0]!.terrain, "coast", "precinct adjacent to sea → coast");
-});
-
-test("scenarioToSpike: explicit terrain annotation overrides derivation", () => {
-	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
-	const scenario = makeScenario({
-		parties: [PARTY_R, PARTY_D],
-		districts: [{ id: did("d1") }, { id: did("d2") }],
-		precincts: [{
-			...makePrecinct(0, 0, [g], "d1"),
-			terrain: "lakeside" as const,
-		}],
-		terrain_tiles: [{ position: { q: 1, r: 0 }, type: "sea" }],
-	});
-	const { precincts } = scenarioToSpike(scenario);
-	assertEqual(precincts[0]!.terrain, "lakeside", "explicit terrain wins over derived coast");
+	assertEqual(precincts[0]!.terrainAnnotation?.coast, true, "precinct adjacent to sea → coast");
 });
 
 test("scenarioToSpike: river edges converted to integer index pairs", () => {
@@ -323,23 +308,6 @@ test("scenarioToSpike: passableNeighbors = neighbors when river_blocks_contiguit
 	assertEqual(precincts[0]!.passableNeighbors![0], 1, "passable unchanged when not blocking");
 });
 
-test("scenarioToSpike: sea takes priority over lake in derivation (coast wins)", () => {
-	// Precinct at (0,0) with sea at (1,0) and lake at (-1,0) on opposite sides.
-	// Per priority: sea > lake → terrain should be "coast", not "lakeside".
-	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
-	const scenario = makeScenario({
-		parties: [PARTY_R, PARTY_D],
-		districts: [{ id: did("d1") }, { id: did("d2") }],
-		precincts: [makePrecinct(0, 0, [g], "d1")],
-		terrain_tiles: [
-			{ position: { q: -1, r: 0 }, type: "lake" },
-			{ position: { q: 1, r: 0 }, type: "sea" },
-		],
-	});
-	const { precincts } = scenarioToSpike(scenario);
-	assertEqual(precincts[0]!.terrain, "coast", "sea priority over lake → coast");
-});
-
 test("scenarioToSpike: foothill annotation derived from mountain adjacency", () => {
 	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
 	const scenario = makeScenario({
@@ -349,7 +317,7 @@ test("scenarioToSpike: foothill annotation derived from mountain adjacency", () 
 		terrain_tiles: [{ position: { q: 1, r: 0 }, type: "mountain" }],
 	});
 	const { precincts } = scenarioToSpike(scenario);
-	assertEqual(precincts[0]!.terrain, "foothill", "precinct adjacent to mountain → foothill");
+	assertEqual(precincts[0]!.terrainAnnotation?.foothill, true, "precinct adjacent to mountain → foothill=true");
 });
 
 test("scenarioToSpike: riverside annotation derived when no terrain tile adjacency", () => {
@@ -363,13 +331,12 @@ test("scenarioToSpike: riverside annotation derived when no terrain tile adjacen
 		river_edges: [[p1.id, p2.id]],
 	});
 	const { precincts } = scenarioToSpike(scenario);
-	assertEqual(precincts[0]!.terrain, "riverside", "p1 in river edge → riverside");
-	assertEqual(precincts[1]!.terrain, "riverside", "p2 in river edge → riverside");
+	assertEqual(precincts[0]!.terrainAnnotation?.riverside, true, "p1 in river edge → riverside=true");
+	assertEqual(precincts[1]!.terrainAnnotation?.riverside, true, "p2 in river edge → riverside=true");
 });
 
-test("scenarioToSpike: foothill takes priority over riverside", () => {
-	// Precinct adjacent to a mountain tile AND in a river edge → foothill.
-	// Per priority: coast > lakeside > foothill > riverside.
+test("scenarioToSpike: foothill suppresses riverside when mountain is adjacent", () => {
+	// riverside is only set when isRiverside && !hasSea && !hasMountain.
 	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
 	const p1 = makePrecinct(0, 0, [g], "d1");
 	const p2 = makePrecinct(0, 1, [g], "d1"); // adjacent to p1 via edge 1 (down)
@@ -381,23 +348,21 @@ test("scenarioToSpike: foothill takes priority over riverside", () => {
 		river_edges: [[p1.id, p2.id]],
 	});
 	const { precincts } = scenarioToSpike(scenario);
-	assertEqual(precincts[0]!.terrain, "foothill", "foothill priority over riverside");
+	assertEqual(precincts[0]!.terrainAnnotation?.foothill, true, "foothill=true (mountain adjacent)");
+	assertEqual(precincts[0]!.terrainAnnotation?.riverside, false, "riverside=false (suppressed by foothill)");
 });
 
-test("scenarioToSpike: has_internal_lake round-trips through adapter", () => {
+test("scenarioToSpike: lakeside annotation derived from adjacency to lake tile", () => {
 	const g = makeGroup({ [pid("r_party")]: 0.5, [pid("d_party")]: 0.5 });
 	const scenario = makeScenario({
 		parties: [PARTY_R, PARTY_D],
-		districts: [{ id: did("d1") }, { id: did("d2") }],
-		precincts: [{
-			...makePrecinct(0, 0, [g], "d1"),
-			terrain: "lakeside" as const,
-			has_internal_lake: true,
-		}],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+		terrain_tiles: [{ position: { q: 1, r: 0 }, type: "lake" }],
 	});
 	const { precincts } = scenarioToSpike(scenario);
-	assertEqual(precincts[0]!.terrain, "lakeside", "lakeside set");
-	assertEqual(precincts[0]!.has_internal_lake, true, "has_internal_lake propagated");
+	assertEqual(precincts[0]!.terrainAnnotation?.lakeside, true, "precinct adjacent to lake → lakeside=true");
+	assertEqual(precincts[0]!.terrainAnnotation?.riverside, false, "riverside=false (suppressed by lakeside)");
 });
 
 test("scenarioToSpike: passableNeighbors nulls river edges when river_blocks_contiguity is true", () => {

--- a/game/web/src/model/loader.ts
+++ b/game/web/src/model/loader.ts
@@ -35,7 +35,6 @@ import type {
   SuccessCriterion,
   GeometrySpec,
   TerrainTile,
-  TerrainAnnotation,
 } from "./scenario.js";
 
 // Flat-top axial hex direction vectors (mirrors HEX_DIRECTIONS in hex-geometry.ts)
@@ -213,19 +212,6 @@ function parsePrecinct(raw: unknown, idx: number): Omit<Precinct, "initial_distr
   if (r["neighbors"] !== undefined) {
     const nbRaw = requireArray(r["neighbors"], `${label}.neighbors`);
     pc.neighbors = nbRaw.map((n, i) => requireString(n, `${label}.neighbors[${i}]`) as PrecinctId);
-  }
-
-  // Terrain annotation (optional; derived from adjacency if absent)
-  if (r["terrain"] !== undefined) {
-    const t = requireString(r["terrain"], `${label}.terrain`);
-    const validAnnotations = ["coast", "lakeside", "riverside", "foothill"];
-    if (!validAnnotations.includes(t)) {
-      throw new Error(`${label}.terrain: unknown value "${t}"; expected one of: ${validAnnotations.join(", ")}`);
-    }
-    pc.terrain = t as TerrainAnnotation;
-  }
-  if (r["has_internal_lake"] !== undefined) {
-    pc.has_internal_lake = requireBoolean(r["has_internal_lake"], `${label}.has_internal_lake`);
   }
 
   // initial_district_id: absent, null, or a string

--- a/game/web/src/model/loader_test.ts
+++ b/game/web/src/model/loader_test.ts
@@ -792,7 +792,6 @@ test("terrain: happy path — terrain_tiles, river_edges, river_blocks_contiguit
         position: { q: 1, r: 0 },
         total_population: 800,
         demographic_groups: [{ id: "g2", population_share: 1.0, vote_shares: { blue: 0.5, red: 0.5 }, turnout_rate: 0.6 }],
-        terrain: "coast",
       },
     ],
     terrain_tiles: [
@@ -859,24 +858,6 @@ test("terrain: rejects river_edges referencing unknown precinct", () => {
     })),
     /river_edges.*p_unknown.*does not exist/
   );
-});
-
-test("terrain: precinct terrain field parsed and returned", () => {
-  const result = loadScenario(minimalScenario({
-    precincts: [
-      {
-        id: "p1",
-        editable: true,
-        position: { q: 0, r: 0 },
-        total_population: 1000,
-        demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
-        terrain: "riverside",
-        has_internal_lake: true,
-      },
-    ],
-  }));
-  assertEqual(result.precincts[0]!.terrain, "riverside");
-  assertEqual(result.precincts[0]!.has_internal_lake, true);
 });
 
 test("terrain: rejects river edge between non-adjacent precincts", () => {
@@ -949,24 +930,6 @@ test("terrain: rejects river_edges when geometry is custom", () => {
       river_edges: [["p1", "p2"]],
     })),
     /custom geometry is not supported/
-  );
-});
-
-test("terrain: rejects unknown terrain annotation value", () => {
-  assertThrows(
-    () => loadScenario(minimalScenario({
-      precincts: [
-        {
-          id: "p1",
-          editable: true,
-          position: { q: 0, r: 0 },
-          total_population: 1000,
-          demographic_groups: [{ id: "g1", population_share: 1.0, vote_shares: { blue: 0.6, red: 0.4 }, turnout_rate: 0.7 }],
-          terrain: "volcano",
-        },
-      ],
-    })),
-    /terrain.*unknown value.*volcano/
   );
 });
 

--- a/game/web/src/model/scenario.ts
+++ b/game/web/src/model/scenario.ts
@@ -46,8 +46,6 @@ export interface HexAxialPosition {
 
 export type TerrainType = "sea" | "lake" | "mountain";
 
-export type TerrainAnnotation = "coast" | "lakeside" | "riverside" | "foothill";
-
 export interface TerrainTile {
 	position: HexAxialPosition;
 	type: TerrainType;
@@ -125,10 +123,6 @@ export interface Precinct {
 	initial_district_id?: DistrictId | null;
 	name?: string;
 	tags?: string[];
-	/** Explicit terrain annotation; derived from adjacency if absent */
-	terrain?: TerrainAnnotation;
-	/** When true and terrain === "lakeside": render small internal lake within hex */
-	has_internal_lake?: boolean;
 }
 
 // ─── Events ───────────────────────────────────────────────────────────────────

--- a/game/web/src/model/types.ts
+++ b/game/web/src/model/types.ts
@@ -67,10 +67,8 @@ export interface Precinct {
 	 * Absent only on legacy/test precincts without terrain — BFS falls back to neighbors.
 	 */
 	passableNeighbors?: (number | null)[];
-	/** Terrain annotation derived from adjacency (or explicitly authored) */
-	terrain?: "coast" | "lakeside" | "riverside" | "foothill";
-	/** When true: precinct is lakeside with a small lake rendered within the hex */
-	has_internal_lake?: boolean;
+	/** Composable terrain annotations — independent booleans, any combination valid. */
+	terrainAnnotation?: TerrainAnnotation;
 	/** Population count (arbitrary units) */
 	population: number;
 	/** Partisan vote share, floats summing to 1.0 */
@@ -81,6 +79,18 @@ export interface Precinct {
 	demographics: Demographics;
 	/** Per-group population shares from scenario demographic_groups (for info panel) */
 	groupShares?: { name: string; share: number; dimensions?: Record<string, string> }[];
+}
+
+/**
+ * Composable terrain annotations for a precinct. All fields are independent —
+ * a single precinct can be coast AND foothill AND lakeside simultaneously.
+ * All derived at adapter time from tile adjacency and river membership.
+ */
+export interface TerrainAnnotation {
+	coast: boolean;
+	foothill: boolean;
+	lakeside: boolean;
+	riverside: boolean;
 }
 
 /** Runtime terrain tile (non-precinct; non-assignable; non-interactive) */
@@ -146,7 +156,7 @@ export interface StrokeDiff {
  *  Safe for deuteranopia, protanopia, and tritanopia.
  *  Chosen to avoid collision with party colors D=#3a7bd5 and R=#e94560.
  *  Sky blue (#56B4E9) was swapped for yellow (#F0E442) to avoid visual conflict
- *  with water-terrain fills (sea #3a7fc1, lake #4dd0e1, river #38bdf8) — GAME-082.
+ *  with water-terrain fills (sea #3a7fc1, lake/river #4dd0e1) — GAME-082.
  */
 export const DISTRICT_COLORS: readonly string[] = [
 	"#E69F00", // amber

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -46,6 +46,8 @@ export interface MapRenderer {
 	 * included from v1 so callers are already written to the interface.
 	 */
 	setCountyBordersVisible(visible: boolean): void;
+	/** Toggle hex coordinate labels (debug overlay). */
+	setCoordLabelsVisible(visible: boolean): void;
 }
 
 // ─── Internal types ───────────────────────────────────────────────────────────
@@ -235,6 +237,7 @@ export class SvgMapRenderer implements MapRenderer {
 	private borderGroup: GSel;
 	private hexGroup: GSel;
 	private terrainOverlayGroup: GSel;
+	private hoverHighlightGroup: GSel;
 	private riverGroup: GSel;
 	private previewBorderGroup: GSel;
 	private getState: () => GameStore;
@@ -265,6 +268,7 @@ export class SvgMapRenderer implements MapRenderer {
 
 	// Base stroke widths (apparent px at any zoom level)
 	private static readonly BOUNDARY_BASE_WIDTH = 2;
+	private static readonly TERRAIN_BOUNDARY_WIDTH = 2;
 	private static readonly PREVIEW_BASE_WIDTH = 2.5;
 	private static readonly COUNTY_BASE_WIDTH = 3;
 
@@ -279,6 +283,9 @@ export class SvgMapRenderer implements MapRenderer {
 
 	// Opacity values
 	private static readonly BOUNDARY_OPACITY = 0.6;
+	// Terrain boundary sits above hex fills (no hex-fill attenuation); lower opacity
+	// compensates so it appears the same visual weight as district boundaries below hex fills.
+	private static readonly TERRAIN_BOUNDARY_OPACITY = 0.4;
 	private static readonly COUNTY_OPACITY = 0.7;
 	private static readonly PREVIEW_OPACITY = 0.85;
 	private static readonly LEAN_OPACITY = 0.9;
@@ -304,6 +311,9 @@ export class SvgMapRenderer implements MapRenderer {
 	// the district boundary line on these edges (the terrain intrusion fill covers them).
 	private terrainFacingEdges: Set<string> = new Set();
 	private countyBordersVisible = false;
+	private coordLabelsVisible = false;
+	private coordLabelsRendered = false;
+	private coordLabelGroup!: GSel;
 
 	// Terrain styling (DESIGN-008): fills, glyphs, opacity for sea/lake/mountain tiles
 	private static readonly TERRAIN_FILL_SEA = "#3a7fc1";
@@ -313,21 +323,16 @@ export class SvgMapRenderer implements MapRenderer {
 	private static readonly TERRAIN_GLYPH_MOUNTAIN = "△";
 	private static readonly TERRAIN_GLYPH_COLOR = "rgba(255,255,255,0.45)";
 	private static readonly TERRAIN_GLYPH_FONT_SIZE = 22; // pixel size at 1× zoom
-	private static readonly RIVER_STROKE = "#38bdf8";
+	private static readonly RIVER_STROKE = "#4dd0e1";
 	private static readonly RIVER_BASE_WIDTH = 9;
 	private static readonly RIVER_OPACITY = 0.9;
-	private static readonly INTERNAL_LAKE_FILL = "#4dd0e1";
-	private static readonly INTERNAL_LAKE_OPACITY = 0.55;
-	private static readonly INTERNAL_LAKE_RX_FACTOR = 0.55; // hex_size × factor = ellipse radius
-	private static readonly INTERNAL_LAKE_RY_FACTOR = 0.45;
-	private static readonly LAKESIDE_STROKE = "#4dd0e1";
-	private static readonly LAKESIDE_EDGE_BASE_WIDTH = 5; // lakeside still rendered as a straight line
-	private static readonly TERRAIN_EDGE_OPACITY = 0.95;
 	// Coast/foothill render as filled intrusion shapes (not strokes). The intrusion's curved
 	// inner edge bulges this many pixels into the precinct at its deepest point (at the edge
 	// midpoint). Filled with the exact terrain-tile color (TERRAIN_FILL_SEA / TERRAIN_FILL_MOUNTAIN).
 	private static readonly COAST_INTRUSION_DEPTH = 5;
 	private static readonly FOOTHILL_INTRUSION_DEPTH = 6;
+	private static readonly LAKE_INTRUSION_DEPTH = 5;
+	private static readonly COORD_LABEL_FONT_SIZE = 9; // apparent px at any zoom level
 
 	// Keyboard precinct navigation state
 	private focusedPrecinctId: number | null = null;
@@ -350,7 +355,7 @@ export class SvgMapRenderer implements MapRenderer {
 		//   terrainGroup        — non-precinct tiles (sea/lake/mountain), bottom
 		//   borderGroup         — committed district boundaries (solid white)
 		//   hexGroup            — precinct fills
-		//   terrainOverlayGroup — coast/lakeside edge strokes + internal lakes (above hex fills)
+		//   terrainOverlayGroup — coast/foothill intrusion fills + lake blobs (above hex fills)
 		//   countyBorderGroup   — county boundary overlay (dashed gray; off by default)
 		//   riverGroup          — blue river strokes along hex edges (above precincts + county borders)
 		//   previewBorderGroup  — in-stroke boundary preview (top)
@@ -364,9 +369,11 @@ export class SvgMapRenderer implements MapRenderer {
 		this.borderGroup = this.zoomGroup.append("g").attr("class", "borders");
 		this.hexGroup = this.zoomGroup.append("g").attr("class", "hexes");
 		this.terrainOverlayGroup = this.zoomGroup.append("g").attr("class", "terrain-overlay");
+		this.hoverHighlightGroup = this.zoomGroup.append("g").attr("class", "hover-highlight");
 		this.countyBorderGroup = this.zoomGroup.append("g").attr("class", "county-borders");
 		this.riverGroup = this.zoomGroup.append("g").attr("class", "rivers");
 		this.previewBorderGroup = this.zoomGroup.append("g").attr("class", "preview-borders");
+		this.coordLabelGroup = this.zoomGroup.append("g").attr("class", "coord-labels").attr("display", "none");
 
 		const pops = getState().precincts.map((p) => p.population);
 		this.popMin = Math.min(...pops);
@@ -383,7 +390,6 @@ export class SvgMapRenderer implements MapRenderer {
 		// One-shot terrain rendering — terrain is immutable per scenario.
 		this.renderTerrainTiles();
 		this.renderRivers();
-		this.renderInternalLakes();
 		this.renderTerrainEdges();
 	}
 
@@ -399,6 +405,54 @@ export class SvgMapRenderer implements MapRenderer {
 		} else {
 			this.countyBorderGroup.selectAll("line.county-boundary").remove();
 		}
+	}
+
+	setCoordLabelsVisible(visible: boolean) {
+		this.coordLabelsVisible = visible;
+		this.renderCoordLabels();
+	}
+
+	private renderCoordLabels() {
+		if (!this.coordLabelsRendered) {
+			const { precincts, terrainTiles } = this.getState();
+			const fs = SvgMapRenderer.COORD_LABEL_FONT_SIZE / this.currentK;
+			const sw = 3 / this.currentK;
+			const labelAttrs = <T extends { coord: { q: number; r: number }; center: { x: number; y: number } }>(sel: d3.Selection<SVGTextElement, T, SVGGElement, unknown>) =>
+				sel
+					.attr("text-anchor", "middle")
+					.attr("dominant-baseline", "central")
+					.attr("font-family", "monospace")
+					.attr("font-size", fs)
+					.attr("fill", "white")
+					.attr("stroke", "rgba(0,0,0,0.75)")
+					.attr("stroke-width", sw)
+					.attr("paint-order", "stroke")
+					.attr("pointer-events", "none");
+
+			labelAttrs(
+				this.coordLabelGroup
+					.selectAll<SVGTextElement, Precinct>("text.coord-label")
+					.data(precincts)
+					.join("text")
+					.attr("class", "coord-label")
+					.attr("x", (d) => d.center.x)
+					.attr("y", (d) => d.center.y)
+			).text((d) => `${d.coord.q},${d.coord.r}`);
+
+			// Terrain tiles (mountain/sea/lake) are not precincts — label them separately.
+			labelAttrs(
+				this.coordLabelGroup
+					.selectAll<SVGTextElement, TerrainTileRuntime>("text.coord-label-tile")
+					.data(terrainTiles ?? [])
+					.join("text")
+					.attr("class", "coord-label-tile")
+					.attr("x", (d) => d.center.x)
+					.attr("y", (d) => d.center.y)
+			).text((d) => `${d.coord.q},${d.coord.r}`);
+
+			this.coordLabelsRendered = true;
+		}
+		this.coordLabelGroup.attr("display", this.coordLabelsVisible ? null : "none");
 	}
 
 	private renderCountyBorders() {
@@ -534,24 +588,6 @@ export class SvgMapRenderer implements MapRenderer {
 			.style("pointer-events", "none");
 	}
 
-	private renderInternalLakes() {
-		const precincts = this.getState().precincts.filter((p) => p.has_internal_lake === true);
-		if (precincts.length === 0) return;
-
-		this.terrainOverlayGroup
-			.selectAll<SVGEllipseElement, Precinct>("ellipse.internal-lake")
-			.data(precincts, (d) => String(d.id))
-			.join("ellipse")
-			.attr("class", "internal-lake")
-			.attr("cx", (d) => d.center.x)
-			.attr("cy", (d) => d.center.y)
-			.attr("rx", HEX_SIZE * SvgMapRenderer.INTERNAL_LAKE_RX_FACTOR)
-			.attr("ry", HEX_SIZE * SvgMapRenderer.INTERNAL_LAKE_RY_FACTOR)
-			.attr("fill", SvgMapRenderer.INTERNAL_LAKE_FILL)
-			.attr("opacity", SvgMapRenderer.INTERNAL_LAKE_OPACITY)
-			.style("pointer-events", "none");
-	}
-
 	private renderTerrainEdges() {
 		// For each coast/foothill precinct, draw an "intrusion" — a filled closed shape that
 		// looks like the adjacent terrain has bled into the precinct. The shape is bounded by
@@ -565,20 +601,19 @@ export class SvgMapRenderer implements MapRenderer {
 		// two intrusions. We render a "corner cap" (filled rounded shape) at those corners to
 		// chop off the point and merge the two intrusions visually.
 		//
-		// Lakeside still uses a straight stroked line — the lake tile fill (plus any internal
-		// lake ellipse) already carries the visual weight.
 		const { precincts, terrainTiles } = this.getState();
 		if (!terrainTiles || terrainTiles.length === 0) return;
 
 		const tilePosMap = new Map<string, TerrainTileRuntime["type"]>();
 		for (const tile of terrainTiles) tilePosMap.set(`${tile.coord.q},${tile.coord.r}`, tile.type);
 
-		interface IntrusionShape { terrainType: "sea" | "mountain"; path: string; boundaryPath: string; }
-		interface StraightEdge extends Segment { terrainType: "lake"; }
-		interface CornerCap { cx: number; cy: number; r: number; terrainType: "sea" | "mountain"; }
+		interface IntrusionShape { terrainType: "sea" | "mountain" | "lake"; path: string; boundaryPath: string; }
+		interface CornerCap { cx: number; cy: number; r: number; terrainType: "sea" | "mountain" | "lake"; }
+		// SVG arc tracing the district-facing edge of a corner cap (the 120° interior arc).
+		interface CapArc { path: string; terrainType: "sea" | "mountain" | "lake"; }
 		const intrusions: IntrusionShape[] = [];
-		const straight: StraightEdge[] = [];
 		const cornerCaps: CornerCap[] = [];
+		const capArcs: CapArc[] = [];
 
 		// Curve generator for the inner (eaten-away) boundary. d3.curveBasis approximates the
 		// sample points smoothly without rigidly passing through them — gives a "crinkly but
@@ -591,10 +626,10 @@ export class SvgMapRenderer implements MapRenderer {
 		// "smooth": symmetric with a slight midpoint dip — gentle coastline ripple.
 		// "rugged": asymmetric with two unequal peaks — feels like an uneven mountain edge.
 		const profileSmooth: ReadonlyArray<[number, number]> = [
-			[0, 0], [0.18, 0.55], [0.38, 0.90], [0.55, 0.70], [0.72, 0.95], [0.85, 0.55], [1, 0],
+			[0, 0], [0.13, 0.50], [0.27, 0.95], [0.42, 0.58], [0.55, 1.05], [0.68, 0.52], [0.80, 0.90], [0.92, 0.42], [1, 0],
 		];
 		const profileRugged: ReadonlyArray<[number, number]> = [
-			[0, 0], [0.15, 0.70], [0.30, 1.05], [0.48, 0.55], [0.65, 1.10], [0.82, 0.65], [1, 0],
+			[0, 0], [0.12, 0.72], [0.25, 1.20], [0.38, 0.38], [0.52, 1.25], [0.65, 0.32], [0.78, 1.10], [0.90, 0.55], [1, 0],
 		];
 
 		const buildIntrusionAndBoundary = (
@@ -613,27 +648,28 @@ export class SvgMapRenderer implements MapRenderer {
 			const nx = dx / len;
 			const ny = dy / len;
 			// Build inner-curve sample points from c1 back to c0 (reverse t so we walk c1 → c0).
+			// Sample 0 is at c1 (t=1, depth 0); last sample is at c0 (t=0, depth 0).
 			const innerPts: Point2D[] = profile.map(([tAlong, dProfile]) => {
-				const t = 1 - tAlong; // walk from c1 (t=1) back to c0 (t=0)
+				const t = 1 - tAlong;
 				const ex = c0[0] + t * (c1[0] - c0[0]);
 				const ey = c0[1] + t * (c1[1] - c0[1]);
 				const off = depth * dProfile;
 				return [ex + nx * off, ey + ny * off];
 			});
-			// d3.line emits an open curve from the first to last point. That curve IS the
-			// district outline for this terrain-facing edge.
-			const inner = innerCurve(innerPts) ?? "";
-			// To build the closed intrusion fill, prefix the outer straight edge and replace
-			// the inner curve's leading "M" with "L" so the pen continues.
-			const innerContinued = inner.replace(/^M/, "L");
+			// Fill uses ALL sample points (curve must reach both corners to close the shape).
+			const innerFull = innerCurve(innerPts) ?? "";
+			const innerContinued = innerFull.replace(/^M/, "L");
 			const fillPath = `M${c0[0]},${c0[1]} L${c1[0]},${c1[1]}${innerContinued} Z`;
-			return { fillPath, boundaryPath: inner };
+			// Boundary uses the full inner curve including endpoints. Corner caps are rendered
+			// beneath the boundary curves so the line remains visible at capped corners.
+			const boundaryPath = innerPts.length >= 2 ? (innerCurve(innerPts) ?? "") : "";
+			return { fillPath, boundaryPath };
 		};
 
 		for (const p of precincts) {
-			if (p.terrain !== "coast" && p.terrain !== "lakeside" && p.terrain !== "foothill") continue;
+			if (!p.terrainAnnotation?.coast && !p.terrainAnnotation?.foothill && !p.terrainAnnotation?.lakeside) continue;
 			const corners = hexCorners(p.center);
-			// First pass: per-edge intrusion shapes (or straight lakeside line)
+			// First pass: per-edge intrusion shapes
 			for (let i = 0; i < 6; i++) {
 				const dir = HEX_DIRECTIONS[i];
 				if (dir === undefined) continue;
@@ -641,20 +677,23 @@ export class SvgMapRenderer implements MapRenderer {
 				const tileType = tilePosMap.get(nKey);
 				if (tileType === undefined) continue;
 				const matches =
-					(p.terrain === "coast" && tileType === "sea") ||
-					(p.terrain === "lakeside" && tileType === "lake") ||
-					(p.terrain === "foothill" && tileType === "mountain");
+					(p.terrainAnnotation?.coast === true && tileType === "sea") ||
+					(p.terrainAnnotation?.foothill === true && tileType === "mountain") ||
+					(p.terrainAnnotation?.lakeside === true && tileType === "lake");
 				if (!matches) continue;
 				const c0 = corners[i];
 				const c1 = corners[(i + 1) % 6];
 				if (c0 === undefined || c1 === undefined) continue;
-				if (tileType === "lake") {
-					straight.push({ x1: c0[0], y1: c0[1], x2: c1[0], y2: c1[1], terrainType: "lake" });
-				} else if (tileType === "sea") {
+				if (tileType === "sea") {
 					const { fillPath, boundaryPath } = buildIntrusionAndBoundary(
 						c0, c1, p.center, SvgMapRenderer.COAST_INTRUSION_DEPTH, profileSmooth,
 					);
 					intrusions.push({ terrainType: "sea", path: fillPath, boundaryPath });
+				} else if (tileType === "lake") {
+					const { fillPath, boundaryPath } = buildIntrusionAndBoundary(
+						c0, c1, p.center, SvgMapRenderer.LAKE_INTRUSION_DEPTH, profileSmooth,
+					);
+					intrusions.push({ terrainType: "lake", path: fillPath, boundaryPath });
 				} else {
 					const { fillPath, boundaryPath } = buildIntrusionAndBoundary(
 						c0, c1, p.center, SvgMapRenderer.FOOTHILL_INTRUSION_DEPTH, profileRugged,
@@ -662,10 +701,11 @@ export class SvgMapRenderer implements MapRenderer {
 					intrusions.push({ terrainType: "mountain", path: fillPath, boundaryPath });
 				}
 			}
-			// Second pass: corner caps. Corner i is shared between edge (i+5)%6 (which ENDS
-			// at corner i) and edge i (which STARTS at corner i). If both face the same
-			// terrain type (sea or mountain — lakeside is straight, no point issue), add a
-			// filled circle at the corner to chop off the pointy bit.
+			// Second pass: corner caps + cap boundary arcs. Corner i is shared between
+			// edge (i+5)%6 (which ENDS at corner i) and edge i (which STARTS at corner i).
+			// If both face the same terrain type (sea or mountain), add a filled circle at
+			// the corner to chop off the pointy bit, and a 120° arc tracing the district-
+			// facing edge of that cap as the district boundary at the corner.
 			for (let i = 0; i < 6; i++) {
 				const leftEdge = (i + 5) % 6;
 				const rightEdge = i;
@@ -675,16 +715,82 @@ export class SvgMapRenderer implements MapRenderer {
 				const lType = tilePosMap.get(`${p.coord.q + lDir[0]},${p.coord.r + lDir[1]}`);
 				const rType = tilePosMap.get(`${p.coord.q + rDir[0]},${p.coord.r + rDir[1]}`);
 				if (lType !== rType) continue;
-				if (lType !== "sea" && lType !== "mountain") continue;
-				const corner = corners[i];
-				if (corner === undefined) continue;
-				const r = lType === "sea" ? SvgMapRenderer.COAST_INTRUSION_DEPTH + 2 : SvgMapRenderer.FOOTHILL_INTRUSION_DEPTH + 2;
-				cornerCaps.push({ cx: corner[0], cy: corner[1], r, terrainType: lType });
+				if (lType !== "sea" && lType !== "mountain" && lType !== "lake") continue;
+				const capCenter = corners[i];
+				if (capCenter === undefined) continue;
+				const r = lType === "sea" || lType === "lake"
+					? SvgMapRenderer.COAST_INTRUSION_DEPTH + 4
+					: SvgMapRenderer.FOOTHILL_INTRUSION_DEPTH + 4;
+				cornerCaps.push({ cx: capCenter[0], cy: capCenter[1], r, terrainType: lType });
+
+				// Compute the arc endpoints from the direction the adjacent intrusion boundary
+				// curves EXIT the cap circle — not from the hex edge directions. Using the edge
+				// directions would make the arc endpoints land inside the intrusion fills (terrain
+				// territory), causing the white arc to draw over sea/mountain color.
+				//
+				// Each intrusion boundary curve at its cap end has depth 0 at capCenter and its
+				// first non-zero sample slightly inward from the edge. The vector from capCenter
+				// toward that sample gives the exit direction; we project it to radius r on the cap.
+				//
+				// Profile first-sample fractions (tAlong from the capCenter end of each intrusion):
+				//   left intrusion c1=capCenter: first sample at tAlong=0.18 (smooth) or 0.15 (rugged)
+				//   right intrusion c0=capCenter: last sample before capCenter at tAlong=0.85/0.82
+				//     → distance from capCenter = (1-tAlong)*edgeLen, so tFrac = 0.15 (smooth) or 0.18 (rugged)
+				const leftAdj = corners[(i - 1 + 6) % 6];
+				const rightAdj = corners[(i + 1) % 6];
+				if (leftAdj === undefined || rightAdj === undefined) continue;
+
+				const depthVal = lType === "mountain" ? SvgMapRenderer.FOOTHILL_INTRUSION_DEPTH
+					: lType === "lake" ? SvgMapRenderer.LAKE_INTRUSION_DEPTH
+					: SvgMapRenderer.COAST_INTRUSION_DEPTH;
+				const [tFracL, dProfL] = lType === "mountain" ? [0.12, 0.72] as const : [0.13, 0.50] as const;
+				const [tFracR, dProfR] = lType === "mountain" ? [0.10, 0.55] as const : [0.08, 0.42] as const;
+
+				// Inward normal for left edge (from leftAdj to capCenter)
+				const lMidX = (leftAdj[0] + capCenter[0]) / 2, lMidY = (leftAdj[1] + capCenter[1]) / 2;
+				const lNLen = Math.hypot(p.center.x - lMidX, p.center.y - lMidY) || 1;
+				const lNx = (p.center.x - lMidX) / lNLen, lNy = (p.center.y - lMidY) / lNLen;
+
+				// Inward normal for right edge (from capCenter to rightAdj)
+				const rMidX = (capCenter[0] + rightAdj[0]) / 2, rMidY = (capCenter[1] + rightAdj[1]) / 2;
+				const rNLen = Math.hypot(p.center.x - rMidX, p.center.y - rMidY) || 1;
+				const rNx = (p.center.x - rMidX) / rNLen, rNy = (p.center.y - rMidY) / rNLen;
+
+				// Exit direction = along-edge component + inward component, projected to radius r
+				const lDx = tFracL * (leftAdj[0] - capCenter[0]) + depthVal * dProfL * lNx;
+				const lDy = tFracL * (leftAdj[1] - capCenter[1]) + depthVal * dProfL * lNy;
+				const lDLen = Math.hypot(lDx, lDy) || 1;
+				const startX = capCenter[0] + r * lDx / lDLen;
+				const startY = capCenter[1] + r * lDy / lDLen;
+
+				const rDx = tFracR * (rightAdj[0] - capCenter[0]) + depthVal * dProfR * rNx;
+				const rDy = tFracR * (rightAdj[1] - capCenter[1]) + depthVal * dProfR * rNy;
+				const rDLen = Math.hypot(rDx, rDy) || 1;
+				const endX = capCenter[0] + r * rDx / rDLen;
+				const endY = capCenter[1] + r * rDy / rDLen;
+
+				// Sweep: cross product of exit directions → positive in SVG (y-down) = CW = sweep 1.
+				const cross = lDx * rDy - lDy * rDx;
+				const sweep = cross > 0 ? 1 : 0;
+				// Arc spans less than 120° (interior minus inward offsets) → large-arc-flag=0.
+				capArcs.push({
+					path: `M${startX},${startY} A${r},${r} 0 0,${sweep} ${endX},${endY}`,
+					terrainType: lType,
+				});
 			}
 		}
 
-		const fillForIntrusion = (t: "sea" | "mountain"): string =>
-			t === "sea" ? SvgMapRenderer.TERRAIN_FILL_SEA : SvgMapRenderer.TERRAIN_FILL_MOUNTAIN;
+		const fillForIntrusion = (t: "sea" | "mountain" | "lake"): string =>
+			t === "sea" ? SvgMapRenderer.TERRAIN_FILL_SEA
+			: t === "lake" ? SvgMapRenderer.TERRAIN_FILL_LAKE
+			: SvgMapRenderer.TERRAIN_FILL_MOUNTAIN;
+
+		// Layer order (bottom → top within terrainOverlayGroup):
+		// 1. Intrusion fills — terrain color, cover hex edge area
+		// 2. Intrusion boundary curves — white, full inner curve reaching hex corners
+		// 3. Corner cap fills — terrain color, sits on top of boundary curves and hides
+		//    the boundary curve endpoint that falls inside the cap (at the hex corner)
+		// 4. Cap boundary arcs — white 120° arc tracing the district-facing edge of each cap
 
 		this.terrainOverlayGroup
 			.selectAll<SVGPathElement, IntrusionShape>("path.terrain-edge")
@@ -696,7 +802,23 @@ export class SvgMapRenderer implements MapRenderer {
 			.attr("stroke", "none")
 			.style("pointer-events", "none");
 
-		// Corner caps render AFTER intrusions so they sit on top of any pointy bits.
+		// Intrusion boundary curves: full inner curve (reaches hex corners). The endpoint
+		// inside the cap will be hidden by the cap fill rendered next.
+		this.terrainOverlayGroup
+			.selectAll<SVGPathElement, IntrusionShape>("path.terrain-boundary")
+			.data(intrusions)
+			.join("path")
+			.attr("class", (d) => `terrain-boundary terrain-boundary-${d.terrainType}`)
+			.attr("d", (d) => d.boundaryPath)
+			.attr("fill", "none")
+			.attr("stroke", "#ffffff")
+			.attr("stroke-width", SvgMapRenderer.TERRAIN_BOUNDARY_WIDTH / this.currentK)
+			.attr("stroke-linecap", "round")
+			.attr("opacity", SvgMapRenderer.TERRAIN_BOUNDARY_OPACITY)
+			.style("pointer-events", "none");
+
+		// Corner cap fills: hide the part of the intrusion boundary curves that falls
+		// inside the cap (the depth-0 endpoint at the hex corner).
 		this.terrainOverlayGroup
 			.selectAll<SVGCircleElement, CornerCap>("circle.terrain-corner-cap")
 			.data(cornerCaps)
@@ -709,35 +831,18 @@ export class SvgMapRenderer implements MapRenderer {
 			.attr("stroke", "none")
 			.style("pointer-events", "none");
 
+		// Cap boundary arcs: white 120° arc tracing the district-facing visible edge of each cap.
 		this.terrainOverlayGroup
-			.selectAll<SVGLineElement, StraightEdge>("line.terrain-edge")
-			.data(straight)
-			.join("line")
-			.attr("class", "terrain-edge terrain-edge-lake")
-			.attr("x1", (d) => d.x1)
-			.attr("y1", (d) => d.y1)
-			.attr("x2", (d) => d.x2)
-			.attr("y2", (d) => d.y2)
-			.attr("stroke", SvgMapRenderer.LAKESIDE_STROKE)
-			.attr("stroke-width", SvgMapRenderer.LAKESIDE_EDGE_BASE_WIDTH / this.currentK)
-			.attr("stroke-linecap", "round")
-			.attr("opacity", SvgMapRenderer.TERRAIN_EDGE_OPACITY)
-			.style("pointer-events", "none");
-
-		// Terrain boundary curves — the district outline follows the eaten-away inner
-		// curve of each intrusion. Renders last so it sits on top of the intrusion fill
-		// (and any corner caps). Same styling as the straight district boundary lines.
-		this.terrainOverlayGroup
-			.selectAll<SVGPathElement, IntrusionShape>("path.terrain-boundary")
-			.data(intrusions)
+			.selectAll<SVGPathElement, CapArc>("path.terrain-cap-arc")
+			.data(capArcs)
 			.join("path")
-			.attr("class", (d) => `terrain-boundary terrain-boundary-${d.terrainType}`)
-			.attr("d", (d) => d.boundaryPath)
+			.attr("class", (d) => `terrain-cap-arc terrain-cap-arc-${d.terrainType}`)
+			.attr("d", (d) => d.path)
 			.attr("fill", "none")
 			.attr("stroke", "#ffffff")
-			.attr("stroke-width", SvgMapRenderer.BOUNDARY_BASE_WIDTH / this.currentK)
+			.attr("stroke-width", SvgMapRenderer.TERRAIN_BOUNDARY_WIDTH / this.currentK)
 			.attr("stroke-linecap", "round")
-			.attr("opacity", SvgMapRenderer.BOUNDARY_OPACITY)
+			.attr("opacity", SvgMapRenderer.TERRAIN_BOUNDARY_OPACITY)
 			.style("pointer-events", "none");
 	}
 
@@ -804,14 +909,18 @@ export class SvgMapRenderer implements MapRenderer {
 					.selectAll<SVGPathElement, Point2D[]>("path.river-chain")
 					.attr("stroke-width", SvgMapRenderer.RIVER_BASE_WIDTH / this.currentK);
 				// Coast/foothill render as filled <path> (no stroke, no scaling needed).
-				// Lakeside is still a straight stroked <line>; scale its width inversely.
-				this.terrainOverlayGroup
-					.selectAll<SVGLineElement, Segment>("line.terrain-edge")
-					.attr("stroke-width", SvgMapRenderer.LAKESIDE_EDGE_BASE_WIDTH / this.currentK);
-				// Terrain-boundary curves (district outline along intrusion inner curve).
+				// Terrain-boundary curves and cap arcs (district outline along terrain edge).
+				const tbw = SvgMapRenderer.TERRAIN_BOUNDARY_WIDTH / this.currentK;
 				this.terrainOverlayGroup
 					.selectAll<SVGPathElement, unknown>("path.terrain-boundary")
-					.attr("stroke-width", SvgMapRenderer.BOUNDARY_BASE_WIDTH / this.currentK);
+					.attr("stroke-width", tbw);
+				this.terrainOverlayGroup
+					.selectAll<SVGPathElement, unknown>("path.terrain-cap-arc")
+					.attr("stroke-width", tbw);
+				// Hover edge highlights (only present while a precinct is hovered).
+				this.hoverHighlightGroup
+					.selectAll<SVGLineElement, unknown>("line.hover-edge")
+					.attr("stroke-width", SvgMapRenderer.HOVER_STROKE_WIDTH / this.currentK);
 				this.countyBorderGroup
 					.selectAll<SVGLineElement, Segment>("line.county-boundary")
 					.attr("stroke-width", SvgMapRenderer.COUNTY_BASE_WIDTH / this.currentK)
@@ -820,6 +929,12 @@ export class SvgMapRenderer implements MapRenderer {
 					d3.select(this.keyboardFocusPath)
 						.attr("stroke-width", 2 / this.currentK)
 						.attr("stroke-dasharray", `${4 / this.currentK},${2 / this.currentK}`);
+				}
+				if (this.coordLabelsRendered) {
+					const fs = SvgMapRenderer.COORD_LABEL_FONT_SIZE / this.currentK;
+					this.coordLabelGroup.selectAll("text.coord-label, text.coord-label-tile")
+						.attr("font-size", fs)
+						.attr("stroke-width", 3 / this.currentK);
 				}
 			});
 
@@ -948,8 +1063,9 @@ export class SvgMapRenderer implements MapRenderer {
 
 	/**
 	 * Single delegated mousemove/mouseout on the SVG.
-	 * Hover only sets stroke/opacity — never fill — so clearHover never needs to
-	 * restore fill (which would clobber in-progress paint visuals).
+	 * Hover brightens opacity and draws edge highlights in hoverHighlightGroup for
+	 * non-terrain-facing edges only — terrain-facing edges are skipped so the highlight
+	 * doesn't float over intrusion fills or show clipped corners at corner caps.
 	 */
 	private initHoverEvents() {
 		const svgNode = this.svg.node()!;
@@ -968,10 +1084,30 @@ export class SvgMapRenderer implements MapRenderer {
 				this.clearHover();
 				if (path === this.keyboardFocusPath) return;
 				this.hoveredPath = path;
-				d3.select(path)
+				d3.select(path).attr("opacity", SvgMapRenderer.HOVER_OPACITY);
+
+				// Draw highlight segments only on non-terrain-facing edges, in
+				// hoverHighlightGroup (above terrainOverlayGroup) so they're visible
+				// over district boundary lines but never over terrain fills.
+				const corners = hexCorners(d.center);
+				const segs: Segment[] = [];
+				for (let i = 0; i < 6; i++) {
+					if (this.terrainFacingEdges.has(`${d.id}:${i}`)) continue;
+					const c0 = corners[i], c1 = corners[(i + 1) % 6];
+					if (c0 && c1) segs.push({ x1: c0[0], y1: c0[1], x2: c1[0], y2: c1[1] });
+				}
+				this.hoverHighlightGroup
+					.selectAll<SVGLineElement, Segment>("line.hover-edge")
+					.data(segs)
+					.join("line")
+					.attr("class", "hover-edge")
+					.attr("x1", (s) => s.x1).attr("y1", (s) => s.y1)
+					.attr("x2", (s) => s.x2).attr("y2", (s) => s.y2)
 					.attr("stroke", "#ffffff")
 					.attr("stroke-width", SvgMapRenderer.HOVER_STROKE_WIDTH / this.currentK)
-					.attr("opacity", SvgMapRenderer.HOVER_OPACITY);
+					.attr("stroke-linecap", "round")
+					.attr("opacity", SvgMapRenderer.BOUNDARY_OPACITY)
+					.style("pointer-events", "none");
 
 				const { assignments } = this.getState();
 				const dId = assignments.get(d.id);
@@ -1019,9 +1155,10 @@ export class SvgMapRenderer implements MapRenderer {
 		}
 	}
 
-	/** Restores stroke/opacity only — never fill (hover never changes fill). */
+	/** Restores hex opacity and removes hover edge segments. Never touches fill. */
 	private clearHover() {
 		if (this.hoveredPath === null) return;
+		this.hoverHighlightGroup.selectAll("line.hover-edge").remove();
 		if (this.hoveredPath === this.keyboardFocusPath) {
 			this.hoveredPath = null;
 			return;
@@ -1031,10 +1168,7 @@ export class SvgMapRenderer implements MapRenderer {
 		const { assignments } = this.getState();
 		const d = d3.select<SVGPathElement, Precinct>(path).datum();
 		if (d !== undefined) {
-			d3.select(path)
-				.attr("stroke", "none")
-				.attr("stroke-width", 0.5)
-				.attr("opacity", this.hexOpacity(d, assignments));
+			d3.select(path).attr("opacity", this.hexOpacity(d, assignments));
 		}
 	}
 

--- a/thoughts/shared/tickets/GAME-083-unassigned-precinct-visual-feedback.md
+++ b/thoughts/shared/tickets/GAME-083-unassigned-precinct-visual-feedback.md
@@ -1,0 +1,33 @@
+---
+id: GAME-083
+title: Unassigned precinct visual feedback
+area: GAME
+status: open
+created: 2026-05-20
+---
+
+## Summary
+
+Precincts that have not yet been assigned to a district have no visual distinction
+from assigned ones (other than their district color). On a large circular map like
+tutorial-003, the default state is difficult to read and provides no feedback
+about population balance or assignment progress.
+
+## Current State
+
+- Unassigned precincts show no distinct background color
+- No border/outline distinguishes unassigned from assigned precincts
+- Population density is not visually conveyed on unassigned hexes
+
+## Goals / Acceptance Criteria
+
+- [ ] Unassigned precincts render with a distinct fill — a white-to-dark-grey gradient
+      or flat neutral colour that clearly signals "not yet assigned"
+- [ ] The unassigned fill is visually distinct from all four district colours
+- [ ] When a precinct is assigned to a district it transitions cleanly to the district colour
+- [ ] (Optional) Population density hinted via shade within the neutral range
+
+## References
+
+- Raised after tutorial-003 expansion to 127 precincts (R=6 circle) made the
+  lack of feedback obvious on load

--- a/thoughts/shared/tickets/GAME-084-map-generation-pipeline.md
+++ b/thoughts/shared/tickets/GAME-084-map-generation-pipeline.md
@@ -1,0 +1,82 @@
+---
+id: GAME-084
+title: Map generation pipeline — spec-driven, staged, single format
+area: GAME
+status: open
+created: 2026-05-20
+---
+
+## Summary
+
+Replace the current per-scenario bespoke generators with a staged pipeline that
+produces scenario JSON incrementally. Each stage is independently tunable and
+re-runnable. A human-readable spec file is the checked-in source of intent;
+the scenario JSON is the compiled output.
+
+## Current State
+
+One `.main.kts` generator per scenario. Each hardcodes all positions, terrain,
+demographics, and narrative. Generators are not reused and are effectively
+orphaned after initial JSON production — incremental changes go directly to JSON.
+
+## Design
+
+### Pipeline stages
+
+1. **Terrain generator** — takes a map spec, produces hex positions + terrain
+   tiles (mountain, sea, lake) + lake clusters (explicit lakeside precincts) +
+   river edges. No population or demographic data yet.
+2. **Population stage** — takes terrain output + parameters (base density,
+   hotspots, coastal/mountain gradients), adds `total_population` per precinct.
+3. **Demographics stage** — takes populated map + parameters (regional lean
+   gradients, competitive clusters, turnout distribution), adds
+   `demographic_groups` per precinct.
+4. **Scenario assembler** — takes enriched map + a scenario spec (narrative,
+   parties, districts, success criteria), produces the final scenario JSON.
+
+### Spec file
+
+A lightweight, human-readable, tunable descriptor checked in alongside the
+scenario JSON. Documents intent and allows pipeline re-runs from a clean state.
+Agents tune the spec; the pipeline executes it.
+
+### Single format throughout
+
+All stages produce increasingly-complete scenario JSON — not separate
+intermediate formats. This requires one loader change (see below) but avoids
+maintaining multiple schemas.
+
+## Loader change required
+
+**Separate validation from loading.** Currently the loader validates completeness
+(all precincts assigned, parties present, etc.) at load time. Change this to:
+- Load tolerates absent optional fields (population, demographics, districts)
+- Completeness validation runs at game-start only
+
+This allows partial scenarios to be rendered for inspection (terrain preview
+before demographics exist) and keeps the pipeline output format identical to
+the final scenario format.
+
+## Goals / Acceptance Criteria
+
+- [ ] Loader separates load-time parsing from game-start completeness validation
+- [ ] Terrain generator: takes map spec, produces valid (partial) scenario JSON
+      with hex positions + terrain tiles + lake clusters + river edges
+- [ ] Population stage: takes partial scenario JSON + params, enriches with
+      `total_population` per precinct
+- [ ] Demographics stage: takes populated scenario JSON + params, enriches with
+      `demographic_groups`
+- [ ] Scenario assembler: takes enriched JSON + scenario spec, produces final
+      scenario JSON ready for gameplay
+- [ ] Existing scenarios migrated to have a companion spec file
+- [ ] Per-scenario bespoke generators removed
+
+## Scope note
+
+The pipeline is for new scenarios and reworked existing ones. The old generators
+are not deleted until the pipeline covers their use cases.
+
+## References
+
+- GAME-083: unassigned precinct visual feedback (related UX work)
+- Discussed after tutorial-003 R=6 expansion (2026-05-20)

--- a/thoughts/shared/tickets/GAME-085-composable-terrain-annotations.md
+++ b/thoughts/shared/tickets/GAME-085-composable-terrain-annotations.md
@@ -1,0 +1,100 @@
+---
+id: GAME-085
+title: "Composable terrain annotations: replace single terrain type with independent boolean properties"
+area: game, rendering, model
+status: open
+created: 2026-05-21
+---
+
+## Summary
+
+The current precinct `terrain` field is a single string (`"coast" | "lakeside" | "foothill" | "riverside"`) assigned by a priority chain. This makes the features mutually exclusive — a precinct adjacent to both a mountain and a lake can only be one type, which is an architectural bug (e.g. combo-6 lakeside at (0,-5) is also adjacent to mountain tile (-1,-5) but cannot express both). Replace it with independent boolean properties so multiple terrain effects can render simultaneously.
+
+## Current State
+
+- `Precinct.terrain?: "coast" | "lakeside" | "riverside" | "foothill"` — single string, priority-ordered in adapter
+- Priority: coast > lakeside > foothill > riverside (so foothill + lakeside is impossible)
+- `has_internal_lake` exists as a separate boolean but only controls a legacy rendering path
+- Scenario JSON and generator both author `"terrain": "lakeside"` explicitly
+
+## Design
+
+### Precinct schema
+
+Replace `terrain` and `has_internal_lake` with:
+
+```
+has_lake?: boolean       // water body present in this hex (marsh, shore, or open-water face)
+```
+
+`coast`, `foothill`, and `riverside` become **derived-only** — computed by the adapter from tile adjacency and river membership, never stored in JSON. Only `has_lake` is authored (or derived from lake tile adjacency).
+
+### Adapter derivation (replaces priority chain)
+
+```
+coast    = any neighbour is a sea tile
+foothill = any neighbour is a mountain tile
+haslake  = has_lake: true in JSON  OR  any neighbour is a lake tile
+riverside = precinct appears in river_edges (and none of above)
+```
+
+All four can be simultaneously true on a single precinct. Renderer receives an annotation struct with independent booleans.
+
+### Generator convention
+
+- **Small lake / marsh**: set `has_lake: true` directly on precinct
+- **Large lake**: place lake tile(s); adjacent precincts derive `has_lake` automatically — no explicit authoring needed
+- **Shore precinct adjacent to mountain**: gets both `has_lake` (derived from lake tile) AND `foothill` (derived from mountain tile) — renders both effects
+
+### Enclosed-precinct rule
+
+A `has_lake: true` precinct whose **all six neighbours** are also water (either `has_lake: true` precincts or lake tiles) is **auto-promoted to a lake tile** at adapter load time — removed from playable precincts, added to terrain tiles. This prevents a fully water-surrounded playable precinct that is visually indistinguishable from open water.
+
+**Island exception**: if the author wants a playable island inside a lake, leave the island precinct with `has_lake: false`. The surrounding lake blobs frame it visually; the island renders as land.
+
+### Typology
+
+| Scenario | Model |
+|----------|-------|
+| Marsh / pond inside a precinct | `has_lake: true`, land neighbours |
+| Small multi-hex lake with shore | ring of `has_lake: true` precincts; open-water center auto-promotes to lake tile at load |
+| Large lake (explicit) | lake tile cluster; neighbours derive `has_lake` |
+| Island inside a lake | lake tile ring; island precinct has `has_lake: false` |
+| Foothill + lakeside simultaneously | `has_lake: true` + mountain-tile neighbour → both render |
+
+## Goals / Acceptance Criteria
+
+**Completed (merged):**
+- [x] `Precinct.terrain` field removed from TypeScript types, loader, and adapter
+- [x] `Precinct.has_internal_lake` removed (superseded)
+- [x] Adapter derives `{ coast, foothill, riverside }` as independent booleans from adjacency (never authored in JSON)
+- [x] Renderer applies all applicable terrain effects to a single precinct simultaneously (coast fringe + foothill fringe can coexist)
+- [x] Scenario JSON files updated: legacy `terrain` values removed; coast/foothill dropped from JSON output
+- [x] `gen-tutorial-003` updated — lake blob precincts removed; lake tile at (7,0) still renders
+
+**Deferred to GAME-086:**
+- [ ] Lakeside precinct visual overlay (edge stroke or intrusion shape for precincts adjacent to lake tiles)
+- [ ] `has_lake?: boolean` authoring or derived-from-tile-adjacency annotation for lakeside precincts
+- [ ] Adapter auto-promotes enclosed `has_lake: true` precincts to lake tiles (enclosed-precinct rule)
+- [ ] Island case: `has_lake: false` precinct surrounded by lake tiles renders as land
+
+Note: The metaball lake blob approach was attempted and removed. The lake blob code drove SVG filter/clip complexity that produced visual artifacts at precinct boundaries. GAME-086 will revisit with a simpler design (edge stroke or intrusion, matching coast/foothill pattern).
+
+## Test Coverage
+
+**Completed:**
+- [x] Unit test: adapter derives `coast: true` for precinct adjacent to sea tile
+- [x] Unit test: adapter derives `foothill: true` for precinct adjacent to mountain tile
+- [x] Unit test: precinct adjacent to sea tile AND mountain tile gets both simultaneously
+- [x] Unit test: riverside only set when no coast/foothill (exclusive)
+
+**Deferred to GAME-086:**
+- [ ] Unit test: adapter derives `lakeside: true` for precinct adjacent to lake tile
+- [ ] E2e: tutorial-003 lakeside precinct renders expected visual element
+
+## References
+
+- GAME-082: original terrain visual treatment (where `terrain` priority bug was introduced)
+- `game/web/src/model/adapter.ts` lines ~88–106 — current priority chain to replace
+- `game/web/src/model/types.ts` line ~71 — `terrain` field to remove
+- `game/web/src/model/scenario.ts` lines ~114–126 — `Precinct` interface

--- a/thoughts/shared/tickets/GAME-086-lake-rendering.md
+++ b/thoughts/shared/tickets/GAME-086-lake-rendering.md
@@ -1,0 +1,43 @@
+---
+id: GAME-086
+title: Lake rendering — precinct-level lake overlay with proper visual design
+area: game, rendering, UX
+status: open
+created: 2026-05-21
+---
+
+## Summary
+
+GAME-085 introduced composable terrain annotations. A `has_lake` precinct property was also implemented, driving a metaball SVG overlay for precincts adjacent to bodies of water. The metaball approach (Gaussian blur + feColorMatrix threshold) produced merged organic blobs for connected lake clusters, but the visual failed in two ways: (1) the blob hard-stopped at non-lake precinct boundaries with no graceful pullback, and (2) every attempted fix (negative repulsors, clip path inset, bezier crinkle) introduced new artifacts (cats-eye gaps, circular cuts, uneven crinkle). The lake blob code was removed in GAME-085 cleanup rather than shipped in a broken state.
+
+Lake *tiles* (type="lake" in terrain_tiles) still render as aqua hexagons. What is missing is any visual indication on *precincts* that they border a lake — the "lakeside" annotation that coast and foothill precincts get for sea and mountain adjacency.
+
+## Current State
+
+- Lake terrain tiles render as aqua hex fills (correct; no change needed).
+- `has_lake` precinct field: removed from schema, loader, adapter, and all scenario files.
+- `hasLake` TerrainAnnotation flag: removed from types, adapter, renderer.
+- No lake-specific precinct overlay renders at all.
+- The `tutorial-003` scenario still has a lake tile at (7,0); the adjacent precinct (6,0) has no visual indication of lakeside status beyond seeing the tile itself.
+
+## Goals / Acceptance Criteria
+
+- [ ] Design: decide visual language for lakeside precincts — edge stroke, fill tint, or intrusion shape consistent with coast/foothill treatment
+- [ ] Derive lakeside annotation from adjacency to lake tiles (no authored `has_lake` field — mirror the coast/foothill approach)
+- [ ] Render lakeside visual on precincts adjacent to lake tiles
+- [ ] For multi-precinct lake clusters (precincts sharing a lake-adjacent edge), decide whether merged visuals are needed or per-precinct treatment suffices
+- [ ] tutorial-003 updated to demonstrate at least one lakeside precinct
+- [ ] E2E tests cover the lakeside rendering
+
+## Test Coverage
+
+- [ ] Unit: adapter correctly derives `lakeside: true` for precincts adjacent to lake tiles
+- [ ] Unit: precincts not adjacent to lake tiles have `lakeside: false` (or annotation absent)
+- [ ] E2E: tutorial-003 lakeside precinct(s) render with expected visual element
+
+## References
+
+- GAME-085: composable terrain annotations (parent ticket; lake removed here)
+- `game/web/src/render/mapRenderer.ts` — `renderTerrainEdges()` is the reference implementation for coast/foothill intrusion rendering; lakeside should follow the same pattern
+- `game/web/src/model/adapter.ts` — terrain annotation derivation; add `lake` adjacency check alongside `sea`/`mountain`
+- Removed lake blob code: see git history for the `renderLakeBlobs` method if metaball approach is reconsidered

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -116,6 +116,10 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-080-district-demographic-rollup.md` | game, UX | Live per-district demographic stat derived from criteria (majority_minority → show % of target group); compact line under district button; updates on paint |
 | `GAME-081-information-density-implementation.md` | game, UX | Implement DESIGN-015 layout: district state visible at 5+ districts without scrolling; integrates GAME-080 stat placement |
 | `GAME-082-terrain-visual-treatment-refinement.md` | game, rendering, UX | Visual-tuning pass over GAME-075 terrain layer: thicker rivers, more prominent coast/lakeside edges, foothill rendering pickup, internal-lake validation |
+| `GAME-083-unassigned-precinct-visual-feedback.md` | game, rendering, UX | Unassigned precincts need a distinct neutral fill (white→dark-grey range); currently indistinguishable from assigned ones |
+| `GAME-084-map-generation-pipeline.md` | game, tooling | Spec-driven staged pipeline (terrain→population→demographics→assembler); single scenario JSON format throughout; requires loader validation split |
+| `GAME-085-composable-terrain-annotations.md` | game, rendering, model | Replace single `terrain` type with composable boolean properties; `has_lake` explicit, coast/foothill/riverside derived; enclosed-precinct auto-promotion rule |
+| `GAME-086-lake-rendering.md` | game, rendering, UX | Lakeside precinct visual overlay deferred from GAME-085; metaball approach removed; needs fresh design — edge stroke or intrusion shape consistent with coast/foothill treatment |
 
 ---
 


### PR DESCRIPTION
## Prerequisites
- [ ] N/A | Parent PR merged: N/A (on main)

## Summary
- Completes GAME-085 schema cleanup: removes single-string `Precinct.terrain` field, `has_internal_lake`, and ~230 lines of dead `renderLakeBlobs_REMOVED()` code from `mapRenderer.ts`; coast/foothill/riverside now derived as independent composable booleans from tile adjacency
- Implements GAME-086 lake-shore rendering: adds `lakeside: boolean` to `TerrainAnnotation`, derived from lake-tile adjacency in the adapter; `renderTerrainEdges` extended to render lake intrusion shapes (smooth profile, `#4dd0e1` fill, depth=5) including corner caps and boundary arcs
- Unifies river stroke color with lake fill (`#38bdf8` → `#4dd0e1`)
- Repositions lake tile `(7,0)` → `(-1,1)` (center of map, all 6 neighbours become lakeside precincts) and sea tiles from `r=7` → `r=6` (4 tiles now inside R=6 circle; 9 coast-facing edges total)
- River shortened from 19 → 16 edges, splits into 2 chains around the new central lake tile
- `tutorial-003.json` regenerated: 119 precincts, 16 river edges

## Validation performed
- [ ] N/A — no kubectl/ansible/SOPS changes
- `bazel build //game/web/...` passes clean
- `bazel test //game/web/src/model:adapter_test` passes (includes new lakeside derivation unit test)
- Generator re-run confirms 119 precincts, 16 river edges

## Affected machines / services
- Browser game client only (static assets)

## Deployment steps (POST-MERGE)
- Deploy via `game/release.main.kts` to staging after merge

## Tickets addressed
- see GAME-085 (composable terrain annotations — cleanup completed here)
- see GAME-086 (lake rendering — implemented here)

## Rollback
- Revert squash commit on main; redeploy
