### PR TITLE
feat(GAME-084): pipeline orchestrator + generate-scenario CLI

### DIFF
--- a/game/web/src/model/BUILD.bazel
+++ b/game/web/src/model/BUILD.bazel
@@ -86,7 +86,7 @@ ts_project(
     tsconfig = ":tsconfig",
     declaration = True,
     deps = [":model_lib", ":runtime_types_lib"],
-    visibility = ["//game/web:__pkg__", "//game/web/src/model:__pkg__"],
+    visibility = ["//game/web:__subpackages__"],
 )
 
 # ── campaigns_lib: Campaign type + registry + last-played persistence ─────────

--- a/game/web/src/pipeline/BUILD.bazel
+++ b/game/web/src/pipeline/BUILD.bazel
@@ -7,10 +7,12 @@ Bazel targets for the GAME-084 map generation pipeline.
   population_stage_lib   — population-stage.ts (Stage 2: per-precinct total_population)
   demographics_stage_lib — demographics-stage.ts (Stage 3: zone-based vote share generation)
   assembler_lib          — assembler.ts (Stage 4: scenario assembly)
+  pipeline_runner_lib    — pipeline-runner.ts (orchestrates all four stages)
+  generate_scenario      — generate-scenario.ts (CLI: spec YAML → scenario JSON)
 """
 
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
-load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_test")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 ts_config(
@@ -285,6 +287,117 @@ js_test(
     ],
     node_options = [
         "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# ── pipeline_runner_lib: orchestrates all four stages ─────────────────────────
+
+ts_project(
+    name = "pipeline_runner_lib",
+    srcs = ["pipeline-runner.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":spec_types_lib",
+        ":terrain_generator_lib",
+        ":population_stage_lib",
+        ":demographics_stage_lib",
+        ":assembler_lib",
+        "//game/web/src/model:model_lib",
+    ],
+    visibility = ["//game/web:__subpackages__"],
+)
+
+build_test(
+    name = "pipeline_runner_typecheck_test",
+    targets = [":pipeline_runner_lib"],
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "pipeline_runner_test_lib",
+    srcs = ["pipeline-runner_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":pipeline_runner_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+js_test(
+    name = "pipeline_runner_test",
+    entry_point = "pipeline-runner_test.js",
+    data = [
+        ":pipeline_runner_test_lib",
+        ":pipeline_runner_lib",
+        ":assembler_lib",
+        ":demographics_stage_lib",
+        ":population_stage_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# ── tsconfig_cli: adds Node.js types for the generate-scenario CLI ────────────
+
+ts_config(
+    name = "tsconfig_cli",
+    src = "tsconfig.cli.json",
+    deps = [":tsconfig"],
+    visibility = ["//game/web/src/pipeline:__pkg__"],
+)
+
+# ── generate_scenario_lib: compile generate-scenario.ts ──────────────────────
+
+ts_project(
+    name = "generate_scenario_lib",
+    srcs = ["generate-scenario.ts"],
+    tsconfig = ":tsconfig_cli",
+    declaration = True,
+    deps = [
+        ":pipeline_runner_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:loader_lib",
+        "//game:node_modules/yaml",
+        "//game:node_modules/@types/node",
+    ],
+    visibility = ["//game/web/src/pipeline:__pkg__"],
+)
+
+build_test(
+    name = "generate_scenario_typecheck_test",
+    targets = [":generate_scenario_lib"],
+    visibility = ["//visibility:public"],
+)
+
+# ── generate_scenario: CLI binary (bazel run //game/web/src/pipeline:generate_scenario) ──
+
+js_binary(
+    name = "generate_scenario",
+    entry_point = "generate-scenario.js",
+    data = [
+        ":generate_scenario_lib",
+        ":pipeline_runner_lib",
+        ":assembler_lib",
+        ":demographics_stage_lib",
+        ":population_stage_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:loader_lib",
+        "//game/web/src/model:model_lib",
+        "//game:node_modules/yaml",
+        "//game:node_modules/@types/node",
     ],
     visibility = ["//visibility:public"],
 )

--- a/game/web/src/pipeline/generate-scenario.ts
+++ b/game/web/src/pipeline/generate-scenario.ts
@@ -1,0 +1,48 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { runPipeline } from "./pipeline-runner.js";
+import { parseScenario, validateScenarioComplete } from "../model/loader.js";
+import type { PipelineSpec } from "./spec-types.js";
+
+const workspaceDir = process.env["BUILD_WORKSPACE_DIRECTORY"] ?? process.cwd();
+
+function resolvePath(p: string): string {
+  return path.isAbsolute(p) ? p : path.resolve(workspaceDir, p);
+}
+
+const args = process.argv.slice(2);
+if (args.length < 1) {
+  console.error("Usage: generate-scenario <spec-file.spec.yaml> [output.json]");
+  process.exit(1);
+}
+
+const specPath = resolvePath(args[0]!);
+
+let outputPath: string;
+if (args[1] !== undefined) {
+  outputPath = resolvePath(args[1]);
+} else {
+  const derived = specPath.replace(/\.spec\.yaml$/, ".json");
+  if (derived === specPath) {
+    console.error(`Error: spec path does not end in .spec.yaml; provide an explicit output path.`);
+    process.exit(1);
+  }
+  outputPath = derived;
+}
+
+const raw = fs.readFileSync(specPath, "utf-8");
+const spec = parseYaml(raw) as PipelineSpec;
+
+const partial = runPipeline(spec);
+
+const parsed = parseScenario(partial);
+const result = validateScenarioComplete(parsed);
+
+const outDir = path.dirname(outputPath);
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir, { recursive: true });
+}
+
+fs.writeFileSync(outputPath, JSON.stringify(result, null, 2) + "\n", "utf-8");
+console.log(`Written: ${outputPath}`);

--- a/game/web/src/pipeline/pipeline-runner.ts
+++ b/game/web/src/pipeline/pipeline-runner.ts
@@ -1,0 +1,27 @@
+import { generateTerrain } from "./terrain-generator.js";
+import { populateScenario } from "./population-stage.js";
+import { addDemographics, assignCounties } from "./demographics-stage.js";
+import { assembleScenario } from "./assembler.js";
+import type { PartialScenario } from "../model/scenario.js";
+import type { PipelineSpec } from "./spec-types.js";
+
+export function runPipeline(spec: PipelineSpec): PartialScenario {
+  let partial = generateTerrain(spec);
+
+  if (spec.population) {
+    partial = populateScenario(partial, spec.population);
+  }
+
+  if (spec.demographics) {
+    partial = addDemographics(partial, spec.demographics);
+    if (spec.demographics.county_labels && spec.demographics.county_labels.length > 0) {
+      partial = assignCounties(partial, spec.demographics.county_labels);
+    }
+  }
+
+  if (spec.assembly) {
+    partial = assembleScenario(partial, spec.assembly);
+  }
+
+  return partial;
+}

--- a/game/web/src/pipeline/pipeline-runner_test.ts
+++ b/game/web/src/pipeline/pipeline-runner_test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the pipeline runner (GAME-084 wiring — all stages).
+ *
+ * Covers:
+ *   runPipeline:
+ *   - all four stages present → output has populated fields from each stage
+ *   - population absent → precincts have no total_population
+ *   - demographics absent → precincts have no demographic_groups
+ *   - assembly absent → scenario has no parties or districts
+ *   - demographics.county_labels absent → precincts have no county_id
+ *   - demographics.county_labels empty → precincts have no county_id (no throw)
+ *
+ * Run via Bazel: bazel test //game/web/src/pipeline:pipeline_runner_test
+ */
+
+import { runPipeline } from "./pipeline-runner.js";
+import type { PipelineSpec } from "./spec-types.js";
+import {
+  test,
+  assertEqual,
+  summarize,
+} from "../testing/test_runner.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function baseSpec(): PipelineSpec {
+  return {
+    format_version: "1",
+    scenario: {
+      id: "test-pipeline",
+      title: "Pipeline Runner Test",
+      election_type: "state_house",
+      region: { id: "r1", name: "Test Region" },
+    },
+    map: { geometry: "hex_axial", shape: "hex_circle", radius: 2 },
+  };
+}
+
+function withAllStages(): PipelineSpec {
+  return {
+    ...baseSpec(),
+    population: { seed: 1, base: 1000, variance: 0 },
+    demographics: {
+      seed: 1,
+      parties: ["ken", "ryu"],
+      group: { id_suffix: "all" },
+      turnout: { min: 0.6, max: 0.7 },
+      jitter: 0.0,
+      zones: [{ name: "all", filter: { default: true }, party_base: { ken: 0.55 } }],
+      county_labels: [
+        { id: "region_west", filter: { q_lte: 0 } },
+        { id: "region_east", filter: { default: true } },
+      ],
+    },
+    assembly: {
+      parties: [
+        { id: "ken", name: "Ken Party", abbreviation: "KEN" },
+        { id: "ryu", name: "Ryu Party", abbreviation: "RYU" },
+      ],
+      districts: [
+        { id: "d1", name: "District 1" },
+        { id: "d2", name: "District 2" },
+      ],
+      rules: { population_tolerance: 0.10, contiguity: "required" },
+      initial_district_rule: {
+        type: "diagonal_strip",
+        strips: [
+          { max_k: 0, district: "d1" },
+          { default: true, district: "d2" },
+        ],
+      },
+      success_criteria: [
+        {
+          id: "sc1",
+          required: true,
+          description: "All districts in use.",
+          criterion: { type: "district_count" },
+        },
+      ],
+      narrative: {
+        character: { name: "You", role: "Strategist", motivation: "Win." },
+        intro_slides: [{ body: "Welcome." }],
+        objective: "Draw fair districts.",
+      },
+    },
+  };
+}
+
+// ─── All stages present ────────────────────────────────────────────────────────
+
+test("runPipeline: all stages present — precincts have total_population", () => {
+  const result = runPipeline(withAllStages());
+  for (const p of result.precincts) {
+    assertEqual(typeof p.total_population, "number");
+  }
+});
+
+test("runPipeline: all stages present — precincts have demographic_groups", () => {
+  const result = runPipeline(withAllStages());
+  for (const p of result.precincts) {
+    assertEqual((p.demographic_groups?.length ?? 0) > 0, true);
+  }
+});
+
+test("runPipeline: all stages present — precincts have county_id", () => {
+  const result = runPipeline(withAllStages());
+  for (const p of result.precincts) {
+    assertEqual(typeof p.county_id, "string");
+  }
+});
+
+test("runPipeline: all stages present — scenario has parties and districts", () => {
+  const result = runPipeline(withAllStages());
+  assertEqual((result.parties?.length ?? 0) > 0, true);
+  assertEqual((result.districts?.length ?? 0) > 0, true);
+});
+
+test("runPipeline: all stages present — precincts have initial_district_id", () => {
+  const result = runPipeline(withAllStages());
+  for (const p of result.precincts) {
+    assertEqual(typeof p.initial_district_id, "string");
+  }
+});
+
+// ─── Absent stages ────────────────────────────────────────────────────────────
+
+test("runPipeline: population absent — precincts have no total_population", () => {
+  const spec: PipelineSpec = { ...baseSpec() };
+  const result = runPipeline(spec);
+  for (const p of result.precincts) {
+    assertEqual(p.total_population, undefined);
+  }
+});
+
+test("runPipeline: demographics absent — precincts have no demographic_groups", () => {
+  const spec: PipelineSpec = {
+    ...baseSpec(),
+    population: { seed: 1, base: 1000, variance: 0 },
+  };
+  const result = runPipeline(spec);
+  for (const p of result.precincts) {
+    assertEqual(p.demographic_groups, undefined);
+  }
+});
+
+test("runPipeline: assembly absent — scenario has no parties", () => {
+  const spec: PipelineSpec = {
+    ...baseSpec(),
+    population: { seed: 1, base: 1000, variance: 0 },
+    demographics: {
+      seed: 1,
+      parties: ["ken", "ryu"],
+      group: { id_suffix: "all" },
+      turnout: { min: 0.6, max: 0.7 },
+      jitter: 0.0,
+      zones: [{ name: "all", filter: { default: true }, party_base: { ken: 0.55 } }],
+    },
+  };
+  const result = runPipeline(spec);
+  assertEqual(result.parties, undefined);
+  assertEqual(result.districts, undefined);
+});
+
+test("runPipeline: county_labels absent — precincts have no county_id", () => {
+  const spec: PipelineSpec = {
+    ...baseSpec(),
+    demographics: {
+      seed: 1,
+      parties: ["ken", "ryu"],
+      group: { id_suffix: "all" },
+      turnout: { min: 0.6, max: 0.7 },
+      jitter: 0.0,
+      zones: [{ name: "all", filter: { default: true }, party_base: { ken: 0.55 } }],
+    },
+  };
+  const result = runPipeline(spec);
+  for (const p of result.precincts) {
+    assertEqual(p.county_id, undefined);
+  }
+});
+
+test("runPipeline: county_labels empty array — precincts have no county_id, no throw", () => {
+  const spec: PipelineSpec = {
+    ...baseSpec(),
+    demographics: {
+      seed: 1,
+      parties: ["ken", "ryu"],
+      group: { id_suffix: "all" },
+      turnout: { min: 0.6, max: 0.7 },
+      jitter: 0.0,
+      zones: [{ name: "all", filter: { default: true }, party_base: { ken: 0.55 } }],
+      county_labels: [],
+    },
+  };
+  const result = runPipeline(spec);
+  for (const p of result.precincts) {
+    assertEqual(p.county_id, undefined);
+  }
+});
+
+summarize();

--- a/game/web/src/pipeline/tsconfig.cli.json
+++ b/game/web/src/pipeline/tsconfig.cli.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Summary

Implements GAME-084 pipeline wiring: the `runPipeline` orchestrator and the `generate-scenario` CLI that ties all four generation stages together.

- **`pipeline-runner.ts`**: exports `runPipeline(spec: PipelineSpec): PartialScenario` — chains `generateTerrain` → `populateScenario` → `addDemographics`/`assignCounties` → `assembleScenario`; each stage is skipped when its spec section is absent; `county_labels` guarded by `.length > 0`
- **`pipeline-runner_test.ts`**: 10 tests — all stages present, each stage absent, `county_labels` absent vs empty array
- **`generate-scenario.ts`**: CLI reads YAML via `yaml` package, calls `runPipeline`, validates via `parseScenario + validateScenarioComplete`, writes JSON; `argv[2]`=spec path, `argv[3]`=optional output (defaults to replacing `.spec.yaml` → `.json`)
- **`tsconfig.cli.json`**: extends pipeline tsconfig; adds `"types": ["node"]` for the CLI
- **`BUILD.bazel`** (pipeline): adds `pipeline_runner_lib`, `pipeline_runner_typecheck_test`, `pipeline_runner_test_lib`, `pipeline_runner_test`, `tsconfig_cli`, `generate_scenario_lib`, `generate_scenario_typecheck_test`, `generate_scenario` (`js_binary`)
- **`model/BUILD.bazel`**: broadens `loader_lib` visibility to `//game/web:__subpackages__` (needed so the CLI can import `parseScenario`/`validateScenarioComplete`)

see #259 (GAME-084 wiring)

## Affected machines / services

N/A — pipeline library + CLI tool only; no deployed services changed.

## Validation performed

- `bazel test //game/web/src/pipeline/...` — all 13 tests pass (12 existing + 1 new typecheck + 10 new unit tests)
- `bazel run //game/web/src/pipeline:generate_scenario -- <absolute>/scenario-002.spec.yaml /tmp/out.json` — produces valid scenario JSON: 91 precincts, 2 parties, 4 districts

## Deployment steps

N/A — library + CLI only; deployed as part of next game build.

## Tickets addressed

- GAME-084 (pipeline wiring)

## Rollback

Revert this PR. No data migrations or external state affected.
