### PR TITLE
feat(GAME-084): demographics stage — zone-based vote share generation [AC4]

### DIFF
--- a/game/scenarios/scenario-002.spec.yaml
+++ b/game/scenarios/scenario-002.spec.yaml
@@ -5,7 +5,7 @@
 # Stage completion:
 #   [x] Stage 1: map + terrain  (terrain-generator.ts)
 #   [x] Stage 2: population     (population-stage.ts)
-#   [ ] Stage 3: demographics   (demographics-stage.ts — not yet implemented)
+#   [x] Stage 3: demographics   (demographics-stage.ts)
 #   [ ] Stage 4: assembly       (assembler.ts — not yet implemented)
 
 format_version: "1"
@@ -42,34 +42,34 @@ population:
   variance: 150
 
 # ── Stage 3: Demographics ─────────────────────────────────────────────────────
-# (populated by demographics-stage.ts once implemented)
-#
-# demographics:
-#   seed: 42
-#   group:
-#     id_suffix: all
-#     name: All voters
-#   turnout:
-#     min: 0.55
-#     max: 0.70
-#   jitter: 0.04
-#   zones:
-#     - name: west
-#       filter: { q_lte: 0 }
-#       party_base: { ken: 0.62 }
-#     - name: inner_east
-#       filter: { q_gte: 1, hex_dist_lte: 3 }
-#       party_base: { ken: 0.25 }
-#     - name: outer_east
-#       filter: { default: true }
-#       party_base: { ken: 0.52 }
-#   county_labels:
-#     - id: clearwater_west
-#       filter: { q_lte: 0 }
-#     - id: clearwater_east
-#       filter: { q_gte: 1, hex_dist_lte: 3 }
-#     - id: clearwater_central
-#       filter: { default: true }
+
+demographics:
+  seed: 42
+  parties: [ken, ryu]
+  group:
+    id_suffix: all
+    name: All voters
+  turnout:
+    min: 0.55
+    max: 0.70
+  jitter: 0.04
+  zones:
+    - name: west
+      filter: { q_lte: 0 }
+      party_base: { ken: 0.62 }
+    - name: inner_east
+      filter: { q_gte: 1, hex_dist_lte: 3 }
+      party_base: { ken: 0.25 }
+    - name: outer_east
+      filter: { default: true }
+      party_base: { ken: 0.52 }
+  county_labels:
+    - id: clearwater_west
+      filter: { q_lte: 0 }
+    - id: clearwater_east
+      filter: { q_gte: 1, hex_dist_lte: 3 }
+    - id: clearwater_central
+      filter: { default: true }
 
 # ── Stage 4: Assembly ─────────────────────────────────────────────────────────
 # (populated by assembler.ts once implemented)

