### PR TITLE
feat(GAME-084): population stage — seeded PRNG + per-precinct total_population [AC3]

### DIFF
--- a/game/scenarios/scenario-002.spec.yaml
+++ b/game/scenarios/scenario-002.spec.yaml
@@ -4,7 +4,7 @@
 #
 # Stage completion:
 #   [x] Stage 1: map + terrain  (terrain-generator.ts)
-#   [ ] Stage 2: population     (population-stage.ts — not yet implemented)
+#   [x] Stage 2: population     (population-stage.ts)
 #   [ ] Stage 3: demographics   (demographics-stage.ts — not yet implemented)
 #   [ ] Stage 4: assembly       (assembler.ts — not yet implemented)
 
@@ -35,12 +35,11 @@ map:
 terrain: {}
 
 # ── Stage 2: Population ───────────────────────────────────────────────────────
-# (populated by population-stage.ts once implemented)
-#
-# population:
-#   seed: 42
-#   base: 1500
-#   variance: 150
+
+population:
+  seed: 42
+  base: 1500
+  variance: 150
 
 # ── Stage 3: Demographics ─────────────────────────────────────────────────────
 # (populated by demographics-stage.ts once implemented)

--- a/game/web/src/pipeline/BUILD.bazel
+++ b/game/web/src/pipeline/BUILD.bazel
@@ -3,6 +3,8 @@ Bazel targets for the GAME-084 map generation pipeline.
 
   spec_types_lib        — spec-types.ts (YAML pipeline spec TypeScript types)
   terrain_generator_lib — terrain-generator.ts (Stage 1: hex grid + terrain + rivers)
