### PR TITLE
feat(GAME-084): terrain generator — hex_circle + terrain tiles + river edges [AC2]

### DIFF
--- a/game/package-lock.json
+++ b/game/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "d3": "^7.9.0",
+        "yaml": "^2.9.0",
         "zundo": "^2.3.0",
         "zustand": "^5.0.3"
       },
@@ -880,6 +881,21 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zundo": {
       "version": "2.3.0",

--- a/game/package.json
+++ b/game/package.json
@@ -5,6 +5,7 @@
   "description": "Redistricting simulator — educational browser game",
   "dependencies": {
     "d3": "^7.9.0",
+    "yaml": "^2.9.0",
     "zundo": "^2.3.0",
     "zustand": "^5.0.3"
   },

--- a/game/pnpm-lock.yaml
+++ b/game/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       d3:
         specifier: ^7.9.0
         version: 7.9.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zundo:
         specifier: ^2.3.0
         version: 2.3.0(zustand@5.0.12(react@18.3.1))
@@ -316,6 +319,11 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   zundo@2.3.0:
     resolution: {integrity: sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==}
@@ -661,6 +669,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   undici-types@7.24.6: {}
+
+  yaml@2.9.0: {}
 
   zundo@2.3.0(zustand@5.0.12(react@18.3.1)):
     dependencies:

