### PR TITLE
test(loader): integration tests — load all 11 real scenario files through loadScenario

### DIFF
--- a/game/package-lock.json
+++ b/game/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@types/d3": "^7.4.3",
+        "@types/node": "^25.9.1",
         "react": "^18.3.1"
       }
     },
@@ -324,6 +325,16 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -861,6 +872,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/zundo": {

--- a/game/package.json
+++ b/game/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@types/d3": "^7.4.3",
+    "@types/node": "^25.9.1",
     "react": "^18.3.1"
   },
   "pnpm": {

--- a/game/pnpm-lock.yaml
+++ b/game/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -130,6 +133,9 @@ packages:
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -308,6 +314,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   zundo@2.3.0:
     resolution: {integrity: sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==}
     peerDependencies:
@@ -455,6 +464,10 @@ snapshots:
       '@types/d3-zoom': 3.0.8
 
   '@types/geojson@7946.0.16': {}
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
 
   commander@7.2.0: {}
 
@@ -646,6 +659,8 @@ snapshots:
   rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
+
+  undici-types@7.24.6: {}
 
   zundo@2.3.0(zustand@5.0.12(react@18.3.1)):
     dependencies:

--- a/game/scenarios/BUILD.bazel
+++ b/game/scenarios/BUILD.bazel
@@ -1,5 +1,16 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+
 filegroup(
     name = "scenario_files",
+    srcs = glob(["*.json"]),
+    visibility = ["//visibility:public"],
+)
+
+# js_library wrapper so aspect_rules_js js_test targets can reference these
+# JSON files as data deps (aspect_rules_js requires cross-package data to be
+# in the bazel bin tree, which js_library handles via copy_to_bin).
+js_library(
+    name = "scenario_json",
     srcs = glob(["*.json"]),
     visibility = ["//visibility:public"],
 )

--- a/game/web/src/model/BUILD.bazel
+++ b/game/web/src/model/BUILD.bazel
@@ -284,6 +284,49 @@ js_test(
     visibility = ["//visibility:public"],
 )
 
+# ── tsconfig_integration: tsconfig that adds Node types for integration tests ─
+
+ts_config(
+    name = "tsconfig_integration",
+    src = "tsconfig.integration.json",
+    deps = [":tsconfig"],
+    visibility = ["//game/web/src/model:__pkg__"],
+)
+
+# ── loader_integration_test_lib: compile integration tests ───────────────────
+
+ts_project(
+    name = "loader_integration_test_lib",
+    srcs = ["loader_integration_test.ts"],
+    tsconfig = ":tsconfig_integration",
+    declaration = True,
+    deps = [
+        ":loader_lib",
+        "//game:node_modules/@types/node",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+# ── loader_integration_test: load every real scenario JSON through loadScenario ─
+
+js_test(
+    name = "loader_integration_test",
+    entry_point = "loader_integration_test.js",
+    data = [
+        ":loader_integration_test_lib",
+        ":loader_lib",
+        ":runtime_types_lib",
+        ":model_lib",
+        "//game/scenarios:scenario_json",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # ── loader_typecheck_test: type-check passes ──────────────────────────────────
 
 build_test(

--- a/game/web/src/model/loader_integration_test.ts
+++ b/game/web/src/model/loader_integration_test.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration tests: load every real scenario JSON file through loadScenario.
+ *
+ * These tests guard against loader regressions that unit tests with synthetic
+ * fixtures would miss — they exercise the full parser+validator on actual game
+ * content.
+ *
+ * Run via Bazel: bazel test //game/web/src/model:loader_integration_test
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { loadScenario } from "./loader.js";
+import { test, assertEqual, assertDoesNotThrow, summarize } from "../testing/test_runner.js";
+
+// ─── Runfiles path resolution ─────────────────────────────────────────────────
+
+function scenarioPath(filename: string): string {
+  // Bazel js_test sets RUNFILES_DIR; files are under _main/<workspace-relative-path>.
+  const runfiles = process.env["RUNFILES_DIR"];
+  if (!runfiles) throw new Error("RUNFILES_DIR not set — must run via bazel test");
+  // Try _main canonical name (Bazel ≥ 7) first, then bare runfiles root.
+  for (const prefix of ["_main", ""]) {
+    const p = prefix
+      ? join(runfiles, prefix, "game", "scenarios", filename)
+      : join(runfiles, "game", "scenarios", filename);
+    try {
+      readFileSync(p);
+      return p;
+    } catch {
+      // try next prefix
+    }
+  }
+  throw new Error(`Scenario file not found in runfiles: ${filename}`);
+}
+
+function loadJson(filename: string): unknown {
+  return JSON.parse(readFileSync(scenarioPath(filename), "utf8"));
+}
+
+// ─── Scenario metadata table ──────────────────────────────────────────────────
+
+const SCENARIOS: { file: string; id: string; precincts: number; districts: number }[] = [
+  { file: "tutorial-001.json",  id: "tutorial-001",  precincts: 30,  districts: 2 },
+  { file: "tutorial-002.json",  id: "tutorial-002",  precincts: 196, districts: 3 },
+  { file: "tutorial-003.json",  id: "tutorial-003",  precincts: 119, districts: 4 },
+  { file: "scenario-002.json",  id: "scenario-002",  precincts: 91,  districts: 4 },
+  { file: "scenario-003.json",  id: "scenario-003",  precincts: 127, districts: 5 },
+  { file: "scenario-004.json",  id: "scenario-004",  precincts: 127, districts: 5 },
+  { file: "scenario-005.json",  id: "scenario-005",  precincts: 127, districts: 5 },
+  { file: "scenario-006.json",  id: "scenario-006",  precincts: 127, districts: 5 },
+  { file: "scenario-007.json",  id: "scenario-007",  precincts: 127, districts: 5 },
+  { file: "scenario-008.json",  id: "scenario-008",  precincts: 127, districts: 5 },
+  { file: "scenario-009.json",  id: "scenario-009",  precincts: 127, districts: 5 },
+];
+
+// ─── Per-scenario tests ───────────────────────────────────────────────────────
+
+for (const { file, id, precincts, districts } of SCENARIOS) {
+  test(`${id}: loads and validates without error`, () => {
+    assertDoesNotThrow(() => loadScenario(loadJson(file)), `loadScenario(${file})`);
+  });
+
+  test(`${id}: precinct count = ${precincts}`, () => {
+    const scenario = loadScenario(loadJson(file));
+    assertEqual(scenario.precincts.length, precincts);
+  });
+
+  test(`${id}: district count = ${districts}`, () => {
+    const scenario = loadScenario(loadJson(file));
+    assertEqual(scenario.districts.length, districts);
+  });
+
+  test(`${id}: scenario id matches filename`, () => {
+    const scenario = loadScenario(loadJson(file));
+    assertEqual(scenario.id, id as typeof scenario.id);
+  });
+
+  test(`${id}: all editable precincts have initial_district_id resolved`, () => {
+    const scenario = loadScenario(loadJson(file));
+    for (const pc of scenario.precincts) {
+      if (pc.editable) {
+        if (pc.initial_district_id === undefined || pc.initial_district_id === null) {
+          throw new Error(`Editable precinct "${pc.id}" has unresolved initial_district_id`);
+        }
+      }
+    }
+  });
+}
+
+summarize();

--- a/game/web/src/model/tsconfig.integration.json
+++ b/game/web/src/model/tsconfig.integration.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `loader_integration_test.ts`: reads every real scenario JSON file from Bazel runfiles and passes it through `loadScenario`, guarding against loader regressions that synthetic-fixture unit tests miss
- 55 tests across 11 scenarios (tutorial-001/002/003, scenario-002 through 009): load-without-throw, precinct count, district count, id-matches-filename, all editable precincts have resolved `initial_district_id`
- New `scenarios/BUILD.bazel` `js_library` target (`scenario_json`) — required for cross-package JSON data access from `aspect_rules_js` `js_test`
- New `tsconfig.integration.json` (extends model tsconfig, adds `"types": ["node"]`) so the test can use `fs.readFileSync` without polluting game code with Node types
- Adds `@types/node` as a devDependency (`package.json` + `pnpm-lock.yaml`)

## Affected machines / services

None

## Validation performed

- [x] `bazel test //game/web/src/model:loader_integration_test` — 55/55 pass; all 11 real scenario files load and validate cleanly
- [x] `bazel test //game/web/src/model/...` — all 9 model test targets pass

## Deployment steps (POST-MERGE)

None

## Tickets addressed

- N/A — test coverage improvement ahead of GAME-084; no ticket required

## Rollback

Revert commit