+  prng_lib              — prng.ts (seeded mulberry32 PRNG, shared across stages)
+  population_stage_lib  — population-stage.ts (Stage 2: per-precinct total_population)
 """
 
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
@@ -70,6 +72,101 @@ js_test(
     entry_point = "terrain-generator_test.js",
     data = [
         ":terrain_generator_test_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# ── prng_lib: seeded mulberry32 PRNG, shared across pipeline stages ───────────
+
+ts_project(
+    name = "prng_lib",
+    srcs = ["prng.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    visibility = ["//game/web:__subpackages__"],
+)
+
+build_test(
+    name = "prng_typecheck_test",
+    targets = [":prng_lib"],
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "prng_test_lib",
+    srcs = ["prng_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":prng_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+js_test(
+    name = "prng_test",
+    entry_point = "prng_test.js",
+    data = [
+        ":prng_test_lib",
+        ":prng_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# ── population_stage_lib: Stage 2 — per-precinct total_population ─────────────
+
+ts_project(
+    name = "population_stage_lib",
+    srcs = ["population-stage.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":prng_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+    ],
+    visibility = ["//game/web:__subpackages__"],
+)
+
+build_test(
+    name = "population_stage_typecheck_test",
+    targets = [":population_stage_lib"],
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "population_stage_test_lib",
+    srcs = ["population-stage_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":population_stage_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+js_test(
+    name = "population_stage_test",
+    entry_point = "population-stage_test.js",
+    data = [
+        ":population_stage_test_lib",
+        ":population_stage_lib",
         ":terrain_generator_lib",
         ":spec_types_lib",
         "//game/web/src/model:model_lib",

--- a/game/web/src/pipeline/population-stage.ts
+++ b/game/web/src/pipeline/population-stage.ts
@@ -1,0 +1,28 @@
+/**
+ * Stage 2 of the GAME-084 map generation pipeline: population stage.
+ *
+ * Takes a PartialScenario (from the terrain generator) and a PopulationSpec,
+ * and assigns a deterministic integer total_population to every precinct.
+ *
+ * Semantics:
+ *   - Always overwrites any existing total_population (spec is source of truth).
+ *   - Population = base + prng.nextInt(-variance, variance), evaluated once per
+ *     precinct in the order they appear in the precincts array.
+ *   - Outputs are integers; no fractional populations.
+ */
+
+import type { PartialScenario } from "../model/scenario.js";
+import type { PopulationSpec } from "./spec-types.js";
+import { makePrng } from "./prng.js";
+
+export function populateScenario(
+  partial: PartialScenario,
+  spec: PopulationSpec,
+): PartialScenario {
+  const prng = makePrng(spec.seed);
+  const precincts = partial.precincts.map(p => ({
+    ...p,
+    total_population: spec.base + prng.nextInt(-spec.variance, spec.variance),
+  }));
+  return { ...partial, precincts };
+}

--- a/game/web/src/pipeline/population-stage_test.ts
+++ b/game/web/src/pipeline/population-stage_test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the population stage (GAME-084 Stage 2 pipeline).
+ *
+ * Covers:
+ *   - All precincts receive total_population
+ *   - Values are integers in [base - variance, base + variance]
+ *   - Determinism: same spec → same output
+ *   - Overwrite semantics: existing total_population is replaced
+ *   - Input PartialScenario is not mutated
+ *   - Different seeds → different populations
+ *
+ * Run via Bazel: bazel test //game/web/src/pipeline:population_stage_test
+ */
+
+import { populateScenario } from "./population-stage.js";
+import { generateTerrain } from "./terrain-generator.js";
+import type { PipelineSpec, PopulationSpec } from "./spec-types.js";
+import type { PartialScenario } from "../model/scenario.js";
+import {
+  test,
+  assertEqual,
+  summarize,
+} from "../testing/test_runner.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function minimalTerrainSpec(radius: number): PipelineSpec {
+  return {
+    format_version: "1",
+    scenario: {
+      id: "test-001",
+      title: "Test",
+      election_type: "congressional",
+      region: { id: "r1", name: "Test Region" },
+    },
+    map: { geometry: "hex_axial", shape: "hex_circle", radius },
+  };
+}
+
+function basePopSpec(overrides: Partial<PopulationSpec> = {}): PopulationSpec {
+  return { seed: 42, base: 1000, variance: 100, ...overrides };
+}
+
+function makePartial(radius: number): PartialScenario {
+  return generateTerrain(minimalTerrainSpec(radius));
+}
+
+// ─── Basic population assignment ──────────────────────────────────────────────
+
+test("populateScenario: all precincts receive total_population", () => {
+  const partial = makePartial(3);
+  const result = populateScenario(partial, basePopSpec());
+  assertEqual(result.precincts.every(p => p.total_population !== undefined), true);
+});
+
+test("populateScenario: precinct count is unchanged", () => {
+  const partial = makePartial(5);
+  const result = populateScenario(partial, basePopSpec());
+  assertEqual(result.precincts.length, partial.precincts.length);
+});
+
+test("populateScenario: total_population values are integers", () => {
+  const partial = makePartial(2);
+  const result = populateScenario(partial, basePopSpec());
+  for (const p of result.precincts) {
+    assertEqual(Number.isInteger(p.total_population!), true);
+  }
+});
+
+test("populateScenario: total_population within [base - variance, base + variance]", () => {
+  const spec = basePopSpec({ base: 1500, variance: 150 });
+  const partial = makePartial(5);
+  const result = populateScenario(partial, spec);
+  for (const p of result.precincts) {
+    assertEqual(p.total_population! >= 1350, true);
+    assertEqual(p.total_population! <= 1650, true);
+  }
+});
+
+// ─── Determinism ──────────────────────────────────────────────────────────────
+
+test("populateScenario: same spec produces same populations", () => {
+  const partial = makePartial(3);
+  const spec = basePopSpec({ seed: 7 });
+  const a = populateScenario(partial, spec);
+  const b = populateScenario(partial, spec);
+  const aVals = a.precincts.map(p => p.total_population);
+  const bVals = b.precincts.map(p => p.total_population);
+  for (let i = 0; i < aVals.length; i++) {
+    assertEqual(aVals[i], bVals[i]);
+  }
+});
+
+test("populateScenario: different seeds produce different populations", () => {
+  const partial = makePartial(5);
+  const a = populateScenario(partial, basePopSpec({ seed: 1 }));
+  const b = populateScenario(partial, basePopSpec({ seed: 2 }));
+  const aVals = a.precincts.map(p => p.total_population);
+  const bVals = b.precincts.map(p => p.total_population);
+  const anyDiff = aVals.some((v, i) => v !== bVals[i]);
+  assertEqual(anyDiff, true);
+});
+
+// ─── Overwrite semantics ──────────────────────────────────────────────────────
+
+test("populateScenario: overwrites existing total_population", () => {
+  const partial = makePartial(1);
+  // Pre-populate with sentinel value 99999
+  const prePopulated: PartialScenario = {
+    ...partial,
+    precincts: partial.precincts.map(p => ({ ...p, total_population: 99999 })),
+  };
+  const result = populateScenario(prePopulated, basePopSpec());
+  // All sentinels should be gone
+  assertEqual(result.precincts.every(p => p.total_population !== 99999), true);
+});
+
+// ─── Immutability ─────────────────────────────────────────────────────────────
+
+test("populateScenario: does not mutate input PartialScenario", () => {
+  const partial = makePartial(2);
+  // Snapshot IDs and positions before
+  const beforeIds = partial.precincts.map(p => p.id);
+  populateScenario(partial, basePopSpec());
+  // Original precincts unchanged
+  for (let i = 0; i < beforeIds.length; i++) {
+    assertEqual(partial.precincts[i]!.id, beforeIds[i]);
+    assertEqual(partial.precincts[i]!.total_population, undefined);
+  }
+});
+
+// ─── Metadata passthrough ─────────────────────────────────────────────────────
+
+test("populateScenario: metadata fields are preserved unchanged", () => {
+  const partial = makePartial(1);
+  const result = populateScenario(partial, basePopSpec());
+  assertEqual(result.format_version, partial.format_version);
+  assertEqual(result.id, partial.id);
+  assertEqual(result.title, partial.title);
+  assertEqual(result.election_type, partial.election_type);
+  assertEqual(result.geometry.type, partial.geometry.type);
+});
+
+summarize();

--- a/game/web/src/pipeline/prng.ts
+++ b/game/web/src/pipeline/prng.ts
@@ -1,0 +1,33 @@
+/**
+ * Seeded deterministic PRNG (mulberry32) for the GAME-084 pipeline.
+ *
+ * Used by population-stage and demographics-stage so that any pipeline run
+ * with the same spec produces the exact same scenario JSON.
+ */
+
+export interface Prng {
+  /** Returns a float in [min, max). */
+  nextDouble(min: number, max: number): number;
+  /** Returns an integer in [min, max] (both endpoints inclusive). */
+  nextInt(min: number, max: number): number;
+}
+
+export function makePrng(seed: number): Prng {
+  let s = seed >>> 0;
+
+  function next(): number {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  return {
+    nextDouble(min: number, max: number): number {
+      return min + next() * (max - min);
+    },
+    nextInt(min: number, max: number): number {
+      return Math.floor(min + next() * (max - min + 1));
+    },
+  };
+}

--- a/game/web/src/pipeline/prng_test.ts
+++ b/game/web/src/pipeline/prng_test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the mulberry32 PRNG (prng.ts).
+ *
+ * Covers:
+ *   - Determinism: same seed → same sequence
+ *   - Independence: different seeds → different sequences
+ *   - nextDouble: values in [min, max)
+ *   - nextInt: integer outputs in [min, max]
+ *   - Sequence advances: successive calls differ
+ *
+ * Run via Bazel: bazel test //game/web/src/pipeline:prng_test
+ */
+
+import { makePrng } from "./prng.js";
+import {
+  test,
+  assertEqual,
+  summarize,
+} from "../testing/test_runner.js";
+
+// ─── Determinism ──────────────────────────────────────────────────────────────
+
+test("prng: same seed produces same sequence", () => {
+  const a = makePrng(42);
+  const b = makePrng(42);
+  for (let i = 0; i < 20; i++) {
+    assertEqual(a.nextDouble(0, 1), b.nextDouble(0, 1));
+  }
+});
+
+test("prng: different seeds produce different sequences", () => {
+  const a = makePrng(42);
+  const b = makePrng(99);
+  let allSame = true;
+  for (let i = 0; i < 10; i++) {
+    if (a.nextDouble(0, 1) !== b.nextDouble(0, 1)) { allSame = false; break; }
+  }
+  assertEqual(allSame, false);
+});
+
+test("prng: seed 0 is valid and deterministic", () => {
+  const a = makePrng(0);
+  const b = makePrng(0);
+  assertEqual(a.nextDouble(0, 1), b.nextDouble(0, 1));
+});
+
+// ─── Sequence advancement ─────────────────────────────────────────────────────
+
+test("prng: successive nextDouble calls return distinct values", () => {
+  const prng = makePrng(1);
+  const v1 = prng.nextDouble(0, 1);
+  const v2 = prng.nextDouble(0, 1);
+  assertEqual(v1 !== v2, true);
+});
+
+test("prng: nextInt and nextDouble advance the same state", () => {
+  // Two PRNGs with same seed; one mixes nextInt+nextDouble, the other doesn't.
+  // They should diverge after the first mixed call.
+  const a = makePrng(7);
+  const b = makePrng(7);
+  a.nextInt(0, 10);      // consumes one draw from a
+  b.nextDouble(0, 1);    // consumes one draw from b — same underlying call
+  // Next draw should match since both consumed one step
+  assertEqual(a.nextDouble(0, 1), b.nextDouble(0, 1));
+});
+
+// ─── nextDouble range ─────────────────────────────────────────────────────────
+
+test("prng: nextDouble returns values in [min, max)", () => {
+  const prng = makePrng(12345);
+  const min = 10;
+  const max = 20;
+  for (let i = 0; i < 1000; i++) {
+    const v = prng.nextDouble(min, max);
+    assertEqual(v >= min, true);
+    assertEqual(v < max, true);
+  }
+});
+
+test("prng: nextDouble respects negative range", () => {
+  const prng = makePrng(999);
+  for (let i = 0; i < 100; i++) {
+    const v = prng.nextDouble(-5, -1);
+    assertEqual(v >= -5, true);
+    assertEqual(v < -1, true);
+  }
+});
+
+// ─── nextInt range and integrality ────────────────────────────────────────────
+
+test("prng: nextInt returns integers", () => {
+  const prng = makePrng(17);
+  for (let i = 0; i < 100; i++) {
+    const v = prng.nextInt(-150, 150);
+    assertEqual(Number.isInteger(v), true);
+  }
+});
+
+test("prng: nextInt stays within [min, max] inclusive", () => {
+  const prng = makePrng(37);
+  const min = -150;
+  const max = 150;
+  for (let i = 0; i < 1000; i++) {
+    const v = prng.nextInt(min, max);
+    assertEqual(v >= min, true);
+    assertEqual(v <= max, true);
+  }
+});
+
+test("prng: nextInt with symmetric range produces both extremes over many draws", () => {
+  // With 10,000 draws in [-10, 10], both endpoints should appear.
+  const prng = makePrng(555);
+  let sawMin = false;
+  let sawMax = false;
+  for (let i = 0; i < 10000; i++) {
+    const v = prng.nextInt(-10, 10);
+    if (v === -10) sawMin = true;
+    if (v === 10) sawMax = true;
+    if (sawMin && sawMax) break;
+  }
+  assertEqual(sawMin, true);
+  assertEqual(sawMax, true);
+});
+
+test("prng: nextInt with single-value range always returns that value", () => {
+  const prng = makePrng(1);
+  for (let i = 0; i < 10; i++) {
+    assertEqual(prng.nextInt(5, 5), 5);
+  }
+});
+
+summarize();

--- a/game/web/src/pipeline/spec-types.ts
+++ b/game/web/src/pipeline/spec-types.ts
@@ -55,6 +55,17 @@ export interface TerrainSpec {
   river_edges?: [HexPos, HexPos][];
 }
 
+// ─── Stage 2: Population ─────────────────────────────────────────────────────
+
+export interface PopulationSpec {
+  /** Seed for the deterministic PRNG used to generate per-precinct populations. */
+  seed: number;
+  /** Base population per precinct before random variance is applied. */
+  base: number;
+  /** Maximum +/- deviation from base (uniform distribution, integer output). */
+  variance: number;
+}
+
 // ─── Pipeline spec (full file) ────────────────────────────────────────────────
 
 export interface PipelineSpec {
@@ -62,5 +73,6 @@ export interface PipelineSpec {
   scenario: ScenarioMetaSpec;
   map: MapSpec;
   terrain?: TerrainSpec;
-  // population, demographics, assembly sections added in later stages
+  population?: PopulationSpec;
+  // demographics, assembly sections added in later stages
 }


### PR DESCRIPTION
## Summary

- Implements AC3 of GAME-084: per-precinct population generation using a seeded PRNG
- Adds `mulberry32` PRNG (`prng.ts`) as a shared deterministic random number generator for all pipeline stages — contract locked in with 11 dedicated tests
- Adds `populateScenario` (`population-stage.ts`): given a `PartialScenario` and a `PopulationSpec`, assigns integer `total_population` to every precinct; always overwrites existing values (spec is source of truth)
- Extends `spec-types.ts` with `PopulationSpec` and wires it into `PipelineSpec.population`
- Activates the population section in `game/scenarios/scenario-002.spec.yaml` (seed=42, base=1500, variance=150)

## Affected machines / services

- No runtime change: all new code is in the pipeline library, not loaded by the game at runtime
- `scenario-002.spec.yaml` updated; the generated JSON will be regenerated in a later stage (AC5)

## Validation performed

- `bazel test //game/web/src/pipeline:prng_test` — 11 tests PASS
- `bazel test //game/web/src/pipeline:population_stage_test` — 9 tests PASS
- `bazel test //game/web/src/pipeline:terrain_generator_test` — 21 tests PASS (no regression)
- TypeCheck build tests for all three new libraries pass

## Deployment steps

N/A — library code only; no deploy required.

## Tickets addressed

see #259 (GAME-084)

## Rollback

Revert this PR. No database or deployed state affected.