--- a/game/scenarios/scenario-002.spec.yaml
+++ b/game/scenarios/scenario-002.spec.yaml
@@ -1,0 +1,153 @@
+# Spec file for scenario-002: "Clearwater County: The Governor's Map"
+# Source of truth for the map generation pipeline (GAME-084).
+# Generated output: game/scenarios/scenario-002.json
+#
+# Stage completion:
+#   [x] Stage 1: map + terrain  (terrain-generator.ts)
+#   [ ] Stage 2: population     (population-stage.ts — not yet implemented)
+#   [ ] Stage 3: demographics   (demographics-stage.ts — not yet implemented)
+#   [ ] Stage 4: assembly       (assembler.ts — not yet implemented)
+
+format_version: "1"
+
+# ── Scenario identity ─────────────────────────────────────────────────────────
+
+scenario:
+  id: scenario-002
+  title: "Clearwater County: The Governor's Map"
+  election_type: state_house
+  region:
+    id: clearwater_county
+    name: Clearwater County
+
+# ── Stage 1a: Map layout ──────────────────────────────────────────────────────
+
+map:
+  geometry: hex_axial
+  shape: hex_circle
+  radius: 5
+
+# ── Stage 1b: Terrain placement ───────────────────────────────────────────────
+#
+# scenario-002 is a pure political puzzle with no geographic features.
+# The terrain section is empty; precincts fill the full R=5 hex circle.
+
+terrain: {}
+
+# ── Stage 2: Population ───────────────────────────────────────────────────────
+# (populated by population-stage.ts once implemented)
+#
+# population:
+#   seed: 42
+#   base: 1500
+#   variance: 150
+
+# ── Stage 3: Demographics ─────────────────────────────────────────────────────
+# (populated by demographics-stage.ts once implemented)
+#
+# demographics:
+#   seed: 42
+#   group:
+#     id_suffix: all
+#     name: All voters
+#   turnout:
+#     min: 0.55
+#     max: 0.70
+#   jitter: 0.04
+#   zones:
+#     - name: west
+#       filter: { q_lte: 0 }
+#       party_base: { ken: 0.62 }
+#     - name: inner_east
+#       filter: { q_gte: 1, hex_dist_lte: 3 }
+#       party_base: { ken: 0.25 }
+#     - name: outer_east
+#       filter: { default: true }
+#       party_base: { ken: 0.52 }
+#   county_labels:
+#     - id: clearwater_west
+#       filter: { q_lte: 0 }
+#     - id: clearwater_east
+#       filter: { q_gte: 1, hex_dist_lte: 3 }
+#     - id: clearwater_central
+#       filter: { default: true }
+
+# ── Stage 4: Assembly ─────────────────────────────────────────────────────────
+# (populated by assembler.ts once implemented)
+#
+# assembly:
+#   parties:
+#     - { id: ken, name: Ken Party, abbreviation: KEN }
+#     - { id: ryu, name: Ryu Party, abbreviation: RYU }
+#   districts:
+#     - { id: d1, name: District 1 }
+#     - { id: d2, name: District 2 }
+#     - { id: d3, name: District 3 }
+#     - { id: d4, name: District 4 }
+#   default_district_id: d1
+#   initial_district_rule:
+#     type: diagonal_strip
+#     strips:
+#       - { max_k: -3, district: d1 }
+#       - { max_k: -1, district: d2 }
+#       - { max_k: 1,  district: d3 }
+#       - { default: true, district: d4 }
+#   rules:
+#     population_tolerance: 0.10
+#     contiguity: required
+#   success_criteria:
+#     - id: sc-district-count
+#       required: true
+#       description: All four districts are in use and every precinct is assigned.
+#       criterion: { type: district_count }
+#     - id: sc-population-balance
+#       required: true
+#       description: All four districts have roughly equal population (within 10%).
+#       criterion: { type: population_balance }
+#     - id: sc-ken-seats
+#       required: true
+#       description: The governor's Ken Party wins at least 3 of the 4 districts.
+#       criterion: { type: seat_count, party: ken, operator: gte, count: 3 }
+#     - id: sc-compactness
+#       required: false
+#       description: All districts are reasonably compact (≥ 40%).
+#       criterion: { type: compactness, operator: gte, threshold: 0.40 }
+#   narrative:
+#     character:
+#       name: You
+#       role: Ken Party Campaign Strategist, Clearwater County
+#       motivation: >
+#         The governor wants a reliable majority in Clearwater County. The current
+#         map splits the vote evenly — two Ken, two Ryu. That's not good enough.
+#         You've been brought in to redraw the lines so Ken wins three of four seats.
+#     intro_slides:
+#       - heading: The Governor's Problem
+#         body: >
+#           Clearwater County elects four representatives. Right now, the map gives
+#           each party two seats. The governor — a Ken partisan — wants three.
+#
+#           The population hasn't changed. The voters haven't changed. But the lines
+#           can change.
+#       - heading: How Redistricting Works
+#         body: >
+#           Every ten years, district boundaries are redrawn. The official reason is
+#           to reflect population changes. The real reason, often, is to change who
+#           wins.
+#
+#           You're looking at a map of precincts — small geographic units with known
+#           voting patterns. Your job is to group them into districts that favor the
+#           Ken Party.
+#       - heading: Your First Gerrymander
+#         body: >
+#           Look at the map. The southeast corner votes heavily Ryu. The north and
+#           southwest lean Ken.
+#
+#           If you can contain the Ryu stronghold in one district and spread Ken
+#           voters across the other three, the governor gets the majority. The tools
+#           are simple — the consequences are not.
+#     objective: Redraw the map so the Ken Party wins at least 3 of 4 districts.
+#   instigator_character: governor
+#   character_demographics:
+#     governor: bm
+#     commissioner: bf
+#     judge: lm