--- a/game/web/src/pipeline/BUILD.bazel
+++ b/game/web/src/pipeline/BUILD.bazel
@@ -1,10 +1,11 @@
 """
 Bazel targets for the GAME-084 map generation pipeline.
 
-  spec_types_lib        — spec-types.ts (YAML pipeline spec TypeScript types)
-  terrain_generator_lib — terrain-generator.ts (Stage 1: hex grid + terrain + rivers)
-  prng_lib              — prng.ts (seeded mulberry32 PRNG, shared across stages)
-  population_stage_lib  — population-stage.ts (Stage 2: per-precinct total_population)
+  spec_types_lib         — spec-types.ts (YAML pipeline spec TypeScript types)
+  terrain_generator_lib  — terrain-generator.ts (Stage 1: hex grid + terrain + rivers)
+  prng_lib               — prng.ts (seeded mulberry32 PRNG, shared across stages)
+  population_stage_lib   — population-stage.ts (Stage 2: per-precinct total_population)
+  demographics_stage_lib — demographics-stage.ts (Stage 3: zone-based vote share generation)
 """
 
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
@@ -167,6 +168,59 @@ js_test(
     data = [
         ":population_stage_test_lib",
         ":population_stage_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# ── demographics_stage_lib: Stage 3 — zone-based vote share generation ────────
+
+ts_project(
+    name = "demographics_stage_lib",
+    srcs = ["demographics-stage.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":prng_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+    ],
+    visibility = ["//game/web:__subpackages__"],
+)
+
+build_test(
+    name = "demographics_stage_typecheck_test",
+    targets = [":demographics_stage_lib"],
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "demographics_stage_test_lib",
+    srcs = ["demographics-stage_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":demographics_stage_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+js_test(
+    name = "demographics_stage_test",
+    entry_point = "demographics-stage_test.js",
+    data = [
+        ":demographics_stage_test_lib",
+        ":demographics_stage_lib",
         ":terrain_generator_lib",
         ":spec_types_lib",
         "//game/web/src/model:model_lib",

--- a/game/web/src/pipeline/demographics-stage.ts
+++ b/game/web/src/pipeline/demographics-stage.ts
@@ -1,0 +1,80 @@
+import type { PartialScenario } from "../model/scenario.js";
+import type { GroupId, PartyId } from "../model/scenario.js";
+import type { DemographicsSpec, ZoneFilter, CountyLabelSpec } from "./spec-types.js";
+import { makePrng } from "./prng.js";
+
+function hexDist(q: number, r: number): number {
+  const s = -q - r;
+  return (Math.abs(q) + Math.abs(r) + Math.abs(s)) / 2;
+}
+
+function matchesFilter(filter: ZoneFilter, q: number, r: number): boolean {
+  if (filter.default) return true;
+  if (filter.q_lte !== undefined && q > filter.q_lte) return false;
+  if (filter.q_gte !== undefined && q < filter.q_gte) return false;
+  if (filter.hex_dist_lte !== undefined && hexDist(q, r) > filter.hex_dist_lte) return false;
+  return true;
+}
+
+export function addDemographics(
+  partial: PartialScenario,
+  spec: DemographicsSpec,
+): PartialScenario {
+  const prng = makePrng(spec.seed);
+  const primaryParty = spec.parties[0] as PartyId;
+  const secondaryParty = spec.parties[1] as PartyId;
+
+  const precincts = partial.precincts.map(p => {
+    const pos = p.position;
+    if (!("q" in pos)) throw new Error(`Precinct ${p.id} has no hex position`);
+    const { q, r } = pos;
+
+    const zone = spec.zones.find(z => matchesFilter(z.filter, q, r));
+    if (!zone) throw new Error(`No zone matched precinct ${p.id} at q=${q} r=${r}`);
+
+    const rawJitter = prng.nextDouble(-spec.jitter, spec.jitter);
+    const primaryBase = zone.party_base[primaryParty] ?? 0;
+    const primaryShare = Math.min(1, Math.max(0, primaryBase + rawJitter));
+    const secondaryShare = 1 - primaryShare;
+
+    const turnout = prng.nextDouble(spec.turnout.min, spec.turnout.max);
+
+    const groupId = `${p.id}-${spec.group.id_suffix}` as GroupId;
+
+    return {
+      ...p,
+      demographic_groups: [
+        {
+          id: groupId,
+          ...(spec.group.name !== undefined ? { name: spec.group.name } : {}),
+          population_share: 1.0,
+          vote_shares: {
+            [primaryParty]: primaryShare,
+            [secondaryParty]: secondaryShare,
+          } as Record<PartyId, number>,
+          turnout_rate: turnout,
+        },
+      ],
+    };
+  });
+
+  return { ...partial, precincts };
+}
+
+export function assignCounties(
+  partial: PartialScenario,
+  countyLabels: CountyLabelSpec[],
+): PartialScenario {
+  const precincts = partial.precincts.map(p => {
+    const pos = p.position;
+    if (!("q" in pos)) throw new Error(`Precinct ${p.id} has no hex position`);
+    const { q, r } = pos;
+
+    const label = countyLabels.find(cl => matchesFilter(cl.filter, q, r));
+    if (!label) throw new Error(`No county label matched precinct ${p.id} at q=${q} r=${r}`);
+
+    return { ...p, county_id: label.id };
+  });
+
+  return { ...partial, precincts };
+}

--- a/game/web/src/pipeline/demographics-stage_test.ts
+++ b/game/web/src/pipeline/demographics-stage_test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for the demographics stage (GAME-084 Stage 3 pipeline).
+ *
+ * Covers:
+ *   addDemographics:
+ *   - All precincts get a demographic_groups array with one group
+ *   - Group ID format: "<precinct_id>-<id_suffix>"
+ *   - population_share is exactly 1.0
+ *   - vote_shares sum to 1.0 (primary + secondary = 1)
+ *   - Both party keys present in vote_shares
+ *   - Vote shares are in [0, 1]
+ *   - Turnout in [spec.turnout.min, spec.turnout.max]
+ *   - Zone matching: first-match-wins, ANDed filter conditions
+ *   - hex_dist_lte boundary (at boundary = match, just outside = no match)
+ *   - No-match throws
+ *   - Determinism: same spec → same output
+ *   - Different seeds → different outputs
+ *   - Input PartialScenario is not mutated
+ *   - Metadata fields are preserved
+ *   - group.name is propagated when present, absent when not
+ *
+ *   assignCounties:
+ *   - All precincts get county_id
+ *   - county_id matches expected zone
+ *   - No-match throws
+ *   - Input not mutated
+ *
+ * Run via Bazel: bazel test //game/web/src/pipeline:demographics_stage_test
+ */
+
+import { addDemographics, assignCounties } from "./demographics-stage.js";
+import { generateTerrain } from "./terrain-generator.js";
+import type { PipelineSpec, DemographicsSpec, CountyLabelSpec } from "./spec-types.js";
+import type { PartialScenario, PartialPrecinct, PartyId } from "../model/scenario.js";
+import type { HexAxialPosition } from "../model/scenario.js";
+import {
+  test,
+  assertEqual,
+  summarize,
+} from "../testing/test_runner.js";
+
+const KEN = "ken" as PartyId;
+const RYU = "ryu" as PartyId;
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function minimalTerrainSpec(radius: number): PipelineSpec {
+  return {
+    format_version: "1",
+    scenario: {
+      id: "test-demo",
+      title: "Test Demo",
+      election_type: "congressional",
+      region: { id: "r1", name: "Test Region" },
+    },
+    map: { geometry: "hex_axial", shape: "hex_circle", radius },
+  };
+}
+
+function makePartial(radius: number): PartialScenario {
+  return generateTerrain(minimalTerrainSpec(radius));
+}
+
+function baseDemoSpec(overrides: Partial<DemographicsSpec> = {}): DemographicsSpec {
+  return {
+    seed: 99,
+    parties: ["ken", "ryu"],
+    group: { id_suffix: "all", name: "All voters" },
+    turnout: { min: 0.55, max: 0.70 },
+    jitter: 0.04,
+    zones: [{ name: "all", filter: { default: true }, party_base: { ken: 0.55 } }],
+    ...overrides,
+  };
+}
+
+function hexPos(p: PartialPrecinct): HexAxialPosition {
+  const pos = p.position;
+  if (!("q" in pos)) throw new Error("Expected hex position");
+  return pos as HexAxialPosition;
+}
+
+// ─── Group structure ───────────────────────────────────────────────────────────
+
+test("addDemographics: all precincts get exactly one demographic group", () => {
+  const partial = makePartial(3);
+  const result = addDemographics(partial, baseDemoSpec());
+  for (const p of result.precincts) {
+    assertEqual(p.demographic_groups?.length, 1);
+  }
+});
+
+test("addDemographics: group ID format is <precinct_id>-<id_suffix>", () => {
+  const partial = makePartial(2);
+  const result = addDemographics(partial, baseDemoSpec({ group: { id_suffix: "all" } }));
+  for (const p of result.precincts) {
+    const group = p.demographic_groups![0]!;
+    assertEqual(group.id, `${p.id}-all`);
+  }
+});
+
+test("addDemographics: population_share is 1.0", () => {
+  const partial = makePartial(2);
+  const result = addDemographics(partial, baseDemoSpec());
+  for (const p of result.precincts) {
+    assertEqual(p.demographic_groups![0]!.population_share, 1.0);
+  }
+});
+
+test("addDemographics: vote_shares sum to 1.0", () => {
+  const partial = makePartial(3);
+  const result = addDemographics(partial, baseDemoSpec());
+  for (const p of result.precincts) {
+    const vs = p.demographic_groups![0]!.vote_shares;
+    const sum = (vs[KEN] ?? 0) + (vs[RYU] ?? 0);
+    // Floating-point: allow tiny epsilon
+    assertEqual(Math.abs(sum - 1.0) < 1e-10, true);
+  }
+});
+
+test("addDemographics: both party keys present in vote_shares", () => {
+  const partial = makePartial(2);
+  const result = addDemographics(partial, baseDemoSpec());
+  for (const p of result.precincts) {
+    const vs = p.demographic_groups![0]!.vote_shares;
+    assertEqual(KEN in vs, true);
+    assertEqual(RYU in vs, true);
+  }
+});
+
+test("addDemographics: vote_shares are in [0, 1]", () => {
+  // Use extreme jitter to stress clamping
+  const spec = baseDemoSpec({ jitter: 0.99, zones: [{ name: "a", filter: { default: true }, party_base: { ken: 0.5 } }] });
+  const partial = makePartial(3);
+  const result = addDemographics(partial, spec);
+  for (const p of result.precincts) {
+    const vs = p.demographic_groups![0]!.vote_shares;
+    assertEqual((vs[KEN] ?? -1) >= 0, true);
+    assertEqual((vs[KEN] ?? 2) <= 1, true);
+    assertEqual((vs[RYU] ?? -1) >= 0, true);
+    assertEqual((vs[RYU] ?? 2) <= 1, true);
+  }
+});
+
+test("addDemographics: turnout_rate within [min, max]", () => {
+  const spec = baseDemoSpec({ turnout: { min: 0.60, max: 0.65 } });
+  const partial = makePartial(3);
+  const result = addDemographics(partial, spec);
+  for (const p of result.precincts) {
+    const t = p.demographic_groups![0]!.turnout_rate;
+    assertEqual(t >= 0.60, true);
+    assertEqual(t <= 0.65, true);
+  }
+});
+
+// ─── group.name propagation ────────────────────────────────────────────────────
+
+test("addDemographics: group.name propagated when present", () => {
+  const spec = baseDemoSpec({ group: { id_suffix: "all", name: "All voters" } });
+  const partial = makePartial(1);
+  const result = addDemographics(partial, spec);
+  for (const p of result.precincts) {
+    assertEqual(p.demographic_groups![0]!.name, "All voters");
+  }
+});
+
+test("addDemographics: group.name absent when not in spec", () => {
+  const spec = baseDemoSpec({ group: { id_suffix: "all" } });
+  const partial = makePartial(1);
+  const result = addDemographics(partial, spec);
+  for (const p of result.precincts) {
+    assertEqual("name" in p.demographic_groups![0]!, false);
+  }
+});
+
+// ─── Zone matching ─────────────────────────────────────────────────────────────
+
+test("addDemographics: zone filter q_lte selects correct precincts", () => {
+  const spec = baseDemoSpec({
+    zones: [
+      { name: "west", filter: { q_lte: 0 }, party_base: { ken: 0.70 } },
+      { name: "east", filter: { default: true }, party_base: { ken: 0.30 } },
+    ],
+    jitter: 0, // no jitter so we can test exact party_base propagation
+    turnout: { min: 0.60, max: 0.60 },
+  });
+  const partial = makePartial(3);
+  const result = addDemographics(partial, spec);
+
+  for (const p of result.precincts) {
+    const { q } = hexPos(p);
+    const group = p.demographic_groups![0]!;
+    if (q <= 0) {
+      // west zone: ken ≈ 0.70
+      assertEqual(Math.abs((group.vote_shares[KEN] ?? 0) - 0.70) < 1e-10, true);
+    } else {
+      // east zone: ken ≈ 0.30
+      assertEqual(Math.abs((group.vote_shares[KEN] ?? 0) - 0.30) < 1e-10, true);
+    }
+  }
+});
+
+test("addDemographics: first-match-wins for overlapping zones", () => {
+  // q_lte: 2 matches any q <= 2; default matches all.
+  // First zone should win for q <= 2.
+  const spec = baseDemoSpec({
+    zones: [
+      { name: "first", filter: { q_lte: 2 }, party_base: { ken: 0.80 } },
+      { name: "second", filter: { default: true }, party_base: { ken: 0.20 } },
+    ],
+    jitter: 0,
+    turnout: { min: 0.60, max: 0.60 },
+    seed: 1,
+  });
+  const partial = makePartial(2);
+  const result = addDemographics(partial, spec);
+
+  for (const p of result.precincts) {
+    const { q } = hexPos(p);
+    const kenShare = p.demographic_groups![0]!.vote_shares[KEN] ?? 0;
+    if (q <= 2) {
+      assertEqual(Math.abs(kenShare - 0.80) < 1e-10, true);
+    } else {
+      assertEqual(Math.abs(kenShare - 0.20) < 1e-10, true);
+    }
+  }
+});
+
+test("addDemographics: ANDed filter conditions both must hold", () => {
+  // Zone matches q_gte: 0 AND hex_dist_lte: 2.
+  // Precincts with q >= 0 but hex_dist > 2 should fall through to default.
+  const spec = baseDemoSpec({
+    zones: [
+      { name: "inner_east", filter: { q_gte: 0, hex_dist_lte: 2 }, party_base: { ken: 0.90 } },
+      { name: "other", filter: { default: true }, party_base: { ken: 0.10 } },
+    ],
+    jitter: 0,
+    turnout: { min: 0.60, max: 0.60 },
+    seed: 5,
+  });
+  const partial = makePartial(3);
+  const result = addDemographics(partial, spec);
+
+  for (const p of result.precincts) {
+    const { q, r } = hexPos(p);
+    const s = -q - r;
+    const dist = (Math.abs(q) + Math.abs(r) + Math.abs(s)) / 2;
+    const kenShare = p.demographic_groups![0]!.vote_shares[KEN] ?? 0;
+    if (q >= 0 && dist <= 2) {
+      assertEqual(Math.abs(kenShare - 0.90) < 1e-10, true);
+    } else {
+      assertEqual(Math.abs(kenShare - 0.10) < 1e-10, true);
+    }
+  }
+});
+
+test("addDemographics: hex_dist_lte boundary — at distance matches, just outside does not", () => {
+  // Radius-3 grid: origin precinct has dist=0, precincts at ring 2 have dist=2.
+  // Zone1: hex_dist_lte: 2 → ken=0.90. Zone2: default → ken=0.10.
+  const spec = baseDemoSpec({
+    zones: [
+      { name: "inner", filter: { hex_dist_lte: 2 }, party_base: { ken: 0.90 } },
+      { name: "outer", filter: { default: true }, party_base: { ken: 0.10 } },
+    ],
+    jitter: 0,
+    turnout: { min: 0.60, max: 0.60 },
+  });
+  const partial = makePartial(3);
+  const result = addDemographics(partial, spec);
+
+  for (const p of result.precincts) {
+    const { q, r } = hexPos(p);
+    const s = -q - r;
+    const dist = (Math.abs(q) + Math.abs(r) + Math.abs(s)) / 2;
+    const kenShare = p.demographic_groups![0]!.vote_shares[KEN] ?? 0;
+    if (dist <= 2) {
+      assertEqual(Math.abs(kenShare - 0.90) < 1e-10, true);
+    } else {
+      assertEqual(Math.abs(kenShare - 0.10) < 1e-10, true);
+    }
+  }
+});
+
+test("addDemographics: throws when no zone matches a precinct", () => {
+  // Only zone matches q_lte: -10, no precinct in radius-1 grid has q <= -10.
+  const spec = baseDemoSpec({
+    zones: [{ name: "impossible", filter: { q_lte: -10 }, party_base: { ken: 0.5 } }],
+  });
+  const partial = makePartial(1);
+  let threw = false;
+  try {
+    addDemographics(partial, spec);
+  } catch {
+    threw = true;
+  }
+  assertEqual(threw, true);
+});
+
+// ─── Determinism ──────────────────────────────────────────────────────────────
+
+test("addDemographics: same spec produces same output", () => {
+  const partial = makePartial(3);
+  const spec = baseDemoSpec({ seed: 42 });
+  const a = addDemographics(partial, spec);
+  const b = addDemographics(partial, spec);
+  for (let i = 0; i < a.precincts.length; i++) {
+    const ga = a.precincts[i]!.demographic_groups![0]!;
+    const gb = b.precincts[i]!.demographic_groups![0]!;
+    assertEqual(ga.turnout_rate, gb.turnout_rate);
+    assertEqual(ga.vote_shares[KEN], gb.vote_shares[KEN]);
+  }
+});
+
+test("addDemographics: different seeds produce different outputs", () => {
+  const partial = makePartial(3);
+  const a = addDemographics(partial, baseDemoSpec({ seed: 1 }));
+  const b = addDemographics(partial, baseDemoSpec({ seed: 2 }));
+  const anyDiff = a.precincts.some((p, i) => {
+    const ga = p.demographic_groups![0]!;
+    const gb = b.precincts[i]!.demographic_groups![0]!;
+    return ga.turnout_rate !== gb.turnout_rate || ga.vote_shares[KEN] !== gb.vote_shares[KEN];
+  });
+  assertEqual(anyDiff, true);
+});
+
+// ─── Immutability ─────────────────────────────────────────────────────────────
+
+test("addDemographics: does not mutate input PartialScenario", () => {
+  const partial = makePartial(2);
+  const beforeIds = partial.precincts.map(p => p.id);
+  addDemographics(partial, baseDemoSpec());
+  for (let i = 0; i < beforeIds.length; i++) {
+    assertEqual(partial.precincts[i]!.id, beforeIds[i]);
+    assertEqual(partial.precincts[i]!.demographic_groups, undefined);
+  }
+});
+
+// ─── Metadata passthrough ─────────────────────────────────────────────────────
+
+test("addDemographics: metadata fields are preserved", () => {
+  const partial = makePartial(1);
+  const result = addDemographics(partial, baseDemoSpec());
+  assertEqual(result.format_version, partial.format_version);
+  assertEqual(result.id, partial.id);
+  assertEqual(result.title, partial.title);
+  assertEqual(result.election_type, partial.election_type);
+});
+
+// ─── assignCounties ────────────────────────────────────────────────────────────
+
+test("assignCounties: all precincts get a county_id", () => {
+  const partial = makePartial(3);
+  const labels: CountyLabelSpec[] = [
+    { id: "west_county", filter: { q_lte: 0 } },
+    { id: "east_county", filter: { default: true } },
+  ];
+  const result = assignCounties(partial, labels);
+  for (const p of result.precincts) {
+    assertEqual(typeof p.county_id, "string");
+  }
+});
+
+test("assignCounties: county_id matches expected zone for each precinct", () => {
+  const partial = makePartial(3);
+  const labels: CountyLabelSpec[] = [
+    { id: "west_county", filter: { q_lte: 0 } },
+    { id: "east_county", filter: { default: true } },
+  ];
+  const result = assignCounties(partial, labels);
+  for (const p of result.precincts) {
+    const { q } = hexPos(p);
+    const expectedId = q <= 0 ? "west_county" : "east_county";
+    assertEqual(p.county_id, expectedId);
+  }
+});
+
+test("assignCounties: throws when no label matches a precinct", () => {
+  const partial = makePartial(1);
+  const labels: CountyLabelSpec[] = [
+    { id: "impossible", filter: { q_lte: -10 } },
+  ];
+  let threw = false;
+  try {
+    assignCounties(partial, labels);
+  } catch {
+    threw = true;
+  }
+  assertEqual(threw, true);
+});
+
+test("assignCounties: does not mutate input PartialScenario", () => {
+  const partial = makePartial(2);
+  const beforeIds = partial.precincts.map(p => p.id);
+  const labels: CountyLabelSpec[] = [{ id: "all", filter: { default: true } }];
+  assignCounties(partial, labels);
+  for (let i = 0; i < beforeIds.length; i++) {
+    assertEqual(partial.precincts[i]!.id, beforeIds[i]);
+    assertEqual(partial.precincts[i]!.county_id, undefined);
+  }
+});
+
+summarize();

--- a/game/web/src/pipeline/spec-types.ts
+++ b/game/web/src/pipeline/spec-types.ts
@@ -66,6 +66,41 @@ export interface PopulationSpec {
   variance: number;
 }
 
+// ─── Stage 3: Demographics ────────────────────────────────────────────────────
+
+export interface ZoneFilter {
+  q_lte?: number;
+  q_gte?: number;
+  hex_dist_lte?: number;
+  default?: true;
+}
+
+export interface ZoneSpec {
+  name: string;
+  filter: ZoneFilter;
+  party_base: Record<string, number>;
+}
+
+export interface CountyLabelSpec {
+  id: string;
+  filter: ZoneFilter;
+}
+
+export interface DemographicsGroupSpec {
+  id_suffix: string;
+  name?: string;
+}
+
+export interface DemographicsSpec {
+  seed: number;
+  parties: string[];
+  group: DemographicsGroupSpec;
+  turnout: { min: number; max: number };
+  jitter: number;
+  zones: ZoneSpec[];
+  county_labels?: CountyLabelSpec[];
+}
+
 // ─── Pipeline spec (full file) ────────────────────────────────────────────────
 
 export interface PipelineSpec {
@@ -74,5 +109,6 @@ export interface PipelineSpec {
   map: MapSpec;
   terrain?: TerrainSpec;
   population?: PopulationSpec;
-  // demographics, assembly sections added in later stages
+  demographics?: DemographicsSpec;
+  // assembly section added in later stages
 }


### PR DESCRIPTION
## Summary

Implements GAME-084 AC4: Stage 3 (demographics) of the map generation pipeline.

- **`spec-types.ts`**: adds `ZoneFilter`, `ZoneSpec`, `CountyLabelSpec`, `DemographicsGroupSpec`, `DemographicsSpec`; updates `PipelineSpec` with `demographics?: DemographicsSpec`
- **`demographics-stage.ts`**: exports `addDemographics` (zone-based vote-share + turnout generation via seeded PRNG) and `assignCounties` (county label assignment); shared private `matchesFilter` helper with ANDed filter conditions, first-match-wins semantics, clamped jitter, two-party complement
- **`demographics-stage_test.ts`**: 19 tests covering group structure, vote_shares sum/bounds/keys, turnout range, group.name propagation, zone first-match-wins, ANDed filters, hex_dist_lte boundary, no-match throws, determinism, different-seeds diverge, immutability, metadata passthrough, assignCounties happy path + no-match throws + immutability
- **`BUILD.bazel`**: adds `demographics_stage_lib`, `demographics_stage_typecheck_test`, `demographics_stage_test_lib`, `demographics_stage_test`
- **`scenario-002.spec.yaml`**: uncomments demographics section (adds `parties: [ken, ryu]`, stage marked `[x]`)

All 8 pipeline tests pass (`bazel test //game/web/src/pipeline/...`).

see #259 (GAME-084 AC4)

## Affected machines / services

N/A — pipeline library code only; no deployed services changed.

## Validation performed

- `bazel test //game/web/src/pipeline/...` — all 8 tests pass (4 unit + 4 typecheck), including 19 new demographics tests
- `bazel build //game/web/src/pipeline:demographics_stage_typecheck_test` — type-checks clean

## Deployment steps

N/A — library change; deployed as part of next game build.

## Tickets addressed

- GAME-084 AC4 (demographics stage)

## Rollback

Revert this PR. No data migrations or external state affected.