--- a/game/web/src/pipeline/BUILD.bazel
+++ b/game/web/src/pipeline/BUILD.bazel
@@ -1,0 +1,82 @@
+"""
+Bazel targets for the GAME-084 map generation pipeline.
+
+  spec_types_lib        — spec-types.ts (YAML pipeline spec TypeScript types)
+  terrain_generator_lib — terrain-generator.ts (Stage 1: hex grid + terrain + rivers)
+"""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//game/web/src/pipeline:__pkg__"],
+)
+
+# ── spec_types_lib: TypeScript types for the YAML pipeline spec format ────────
+
+ts_project(
+    name = "spec_types_lib",
+    srcs = ["spec-types.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    visibility = ["//game/web:__subpackages__"],
+)
+
+# ── terrain_generator_lib: Stage 1 — hex grid + terrain tiles + river edges ──
+
+ts_project(
+    name = "terrain_generator_lib",
+    srcs = ["terrain-generator.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+    ],
+    visibility = ["//game/web:__subpackages__"],
+)
+
+# ── terrain_generator_typecheck_test: type-check passes ──────────────────────
+
+build_test(
+    name = "terrain_generator_typecheck_test",
+    targets = [":terrain_generator_lib"],
+    visibility = ["//visibility:public"],
+)
+
+# ── terrain_generator_test_lib: compile tests ─────────────────────────────────
+
+ts_project(
+    name = "terrain_generator_test_lib",
+    srcs = ["terrain-generator_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+# ── terrain_generator_test: run tests with Node ───────────────────────────────
+
+js_test(
+    name = "terrain_generator_test",
+    entry_point = "terrain-generator_test.js",
+    data = [
+        ":terrain_generator_test_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/game/web/src/pipeline/spec-types.ts
+++ b/game/web/src/pipeline/spec-types.ts
@@ -1,0 +1,66 @@
+/**
+ * TypeScript types for the YAML pipeline spec format.
+ *
+ * Each section corresponds to one pipeline stage:
+ *   map      → terrain generator (Stage 1)
+ *   terrain  → terrain generator (Stage 1)
+ *   population  → population stage (Stage 2)
+ *   demographics → demographics stage (Stage 3)
+ *   assembly → scenario assembler (Stage 4)
+ *
+ * The spec file is the human-readable source of truth checked in alongside
+ * the generated scenario JSON. Agents tune the spec; the pipeline executes it.
+ */
+
+// ─── Shared geometry ──────────────────────────────────────────────────────────
+
+export interface HexPos {
+  q: number;
+  r: number;
+}
+
+// ─── Stage 0: Scenario identity ───────────────────────────────────────────────
+
+export interface ScenarioMetaSpec {
+  id: string;
+  title: string;
+  election_type: "congressional" | "state_senate" | "state_house";
+  region: {
+    id: string;
+    name: string;
+  };
+}
+
+// ─── Stage 1a: Map layout ─────────────────────────────────────────────────────
+
+export type MapShape = "hex_circle";
+
+export interface HexCircleMapSpec {
+  geometry: "hex_axial";
+  shape: "hex_circle";
+  radius: number;
+}
+
+export type MapSpec = HexCircleMapSpec;
+
+// ─── Stage 1b: Terrain placement ──────────────────────────────────────────────
+
+export interface TerrainTileSpec extends HexPos {
+  type: "mountain" | "sea" | "lake";
+}
+
+export interface TerrainSpec {
+  tiles?: TerrainTileSpec[];
+  /** Position pairs; each pair names adjacent precincts separated by a river. */
+  river_edges?: [HexPos, HexPos][];
+}
+
+// ─── Pipeline spec (full file) ────────────────────────────────────────────────
+
+export interface PipelineSpec {
+  format_version: "1";
+  scenario: ScenarioMetaSpec;
+  map: MapSpec;
+  terrain?: TerrainSpec;
+  // population, demographics, assembly sections added in later stages
+}

--- a/game/web/src/pipeline/terrain-generator.ts
+++ b/game/web/src/pipeline/terrain-generator.ts
@@ -1,0 +1,144 @@
+/**
+ * Stage 1 of the GAME-084 map generation pipeline: terrain generator.
+ *
+ * Takes a PipelineSpec and produces a PartialScenario containing:
+ *   - Hex positions for all precincts (no population or demographics yet)
+ *   - Non-precinct terrain tiles (mountain, sea, lake)
+ *   - River edges as precinct-ID pairs
+ *
+ * Validation enforced here:
+ *   - Terrain tiles must not overlap any precinct position
+ *   - River edges must reference precinct positions (not terrain tiles or empty cells)
+ */
+
+import type {
+  GeometrySpec,
+  PartialPrecinct,
+  PartialScenario,
+  PrecinctId,
+  RegionId,
+  ScenarioId,
+  TerrainTile,
+} from "../model/scenario.js";
+
+import type { HexPos, PipelineSpec } from "./spec-types.js";
+
+// Flat-top axial hex direction vectors
+const HEX_DIRS: [number, number][] = [
+  [1, 0], [0, 1], [-1, 1], [-1, 0], [0, -1], [1, -1],
+];
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export function generateTerrain(spec: PipelineSpec): PartialScenario {
+  const { scenario, map, terrain } = spec;
+
+  const positions = generateHexCircle(map.radius);
+
+  const precincts: PartialPrecinct[] = positions.map((pos, idx) => ({
+    id: sequentialId(idx + 1) as PrecinctId,
+    editable: true,
+    position: pos,
+  }));
+
+  const posToId = buildPosIndex(precincts);
+
+  const terrainTiles = buildTerrainTiles(terrain?.tiles ?? [], posToId);
+  const riverEdges = buildRiverEdges(terrain?.river_edges ?? [], posToId);
+
+  const partial: PartialScenario = {
+    format_version: "1",
+    id: scenario.id as ScenarioId,
+    title: scenario.title,
+    election_type: scenario.election_type,
+    region: {
+      id: scenario.region.id as RegionId,
+      name: scenario.region.name,
+    },
+    geometry: { type: "hex_axial" } satisfies GeometrySpec,
+    precincts,
+  };
+
+  if (terrainTiles.length > 0) partial.terrain_tiles = terrainTiles;
+  if (riverEdges.length > 0) partial.river_edges = riverEdges;
+
+  return partial;
+}
+
+// ─── Hex grid generation ──────────────────────────────────────────────────────
+
+/** Generates all positions in a hex circle of the given radius, sorted (r asc, q asc). */
+export function generateHexCircle(radius: number): HexPos[] {
+  const hexes: HexPos[] = [];
+  for (let q = -radius; q <= radius; q++) {
+    const rMin = Math.max(-radius, -q - radius);
+    const rMax = Math.min(radius, -q + radius);
+    for (let r = rMin; r <= rMax; r++) {
+      hexes.push({ q, r });
+    }
+  }
+  return hexes.sort((a, b) => a.r - b.r || a.q - b.q);
+}
+
+/** Expected precinct count for a hex circle of radius R: 3R²+3R+1 */
+export function hexCircleSize(radius: number): number {
+  return 3 * radius * radius + 3 * radius + 1;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function buildPosIndex(precincts: PartialPrecinct[]): Map<string, PrecinctId> {
+  const m = new Map<string, PrecinctId>();
+  for (const p of precincts) {
+    const pos = p.position as HexPos;
+    m.set(posKey(pos.q, pos.r), p.id);
+  }
+  return m;
+}
+
+function buildTerrainTiles(
+  specs: Array<{ q: number; r: number; type: "mountain" | "sea" | "lake" }>,
+  posToId: Map<string, PrecinctId>,
+): TerrainTile[] {
+  return specs.map(t => {
+    if (posToId.has(posKey(t.q, t.r))) {
+      throw new Error(
+        `Terrain tile at (${t.q},${t.r}) overlaps a precinct position`,
+      );
+    }
+    // Tiles outside the precinct grid are intentionally allowed — sea tiles
+    // placed beyond the hex circle boundary create a visible coastline, and
+    // mountain tiles outside the playable area can frame the map edge.
+    return { position: { q: t.q, r: t.r }, type: t.type };
+  });
+}
+
+function buildRiverEdges(
+  specs: [HexPos, HexPos][],
+  posToId: Map<string, PrecinctId>,
+): [PrecinctId, PrecinctId][] {
+  return specs.map(([a, b]) => {
+    const aId = posToId.get(posKey(a.q, a.r));
+    const bId = posToId.get(posKey(b.q, b.r));
+    if (!aId) throw new Error(`River edge start (${a.q},${a.r}) is not a precinct position`);
+    if (!bId) throw new Error(`River edge end (${b.q},${b.r}) is not a precinct position`);
+    if (!areAdjacent(a, b)) {
+      throw new Error(
+        `River edge (${a.q},${a.r})↔(${b.q},${b.r}) connects non-adjacent hexes`,
+      );
+    }
+    return [aId, bId];
+  });
+}
+
+function areAdjacent(a: HexPos, b: HexPos): boolean {
+  return HEX_DIRS.some(([dq, dr]) => a.q + dq === b.q && a.r + dr === b.r);
+}
+
+function posKey(q: number, r: number): string {
+  return `${q},${r}`;
+}
+
+function sequentialId(n: number): string {
+  return `p${String(n).padStart(3, "0")}`;
+}

--- a/game/web/src/pipeline/terrain-generator_test.ts
+++ b/game/web/src/pipeline/terrain-generator_test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the terrain generator (GAME-084 Stage 1 pipeline).
+ *
+ * Covers:
+ *   - Hex circle generation: count, sort order, edge cases
+ *   - generateTerrain: produces valid PartialScenario structure
+ *   - Terrain tiles: accepted, validated, placed in output
+ *   - River edges: translated from position pairs to precinct-ID pairs
+ *   - Error cases: overlapping terrain, non-precinct river endpoints, non-adjacent river pairs
+ *
+ * Run via Bazel: bazel test //game/web/src/pipeline:terrain_generator_test
+ */
+
+import {
+  generateTerrain,
+  generateHexCircle,
+  hexCircleSize,
+} from "./terrain-generator.js";
+import type { PipelineSpec } from "./spec-types.js";
+import {
+  test,
+  assertEqual,
+  assertThrows,
+  assertDoesNotThrow,
+  summarize,
+} from "../testing/test_runner.js";
+
+// ─── Spec fixtures ────────────────────────────────────────────────────────────
+
+function minimalSpec(
+  radius: number,
+  overrides: Partial<PipelineSpec> = {},
+): PipelineSpec {
+  return {
+    format_version: "1",
+    scenario: {
+      id: "test-001",
+      title: "Test Scenario",
+      election_type: "congressional",
+      region: { id: "r1", name: "Test Region" },
+    },
+    map: { geometry: "hex_axial", shape: "hex_circle", radius },
+    ...overrides,
+  };
+}
+
+// ─── generateHexCircle ────────────────────────────────────────────────────────
+
+test("generateHexCircle: R=0 produces single hex at origin", () => {
+  const hexes = generateHexCircle(0);
+  assertEqual(hexes.length, 1);
+  assertEqual(hexes[0]!.q, 0);
+  assertEqual(hexes[0]!.r, 0);
+});
+
+test("generateHexCircle: R=1 produces 7 hexes", () => {
+  assertEqual(generateHexCircle(1).length, 7);
+});
+
+test("generateHexCircle: R=5 produces 91 hexes", () => {
+  assertEqual(generateHexCircle(5).length, 91);
+});
+
+test("generateHexCircle: R=6 produces 127 hexes", () => {
+  assertEqual(generateHexCircle(6).length, 127);
+});
+
+test("generateHexCircle: sorted by r ascending then q ascending", () => {
+  const hexes = generateHexCircle(3);
+  for (let i = 1; i < hexes.length; i++) {
+    const prev = hexes[i - 1]!;
+    const curr = hexes[i]!;
+    const valid =
+      curr.r > prev.r || (curr.r === prev.r && curr.q >= prev.q);
+    assertEqual(valid, true);
+  }
+});
+
+test("generateHexCircle: all positions satisfy hex circle invariant", () => {
+  const R = 4;
+  const hexes = generateHexCircle(R);
+  for (const { q, r } of hexes) {
+    const dist = (Math.abs(q) + Math.abs(r) + Math.abs(q + r)) / 2;
+    assertEqual(dist <= R, true);
+  }
+});
+
+test("hexCircleSize: matches generateHexCircle length for R=0..6", () => {
+  for (let R = 0; R <= 6; R++) {
+    assertEqual(generateHexCircle(R).length, hexCircleSize(R));
+  }
+});
+
+// ─── generateTerrain: basic structure ────────────────────────────────────────
+
+test("generateTerrain: returns PartialScenario with correct metadata", () => {
+  const s = generateTerrain(minimalSpec(1));
+  assertEqual(s.format_version, "1");
+  assertEqual(s.id, "test-001");
+  assertEqual(s.title, "Test Scenario");
+  assertEqual(s.election_type, "congressional");
+  assertEqual(s.region.id, "r1");
+  assertEqual(s.region.name, "Test Region");
+  assertEqual(s.geometry.type, "hex_axial");
+});
+
+test("generateTerrain: R=5 produces 91 precincts", () => {
+  const s = generateTerrain(minimalSpec(5));
+  assertEqual(s.precincts.length, 91);
+});
+
+test("generateTerrain: precincts have no total_population or demographic_groups", () => {
+  const s = generateTerrain(minimalSpec(2));
+  for (const p of s.precincts) {
+    assertEqual(p.total_population, undefined);
+    assertEqual(p.demographic_groups, undefined);
+  }
+});
+
+test("generateTerrain: precinct IDs are sequential p001..pNNN", () => {
+  const s = generateTerrain(minimalSpec(1));
+  const ids = s.precincts.map(p => p.id);
+  assertEqual(ids[0], "p001");
+  assertEqual(ids[6], "p007");
+});
+
+test("generateTerrain: precincts are editable by default", () => {
+  const s = generateTerrain(minimalSpec(1));
+  assertEqual(s.precincts.every(p => p.editable), true);
+});
+
+test("generateTerrain: no terrain_tiles field when spec has none", () => {
+  const s = generateTerrain(minimalSpec(1));
+  assertEqual(s.terrain_tiles, undefined);
+});
+
+test("generateTerrain: no river_edges field when spec has none", () => {
+  const s = generateTerrain(minimalSpec(1));
+  assertEqual(s.river_edges, undefined);
+});
+
+// ─── generateTerrain: terrain tiles ──────────────────────────────────────────
+
+test("generateTerrain: terrain tiles appear in output", () => {
+  const spec = minimalSpec(2, {
+    terrain: {
+      tiles: [{ q: 0, r: 3, type: "mountain" }],
+    },
+  });
+  const s = generateTerrain(spec);
+  assertEqual(s.terrain_tiles?.length, 1);
+  assertEqual(s.terrain_tiles?.[0]?.type, "mountain");
+  assertEqual(s.terrain_tiles?.[0]?.position.q, 0);
+  assertEqual(s.terrain_tiles?.[0]?.position.r, 3);
+});
+
+test("generateTerrain: accepts mountain, sea, and lake tile types", () => {
+  const spec = minimalSpec(3, {
+    terrain: {
+      tiles: [
+        { q: 0, r: 4, type: "mountain" },
+        { q: 1, r: 4, type: "sea" },
+        { q: 2, r: 4, type: "lake" },
+      ],
+    },
+  });
+  const s = generateTerrain(spec);
+  assertEqual(s.terrain_tiles?.length, 3);
+});
+
+test("generateTerrain: terrain tile overlapping precinct throws", () => {
+  // R=2 hex circle includes (0,0); placing mountain there should fail
+  const spec = minimalSpec(2, {
+    terrain: { tiles: [{ q: 0, r: 0, type: "mountain" }] },
+  });
+  assertThrows(() => generateTerrain(spec), /overlap/i);
+});
+
+// ─── generateTerrain: river edges ────────────────────────────────────────────
+
+test("generateTerrain: river edges translated to precinct ID pairs", () => {
+  // R=1 hex; (0,0) and (1,0) are adjacent precincts
+  // Sorted layout (r asc, q asc): r=-1: (0,-1),(1,-1); r=0: (-1,0),(0,0),(1,0); r=1: (-1,1),(0,1)
+  // (0,0) is idx 3 (0-indexed) → p004; (1,0) is idx 4 → p005
+  const spec = minimalSpec(1, {
+    terrain: {
+      river_edges: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
+    },
+  });
+  const s = generateTerrain(spec);
+  assertEqual(s.river_edges?.length, 1);
+  // Both IDs must be valid p0NN identifiers
+  const [a, b] = s.river_edges![0]!;
+  assertEqual(typeof a, "string");
+  assertEqual(typeof b, "string");
+  assertEqual(a !== b, true);
+});
+
+test("generateTerrain: river edge at non-precinct position throws", () => {
+  // (0, 99) is outside the hex circle for R=1
+  const spec = minimalSpec(1, {
+    terrain: {
+      river_edges: [[{ q: 0, r: 0 }, { q: 0, r: 99 }]],
+    },
+  });
+  assertThrows(() => generateTerrain(spec), /not a precinct/i);
+});
+
+test("generateTerrain: river edge between non-adjacent positions throws", () => {
+  // (0,0) and (0,2) are not adjacent in a hex grid
+  const spec = minimalSpec(3, {
+    terrain: {
+      river_edges: [[{ q: 0, r: 0 }, { q: 0, r: 2 }]],
+    },
+  });
+  assertThrows(() => generateTerrain(spec), /non-adjacent/i);
+});
+
+test("generateTerrain: river edge IDs correspond to correct positions", () => {
+  // Verify the ID assigned to a known position
+  const spec = minimalSpec(5);
+  const s = generateTerrain(spec);
+  // Build position→id map from output
+  const posToId = new Map(
+    s.precincts.map(p => {
+      const pos = p.position as { q: number; r: number };
+      return [`${pos.q},${pos.r}`, p.id];
+    }),
+  );
+  // Now add a river between two known adjacent precincts
+  const specWithRiver = minimalSpec(5, {
+    terrain: {
+      river_edges: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
+    },
+  });
+  const sWithRiver = generateTerrain(specWithRiver);
+  const [aId, bId] = sWithRiver.river_edges![0]!;
+  assertEqual(aId, posToId.get("0,0"));
+  assertEqual(bId, posToId.get("1,0"));
+});
+
+summarize();

--- a/game/web/src/pipeline/tsconfig.json
+++ b/game/web/src/pipeline/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "lib": ["ES2022"],
+    "types": [],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "declaration": true
+  }
+}

--- a/thoughts/shared/tickets/GAME-084-map-generation-pipeline.md
+++ b/thoughts/shared/tickets/GAME-084-map-generation-pipeline.md
@@ -4,6 +4,7 @@ title: Map generation pipeline — spec-driven, staged, single format
 area: GAME
 status: open
 created: 2026-05-20
+github_issue: 259
 ---
 
 ## Summary


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #258 (GAME-084 AC1 — loader behavioral split)

## Summary
- Implements GAME-084 Stage 1 (AC2): terrain generator — the first concrete pipeline stage
- `spec-types.ts`: TypeScript types for the YAML pipeline spec format (PipelineSpec, MapSpec, TerrainSpec)
- `terrain-generator.ts`: `generateTerrain(spec) → PartialScenario` — generates hex circle grid positions, validates terrain tile placement, translates river edge position-pairs to precinct-ID pairs with adjacency checking
- `terrain-generator_test.ts`: 21 tests covering hex generation (count, sort, invariant), metadata, terrain tiles (placement, overlap rejection), river edges (translation, non-precinct rejection, non-adjacency rejection)
- `scenario-002.spec.yaml`: first pipeline spec file; map/terrain sections complete; later stages stubbed as YAML comments
- `yaml 2.9.0` added to package.json (needed for CLI stage runners in subsequent stages)

## Validation performed
- [x] `bazel test //game/web/src/pipeline:terrain_generator_test` — 21/21 PASS
- [x] `bazel test //game/web/src/pipeline:terrain_generator_typecheck_test` — PASS
- [x] `bazel test //game/web/src/model:loader_parse_test //game/web/src/model:loader_test` — no regression

## Affected machines / services
- N/A — build/test only; no runtime change

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see #259

## Rollback
- Revert commit; no data or schema changes
