### PR TITLE
feat: generation-quality overhaul — coherent population field + population-aware counties (GAME-088/089)

### DIFF
--- a/game/release.main.kts
+++ b/game/release.main.kts
@@ -49,6 +49,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import java.io.File

--- a/game/scenarios/scenario-002.json
+++ b/game/scenarios/scenario-002.json
@@ -48,7 +48,7 @@
         "q": 0,
         "r": -5
       },
-      "total_population": 1532,
+      "total_population": 1290,
       "demographic_groups": [
         {
           "id": "p001-all",
@@ -72,7 +72,7 @@
         "q": 1,
         "r": -5
       },
-      "total_population": 1486,
+      "total_population": 1307,
       "demographic_groups": [
         {
           "id": "p002-all",
@@ -96,7 +96,7 @@
         "q": 2,
         "r": -5
       },
-      "total_population": 1608,
+      "total_population": 1313,
       "demographic_groups": [
         {
           "id": "p003-all",
@@ -120,7 +120,7 @@
         "q": 3,
         "r": -5
       },
-      "total_population": 1553,
+      "total_population": 1296,
       "demographic_groups": [
         {
           "id": "p004-all",
@@ -144,7 +144,7 @@
         "q": 4,
         "r": -5
       },
-      "total_population": 1431,
+      "total_population": 1304,
       "demographic_groups": [
         {
           "id": "p005-all",
@@ -168,7 +168,7 @@
         "q": 5,
         "r": -5
       },
-      "total_population": 1710,
+      "total_population": 1474,
       "demographic_groups": [
         {
           "id": "p006-all",
@@ -192,7 +192,7 @@
         "q": -1,
         "r": -4
       },
-      "total_population": 1434,
+      "total_population": 1268,
       "demographic_groups": [
         {
           "id": "p007-all",
@@ -216,7 +216,7 @@
         "q": 0,
         "r": -4
       },
-      "total_population": 1555,
+      "total_population": 1426,
       "demographic_groups": [
         {
           "id": "p008-all",
@@ -240,7 +240,7 @@
         "q": 1,
         "r": -4
       },
-      "total_population": 1627,
+      "total_population": 1448,
       "demographic_groups": [
         {
           "id": "p009-all",
@@ -264,7 +264,7 @@
         "q": 2,
         "r": -4
       },
-      "total_population": 1509,
+      "total_population": 1432,
       "demographic_groups": [
         {
           "id": "p010-all",
@@ -288,7 +288,7 @@
         "q": 3,
         "r": -4
       },
-      "total_population": 1442,
+      "total_population": 1416,
       "demographic_groups": [
         {
           "id": "p011-all",
@@ -312,7 +312,7 @@
         "q": 4,
         "r": -4
       },
-      "total_population": 1659,
+      "total_population": 1460,
       "demographic_groups": [
         {
           "id": "p012-all",
@@ -336,7 +336,7 @@
         "q": 5,
         "r": -4
       },
-      "total_population": 1603,
+      "total_population": 1323,
       "demographic_groups": [
         {
           "id": "p013-all",
@@ -360,7 +360,7 @@
         "q": -2,
         "r": -3
       },
-      "total_population": 1444,
+      "total_population": 1260,
       "demographic_groups": [
         {
           "id": "p014-all",
@@ -384,7 +384,7 @@
         "q": -1,
         "r": -3
       },
-      "total_population": 1426,
+      "total_population": 1396,
       "demographic_groups": [
         {
           "id": "p015-all",
@@ -408,7 +408,7 @@
         "q": 0,
         "r": -3
       },
-      "total_population": 1581,
+      "total_population": 1633,
       "demographic_groups": [
         {
           "id": "p016-all",
@@ -432,7 +432,7 @@
         "q": 1,
         "r": -3
       },
-      "total_population": 1637,
+      "total_population": 1635,
       "demographic_groups": [
         {
           "id": "p017-all",
@@ -456,7 +456,7 @@
         "q": 2,
         "r": -3
       },
-      "total_population": 1614,
+      "total_population": 1622,
       "demographic_groups": [
         {
           "id": "p018-all",
@@ -480,7 +480,7 @@
         "q": 3,
         "r": -3
       },
-      "total_population": 1432,
+      "total_population": 1615,
       "demographic_groups": [
         {
           "id": "p019-all",
@@ -504,7 +504,7 @@
         "q": 4,
         "r": -3
       },
-      "total_population": 1508,
+      "total_population": 1424,
       "demographic_groups": [
         {
           "id": "p020-all",
@@ -528,7 +528,7 @@
         "q": 5,
         "r": -3
       },
-      "total_population": 1604,
+      "total_population": 1300,
       "demographic_groups": [
         {
           "id": "p021-all",
@@ -552,7 +552,7 @@
         "q": -3,
         "r": -2
       },
-      "total_population": 1367,
+      "total_population": 1262,
       "demographic_groups": [
         {
           "id": "p022-all",
@@ -576,7 +576,7 @@
         "q": -2,
         "r": -2
       },
-      "total_population": 1545,
+      "total_population": 1393,
       "demographic_groups": [
         {
           "id": "p023-all",
@@ -600,7 +600,7 @@
         "q": -1,
         "r": -2
       },
-      "total_population": 1440,
+      "total_population": 1615,
       "demographic_groups": [
         {
           "id": "p024-all",
@@ -624,7 +624,7 @@
         "q": 0,
         "r": -2
       },
-      "total_population": 1677,
+      "total_population": 1996,
       "demographic_groups": [
         {
           "id": "p025-all",
@@ -648,7 +648,7 @@
         "q": 1,
         "r": -2
       },
-      "total_population": 1615,
+      "total_population": 1979,
       "demographic_groups": [
         {
           "id": "p026-all",
@@ -672,7 +672,7 @@
         "q": 2,
         "r": -2
       },
-      "total_population": 1652,
+      "total_population": 1962,
       "demographic_groups": [
         {
           "id": "p027-all",
@@ -696,7 +696,7 @@
         "q": 3,
         "r": -2
       },
-      "total_population": 1666,
+      "total_population": 1612,
       "demographic_groups": [
         {
           "id": "p028-all",
@@ -720,7 +720,7 @@
         "q": 4,
         "r": -2
       },
-      "total_population": 1526,
+      "total_population": 1408,
       "demographic_groups": [
         {
           "id": "p029-all",
@@ -744,7 +744,7 @@
         "q": 5,
         "r": -2
       },
-      "total_population": 1360,
+      "total_population": 1273,
       "demographic_groups": [
         {
           "id": "p030-all",
@@ -768,7 +768,7 @@
         "q": -4,
         "r": -1
       },
-      "total_population": 1404,
+      "total_population": 1272,
       "demographic_groups": [
         {
           "id": "p031-all",
@@ -792,7 +792,7 @@
         "q": -3,
         "r": -1
       },
-      "total_population": 1620,
+      "total_population": 1408,
       "demographic_groups": [
         {
           "id": "p032-all",
@@ -816,7 +816,7 @@
         "q": -2,
         "r": -1
       },
-      "total_population": 1577,
+      "total_population": 1633,
       "demographic_groups": [
         {
           "id": "p033-all",
@@ -840,7 +840,7 @@
         "q": -1,
         "r": -1
       },
-      "total_population": 1840,
+      "total_population": 2013,
       "demographic_groups": [
         {
           "id": "p034-all",
@@ -864,7 +864,7 @@
         "q": 0,
         "r": -1
       },
-      "total_population": 1926,
+      "total_population": 2512,
       "demographic_groups": [
         {
           "id": "p035-all",
@@ -888,7 +888,7 @@
         "q": 1,
         "r": -1
       },
-      "total_population": 1965,
+      "total_population": 2496,
       "demographic_groups": [
         {
           "id": "p036-all",
@@ -912,7 +912,7 @@
         "q": 2,
         "r": -1
       },
-      "total_population": 1608,
+      "total_population": 1964,
       "demographic_groups": [
         {
           "id": "p037-all",
@@ -936,7 +936,7 @@
         "q": 3,
         "r": -1
       },
-      "total_population": 1446,
+      "total_population": 1597,
       "demographic_groups": [
         {
           "id": "p038-all",
@@ -960,7 +960,7 @@
         "q": 4,
         "r": -1
       },
-      "total_population": 1534,
+      "total_population": 1390,
       "demographic_groups": [
         {
           "id": "p039-all",
@@ -984,7 +984,7 @@
         "q": 5,
         "r": -1
       },
-      "total_population": 1531,
+      "total_population": 1257,
       "demographic_groups": [
         {
           "id": "p040-all",
@@ -1008,7 +1008,7 @@
         "q": -5,
         "r": 0
       },
-      "total_population": 1425,
+      "total_population": 1275,
       "demographic_groups": [
         {
           "id": "p041-all",
@@ -1032,7 +1032,7 @@
         "q": -4,
         "r": 0
       },
-      "total_population": 1561,
+      "total_population": 1413,
       "demographic_groups": [
         {
           "id": "p042-all",
@@ -1056,7 +1056,7 @@
         "q": -3,
         "r": 0
       },
-      "total_population": 1494,
+      "total_population": 1647,
       "demographic_groups": [
         {
           "id": "p043-all",
@@ -1080,7 +1080,7 @@
         "q": -2,
         "r": 0
       },
-      "total_population": 1688,
+      "total_population": 2031,
       "demographic_groups": [
         {
           "id": "p044-all",
@@ -1104,7 +1104,7 @@
         "q": -1,
         "r": 0
       },
-      "total_population": 2052,
+      "total_population": 2559,
       "demographic_groups": [
         {
           "id": "p045-all",
@@ -1128,7 +1128,7 @@
         "q": 0,
         "r": 0
       },
-      "total_population": 2208,
+      "total_population": 2935,
       "demographic_groups": [
         {
           "id": "p046-all",
@@ -1152,7 +1152,7 @@
         "q": 1,
         "r": 0
       },
-      "total_population": 1982,
+      "total_population": 2512,
       "demographic_groups": [
         {
           "id": "p047-all",
@@ -1176,7 +1176,7 @@
         "q": 2,
         "r": 0
       },
-      "total_population": 1658,
+      "total_population": 1990,
       "demographic_groups": [
         {
           "id": "p048-all",
@@ -1200,7 +1200,7 @@
         "q": 3,
         "r": 0
       },
-      "total_population": 1516,
+      "total_population": 1604,
       "demographic_groups": [
         {
           "id": "p049-all",
@@ -1224,7 +1224,7 @@
         "q": 4,
         "r": 0
       },
-      "total_population": 1455,
+      "total_population": 1373,
       "demographic_groups": [
         {
           "id": "p050-all",
@@ -1248,7 +1248,7 @@
         "q": 5,
         "r": 0
       },
-      "total_population": 1374,
+      "total_population": 1247,
       "demographic_groups": [
         {
           "id": "p051-all",
@@ -1272,7 +1272,7 @@
         "q": -5,
         "r": 1
       },
-      "total_population": 1550,
+      "total_population": 1280,
       "demographic_groups": [
         {
           "id": "p052-all",
@@ -1296,7 +1296,7 @@
         "q": -4,
         "r": 1
       },
-      "total_population": 1571,
+      "total_population": 1421,
       "demographic_groups": [
         {
           "id": "p053-all",
@@ -1320,7 +1320,7 @@
         "q": -3,
         "r": 1
       },
-      "total_population": 1639,
+      "total_population": 1654,
       "demographic_groups": [
         {
           "id": "p054-all",
@@ -1344,7 +1344,7 @@
         "q": -2,
         "r": 1
       },
-      "total_population": 1876,
+      "total_population": 2055,
       "demographic_groups": [
         {
           "id": "p055-all",
@@ -1368,7 +1368,7 @@
         "q": -1,
         "r": 1
       },
-      "total_population": 1856,
+      "total_population": 2568,
       "demographic_groups": [
         {
           "id": "p056-all",
@@ -1392,7 +1392,7 @@
         "q": 0,
         "r": 1
       },
-      "total_population": 2114,
+      "total_population": 2561,
       "demographic_groups": [
         {
           "id": "p057-all",
@@ -1416,7 +1416,7 @@
         "q": 1,
         "r": 1
       },
-      "total_population": 1726,
+      "total_population": 2033,
       "demographic_groups": [
         {
           "id": "p058-all",
@@ -1440,7 +1440,7 @@
         "q": 2,
         "r": 1
       },
-      "total_population": 1714,
+      "total_population": 1646,
       "demographic_groups": [
         {
           "id": "p059-all",
@@ -1464,7 +1464,7 @@
         "q": 3,
         "r": 1
       },
-      "total_population": 1408,
+      "total_population": 1401,
       "demographic_groups": [
         {
           "id": "p060-all",
@@ -1488,7 +1488,7 @@
         "q": 4,
         "r": 1
       },
-      "total_population": 1385,
+      "total_population": 1255,
       "demographic_groups": [
         {
           "id": "p061-all",
@@ -1512,7 +1512,7 @@
         "q": -5,
         "r": 2
       },
-      "total_population": 1356,
+      "total_population": 1274,
       "demographic_groups": [
         {
           "id": "p062-all",
@@ -1536,7 +1536,7 @@
         "q": -4,
         "r": 2
       },
-      "total_population": 1475,
+      "total_population": 1415,
       "demographic_groups": [
         {
           "id": "p063-all",
@@ -1560,7 +1560,7 @@
         "q": -3,
         "r": 2
       },
-      "total_population": 1575,
+      "total_population": 1652,
       "demographic_groups": [
         {
           "id": "p064-all",
@@ -1584,7 +1584,7 @@
         "q": -2,
         "r": 2
       },
-      "total_population": 1781,
+      "total_population": 2048,
       "demographic_groups": [
         {
           "id": "p065-all",
@@ -1608,7 +1608,7 @@
         "q": -1,
         "r": 2
       },
-      "total_population": 1867,
+      "total_population": 2054,
       "demographic_groups": [
         {
           "id": "p066-all",
@@ -1632,7 +1632,7 @@
         "q": 0,
         "r": 2
       },
-      "total_population": 1620,
+      "total_population": 2043,
       "demographic_groups": [
         {
           "id": "p067-all",
@@ -1656,7 +1656,7 @@
         "q": 1,
         "r": 2
       },
-      "total_population": 1647,
+      "total_population": 1680,
       "demographic_groups": [
         {
           "id": "p068-all",
@@ -1680,7 +1680,7 @@
         "q": 2,
         "r": 2
       },
-      "total_population": 1648,
+      "total_population": 1448,
       "demographic_groups": [
         {
           "id": "p069-all",
@@ -1704,7 +1704,7 @@
         "q": 3,
         "r": 2
       },
-      "total_population": 1435,
+      "total_population": 1279,
       "demographic_groups": [
         {
           "id": "p070-all",
@@ -1728,7 +1728,7 @@
         "q": -5,
         "r": 3
       },
-      "total_population": 1564,
+      "total_population": 1275,
       "demographic_groups": [
         {
           "id": "p071-all",
@@ -1752,7 +1752,7 @@
         "q": -4,
         "r": 3
       },
-      "total_population": 1421,
+      "total_population": 1415,
       "demographic_groups": [
         {
           "id": "p072-all",
@@ -1776,7 +1776,7 @@
         "q": -3,
         "r": 3
       },
-      "total_population": 1587,
+      "total_population": 1660,
       "demographic_groups": [
         {
           "id": "p073-all",
@@ -1800,7 +1800,7 @@
         "q": -2,
         "r": 3
       },
-      "total_population": 1678,
+      "total_population": 1666,
       "demographic_groups": [
         {
           "id": "p074-all",
@@ -1824,7 +1824,7 @@
         "q": -1,
         "r": 3
       },
-      "total_population": 1467,
+      "total_population": 1666,
       "demographic_groups": [
         {
           "id": "p075-all",
@@ -1848,7 +1848,7 @@
         "q": 0,
         "r": 3
       },
-      "total_population": 1730,
+      "total_population": 1685,
       "demographic_groups": [
         {
           "id": "p076-all",
@@ -1872,7 +1872,7 @@
         "q": 1,
         "r": 3
       },
-      "total_population": 1536,
+      "total_population": 1459,
       "demographic_groups": [
         {
           "id": "p077-all",
@@ -1896,7 +1896,7 @@
         "q": 2,
         "r": 3
       },
-      "total_population": 1627,
+      "total_population": 1311,
       "demographic_groups": [
         {
           "id": "p078-all",
@@ -1920,7 +1920,7 @@
         "q": -5,
         "r": 4
       },
-      "total_population": 1482,
+      "total_population": 1280,
       "demographic_groups": [
         {
           "id": "p079-all",
@@ -1944,7 +1944,7 @@
         "q": -4,
         "r": 4
       },
-      "total_population": 1541,
+      "total_population": 1433,
       "demographic_groups": [
         {
           "id": "p080-all",
@@ -1968,7 +1968,7 @@
         "q": -3,
         "r": 4
       },
-      "total_population": 1468,
+      "total_population": 1445,
       "demographic_groups": [
         {
           "id": "p081-all",
@@ -1992,7 +1992,7 @@
         "q": -2,
         "r": 4
       },
-      "total_population": 1546,
+      "total_population": 1460,
       "demographic_groups": [
         {
           "id": "p082-all",
@@ -2016,7 +2016,7 @@
         "q": -1,
         "r": 4
       },
-      "total_population": 1464,
+      "total_population": 1456,
       "demographic_groups": [
         {
           "id": "p083-all",
@@ -2040,7 +2040,7 @@
         "q": 0,
         "r": 4
       },
-      "total_population": 1586,
+      "total_population": 1460,
       "demographic_groups": [
         {
           "id": "p084-all",
@@ -2064,7 +2064,7 @@
         "q": 1,
         "r": 4
       },
-      "total_population": 1440,
+      "total_population": 1314,
       "demographic_groups": [
         {
           "id": "p085-all",
@@ -2088,7 +2088,7 @@
         "q": -5,
         "r": 5
       },
-      "total_population": 1487,
+      "total_population": 1293,
       "demographic_groups": [
         {
           "id": "p086-all",
@@ -2112,7 +2112,7 @@
         "q": -4,
         "r": 5
       },
-      "total_population": 1605,
+      "total_population": 1307,
       "demographic_groups": [
         {
           "id": "p087-all",
@@ -2136,7 +2136,7 @@
         "q": -3,
         "r": 5
       },
-      "total_population": 1561,
+      "total_population": 1316,
       "demographic_groups": [
         {
           "id": "p088-all",
@@ -2160,7 +2160,7 @@
         "q": -2,
         "r": 5
       },
-      "total_population": 1651,
+      "total_population": 1322,
       "demographic_groups": [
         {
           "id": "p089-all",
@@ -2184,7 +2184,7 @@
         "q": -1,
         "r": 5
       },
-      "total_population": 1619,
+      "total_population": 1319,
       "demographic_groups": [
         {
           "id": "p090-all",
@@ -2208,7 +2208,7 @@
         "q": 0,
         "r": 5
       },
-      "total_population": 1481,
+      "total_population": 1312,
       "demographic_groups": [
         {
           "id": "p091-all",

--- a/game/scenarios/scenario-002.json
+++ b/game/scenarios/scenario-002.json
@@ -48,7 +48,7 @@
         "q": 0,
         "r": -5
       },
-      "total_population": 1290,
+      "total_population": 667,
       "demographic_groups": [
         {
           "id": "p001-all",
@@ -61,8 +61,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,-5)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (0,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -72,7 +73,7 @@
         "q": 1,
         "r": -5
       },
-      "total_population": 1307,
+      "total_population": 675,
       "demographic_groups": [
         {
           "id": "p002-all",
@@ -85,8 +86,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (1,-5)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (1,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -96,7 +98,7 @@
         "q": 2,
         "r": -5
       },
-      "total_population": 1313,
+      "total_population": 677,
       "demographic_groups": [
         {
           "id": "p003-all",
@@ -109,8 +111,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (2,-5)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (2,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -120,7 +123,7 @@
         "q": 3,
         "r": -5
       },
-      "total_population": 1296,
+      "total_population": 669,
       "demographic_groups": [
         {
           "id": "p004-all",
@@ -133,8 +136,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (3,-5)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (3,-5)",
       "initial_district_id": "d2"
     },
     {
@@ -144,7 +148,7 @@
         "q": 4,
         "r": -5
       },
-      "total_population": 1304,
+      "total_population": 2270,
       "demographic_groups": [
         {
           "id": "p005-all",
@@ -157,8 +161,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (4,-5)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (4,-5)",
       "initial_district_id": "d2"
     },
     {
@@ -168,7 +173,7 @@
         "q": 5,
         "r": -5
       },
-      "total_population": 1474,
+      "total_population": 2284,
       "demographic_groups": [
         {
           "id": "p006-all",
@@ -181,8 +186,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (5,-5)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (5,-5)",
       "initial_district_id": "d3"
     },
     {
@@ -192,7 +198,7 @@
         "q": -1,
         "r": -4
       },
-      "total_population": 1268,
+      "total_population": 656,
       "demographic_groups": [
         {
           "id": "p007-all",
@@ -206,6 +212,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-1,-4)",
       "initial_district_id": "d1"
     },
@@ -216,7 +223,7 @@
         "q": 0,
         "r": -4
       },
-      "total_population": 1426,
+      "total_population": 672,
       "demographic_groups": [
         {
           "id": "p008-all",
@@ -229,8 +236,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,-4)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (0,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -240,7 +248,7 @@
         "q": 1,
         "r": -4
       },
-      "total_population": 1448,
+      "total_population": 680,
       "demographic_groups": [
         {
           "id": "p009-all",
@@ -253,8 +261,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (1,-4)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (1,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -264,7 +273,7 @@
         "q": 2,
         "r": -4
       },
-      "total_population": 1432,
+      "total_population": 674,
       "demographic_groups": [
         {
           "id": "p010-all",
@@ -277,8 +286,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (2,-4)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (2,-4)",
       "initial_district_id": "d2"
     },
     {
@@ -288,7 +298,7 @@
         "q": 3,
         "r": -4
       },
-      "total_population": 1416,
+      "total_population": 668,
       "demographic_groups": [
         {
           "id": "p011-all",
@@ -301,8 +311,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (3,-4)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (3,-4)",
       "initial_district_id": "d2"
     },
     {
@@ -312,7 +323,7 @@
         "q": 4,
         "r": -4
       },
-      "total_population": 1460,
+      "total_population": 2293,
       "demographic_groups": [
         {
           "id": "p012-all",
@@ -325,8 +336,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (4,-4)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (4,-4)",
       "initial_district_id": "d3"
     },
     {
@@ -336,7 +348,7 @@
         "q": 5,
         "r": -4
       },
-      "total_population": 1323,
+      "total_population": 2287,
       "demographic_groups": [
         {
           "id": "p013-all",
@@ -349,8 +361,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (5,-4)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (5,-4)",
       "initial_district_id": "d3"
     },
     {
@@ -360,7 +373,7 @@
         "q": -2,
         "r": -3
       },
-      "total_population": 1260,
+      "total_population": 652,
       "demographic_groups": [
         {
           "id": "p014-all",
@@ -374,6 +387,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-2,-3)",
       "initial_district_id": "d1"
     },
@@ -384,7 +398,7 @@
         "q": -1,
         "r": -3
       },
-      "total_population": 1396,
+      "total_population": 661,
       "demographic_groups": [
         {
           "id": "p015-all",
@@ -398,6 +412,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-1,-3)",
       "initial_district_id": "d1"
     },
@@ -408,7 +423,7 @@
         "q": 0,
         "r": -3
       },
-      "total_population": 1633,
+      "total_population": 675,
       "demographic_groups": [
         {
           "id": "p016-all",
@@ -422,6 +437,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (0,-3)",
       "initial_district_id": "d1"
     },
@@ -432,7 +448,7 @@
         "q": 1,
         "r": -3
       },
-      "total_population": 1635,
+      "total_population": 676,
       "demographic_groups": [
         {
           "id": "p017-all",
@@ -446,6 +462,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (1,-3)",
       "initial_district_id": "d2"
     },
@@ -456,7 +473,7 @@
         "q": 2,
         "r": -3
       },
-      "total_population": 1622,
+      "total_population": 671,
       "demographic_groups": [
         {
           "id": "p018-all",
@@ -470,6 +487,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (2,-3)",
       "initial_district_id": "d2"
     },
@@ -480,7 +498,7 @@
         "q": 3,
         "r": -3
       },
-      "total_population": 1615,
+      "total_population": 669,
       "demographic_groups": [
         {
           "id": "p019-all",
@@ -494,6 +512,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (3,-3)",
       "initial_district_id": "d3"
     },
@@ -504,7 +523,7 @@
         "q": 4,
         "r": -3
       },
-      "total_population": 1424,
+      "total_population": 671,
       "demographic_groups": [
         {
           "id": "p020-all",
@@ -517,8 +536,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (4,-3)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (4,-3)",
       "initial_district_id": "d3"
     },
     {
@@ -528,7 +548,7 @@
         "q": 5,
         "r": -3
       },
-      "total_population": 1300,
+      "total_population": 671,
       "demographic_groups": [
         {
           "id": "p021-all",
@@ -541,8 +561,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (5,-3)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (5,-3)",
       "initial_district_id": "d4"
     },
     {
@@ -552,7 +573,7 @@
         "q": -3,
         "r": -2
       },
-      "total_population": 1262,
+      "total_population": 653,
       "demographic_groups": [
         {
           "id": "p022-all",
@@ -566,6 +587,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-3,-2)",
       "initial_district_id": "d1"
     },
@@ -576,7 +598,7 @@
         "q": -2,
         "r": -2
       },
-      "total_population": 1393,
+      "total_population": 660,
       "demographic_groups": [
         {
           "id": "p023-all",
@@ -590,6 +612,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-2,-2)",
       "initial_district_id": "d1"
     },
@@ -600,7 +623,7 @@
         "q": -1,
         "r": -2
       },
-      "total_population": 1615,
+      "total_population": 669,
       "demographic_groups": [
         {
           "id": "p024-all",
@@ -614,6 +637,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-1,-2)",
       "initial_district_id": "d1"
     },
@@ -624,7 +648,7 @@
         "q": 0,
         "r": -2
       },
-      "total_population": 1996,
+      "total_population": 2834,
       "demographic_groups": [
         {
           "id": "p025-all",
@@ -638,6 +662,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (0,-2)",
       "initial_district_id": "d2"
     },
@@ -648,7 +673,7 @@
         "q": 1,
         "r": -2
       },
-      "total_population": 1979,
+      "total_population": 5988,
       "demographic_groups": [
         {
           "id": "p026-all",
@@ -661,8 +686,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_east",
-      "name": "East (1,-2)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (1,-2)",
       "initial_district_id": "d2"
     },
     {
@@ -672,7 +698,7 @@
         "q": 2,
         "r": -2
       },
-      "total_population": 1962,
+      "total_population": 5977,
       "demographic_groups": [
         {
           "id": "p027-all",
@@ -685,8 +711,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_east",
-      "name": "East (2,-2)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (2,-2)",
       "initial_district_id": "d3"
     },
     {
@@ -696,7 +723,7 @@
         "q": 3,
         "r": -2
       },
-      "total_population": 1612,
+      "total_population": 668,
       "demographic_groups": [
         {
           "id": "p028-all",
@@ -710,6 +737,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (3,-2)",
       "initial_district_id": "d3"
     },
@@ -720,7 +748,7 @@
         "q": 4,
         "r": -2
       },
-      "total_population": 1408,
+      "total_population": 666,
       "demographic_groups": [
         {
           "id": "p029-all",
@@ -733,8 +761,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (4,-2)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (4,-2)",
       "initial_district_id": "d4"
     },
     {
@@ -744,7 +773,7 @@
         "q": 5,
         "r": -2
       },
-      "total_population": 1273,
+      "total_population": 658,
       "demographic_groups": [
         {
           "id": "p030-all",
@@ -757,8 +786,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (5,-2)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (5,-2)",
       "initial_district_id": "d4"
     },
     {
@@ -768,7 +798,7 @@
         "q": -4,
         "r": -1
       },
-      "total_population": 1272,
+      "total_population": 1594,
       "demographic_groups": [
         {
           "id": "p031-all",
@@ -782,6 +812,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-4,-1)",
       "initial_district_id": "d1"
     },
@@ -792,7 +823,7 @@
         "q": -3,
         "r": -1
       },
-      "total_population": 1408,
+      "total_population": 666,
       "demographic_groups": [
         {
           "id": "p032-all",
@@ -806,6 +837,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-3,-1)",
       "initial_district_id": "d1"
     },
@@ -816,7 +848,7 @@
         "q": -2,
         "r": -1
       },
-      "total_population": 1633,
+      "total_population": 675,
       "demographic_groups": [
         {
           "id": "p033-all",
@@ -830,6 +862,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-2,-1)",
       "initial_district_id": "d1"
     },
@@ -840,7 +873,7 @@
         "q": -1,
         "r": -1
       },
-      "total_population": 2013,
+      "total_population": 2844,
       "demographic_groups": [
         {
           "id": "p034-all",
@@ -854,6 +887,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-1,-1)",
       "initial_district_id": "d2"
     },
@@ -864,7 +898,7 @@
         "q": 0,
         "r": -1
       },
-      "total_population": 2512,
+      "total_population": 7532,
       "demographic_groups": [
         {
           "id": "p035-all",
@@ -877,8 +911,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,-1)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (0,-1)",
       "initial_district_id": "d2"
     },
     {
@@ -888,7 +923,7 @@
         "q": 1,
         "r": -1
       },
-      "total_population": 2496,
+      "total_population": 7521,
       "demographic_groups": [
         {
           "id": "p036-all",
@@ -901,8 +936,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_east",
-      "name": "East (1,-1)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (1,-1)",
       "initial_district_id": "d3"
     },
     {
@@ -912,7 +948,7 @@
         "q": 2,
         "r": -1
       },
-      "total_population": 1964,
+      "total_population": 5979,
       "demographic_groups": [
         {
           "id": "p037-all",
@@ -925,8 +961,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_east",
-      "name": "East (2,-1)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (2,-1)",
       "initial_district_id": "d3"
     },
     {
@@ -936,7 +973,7 @@
         "q": 3,
         "r": -1
       },
-      "total_population": 1597,
+      "total_population": 663,
       "demographic_groups": [
         {
           "id": "p038-all",
@@ -950,6 +987,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (3,-1)",
       "initial_district_id": "d4"
     },
@@ -960,7 +998,7 @@
         "q": 4,
         "r": -1
       },
-      "total_population": 1390,
+      "total_population": 659,
       "demographic_groups": [
         {
           "id": "p039-all",
@@ -973,8 +1011,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (4,-1)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (4,-1)",
       "initial_district_id": "d4"
     },
     {
@@ -984,7 +1023,7 @@
         "q": 5,
         "r": -1
       },
-      "total_population": 1257,
+      "total_population": 651,
       "demographic_groups": [
         {
           "id": "p040-all",
@@ -997,8 +1036,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (5,-1)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (5,-1)",
       "initial_district_id": "d4"
     },
     {
@@ -1008,7 +1048,7 @@
         "q": -5,
         "r": 0
       },
-      "total_population": 1275,
+      "total_population": 1597,
       "demographic_groups": [
         {
           "id": "p041-all",
@@ -1022,6 +1062,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-5,0)",
       "initial_district_id": "d1"
     },
@@ -1032,7 +1073,7 @@
         "q": -4,
         "r": 0
       },
-      "total_population": 1413,
+      "total_population": 1613,
       "demographic_groups": [
         {
           "id": "p042-all",
@@ -1046,6 +1087,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-4,0)",
       "initial_district_id": "d1"
     },
@@ -1056,7 +1098,7 @@
         "q": -3,
         "r": 0
       },
-      "total_population": 1647,
+      "total_population": 679,
       "demographic_groups": [
         {
           "id": "p043-all",
@@ -1070,6 +1112,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-3,0)",
       "initial_district_id": "d1"
     },
@@ -1080,7 +1123,7 @@
         "q": -2,
         "r": 0
       },
-      "total_population": 2031,
+      "total_population": 2854,
       "demographic_groups": [
         {
           "id": "p044-all",
@@ -1094,6 +1137,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-2,0)",
       "initial_district_id": "d2"
     },
@@ -1104,7 +1148,7 @@
         "q": -1,
         "r": 0
       },
-      "total_population": 2559,
+      "total_population": 4208,
       "demographic_groups": [
         {
           "id": "p045-all",
@@ -1117,8 +1161,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (-1,0)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (-1,0)",
       "initial_district_id": "d2"
     },
     {
@@ -1128,7 +1173,7 @@
         "q": 0,
         "r": 0
       },
-      "total_population": 2935,
+      "total_population": 7571,
       "demographic_groups": [
         {
           "id": "p046-all",
@@ -1141,8 +1186,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,0)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (0,0)",
       "initial_district_id": "d3"
     },
     {
@@ -1152,7 +1198,7 @@
         "q": 1,
         "r": 0
       },
-      "total_population": 2512,
+      "total_population": 7532,
       "demographic_groups": [
         {
           "id": "p047-all",
@@ -1165,8 +1211,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_east",
-      "name": "East (1,0)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (1,0)",
       "initial_district_id": "d3"
     },
     {
@@ -1176,7 +1223,7 @@
         "q": 2,
         "r": 0
       },
-      "total_population": 1990,
+      "total_population": 2831,
       "demographic_groups": [
         {
           "id": "p048-all",
@@ -1190,6 +1237,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (2,0)",
       "initial_district_id": "d4"
     },
@@ -1200,7 +1248,7 @@
         "q": 3,
         "r": 0
       },
-      "total_population": 1604,
+      "total_population": 666,
       "demographic_groups": [
         {
           "id": "p049-all",
@@ -1214,6 +1262,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (3,0)",
       "initial_district_id": "d4"
     },
@@ -1224,7 +1273,7 @@
         "q": 4,
         "r": 0
       },
-      "total_population": 1373,
+      "total_population": 653,
       "demographic_groups": [
         {
           "id": "p050-all",
@@ -1237,8 +1286,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (4,0)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (4,0)",
       "initial_district_id": "d4"
     },
     {
@@ -1248,7 +1298,7 @@
         "q": 5,
         "r": 0
       },
-      "total_population": 1247,
+      "total_population": 645,
       "demographic_groups": [
         {
           "id": "p051-all",
@@ -1261,8 +1311,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (5,0)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (5,0)",
       "initial_district_id": "d4"
     },
     {
@@ -1272,7 +1323,7 @@
         "q": -5,
         "r": 1
       },
-      "total_population": 1280,
+      "total_population": 1601,
       "demographic_groups": [
         {
           "id": "p052-all",
@@ -1286,6 +1337,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-5,1)",
       "initial_district_id": "d1"
     },
@@ -1296,7 +1348,7 @@
         "q": -4,
         "r": 1
       },
-      "total_population": 1421,
+      "total_population": 671,
       "demographic_groups": [
         {
           "id": "p053-all",
@@ -1310,6 +1362,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-4,1)",
       "initial_district_id": "d1"
     },
@@ -1320,7 +1373,7 @@
         "q": -3,
         "r": 1
       },
-      "total_population": 1654,
+      "total_population": 682,
       "demographic_groups": [
         {
           "id": "p054-all",
@@ -1334,6 +1387,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-3,1)",
       "initial_district_id": "d2"
     },
@@ -1344,7 +1398,7 @@
         "q": -2,
         "r": 1
       },
-      "total_population": 2055,
+      "total_population": 2868,
       "demographic_groups": [
         {
           "id": "p055-all",
@@ -1357,8 +1411,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (-2,1)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (-2,1)",
       "initial_district_id": "d2"
     },
     {
@@ -1368,7 +1423,7 @@
         "q": -1,
         "r": 1
       },
-      "total_population": 2568,
+      "total_population": 4213,
       "demographic_groups": [
         {
           "id": "p056-all",
@@ -1381,8 +1436,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (-1,1)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (-1,1)",
       "initial_district_id": "d3"
     },
     {
@@ -1392,7 +1448,7 @@
         "q": 0,
         "r": 1
       },
-      "total_population": 2561,
+      "total_population": 4209,
       "demographic_groups": [
         {
           "id": "p057-all",
@@ -1405,8 +1461,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,1)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (0,1)",
       "initial_district_id": "d3"
     },
     {
@@ -1416,7 +1473,7 @@
         "q": 1,
         "r": 1
       },
-      "total_population": 2033,
+      "total_population": 2855,
       "demographic_groups": [
         {
           "id": "p058-all",
@@ -1430,6 +1487,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (1,1)",
       "initial_district_id": "d4"
     },
@@ -1440,7 +1498,7 @@
         "q": 2,
         "r": 1
       },
-      "total_population": 1646,
+      "total_population": 679,
       "demographic_groups": [
         {
           "id": "p059-all",
@@ -1454,6 +1512,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (2,1)",
       "initial_district_id": "d4"
     },
@@ -1464,7 +1523,7 @@
         "q": 3,
         "r": 1
       },
-      "total_population": 1401,
+      "total_population": 663,
       "demographic_groups": [
         {
           "id": "p060-all",
@@ -1477,8 +1536,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (3,1)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (3,1)",
       "initial_district_id": "d4"
     },
     {
@@ -1488,7 +1548,7 @@
         "q": 4,
         "r": 1
       },
-      "total_population": 1255,
+      "total_population": 649,
       "demographic_groups": [
         {
           "id": "p061-all",
@@ -1501,8 +1561,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (4,1)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (4,1)",
       "initial_district_id": "d4"
     },
     {
@@ -1512,7 +1573,7 @@
         "q": -5,
         "r": 2
       },
-      "total_population": 1274,
+      "total_population": 659,
       "demographic_groups": [
         {
           "id": "p062-all",
@@ -1526,6 +1587,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-5,2)",
       "initial_district_id": "d1"
     },
@@ -1536,7 +1598,7 @@
         "q": -4,
         "r": 2
       },
-      "total_population": 1415,
+      "total_population": 668,
       "demographic_groups": [
         {
           "id": "p063-all",
@@ -1550,6 +1612,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-4,2)",
       "initial_district_id": "d2"
     },
@@ -1560,7 +1623,7 @@
         "q": -3,
         "r": 2
       },
-      "total_population": 1652,
+      "total_population": 681,
       "demographic_groups": [
         {
           "id": "p064-all",
@@ -1574,6 +1637,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-3,2)",
       "initial_district_id": "d2"
     },
@@ -1584,7 +1648,7 @@
         "q": -2,
         "r": 2
       },
-      "total_population": 2048,
+      "total_population": 2864,
       "demographic_groups": [
         {
           "id": "p065-all",
@@ -1597,8 +1661,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (-2,2)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (-2,2)",
       "initial_district_id": "d3"
     },
     {
@@ -1608,7 +1673,7 @@
         "q": -1,
         "r": 2
       },
-      "total_population": 2054,
+      "total_population": 2867,
       "demographic_groups": [
         {
           "id": "p066-all",
@@ -1621,8 +1686,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (-1,2)",
+      "county_id": "clearwater_city",
+      "county_name": "Clearwater City",
+      "name": "City (-1,2)",
       "initial_district_id": "d3"
     },
     {
@@ -1632,7 +1698,7 @@
         "q": 0,
         "r": 2
       },
-      "total_population": 2043,
+      "total_population": 2861,
       "demographic_groups": [
         {
           "id": "p067-all",
@@ -1645,8 +1711,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,2)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (0,2)",
       "initial_district_id": "d4"
     },
     {
@@ -1656,7 +1723,7 @@
         "q": 1,
         "r": 2
       },
-      "total_population": 1680,
+      "total_population": 690,
       "demographic_groups": [
         {
           "id": "p068-all",
@@ -1670,6 +1737,7 @@
         }
       ],
       "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
       "name": "East (1,2)",
       "initial_district_id": "d4"
     },
@@ -1680,7 +1748,7 @@
         "q": 2,
         "r": 2
       },
-      "total_population": 1448,
+      "total_population": 680,
       "demographic_groups": [
         {
           "id": "p069-all",
@@ -1693,8 +1761,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (2,2)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (2,2)",
       "initial_district_id": "d4"
     },
     {
@@ -1704,7 +1773,7 @@
         "q": 3,
         "r": 2
       },
-      "total_population": 1279,
+      "total_population": 661,
       "demographic_groups": [
         {
           "id": "p070-all",
@@ -1717,8 +1786,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (3,2)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (3,2)",
       "initial_district_id": "d4"
     },
     {
@@ -1728,7 +1798,7 @@
         "q": -5,
         "r": 3
       },
-      "total_population": 1275,
+      "total_population": 659,
       "demographic_groups": [
         {
           "id": "p071-all",
@@ -1742,6 +1812,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-5,3)",
       "initial_district_id": "d2"
     },
@@ -1752,7 +1823,7 @@
         "q": -4,
         "r": 3
       },
-      "total_population": 1415,
+      "total_population": 668,
       "demographic_groups": [
         {
           "id": "p072-all",
@@ -1766,6 +1837,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-4,3)",
       "initial_district_id": "d2"
     },
@@ -1776,7 +1848,7 @@
         "q": -3,
         "r": 3
       },
-      "total_population": 1660,
+      "total_population": 684,
       "demographic_groups": [
         {
           "id": "p073-all",
@@ -1790,6 +1862,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-3,3)",
       "initial_district_id": "d3"
     },
@@ -1800,7 +1873,7 @@
         "q": -2,
         "r": 3
       },
-      "total_population": 1666,
+      "total_population": 686,
       "demographic_groups": [
         {
           "id": "p074-all",
@@ -1814,6 +1887,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-2,3)",
       "initial_district_id": "d3"
     },
@@ -1824,7 +1898,7 @@
         "q": -1,
         "r": 3
       },
-      "total_population": 1666,
+      "total_population": 686,
       "demographic_groups": [
         {
           "id": "p075-all",
@@ -1838,6 +1912,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-1,3)",
       "initial_district_id": "d4"
     },
@@ -1848,7 +1923,7 @@
         "q": 0,
         "r": 3
       },
-      "total_population": 1685,
+      "total_population": 692,
       "demographic_groups": [
         {
           "id": "p076-all",
@@ -1861,8 +1936,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,3)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (0,3)",
       "initial_district_id": "d4"
     },
     {
@@ -1872,7 +1948,7 @@
         "q": 1,
         "r": 3
       },
-      "total_population": 1459,
+      "total_population": 685,
       "demographic_groups": [
         {
           "id": "p077-all",
@@ -1885,8 +1961,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (1,3)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (1,3)",
       "initial_district_id": "d4"
     },
     {
@@ -1896,7 +1973,7 @@
         "q": 2,
         "r": 3
       },
-      "total_population": 1311,
+      "total_population": 676,
       "demographic_groups": [
         {
           "id": "p078-all",
@@ -1909,8 +1986,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (2,3)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (2,3)",
       "initial_district_id": "d4"
     },
     {
@@ -1920,7 +1998,7 @@
         "q": -5,
         "r": 4
       },
-      "total_population": 1280,
+      "total_population": 662,
       "demographic_groups": [
         {
           "id": "p079-all",
@@ -1934,6 +2012,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-5,4)",
       "initial_district_id": "d2"
     },
@@ -1944,7 +2023,7 @@
         "q": -4,
         "r": 4
       },
-      "total_population": 1433,
+      "total_population": 675,
       "demographic_groups": [
         {
           "id": "p080-all",
@@ -1958,6 +2037,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-4,4)",
       "initial_district_id": "d3"
     },
@@ -1968,7 +2048,7 @@
         "q": -3,
         "r": 4
       },
-      "total_population": 1445,
+      "total_population": 679,
       "demographic_groups": [
         {
           "id": "p081-all",
@@ -1982,6 +2062,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-3,4)",
       "initial_district_id": "d3"
     },
@@ -1992,7 +2073,7 @@
         "q": -2,
         "r": 4
       },
-      "total_population": 1460,
+      "total_population": 685,
       "demographic_groups": [
         {
           "id": "p082-all",
@@ -2006,6 +2087,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-2,4)",
       "initial_district_id": "d4"
     },
@@ -2016,7 +2098,7 @@
         "q": -1,
         "r": 4
       },
-      "total_population": 1456,
+      "total_population": 683,
       "demographic_groups": [
         {
           "id": "p083-all",
@@ -2030,6 +2112,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-1,4)",
       "initial_district_id": "d4"
     },
@@ -2040,7 +2123,7 @@
         "q": 0,
         "r": 4
       },
-      "total_population": 1460,
+      "total_population": 685,
       "demographic_groups": [
         {
           "id": "p084-all",
@@ -2053,8 +2136,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,4)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (0,4)",
       "initial_district_id": "d4"
     },
     {
@@ -2064,7 +2148,7 @@
         "q": 1,
         "r": 4
       },
-      "total_population": 1314,
+      "total_population": 678,
       "demographic_groups": [
         {
           "id": "p085-all",
@@ -2077,8 +2161,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_central",
-      "name": "Central (1,4)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (1,4)",
       "initial_district_id": "d4"
     },
     {
@@ -2088,7 +2173,7 @@
         "q": -5,
         "r": 5
       },
-      "total_population": 1293,
+      "total_population": 668,
       "demographic_groups": [
         {
           "id": "p086-all",
@@ -2102,6 +2187,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-5,5)",
       "initial_district_id": "d3"
     },
@@ -2112,7 +2198,7 @@
         "q": -4,
         "r": 5
       },
-      "total_population": 1307,
+      "total_population": 674,
       "demographic_groups": [
         {
           "id": "p087-all",
@@ -2126,6 +2212,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-4,5)",
       "initial_district_id": "d3"
     },
@@ -2136,7 +2223,7 @@
         "q": -3,
         "r": 5
       },
-      "total_population": 1316,
+      "total_population": 679,
       "demographic_groups": [
         {
           "id": "p088-all",
@@ -2150,6 +2237,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-3,5)",
       "initial_district_id": "d4"
     },
@@ -2160,7 +2248,7 @@
         "q": -2,
         "r": 5
       },
-      "total_population": 1322,
+      "total_population": 682,
       "demographic_groups": [
         {
           "id": "p089-all",
@@ -2174,6 +2262,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-2,5)",
       "initial_district_id": "d4"
     },
@@ -2184,7 +2273,7 @@
         "q": -1,
         "r": 5
       },
-      "total_population": 1319,
+      "total_population": 680,
       "demographic_groups": [
         {
           "id": "p090-all",
@@ -2198,6 +2287,7 @@
         }
       ],
       "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "West (-1,5)",
       "initial_district_id": "d4"
     },
@@ -2208,7 +2298,7 @@
         "q": 0,
         "r": 5
       },
-      "total_population": 1312,
+      "total_population": 677,
       "demographic_groups": [
         {
           "id": "p091-all",
@@ -2221,8 +2311,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_west",
-      "name": "West (0,5)",
+      "county_id": "clearwater_east",
+      "county_name": "Clearwater East",
+      "name": "East (0,5)",
       "initial_district_id": "d4"
     }
   ],

--- a/game/scenarios/scenario-002.spec.yaml
+++ b/game/scenarios/scenario-002.spec.yaml
@@ -36,32 +36,48 @@ terrain: {}
 
 # ── Stage 2: Population ───────────────────────────────────────────────────────
 #
-# Clearwater County urban/suburban mix:
-#   Clearwater City: the county seat, located in the center of the county.
-#   East Mills: a smaller mill town to the east.
-# Both settlements add Gaussian population bumps on top of the terrain-suitability base.
-# The scenario has no terrain features so all precincts start at suitability 1.0.
+# Clearwater County urban/suburban mix — three density clusters so the field is
+# non-monotonic (not a single cone) and the county stage gets clean seeds:
+#   Clearwater City: the county seat, in the centre (dominant).
+#   East Mills:      a mill town to the east.
+#   West Bend:       a smaller town to the west.
+# Settlements add Gaussian bumps on top of the terrain-suitability base; the
+# gradient is kept gentle so the secondary towns survive as local maxima.
 
 population:
   seed: 42
-  base: 1500
-  variance: 150
-  # GAME-088 field-shaping (opt-in). Tuned conservatively so the fixed e2e
-  # painting stays within ±10% district balance; tune up once the e2e re-solves.
+  base: 800                 # low rural floor; the cores (settlements) carry the density
+  variance: 120
+  # "Big core, low floor" experiment (A): near-zero gradient, big settlement peaks,
+  # so density is core-defined with a ~5-7x urban/rural ratio rather than a smooth cone.
   gradient:
-    strength: 0.25          # gentle monocentric tilt (Clearwater City core → rural rim)
+    strength: 0.05          # near-flat macro tilt — cores define density, not a radial slope
   smoothing: 2              # neighbour-average the jitter — removes salt-and-pepper
-  contrast: 1.25            # widen dynamic range so density reads as a gradient
+  contrast: 1.2             # mild; the peaks already carry the dynamic range
   target_total: 144891     # preserve the existing total (shape change, not magnitude)
   settlements:
+    # City core sculpted from two overlapping plateaus so the dense area fans out
+    # (an irregular blob with a sharp edge) instead of a smooth circular cone.
     - label: Clearwater City
       anchor: center
-      peak: 600
+      peak: 4200
       radius: 3
+      profile: plateau
+    - label: Clearwater City (NE lobe)
+      anchor: { q: 1, r: -1 }
+      peak: 3200
+      radius: 2
+      profile: plateau
     - label: East Mills
       anchor: east
-      peak: 200
-      radius: 1
+      peak: 2200
+      radius: 2
+      profile: plateau
+    - label: West Bend
+      anchor: west
+      peak: 1400
+      radius: 2
+      profile: plateau
 
 # ── Stage 3: Demographics ─────────────────────────────────────────────────────
 
@@ -85,13 +101,22 @@ demographics:
     - name: outer_east
       filter: { default: true }
       party_base: { ken: 0.52 }
-  county_labels:
-    - id: clearwater_west
-      filter: { q_lte: 0 }
-    - id: clearwater_east
-      filter: { q_gte: 1, hex_dist_lte: 3 }
-    - id: clearwater_central
-      filter: { default: true }
+
+# ── Stage 3b: Counties (GAME-089) ─────────────────────────────────────────────
+#
+# Cosmetic county boundaries that follow the population field (replaces the old
+# geometric county_labels slices). county_id only drives the dashed border overlay.
+#
+# model: city_county — "like San Francisco / Denver": the dense Clearwater City
+#   core becomes its own county; the surrounding area is absorbed by the West Bend
+#   and East Mills counties. Gives a centred city county + a west + an east county.
+# (Other presets: seat_and_hinterland = town+rural surround; split_metro = Portland.)
+
+counties:
+  model: city_county
+  target_count: 3          # Clearwater City + West Bend + East Mills
+  core_density: 0.32       # how far "out to a certain density" the city county reaches
+  id_prefix: clearwater
 
 # ── Stage 4: Assembly ─────────────────────────────────────────────────────────
 

--- a/game/scenarios/scenario-002.spec.yaml
+++ b/game/scenarios/scenario-002.spec.yaml
@@ -46,6 +46,13 @@ population:
   seed: 42
   base: 1500
   variance: 150
+  # GAME-088 field-shaping (opt-in). Tuned conservatively so the fixed e2e
+  # painting stays within ±10% district balance; tune up once the e2e re-solves.
+  gradient:
+    strength: 0.25          # gentle monocentric tilt (Clearwater City core → rural rim)
+  smoothing: 2              # neighbour-average the jitter — removes salt-and-pepper
+  contrast: 1.25            # widen dynamic range so density reads as a gradient
+  target_total: 144891     # preserve the existing total (shape change, not magnitude)
   settlements:
     - label: Clearwater City
       anchor: center

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -119,56 +119,58 @@ test("scenario-002: governor sprite appears in the sc-ken-seats criterion row", 
 
 test("scenario-002 winnability: packing east Ryu bloc into one district passes", async ({ page }) => {
   /**
-   * Hex-of-hexes R=5: 91 precincts, 4 districts of ~23.
-   * Geography: inner-east (q≥1, d≤3) = 25% Ken (Ryu stronghold),
-   *            west (q≤0) = 62% Ken, outer-east = 52% Ken.
+   * Hex-of-hexes R=5: 91 precincts, 4 districts (population-balanced, not count-
+   * balanced — the GAME-088 field has a dense city core, ~12x urban/rural).
    *
-   * Winning strategy: pack the Ryu stronghold into D4, spread Ken across D1-D3.
-   *   D1 (23): west-center blob — Ken territory
-   *   D2 (22): southwest + south — Ken territory
-   *   D3 (23): northeast arc + outer-east — competitive Ken
-   *   D4 (23): inner-east Ryu core + nearby expansion — Ryu sacrifice
-   * Result: 3 Ken / 1 Ryu ✓
+   * Geography (GAME-088/089 field): a dense Clearwater City core; its EAST half
+   * (q≥1, near centre) is the high-density Ryu stronghold, its WEST half leans Ken,
+   * and the rural ring leans Ken. Ryu wins the popular vote, so Ken must gerrymander.
+   *
+   * Winning strategy: pack the dense east-core Ryu precincts into one sink (D1),
+   * then split the Ken-leaning remainder into three balanced majority-Ken districts.
+   *   D1 (7 hexes, ~34k): east-core Ryu sink — Ryu by ~17k
+   *   D2 (west, ~36k):    Ken-leaning west — Ken
+   *   D3 (north, ~39k):   west-core Ken + north rural, absorbs one Ryu spike — Ken
+   *   D4 (south+east, ~35k): Ken rural wrap + the remaining smaller Ryu density — Ken
+   * Result: 3 Ken / 1 Ryu ✓  (verified offline against the sim's pop×partyShare vote model)
    */
   await loadScenario(page, "scenario-002");
 
   // GAME-059: Submit always enabled; initial diagonal-strip assignment fails criteria but can be submitted
   await expect(page.locator("#btn-submit")).toBeEnabled(); // GAME-059: validity gate removed
 
-  // D1: west-center Ken blob (23 hexes)
+  // D1: pack the dense east-of-centre city core (the Ryu stronghold) into one sink.
   await paintHexes(page, [
-    [-3,-2],[-2,-2],[-1,-2], [-4,-1],[-3,-1],[-2,-1],[-1,-1],
-    [-5,0],[-4,0],[-3,0],[-2,0],[-1,0],[0,0],
-    [-5,1],[-4,1],[-3,1],[-2,1],[-1,1],[0,1],
-    [-5,2],[-4,2],[-3,2],[-2,2],
+    [1,-2],[1,-1],[2,-1],[2,-2],[1,0],[3,-1],[3,0],
   ], 1);
 
-  // D2: south + southwest Ken territory (22 hexes)
+  // D2: the Ken-leaning west (rural west + the Ken half of the city core).
   await paintHexes(page, [
-    [-1,2],[0,2],
-    [-5,3],[-4,3],[-3,3],[-2,3],[-1,3],[0,3],[2,3],
-    [-5,4],[-4,4],[-3,4],[-2,4],[-1,4],[0,4],[1,4],
-    [-5,5],[-4,5],[-3,5],[-2,5],[-1,5],[0,5],
+    [-2,-3],[-3,-2],[-2,-2],
+    [-4,-1],[-3,-1],[-2,-1],[-1,-1],
+    [-5,0],[-4,0],[-3,0],[-2,0],[-1,0],
+    [-5,1],[-4,1],[-3,1],[-2,1],[-1,1],
+    [-5,2],[-4,2],[-3,2],[-2,2],[-1,2],
   ], 2);
 
-  // D3: north + outer-east Ken arc (23 hexes)
+  // D3: the north — west-core Ken (0,0)/(0,-1) + north rural, absorbing the (1,-2) Ryu spike.
   await paintHexes(page, [
     [0,-5],[1,-5],[2,-5],[3,-5],[4,-5],[5,-5],
-    [-1,-4],[0,-4],[5,-4],
-    [-2,-3],[-1,-3],[5,-3],
-    [4,-2],[5,-2], [4,-1],[5,-1],
-    [4,0],[5,0], [3,1],[4,1],
-    [2,2],[3,2], [1,3],
+    [-1,-4],[0,-4],[1,-4],[2,-4],[3,-4],[4,-4],[5,-4],
+    [-1,-3],[0,-3],[1,-3],[2,-3],[3,-3],[4,-3],[5,-3],
+    [-1,-2],[0,-2],[3,-2],
+    [0,-1],[0,0],
   ], 3);
 
-  // D4: inner-east Ryu sacrifice — stronghold packed into one district (23 hexes)
+  // D4: a Ken majority wrapping the south and up the east edge + remaining small Ryu density.
   await paintHexes(page, [
-    [1,-4],[2,-4],[3,-4],[4,-4],
-    [0,-3],[1,-3],[2,-3],[3,-3],[4,-3],
-    [0,-2],[1,-2],[2,-2],[3,-2],
-    [0,-1],[1,-1],[2,-1],[3,-1],
-    [1,0],[2,0],[3,0],
-    [1,1],[2,1], [1,2],
+    [4,-2],[5,-2],[4,-1],[5,-1],
+    [2,0],[4,0],[5,0],
+    [0,1],[1,1],[2,1],[3,1],[4,1],
+    [0,2],[1,2],[2,2],[3,2],
+    [-5,3],[-4,3],[-3,3],[-2,3],[-1,3],[0,3],[1,3],[2,3],
+    [-5,4],[-4,4],[-3,4],[-2,4],[-1,4],[0,4],[1,4],
+    [-5,5],[-4,5],[-3,5],[-2,5],[-1,5],[0,5],
   ], 4);
 
   await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -566,6 +566,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		const key = partyIdToKey.get(p.id);
 		if (key !== undefined) partyLabels[key as "R" | "D" | "L" | "G" | "I"] = p.name;
 	});
+	renderer.setPartyLabels(partyLabels);
 
 	// ── Update cycle ──────────────────────────────────────────────────────────
 	function updateUI() {

--- a/game/web/src/model/adapter.ts
+++ b/game/web/src/model/adapter.ts
@@ -139,6 +139,7 @@ export function scenarioToSpike(scenario: Scenario): {
 		};
 		if (pc.name !== undefined) spikePrecinct.name = pc.name;
 		if (pc.county_id !== undefined) spikePrecinct.county_id = pc.county_id;
+		if (pc.county_name !== undefined) spikePrecinct.county_name = pc.county_name;
 		// Only store annotation when at least one flag is true (avoids polluting all precincts)
 		if (hasSea || hasMountain || isRiverside || hasLakeAdj) {
 			spikePrecinct.terrainAnnotation = terrainAnnotation;

--- a/game/web/src/model/loader.ts
+++ b/game/web/src/model/loader.ts
@@ -178,6 +178,9 @@ function parsePrecinct(raw: unknown, idx: number): PartialPrecinct {
   if (r["county_id"] !== undefined) {
     pc.county_id = requireString(r["county_id"], `${label}.county_id`);
   }
+  if (r["county_name"] !== undefined) {
+    pc.county_name = requireString(r["county_name"], `${label}.county_name`);
+  }
   if (r["name"] !== undefined) {
     pc.name = requireString(r["name"], `${label}.name`);
   }

--- a/game/web/src/model/scenario.ts
+++ b/game/web/src/model/scenario.ts
@@ -113,6 +113,8 @@ export interface Precinct {
 	/** false = context precinct: read-only, participates in sim, must have initial_district_id */
 	editable: boolean;
 	county_id?: string;
+	/** Human-readable county name for the precinct-info panel (GAME-089). */
+	county_name?: string;
 	/** HexAxialPosition for hex_axial geometry; CartesianPosition for custom */
 	position: HexAxialPosition | CartesianPosition;
 	/** Required for custom geometry only; must be symmetric */
@@ -255,6 +257,7 @@ export interface PartialPrecinct {
 	id: PrecinctId;
 	editable: boolean;
 	county_id?: string;
+	county_name?: string;
 	position: HexAxialPosition | CartesianPosition;
 	neighbors?: PrecinctId[];
 	total_population?: number;

--- a/game/web/src/model/types.ts
+++ b/game/web/src/model/types.ts
@@ -51,6 +51,8 @@ export interface Precinct {
 	name?: string;
 	/** County identifier from scenario (used for county border overlay) */
 	county_id?: string;
+	/** Human-readable county name (shown in the precinct-info panel) */
+	county_name?: string;
 	/** Axial hex grid coordinates */
 	coord: HexCoord;
 	/** Pixel center (pre-computed for rendering) */

--- a/game/web/src/pipeline/BUILD.bazel
+++ b/game/web/src/pipeline/BUILD.bazel
@@ -235,6 +235,60 @@ js_test(
     visibility = ["//visibility:public"],
 )
 
+# ── county_stage_lib: Stage 3b — population-aware county assignment (GAME-089) ──
+
+ts_project(
+    name = "county_stage_lib",
+    srcs = ["county-stage.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+    ],
+    visibility = ["//game/web:__subpackages__"],
+)
+
+build_test(
+    name = "county_stage_typecheck_test",
+    targets = [":county_stage_lib"],
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "county_stage_test_lib",
+    srcs = ["county-stage_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":county_stage_lib",
+        ":population_stage_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+js_test(
+    name = "county_stage_test",
+    entry_point = "county-stage_test.js",
+    data = [
+        ":county_stage_test_lib",
+        ":county_stage_lib",
+        ":population_stage_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # ── assembler_lib: Stage 4 — scenario assembly ────────────────────────────────
 
 ts_project(
@@ -303,6 +357,7 @@ ts_project(
         ":terrain_generator_lib",
         ":population_stage_lib",
         ":demographics_stage_lib",
+        ":county_stage_lib",
         ":assembler_lib",
         "//game/web/src/model:model_lib",
     ],
@@ -337,6 +392,7 @@ js_test(
         ":pipeline_runner_lib",
         ":assembler_lib",
         ":demographics_stage_lib",
+        ":county_stage_lib",
         ":population_stage_lib",
         ":terrain_generator_lib",
         ":spec_types_lib",
@@ -391,6 +447,7 @@ js_binary(
         ":pipeline_runner_lib",
         ":assembler_lib",
         ":demographics_stage_lib",
+        ":county_stage_lib",
         ":population_stage_lib",
         ":terrain_generator_lib",
         ":spec_types_lib",

--- a/game/web/src/pipeline/county-stage.ts
+++ b/game/web/src/pipeline/county-stage.ts
@@ -1,0 +1,379 @@
+/**
+ * Stage 3b of the GAME-084 pipeline: population-aware county assignment (GAME-089).
+ *
+ * Replaces the old geometric `county_labels` slices with cosmetic county
+ * boundaries that follow the population field, so counties wrap population
+ * centers the way real US counties do. `county_id` is purely cosmetic — it drives
+ * only the dashed county-border overlay, never contiguity/scoring/districting.
+ *
+ * One algorithm — seeded priority-queue flood-fill — parametrized by a named
+ * `model` preset. See thoughts/shared/research/2026-06-22-us-county-formation-patterns.md
+ * §RECOMMENDED_HEURISTIC. Principles: counties are unequal by design (the target
+ * count only sets how many seeds to drop, never balances them); the region clips
+ * counties at the map edge (a deliberate game simplification).
+ *
+ *   seat_and_hinterland (default) — each seed's flood-grown region is one county.
+ *   city_county                   — the densest center's core is carved as its own
+ *                                   county; the rest is absorbed by the other seeds.
+ *   split_metro                   — the densest center is split across seeds.
+ */
+
+import type { PartialScenario, PartialPrecinct } from "../model/scenario.js";
+import type { CountiesSpec, CountyModel, HexPos } from "./spec-types.js";
+
+// Flat-top axial hex direction vectors (same as terrain-generator / population-stage).
+const HEX_DIRS: [number, number][] = [
+  [1, 0], [0, 1], [-1, 1], [-1, 0], [0, -1], [1, -1],
+];
+
+const DEFAULTS = {
+  catchment_radius: 2,
+  anchor_threshold: 0.15,
+  dominant_threshold: 0.40,
+  core_density: 0.5,
+  trough_weight: 0.5,
+  feature_weight: 1.0,
+};
+
+// ─── Geometry helpers ───────────────────────────────────────────────────────────
+
+function posKey(q: number, r: number): string {
+  return `${q},${r}`;
+}
+
+function pos(p: PartialPrecinct): HexPos {
+  return p.position as HexPos;
+}
+
+function hexDist(a: HexPos, b: HexPos): number {
+  const dq = a.q - b.q;
+  const dr = a.r - b.r;
+  return (Math.abs(dq) + Math.abs(dr) + Math.abs(dq + dr)) / 2;
+}
+
+/** Adjacency: precinct id → ids of existing hex-adjacent neighbours. */
+function buildNeighbors(precincts: PartialPrecinct[]): Map<string, string[]> {
+  const byPos = new Map<string, string>();
+  for (const p of precincts) byPos.set(posKey(pos(p).q, pos(p).r), p.id);
+  const result = new Map<string, string[]>();
+  for (const p of precincts) {
+    const here = pos(p);
+    const ns: string[] = [];
+    for (const [dq, dr] of HEX_DIRS) {
+      const nid = byPos.get(posKey(here.q + dq, here.r + dr));
+      if (nid !== undefined) ns.push(nid);
+    }
+    result.set(p.id, ns);
+  }
+  return result;
+}
+
+/**
+ * Cardinal direction (4-way) of a position relative to the map centre, for
+ * naming. Kept to N/S/E/W so county names read cleanly ("Clearwater East" rather
+ * than "Clearwater Northeast"); seats very near the centre name "central".
+ */
+function cardinal(p: HexPos): string {
+  if (Math.abs(p.q) <= 1 && Math.abs(p.r) <= 1 && Math.abs(p.q + p.r) <= 1) return "central";
+  const scores: [string, number][] = [
+    ["east", p.q], ["west", -p.q],
+    ["north", -p.r], ["south", p.r],
+  ];
+  scores.sort((a, b) => b[1] - a[1]);
+  return scores[0]![0];
+}
+
+// ─── Centers & seeds ────────────────────────────────────────────────────────────
+
+interface Center {
+  id: string;
+  pos: HexPos;
+  pop: number;       // precinct population at the center
+  catchment: number; // summed population within catchment_radius
+}
+
+function popOf(p: PartialPrecinct): number {
+  return p.total_population ?? 0;
+}
+
+/** Local maxima: precincts whose population is ≥ all neighbours'. */
+function localMaxima(precincts: PartialPrecinct[], neighbors: Map<string, string[]>): PartialPrecinct[] {
+  const byId = new Map<string, PartialPrecinct>(precincts.map(p => [p.id, p]));
+  return precincts.filter(p => {
+    const mine = popOf(p);
+    return (neighbors.get(p.id) ?? []).every(nid => popOf(byId.get(nid)!) <= mine);
+  });
+}
+
+function catchmentPop(center: HexPos, precincts: PartialPrecinct[], radius: number): number {
+  let sum = 0;
+  for (const p of precincts) if (hexDist(pos(p), center) <= radius) sum += popOf(p);
+  return sum;
+}
+
+/**
+ * Choose county seeds: start from population local maxima, enforce a minimum
+ * separation, then greedily top up to the target count with the highest-population
+ * precincts that respect separation. Always returns at least one seed.
+ */
+function selectSeeds(
+  precincts: PartialPrecinct[],
+  neighbors: Map<string, string[]>,
+  radius: number,
+  targetCount: number,
+): Center[] {
+  const byId = new Map<string, PartialPrecinct>(precincts.map(p => [p.id, p]));
+  const mkCenter = (p: PartialPrecinct): Center => ({
+    id: p.id,
+    pos: pos(p),
+    pop: popOf(p),
+    catchment: catchmentPop(pos(p), precincts, radius),
+  });
+
+  const farEnough = (p: PartialPrecinct, chosen: Center[]) =>
+    chosen.every(c => hexDist(pos(p), c.pos) >= radius);
+
+  const seeds: Center[] = [];
+  // 1) Local maxima, densest first, respecting separation.
+  const maxima = localMaxima(precincts, neighbors).sort((a, b) => popOf(b) - popOf(a));
+  for (const p of maxima) {
+    if (seeds.length >= targetCount) break;
+    if (farEnough(p, seeds)) seeds.push(mkCenter(p));
+  }
+  // 2) Top up with the highest-population precincts that respect separation.
+  if (seeds.length < targetCount) {
+    const rest = precincts
+      .filter(p => !seeds.some(c => c.id === p.id))
+      .sort((a, b) => popOf(b) - popOf(a));
+    for (const p of rest) {
+      if (seeds.length >= targetCount) break;
+      if (farEnough(p, seeds)) seeds.push(mkCenter(p));
+    }
+  }
+  if (seeds.length === 0 && precincts.length > 0) {
+    // Degenerate fallback: single densest precinct.
+    const densest = precincts.reduce((a, b) => (popOf(b) > popOf(a) ? b : a));
+    seeds.push(mkCenter(densest));
+  }
+  return seeds;
+}
+
+// ─── Flood-fill ─────────────────────────────────────────────────────────────────
+
+interface FloodOpts {
+  precincts: PartialPrecinct[];
+  neighbors: Map<string, string[]>;
+  riverEdges: Set<string>; // "a|b" unordered keys
+  troughWeight: number;
+  featureWeight: number;
+  excluded?: Set<string>;  // precincts already claimed (e.g. carved core)
+}
+
+function edgeKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+/**
+ * Multi-source Dijkstra flood-fill. Returns precinctId → seedId (the county it
+ * was claimed by). Cost to cross into a neighbour rises in population troughs and
+ * across river/feature edges, so borders settle in valleys and along rivers.
+ */
+function floodFill(seeds: string[], opts: FloodOpts): Map<string, string> {
+  const { precincts, neighbors, riverEdges, troughWeight, featureWeight, excluded } = opts;
+  const byId = new Map<string, PartialPrecinct>(precincts.map(p => [p.id, p]));
+  let min = Infinity, max = -Infinity;
+  for (const p of precincts) {
+    if (excluded?.has(p.id)) continue;
+    const v = popOf(p);
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const range = max - min || 1;
+
+  const owner = new Map<string, string>();
+  const best = new Map<string, number>();
+  // Simple array-based priority queue (small graphs: ~100 nodes).
+  const frontier: { id: string; cost: number; seed: string }[] = [];
+  for (const s of seeds) {
+    frontier.push({ id: s, cost: 0, seed: s });
+    best.set(s, 0);
+  }
+  while (frontier.length > 0) {
+    let mi = 0;
+    for (let i = 1; i < frontier.length; i++) if (frontier[i]!.cost < frontier[mi]!.cost) mi = i;
+    const cur = frontier.splice(mi, 1)[0]!;
+    if (owner.has(cur.id)) continue;
+    owner.set(cur.id, cur.seed);
+    for (const nid of neighbors.get(cur.id) ?? []) {
+      if (owner.has(nid) || excluded?.has(nid)) continue;
+      const np = byId.get(nid)!;
+      const trough = troughWeight * (1 - (popOf(np) - min) / range);
+      const feature = riverEdges.has(edgeKey(cur.id, nid)) ? featureWeight : 0;
+      const cost = cur.cost + 1 + trough + feature;
+      if (cost < (best.get(nid) ?? Infinity)) {
+        best.set(nid, cost);
+        frontier.push({ id: nid, cost, seed: cur.seed });
+      }
+    }
+  }
+  return owner;
+}
+
+/**
+ * Carve the urban core around a center: flood out from the peak through precincts
+ * whose population clears a density contour, staying contiguous. The contour is
+ * range-relative — `min + coreDensity × (peak − min)` — so "out to a certain
+ * density" means the same thing whether the field is steep or flat (a peak-
+ * relative cutoff would swallow the whole map on a gentle gradient). Returns the
+ * core precinct ids.
+ */
+function carveCore(
+  center: Center,
+  precincts: PartialPrecinct[],
+  neighbors: Map<string, string[]>,
+  coreDensity: number,
+): Set<string> {
+  const byId = new Map<string, PartialPrecinct>(precincts.map(p => [p.id, p]));
+  let gmin = Infinity;
+  for (const p of precincts) { const v = popOf(p); if (v < gmin) gmin = v; }
+  const threshold = gmin + coreDensity * (center.pop - gmin);
+  const core = new Set<string>([center.id]);
+  const queue = [center.id];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    for (const nid of neighbors.get(id) ?? []) {
+      if (core.has(nid)) continue;
+      if (popOf(byId.get(nid)!) >= threshold) {
+        core.add(nid);
+        queue.push(nid);
+      }
+    }
+  }
+  return core;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export function assignCountiesByPopulation(
+  partial: PartialScenario,
+  spec: CountiesSpec,
+): PartialScenario {
+  const precincts = partial.precincts;
+  if (precincts.length === 0) return partial;
+
+  const model: CountyModel = spec.model ?? "seat_and_hinterland";
+  const radius = spec.catchment_radius ?? DEFAULTS.catchment_radius;
+  const targetCount = spec.target_count ?? Math.max(1, Math.round(precincts.length / 14));
+  const dominantThreshold = spec.dominant_threshold ?? DEFAULTS.dominant_threshold;
+  const coreDensity = spec.core_density ?? DEFAULTS.core_density;
+  const troughWeight = spec.trough_weight ?? DEFAULTS.trough_weight;
+  const featureWeight = spec.feature_weight ?? DEFAULTS.feature_weight;
+  const prefix = spec.id_prefix ?? partial.region?.id ?? "county";
+
+  const neighbors = buildNeighbors(precincts);
+  const total = precincts.reduce((s, p) => s + popOf(p), 0);
+
+  const riverEdges = new Set<string>();
+  for (const [a, b] of partial.river_edges ?? []) riverEdges.add(edgeKey(a, b));
+
+  let seeds = selectSeeds(precincts, neighbors, radius, targetCount);
+  seeds.sort((a, b) => b.catchment - a.catchment); // densest first
+
+  // Identify dominant centers (eligible for core carving). When the author picks
+  // city_county explicitly, the single largest center is treated as dominant even
+  // if it doesn't clear the threshold — the named model is the intent.
+  const dominant = new Set<string>();
+  if (model === "city_county" || model === "split_metro") {
+    for (const c of seeds) if (c.catchment >= dominantThreshold * total) dominant.add(c.id);
+    if (dominant.size === 0 && seeds.length > 0) dominant.add(seeds[0]!.id);
+  }
+
+  const ownerToCounty = new Map<string, string>(); // seedId → county id
+  const coreCounties = new Map<string, Set<string>>(); // county id → precinct ids (carved cores)
+  const usedNames = new Map<string, number>();
+  const countyNames = new Map<string, string>(); // county id → human display name
+  const titleCase = (s: string): string =>
+    s.split(/[_\s]+/).filter(Boolean).map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+  const nameFor = (base: string): string => {
+    const n = usedNames.get(base) ?? 0;
+    usedNames.set(base, n + 1);
+    const id = n === 0 ? `${prefix}_${base}` : `${prefix}_${base}${n + 1}`;
+    const display = `${titleCase(prefix)} ${titleCase(base)}` + (n === 0 ? "" : ` ${n + 1}`);
+    countyNames.set(id, display);
+    return id;
+  };
+
+  const assignment = new Map<string, string>(); // precinctId → county id
+
+  if (model === "city_county") {
+    // Carve each dominant center's core; flood the remainder from the OTHER seeds.
+    const excluded = new Set<string>();
+    for (const c of seeds) {
+      if (!dominant.has(c.id)) continue;
+      const core = carveCore(c, precincts, neighbors, coreDensity);
+      const cid = nameFor("city");
+      coreCounties.set(cid, core);
+      for (const id of core) {
+        assignment.set(id, cid);
+        excluded.add(id);
+      }
+    }
+    const ringSeeds = seeds.filter(c => !dominant.has(c.id));
+    if (ringSeeds.length === 0) {
+      // No non-dominant anchors: the non-core remainder becomes one hinterland county.
+      const cid = nameFor("hinterland");
+      for (const p of precincts) if (!excluded.has(p.id)) assignment.set(p.id, cid);
+    } else {
+      for (const c of ringSeeds) ownerToCounty.set(c.id, nameFor(cardinal(c.pos)));
+      const owner = floodFill(ringSeeds.map(c => c.id), {
+        precincts, neighbors, riverEdges, troughWeight, featureWeight, excluded,
+      });
+      for (const [pid, seedId] of owner) assignment.set(pid, ownerToCounty.get(seedId)!);
+    }
+  } else {
+    // seat_and_hinterland (and split_metro's base): one county per seed.
+    let fillSeeds = seeds.map(c => c.id);
+    if (model === "split_metro") {
+      // Add a second seed inside each dominant center to split the metro.
+      for (const c of seeds) {
+        if (!dominant.has(c.id)) continue;
+        const ring = (neighbors.get(c.id) ?? []);
+        const extra = ring.find(nid => !fillSeeds.includes(nid));
+        if (extra) {
+          fillSeeds.push(extra);
+          ownerToCounty.set(extra, nameFor(`${cardinal(c.pos)}_metro`));
+        }
+      }
+    }
+    for (const c of seeds) {
+      if (!ownerToCounty.has(c.id)) ownerToCounty.set(c.id, nameFor(cardinal(c.pos)));
+    }
+    const owner = floodFill(fillSeeds, {
+      precincts, neighbors, riverEdges, troughWeight, featureWeight,
+    });
+    for (const [pid, seedId] of owner) assignment.set(pid, ownerToCounty.get(seedId)!);
+  }
+
+  // Orphan sweep: any precinct the fill never reached → the county of its nearest
+  // already-assigned precinct (never mints a new county, so no stray singletons).
+  const assignedSnapshot = precincts.filter(p => assignment.has(p.id));
+  for (const p of precincts) {
+    if (assignment.has(p.id)) continue;
+    let best: PartialPrecinct | null = null;
+    let bestD = Infinity;
+    for (const q of assignedSnapshot) {
+      const d = hexDist(pos(p), pos(q));
+      if (d < bestD) { bestD = d; best = q; }
+    }
+    if (best) assignment.set(p.id, assignment.get(best.id)!);
+  }
+
+  const out = precincts.map(p => {
+    const cid = assignment.get(p.id)!;
+    const name = countyNames.get(cid);
+    return name !== undefined
+      ? { ...p, county_id: cid, county_name: name }
+      : { ...p, county_id: cid };
+  });
+  return { ...partial, precincts: out };
+}

--- a/game/web/src/pipeline/county-stage_test.ts
+++ b/game/web/src/pipeline/county-stage_test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the population-aware county stage (GAME-089).
+ *
+ * Covers:
+ *   - Every precinct receives a county_id
+ *   - Determinism (same input → same assignment)
+ *   - Each county is spatially contiguous (flood-fill invariant)
+ *   - County count respects the target
+ *   - seat_and_hinterland: densest center anchors the biggest county
+ *   - city_county: the dense core is carved into its own "_city" county,
+ *     distinct from the surrounding counties
+ *   - Multiple centers → multiple counties (Clark County multi-town absorption)
+ *
+ * Run via Bazel: bazel test //game/web/src/pipeline:county_stage_test
+ */
+
+import { assignCountiesByPopulation } from "./county-stage.js";
+import { populateScenario } from "./population-stage.js";
+import { generateTerrain } from "./terrain-generator.js";
+import type { PipelineSpec, PopulationSpec, CountiesSpec } from "./spec-types.js";
+import type { PartialScenario } from "../model/scenario.js";
+import { test, assertEqual, summarize } from "../testing/test_runner.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function terrainSpec(radius: number): PipelineSpec {
+  return {
+    format_version: "1",
+    scenario: {
+      id: "county-test",
+      title: "County Test",
+      election_type: "state_house",
+      region: { id: "testco", name: "Test County" },
+    },
+    map: { geometry: "hex_axial", shape: "hex_circle", radius },
+  };
+}
+
+// A radius-5 map with a strong central city + a secondary eastern town, so the
+// field has two clear local maxima plus a rural west.
+function populatedPartial(overrides: Partial<PopulationSpec> = {}): PartialScenario {
+  const partial = generateTerrain(terrainSpec(5));
+  const pop: PopulationSpec = {
+    seed: 42,
+    base: 1500,
+    variance: 100,
+    gradient: { strength: 0.3 },
+    smoothing: 2,
+    contrast: 1.3,
+    target_total: 144000,
+    settlements: [
+      { anchor: "center", peak: 800, radius: 3 },
+      { anchor: "east", peak: 400, radius: 1 },
+    ],
+    ...overrides,
+  };
+  return populateScenario(partial, pop);
+}
+
+function pos(p: { position: unknown }): { q: number; r: number } {
+  return p.position as { q: number; r: number };
+}
+
+const HEX_DIRS: [number, number][] = [
+  [1, 0], [0, 1], [-1, 1], [-1, 0], [0, -1], [1, -1],
+];
+
+function isContiguous(result: PartialScenario, countyId: string): boolean {
+  const members = result.precincts.filter(p => p.county_id === countyId);
+  if (members.length <= 1) return true;
+  const ids = new Set(members.map(p => p.id));
+  const byPos = new Map(members.map(p => [`${pos(p).q},${pos(p).r}`, p.id]));
+  const posById = new Map(members.map(p => [p.id, pos(p)]));
+  const start = members[0]!.id;
+  const seen = new Set<string>([start]);
+  const queue = [start];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    const { q, r } = posById.get(id)!;
+    for (const [dq, dr] of HEX_DIRS) {
+      const nid = byPos.get(`${q + dq},${r + dr}`);
+      if (nid !== undefined && ids.has(nid) && !seen.has(nid)) {
+        seen.add(nid);
+        queue.push(nid);
+      }
+    }
+  }
+  return seen.size === members.length;
+}
+
+function countyIds(result: PartialScenario): string[] {
+  return [...new Set(result.precincts.map(p => p.county_id!))];
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────────
+
+test("county: every precinct receives a county_id", () => {
+  const result = assignCountiesByPopulation(populatedPartial(), { model: "seat_and_hinterland" });
+  assertEqual(result.precincts.every(p => typeof p.county_id === "string" && p.county_id.length > 0), true);
+});
+
+test("county: assignment is deterministic", () => {
+  const a = assignCountiesByPopulation(populatedPartial(), { model: "city_county" });
+  const b = assignCountiesByPopulation(populatedPartial(), { model: "city_county" });
+  for (let i = 0; i < a.precincts.length; i++) {
+    assertEqual(a.precincts[i]!.county_id, b.precincts[i]!.county_id);
+  }
+});
+
+test("county: every county is spatially contiguous (seat_and_hinterland)", () => {
+  const result = assignCountiesByPopulation(populatedPartial(), { model: "seat_and_hinterland" });
+  for (const cid of countyIds(result)) {
+    assertEqual(isContiguous(result, cid), true);
+  }
+});
+
+test("county: county count respects the target", () => {
+  const result = assignCountiesByPopulation(populatedPartial(), {
+    model: "seat_and_hinterland",
+    target_count: 3,
+  });
+  assertEqual(countyIds(result).length <= 3, true);
+  assertEqual(countyIds(result).length >= 1, true);
+});
+
+test("county: does not mutate the input scenario", () => {
+  const partial = populatedPartial();
+  assignCountiesByPopulation(partial, { model: "city_county" });
+  assertEqual(partial.precincts.every(p => p.county_id === undefined), true);
+});
+
+test("city_county: the dense core is carved into its own '_city' county", () => {
+  const result = assignCountiesByPopulation(populatedPartial(), {
+    model: "city_county",
+    target_count: 3,
+  });
+  // The densest precinct (the city peak) must live in a county whose id ends in "city".
+  const peak = result.precincts.reduce((a, b) =>
+    (b.total_population ?? 0) > (a.total_population ?? 0) ? b : a);
+  assertEqual(peak.county_id!.endsWith("city"), true);
+  // The city county must not span the whole map — other counties exist.
+  assertEqual(countyIds(result).length >= 2, true);
+});
+
+test("city_county: a rim precinct is in a different county than the city core", () => {
+  const result = assignCountiesByPopulation(populatedPartial(), {
+    model: "city_county",
+    target_count: 3,
+  });
+  const peak = result.precincts.reduce((a, b) =>
+    (b.total_population ?? 0) > (a.total_population ?? 0) ? b : a);
+  // A far-west rim precinct should not be in the city county.
+  const rim = result.precincts.reduce((a, b) => (pos(b).q < pos(a).q ? b : a));
+  assertEqual(rim.county_id !== peak.county_id, true);
+});
+
+test("county: multiple centers produce multiple counties", () => {
+  const result = assignCountiesByPopulation(populatedPartial(), {
+    model: "seat_and_hinterland",
+    target_count: 3,
+  });
+  assertEqual(countyIds(result).length >= 2, true);
+});
+
+test("county: empty scenario is returned unchanged", () => {
+  const partial = generateTerrain(terrainSpec(1));
+  const emptied: PartialScenario = { ...partial, precincts: [] };
+  const result = assignCountiesByPopulation(emptied, { model: "city_county" });
+  assertEqual(result.precincts.length, 0);
+});
+
+summarize();

--- a/game/web/src/pipeline/pipeline-runner.ts
+++ b/game/web/src/pipeline/pipeline-runner.ts
@@ -1,6 +1,7 @@
 import { generateTerrain } from "./terrain-generator.js";
 import { populateScenario } from "./population-stage.js";
 import { addDemographics, assignCounties } from "./demographics-stage.js";
+import { assignCountiesByPopulation } from "./county-stage.js";
 import { assembleScenario } from "./assembler.js";
 import type { PartialScenario } from "../model/scenario.js";
 import type { PipelineSpec } from "./spec-types.js";
@@ -14,9 +15,19 @@ export function runPipeline(spec: PipelineSpec): PartialScenario {
 
   if (spec.demographics) {
     partial = addDemographics(partial, spec.demographics);
-    if (spec.demographics.county_labels && spec.demographics.county_labels.length > 0) {
+    // Legacy geometric counties — only when the population-aware stage is not used.
+    if (
+      !spec.counties &&
+      spec.demographics.county_labels &&
+      spec.demographics.county_labels.length > 0
+    ) {
       partial = assignCounties(partial, spec.demographics.county_labels);
     }
+  }
+
+  // GAME-089: population-aware cosmetic counties (runs after population field exists).
+  if (spec.counties) {
+    partial = assignCountiesByPopulation(partial, spec.counties);
   }
 
   if (spec.assembly) {

--- a/game/web/src/pipeline/population-stage.ts
+++ b/game/web/src/pipeline/population-stage.ts
@@ -114,6 +114,28 @@ function buildTerrainContexts(partial: PartialScenario): Map<string, TerrainCont
   return result;
 }
 
+/**
+ * Settlement population contribution at a given hex distance from the anchor.
+ *   gaussian — peak × exp(-dist²/2σ²), σ = radius/2 (smooth cone).
+ *   plateau  — flat at peak within the inner half-radius, then linear to 0 at
+ *              `radius` (dense core with a sharp edge).
+ */
+function settlementBump(
+  peak: number,
+  radius: number,
+  dist: number,
+  profile: "gaussian" | "plateau",
+): number {
+  if (profile === "plateau") {
+    const inner = radius / 2;
+    if (dist <= inner) return peak;
+    if (dist >= radius) return 0;
+    return peak * (1 - (dist - inner) / (radius - inner));
+  }
+  const sigma = radius / 2;
+  return peak * Math.exp(-(dist * dist) / (2 * sigma * sigma));
+}
+
 function computeSuitability(ctx: TerrainContext, w: Required<TerrainWeightsSpec>): number {
   let s = 1.0;
   if (ctx.lakeside) s *= w.lakeside;
@@ -320,11 +342,10 @@ export function populateScenario(
       suitabilities,
       terrainContexts,
     );
-    const sigma = settlement.radius / 2;
-    const twoSigmaSq = 2 * sigma * sigma;
+    const profile = settlement.profile ?? "gaussian";
     for (const p of partial.precincts) {
       const dist = hexDist(p.position as HexPos, anchorPos);
-      const bump = settlement.peak * Math.exp(-(dist * dist) / twoSigmaSq);
+      const bump = settlementBump(settlement.peak, settlement.radius, dist, profile);
       settlementBumps.set(p.id, (settlementBumps.get(p.id) ?? 0) + bump);
     }
   }

--- a/game/web/src/pipeline/population-stage.ts
+++ b/game/web/src/pipeline/population-stage.ts
@@ -14,9 +14,18 @@
  *     precinct. Anchor types: exact {q,r}, feature-based (lakeside/riverside/
  *     coastal), center, or cardinal directions.
  *
- *   Final formula per precinct:
- *     total_population = round(base × suitability + settlement_bump
- *                              + prng.nextInt(-variance, variance) × suitability)
+ *   Final formula per precinct (GAME-087 core):
+ *     raw = base × suitability × gradient + settlement_bump + jitter × suitability
+ *
+ *   GAME-088 field-shaping layers (all opt-in; unset → legacy additive field):
+ *     gradient   — monocentric multiplier tilting population toward an anchor
+ *     smoothing  — neighbour-averaging passes on the jitter (kills salt-and-pepper)
+ *     contrast   — pow(k) on the normalized field (widens dynamic range)
+ *     target_total — scale the field so Σ total_population hits a target
+ *                    (changes the field's shape without changing its magnitude)
+ *
+ * With no GAME-088 layers set, the formula reduces exactly to GAME-087's
+ *   round(base × suitability + settlement_bump + jitter × suitability).
  *
  * Always overwrites existing total_population; input PartialScenario is not mutated.
  */
@@ -187,6 +196,98 @@ function resolveAnchor(
   return best.position as HexPos;
 }
 
+// ─── GAME-088 field-shaping helpers (all opt-in) ────────────────────────────────
+
+/** Build adjacency: precinct id → ids of existing hex-adjacent neighbours. */
+function buildNeighbors(partial: PartialScenario): Map<string, string[]> {
+  const byPos = new Map<string, string>();
+  for (const p of partial.precincts) {
+    const pos = p.position as HexPos;
+    byPos.set(posKey(pos.q, pos.r), p.id);
+  }
+  const result = new Map<string, string[]>();
+  for (const p of partial.precincts) {
+    const pos = p.position as HexPos;
+    const neighbors: string[] = [];
+    for (const [dq, dr] of HEX_DIRS) {
+      const nid = byPos.get(posKey(pos.q + dq, pos.r + dr));
+      if (nid !== undefined) neighbors.push(nid);
+    }
+    result.set(p.id, neighbors);
+  }
+  return result;
+}
+
+/**
+ * Monocentric gradient multiplier per precinct: `1 - strength` at the rim up to
+ * `1 + strength` at the anchor (mean ~1). Tilts population toward the anchor.
+ */
+function computeGradientMultipliers(
+  partial: PartialScenario,
+  anchorPos: HexPos,
+  strength: number,
+): Map<string, number> {
+  let maxDist = 0;
+  for (const p of partial.precincts) {
+    const d = hexDist(p.position as HexPos, anchorPos);
+    if (d > maxDist) maxDist = d;
+  }
+  const result = new Map<string, number>();
+  for (const p of partial.precincts) {
+    const d = hexDist(p.position as HexPos, anchorPos);
+    const closeness = maxDist > 0 ? 1 - d / maxDist : 1; // 1 at anchor, 0 at rim
+    result.set(p.id, 1 - strength + closeness * 2 * strength);
+  }
+  return result;
+}
+
+/**
+ * Average each precinct's noise value with its neighbours, `passes` times.
+ * Replaces salt-and-pepper independent jitter with a spatially-coherent field.
+ * Mutates `noise` in place.
+ */
+function smoothNoise(
+  noise: Map<string, number>,
+  neighbors: Map<string, string[]>,
+  passes: number,
+): void {
+  for (let pass = 0; pass < passes; pass++) {
+    const next = new Map<string, number>();
+    for (const [id, value] of noise) {
+      const nbrs = neighbors.get(id) ?? [];
+      let sum = value;
+      for (const nid of nbrs) sum += noise.get(nid) ?? 0;
+      next.set(id, sum / (nbrs.length + 1));
+    }
+    for (const [id, value] of next) noise.set(id, value);
+  }
+}
+
+/**
+ * pow-contrast on a field, anchored to its [min, max]: interior values are
+ * reshaped by `n^k` while the extremes stay fixed. k>1 lightens the fringe and
+ * relatively sharpens dense areas, widening the dynamic range.
+ */
+function applyContrast(field: Map<string, number>, k: number): Map<string, number> {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const v of field.values()) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const range = max - min;
+  const result = new Map<string, number>();
+  for (const [id, v] of field) {
+    if (range === 0) {
+      result.set(id, v);
+    } else {
+      const n = (v - min) / range;
+      result.set(id, min + Math.pow(n, k) * range);
+    }
+  }
+  return result;
+}
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 export function populateScenario(
@@ -228,15 +329,54 @@ export function populateScenario(
     }
   }
 
-  const precincts = partial.precincts.map(p => {
-    const suitability = suitabilities.get(p.id)!;
-    const bump = settlementBumps.get(p.id) ?? 0;
-    const jitter = prng.nextInt(-spec.variance, spec.variance);
-    const total_population = Math.round(
-      spec.base * suitability + bump + jitter * suitability,
+  // Gradient multipliers (GAME-088). Default 1.0 everywhere when no gradient spec.
+  let gradientMul: Map<string, number> | null = null;
+  if (spec.gradient && spec.gradient.strength !== 0) {
+    const gradientAnchor = resolveAnchor(
+      spec.gradient.anchor ?? "center",
+      partial,
+      suitabilities,
+      terrainContexts,
     );
-    return { ...p, total_population };
-  });
+    gradientMul = computeGradientMultipliers(partial, gradientAnchor, spec.gradient.strength);
+  }
+
+  // Per-precinct jitter, drawn in precinct order (preserves legacy determinism:
+  // with no field-shaping layers the formula reduces exactly to GAME-087's).
+  const noise = new Map<string, number>();
+  for (const p of partial.precincts) {
+    noise.set(p.id, prng.nextInt(-spec.variance, spec.variance));
+  }
+  if (spec.smoothing !== undefined && spec.smoothing > 0) {
+    smoothNoise(noise, buildNeighbors(partial), spec.smoothing);
+  }
+
+  // Raw field: base × suitability × gradient + settlement bump + jitter × suitability.
+  let field = new Map<string, number>();
+  for (const p of partial.precincts) {
+    const suitability = suitabilities.get(p.id)!;
+    const g = gradientMul?.get(p.id) ?? 1.0;
+    const bump = settlementBumps.get(p.id) ?? 0;
+    field.set(p.id, spec.base * suitability * g + bump + noise.get(p.id)! * suitability);
+  }
+
+  // Contrast: widen dynamic range so density reads as a gradient, not a flat field.
+  if (spec.contrast !== undefined && spec.contrast !== 1) {
+    field = applyContrast(field, spec.contrast);
+  }
+
+  // Normalize to a target total: change the shape of the field, not its magnitude.
+  let scale = 1;
+  if (spec.target_total !== undefined) {
+    let sum = 0;
+    for (const v of field.values()) sum += v;
+    if (sum > 0) scale = spec.target_total / sum;
+  }
+
+  const precincts = partial.precincts.map(p => ({
+    ...p,
+    total_population: Math.round(field.get(p.id)! * scale),
+  }));
 
   return { ...partial, precincts };
 }

--- a/game/web/src/pipeline/population-stage_test.ts
+++ b/game/web/src/pipeline/population-stage_test.ts
@@ -598,4 +598,23 @@ test("contrast: widens dynamic range (denser core) at a fixed total", () => {
   assertEqual(maxOf(sharp) > maxOf(flat), true);
 });
 
+test("settlement plateau: flat top within inner radius, zero beyond radius", () => {
+  const partial = makePartial(4);
+  const spec = basePopSpec({
+    base: 1000, variance: 0,
+    settlements: [{ anchor: "center", peak: 5000, radius: 2, profile: "plateau" }],
+  });
+  const result = populateScenario(partial, spec);
+  const at = (q: number, r: number) =>
+    result.precincts.find(p => {
+      const pos = p.position as { q: number; r: number };
+      return pos.q === q && pos.r === r;
+    })!;
+  // inner = radius/2 = 1 → dist 0 and dist 1 both sit on the flat top (base + peak).
+  assertEqual(at(0, 0).total_population, at(1, 0).total_population);
+  assertEqual(at(0, 0).total_population, 6000);
+  // dist 4 > radius 2 → no bump, base only.
+  assertEqual(at(4, 0).total_population, 1000);
+});
+
 summarize();

--- a/game/web/src/pipeline/population-stage_test.ts
+++ b/game/web/src/pipeline/population-stage_test.ts
@@ -514,4 +514,88 @@ test("resolveAnchor: feature anchor throws when no matching precincts (no sea ti
   assertEqual(threw, true);
 });
 
+// ─── GAME-088: field-shaping layers ─────────────────────────────────────────────
+
+function popStdDev(result: PartialScenario): number {
+  const vals = result.precincts.map(p => p.total_population!);
+  const mean = vals.reduce((s, v) => s + v, 0) / vals.length;
+  const variance = vals.reduce((s, v) => s + (v - mean) ** 2, 0) / vals.length;
+  return Math.sqrt(variance);
+}
+
+test("gradient: unset layers reduce exactly to the legacy additive formula", () => {
+  // Back-compat guard: explicit no-op layers must equal omitting them.
+  const partial = makePartial(3);
+  const legacy = populateScenario(partial, basePopSpec({ base: 1000, variance: 100 }));
+  const noop = populateScenario(
+    partial,
+    basePopSpec({ base: 1000, variance: 100, smoothing: 0, contrast: 1 }),
+  );
+  for (let i = 0; i < legacy.precincts.length; i++) {
+    assertEqual(legacy.precincts[i]!.total_population, noop.precincts[i]!.total_population);
+  }
+});
+
+test("gradient: center precinct outweighs the rim when strength > 0", () => {
+  const partial = makePartial(3);
+  const spec = basePopSpec({ base: 1000, variance: 0, gradient: { strength: 0.5 } });
+  const result = populateScenario(partial, spec);
+  const center = result.precincts.find(p => {
+    const pos = p.position as { q: number; r: number };
+    return pos.q === 0 && pos.r === 0;
+  })!;
+  const maxOther = Math.max(...result.precincts.filter(p => p.id !== center.id).map(p => p.total_population!));
+  assertEqual(center.total_population! > maxOther, true);
+});
+
+test("gradient: strength 0 leaves a flat field flat", () => {
+  const partial = makePartial(3);
+  const spec = basePopSpec({ base: 1000, variance: 0, gradient: { strength: 0 } });
+  const result = populateScenario(partial, spec);
+  for (const p of result.precincts) {
+    assertEqual(p.total_population, 1000);
+  }
+});
+
+test("smoothing: reduces the spread of an i.i.d. jitter field", () => {
+  const partial = makePartial(4);
+  const rough = populateScenario(partial, basePopSpec({ base: 1000, variance: 500, smoothing: 0 }));
+  const smooth = populateScenario(partial, basePopSpec({ base: 1000, variance: 500, smoothing: 3 }));
+  assertEqual(popStdDev(smooth) < popStdDev(rough), true);
+});
+
+test("smoothing: stays deterministic with the same seed", () => {
+  const partial = makePartial(3);
+  const spec = basePopSpec({ base: 1000, variance: 300, smoothing: 2, seed: 11 });
+  const a = populateScenario(partial, spec);
+  const b = populateScenario(partial, spec);
+  for (let i = 0; i < a.precincts.length; i++) {
+    assertEqual(a.precincts[i]!.total_population, b.precincts[i]!.total_population);
+  }
+});
+
+test("target_total: final field sums to the target (within rounding)", () => {
+  const partial = makePartial(5); // 91 precincts
+  const spec = basePopSpec({ base: 1500, variance: 150, target_total: 100000 });
+  const result = populateScenario(partial, spec);
+  const sum = result.precincts.reduce((s, p) => s + p.total_population!, 0);
+  // Per-precinct rounding can drift the sum by at most ~half a unit per precinct.
+  assertEqual(Math.abs(sum - 100000) <= result.precincts.length, true);
+});
+
+test("contrast: widens dynamic range (denser core) at a fixed total", () => {
+  const partial = makePartial(4);
+  const flat = populateScenario(
+    partial,
+    basePopSpec({ base: 1000, variance: 0, gradient: { strength: 0.5 }, target_total: 100000, contrast: 1 }),
+  );
+  const sharp = populateScenario(
+    partial,
+    basePopSpec({ base: 1000, variance: 0, gradient: { strength: 0.5 }, target_total: 100000, contrast: 2 }),
+  );
+  const maxOf = (r: PartialScenario) => Math.max(...r.precincts.map(p => p.total_population!));
+  // Same total, but contrast pushes the peak higher.
+  assertEqual(maxOf(sharp) > maxOf(flat), true);
+});
+
 summarize();

--- a/game/web/src/pipeline/spec-types.ts
+++ b/game/web/src/pipeline/spec-types.ts
@@ -79,6 +79,20 @@ export interface SettlementSpec {
   radius: number;
 }
 
+/**
+ * Optional monocentric density gradient (GAME-088).
+ *
+ * Tilts population toward an anchor so the map reads as "dense core → rural
+ * fringe" instead of a flat field with a central spike. Multiplier ranges from
+ * `1 - strength` at the rim to `1 + strength` at the anchor (mean ~1).
+ */
+export interface PopulationGradientSpec {
+  /** Where density peaks. Defaults to "center". */
+  anchor?: SettlementAnchor;
+  /** 0 = flat (off); higher tilts more population toward the anchor. Suggested 0.2–0.6. */
+  strength: number;
+}
+
 export interface PopulationSpec {
   /** Seed for the deterministic PRNG used to generate per-precinct populations. */
   seed: number;
@@ -90,6 +104,25 @@ export interface PopulationSpec {
   terrain_weights?: TerrainWeightsSpec;
   /** Optional named settlement zones that add Gaussian population bumps. */
   settlements?: SettlementSpec[];
+  // ── GAME-088 field-shaping layers (all opt-in; unset = legacy additive field) ──
+  /** Monocentric density gradient (urban core → rural fringe). Default: off. */
+  gradient?: PopulationGradientSpec;
+  /**
+   * Neighbour-averaging passes applied to the jitter component to remove
+   * salt-and-pepper noise (so neighbours correlate). Default 0 = independent jitter.
+   */
+  smoothing?: number;
+  /**
+   * Contrast exponent (pow) applied to the normalized field. >1 sharpens dense
+   * areas and lightens the fringe; widens dynamic range. Default 1 = off.
+   */
+  contrast?: number;
+  /**
+   * If set, the final field is scaled so total population equals this. Lets us
+   * change the *shape* of the distribution without changing its magnitude
+   * (keeps district-balance tests stable). Default: unset = no normalization.
+   */
+  target_total?: number;
 }
 
 // ─── Stage 3: Demographics ────────────────────────────────────────────────────

--- a/game/web/src/pipeline/spec-types.ts
+++ b/game/web/src/pipeline/spec-types.ts
@@ -77,6 +77,14 @@ export interface SettlementSpec {
   anchor: SettlementAnchor;
   peak: number;
   radius: number;
+  /**
+   * Falloff shape from the anchor (GAME-088).
+   *   gaussian (default) — smooth bell; classic monocentric cone.
+   *   plateau            — flat at peak within the inner half-radius, then a
+   *                        linear drop to 0 at `radius`. Reads as a dense urban
+   *                        core with a sharp edge rather than a smooth slope.
+   */
+  profile?: "gaussian" | "plateau";
 }
 
 /**
@@ -158,6 +166,44 @@ export interface DemographicsSpec {
   jitter: number;
   zones: ZoneSpec[];
   county_labels?: CountyLabelSpec[];
+}
+
+// ─── Stage 3b: Counties (GAME-089) ────────────────────────────────────────────
+
+/**
+ * County-generation archetype. Named to be intuited on sight (the owner reasons
+ * in real-city examples, not raw knobs). See the county-formation research
+ * §RECOMMENDED_HEURISTIC for the full mapping.
+ *
+ *   seat_and_hinterland — town + rural surround; the densest center is just the
+ *                         biggest county (most US county seats). Default.
+ *   city_county         — the dense core is carved as its own county; the
+ *                         surrounding area is absorbed by separate neighbouring
+ *                         counties (San Francisco / Denver / Portland's Multnomah).
+ *   split_metro         — one large center is split across several counties by
+ *                         placing multiple seeds inside it (a big metro).
+ */
+export type CountyModel = "seat_and_hinterland" | "city_county" | "split_metro";
+
+export interface CountiesSpec {
+  /** Named archetype preset. Default: "seat_and_hinterland". */
+  model?: CountyModel;
+  /** Catchment radius in hexes — the "day's ride" size knob. Default 2. */
+  catchment_radius?: number;
+  /** Target number of counties. Default: round(precinct_count / 14). */
+  target_count?: number;
+  /** Catchment-pop fraction of the total for a center to anchor its own county. Default 0.15. */
+  anchor_threshold?: number;
+  /** Catchment-pop fraction making a center "dominant" (core/ring eligible). Default 0.40. */
+  dominant_threshold?: number;
+  /** Urban-core density cutoff as a fraction of the center's peak (city_county). Default 0.5. */
+  core_density?: number;
+  /** Border cost bias toward population troughs (higher = borders settle in valleys). Default 0.5. */
+  trough_weight?: number;
+  /** Border cost bias toward crossing terrain features / rivers. Default 1.0. */
+  feature_weight?: number;
+  /** Prefix for generated county ids (e.g. "clearwater" → "clearwater_city"). Default: region id. */
+  id_prefix?: string;
 }
 
 // ─── Stage 4: Assembly ───────────────────────────────────────────────────────
@@ -247,5 +293,6 @@ export interface PipelineSpec {
   terrain?: TerrainSpec;
   population?: PopulationSpec;
   demographics?: DemographicsSpec;
+  counties?: CountiesSpec;
   assembly?: AssemblySpec;
 }

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -22,7 +22,7 @@
 
 import * as d3 from "d3";
 import { HEX_DIRECTIONS, HEX_SIZE, hexCorners, mapBounds } from "../model/hex-geometry.js";
-import type { Precinct, TerrainTileRuntime } from "../model/types.js";
+import type { Precinct, TerrainTileRuntime, PartyKey } from "../model/types.js";
 import { DISTRICT_COLORS, PARTY_LABELS } from "../model/types.js";
 import type { GameStore } from "../store/gameStore.js";
 
@@ -48,6 +48,8 @@ export interface MapRenderer {
 	setCountyBordersVisible(visible: boolean): void;
 	/** Toggle hex coordinate labels (debug overlay). */
 	setCoordLabelsVisible(visible: boolean): void;
+	/** Provide scenario party display names for the precinct-info panel. */
+	setPartyLabels(labels: Partial<Record<PartyKey, string>>): void;
 }
 
 // ─── Internal types ───────────────────────────────────────────────────────────
@@ -286,7 +288,7 @@ export class SvgMapRenderer implements MapRenderer {
 	// Terrain boundary sits above hex fills (no hex-fill attenuation); lower opacity
 	// compensates so it appears the same visual weight as district boundaries below hex fills.
 	private static readonly TERRAIN_BOUNDARY_OPACITY = 0.4;
-	private static readonly COUNTY_OPACITY = 0.7;
+	private static readonly COUNTY_OPACITY = 0.9;
 	private static readonly PREVIEW_OPACITY = 0.85;
 	private static readonly LEAN_OPACITY = 0.9;
 	private static readonly ASSIGNED_OPACITY = 0.75;
@@ -300,8 +302,9 @@ export class SvgMapRenderer implements MapRenderer {
 	private static readonly HEX_LIGHTNESS_RANGE = 0.30;
 
 	// Dash patterns (on,off in map units before zoom correction)
-	private static readonly COUNTY_DASH_ON = 6;
-	private static readonly COUNTY_DASH_OFF = 4;
+	// Short dashes + wide gaps so an underlying white district border shows through.
+	private static readonly COUNTY_DASH_ON = 3;
+	private static readonly COUNTY_DASH_OFF = 5;
 	private static readonly PREVIEW_DASH_ON = 5;
 	private static readonly PREVIEW_DASH_OFF = 4;
 
@@ -311,6 +314,7 @@ export class SvgMapRenderer implements MapRenderer {
 	// the district boundary line on these edges (the terrain intrusion fill covers them).
 	private terrainFacingEdges: Set<string> = new Set();
 	private countyBordersVisible = false;
+	private partyLabels: Partial<Record<PartyKey, string>> = {};
 	private coordLabelsVisible = false;
 	private coordLabelsRendered = false;
 	private coordLabelGroup!: GSel;
@@ -412,6 +416,10 @@ export class SvgMapRenderer implements MapRenderer {
 		this.renderCoordLabels();
 	}
 
+	setPartyLabels(labels: Partial<Record<PartyKey, string>>) {
+		this.partyLabels = labels;
+	}
+
 	private renderCoordLabels() {
 		if (!this.coordLabelsRendered) {
 			const { precincts, terrainTiles } = this.getState();
@@ -472,7 +480,7 @@ export class SvgMapRenderer implements MapRenderer {
 			.attr("y1", (d) => d.y1)
 			.attr("x2", (d) => d.x2)
 			.attr("y2", (d) => d.y2)
-			.attr("stroke", "#606060")
+			.attr("stroke", "#1c1c1c")
 			.attr("stroke-width", SvgMapRenderer.COUNTY_BASE_WIDTH / this.currentK)
 			.attr("stroke-dasharray", `${SvgMapRenderer.COUNTY_DASH_ON / this.currentK},${SvgMapRenderer.COUNTY_DASH_OFF / this.currentK}`)
 			.attr("opacity", SvgMapRenderer.COUNTY_OPACITY);
@@ -1118,7 +1126,8 @@ export class SvgMapRenderer implements MapRenderer {
 					const topParty = (["D", "R", "L", "G", "I"] as const).reduce((a, b) =>
 						d.partyShare[a] > d.partyShare[b] ? a : b,
 					);
-					const leanLabel = `${PARTY_LABELS[topParty]} (${(d.partyShare[topParty] * 100).toFixed(1)}%)`;
+					const partyName = this.partyLabels[topParty] ?? PARTY_LABELS[topParty];
+					const leanLabel = `${partyName} (${(d.partyShare[topParty] * 100).toFixed(1)}%)`;
 					let groupsHtml = "";
 					if (d.groupShares && d.groupShares.length > 1) {
 						const lines = d.groupShares.map(
@@ -1126,9 +1135,13 @@ export class SvgMapRenderer implements MapRenderer {
 						);
 						groupsHtml = `<br><span style="color:#8898b0">` + lines.join("<br>") + `</span>`;
 					}
+					const countyHtml = d.county_name
+						? `<span style="color:#8898b0">${d.county_name}</span><br>`
+						: "";
 					infoPanel.innerHTML =
 						`<div class="precinct-name">${precinctLabel}</div>` +
 						`<div class="precinct-detail">` +
+						countyHtml +
 						`${distLabel}<br>` +
 						`Pop: ${d.population.toLocaleString()}<br>` +
 						`Lean: ${leanLabel}` +

--- a/thoughts/shared/handoffs/2026-06-22-post-game-087.md
+++ b/thoughts/shared/handoffs/2026-06-22-post-game-087.md
@@ -1,0 +1,109 @@
+---
+date: 2026-06-22
+session: GAME-087 terrain-aware population stage
+branch_at_close: main @ splpzypl (1082d60d)
+---
+
+# Handoff: Post-GAME-087
+
+## What just landed
+
+**GAME-087 — terrain-aware population stage** merged in PR #265.
+
+`populateScenario` was rewritten from flat-random to a two-layer model:
+- **Layer 1** — terrain suitability: per-precinct multiplier from adjacency to lake/sea/mountain tiles and river edges (lakeside 1.4×, riverside 1.3×, coastal 0.9×, mountain-adjacent 0.5×); features compose multiplicatively; overridable via `terrain_weights` spec
+- **Layer 2** — optional Gaussian settlement bumps (`peak × exp(-dist²/2σ²)`, σ=radius/2); anchored to terrain features, exact coords, `center`, or cardinal directions
+
+Files changed:
+- `game/web/src/pipeline/spec-types.ts` — added `TerrainWeightsSpec`, `SettlementAnchorNamed`, `SettlementAnchor`, `SettlementSpec`; extended `PopulationSpec`
+- `game/web/src/pipeline/population-stage.ts` — full rewrite; exports `hexDist`
+- `game/web/src/pipeline/population-stage_test.ts` — ~20 tests; all AC types covered
+- `game/scenarios/scenario-002.spec.yaml` — Clearwater City (anchor:center, peak:600, r:3) + East Mills (anchor:east, peak:200, r:1)
+- `game/scenarios/scenario-002.json` — regenerated; pop range 1356–2208, avg 1592
+- `thoughts/shared/research/2026-05-31-population-distribution-prior-art.md` + `.compressed.md`
+- `thoughts/shared/tickets/GAME-087-terrain-aware-population-stage.md` — status: resolved, github_issue: 266
+
+All e2e tests pass. District balance on scenario-002: D1=+5%, D2=-5%, D3=-5%, D4=+4% (mean=36,222; all within ±5%).
+
+## Working copy state
+
+Working copy is clean and parented on the GAME-087 merge commit. No pending changes.
+
+```
+jj status  →  nothing
+jj log -r @  →  (empty) on top of main @ splpzypl
+```
+
+To start new work: `jj new` to get a scratch change.
+
+## GAME-084: pipeline ticket needs closure
+
+GAME-084 (`thoughts/shared/tickets/GAME-084-map-generation-pipeline.md`) is the parent ticket for the full pipeline. All 4 stages are implemented and wired:
+
+| Stage | Module | Status |
+|---|---|---|
+| Stage 1: terrain | `terrain-generator.ts` | ✅ done (sub-tickets via GAME-084 PRs #258–#264) |
+| Stage 2: population | `population-stage.ts` | ✅ done (GAME-087, PR #265) |
+| Stage 3: demographics | `demographics-stage.ts` | ✅ done |
+| Stage 4: assembly | `assembler.ts` | ✅ done |
+| Orchestrator | `pipeline-runner.ts` | ✅ done |
+| Spec file | `scenario-002.spec.yaml` | ✅ done |
+
+The ticket's ACs (items 2–6) are still showing `[ ]` but the work is complete. The ticket needs:
+1. Check off ACs 2–5 in `GAME-084-map-generation-pipeline.md`
+2. AC 6 ("existing scenarios migrated") and AC 7 ("old generators removed") are still open — decide in-ticket whether to resolve now or file sub-tickets
+3. Update TICKETS.md entry and set `status: resolved` if ACs 6–7 are deferred separately
+4. Create GitHub issue if not already done (check frontmatter: if no `github_issue:` line, run `gh-ticket.main.kts -- create ... --owner cgruber --repo redistricting-sim`)
+
+## Sprint 13 priority queue
+
+Roadmap at `thoughts/shared/plans/2026-04-25-sprint-roadmap.compressed.md` (§SPRINT13).
+
+**tier1-UI** (primary deliverable, not slipping):
+- `DESIGN-014` — non-partisan content framing guidelines; prereq for narrative authoring
+- `GAME-080` — district demographic rollup: live % stat under each district button
+- `DESIGN-015` — information density redesign for 5+ districts
+- `GAME-081` — implement the DESIGN-015 layout (trails DESIGN-015)
+
+**tier1-content**:
+- `DESIGN-008` — terrain model (expanded)
+- `GAME-075` — terrain implementation: schema + generator + renderer + contiguity + ≥1 terrain scenario
+- `DESIGN-012` — tutorial overlay UX design
+- `GAME-076` — tutorial-001 guided walkthrough (overlay engine + 9-step script)
+- `GAME-077` — tutorial-002 guided mode (trails GAME-076)
+
+**tier2** (can slip to S15):
+- `DESIGN-013` — VRA scenario design (trails DESIGN-014)
+- `GAME-078` — VRA scenarios (trails DESIGN-013 + GAME-075)
+- `GAME-079` — scenario-002 playability tuning
+
+**stretch**: GAME-065 (art refinement), GAME-071 (audio fine-tuning)
+
+## Key technical context
+
+**VCS**: jj (colocated). Never use `git` directly. Key commands:
+```bash
+jj new                          # new scratch change
+jj describe --stdin < /tmp/msg  # set commit message
+jj bookmark set <name> -r @-    # set bookmark on last commit
+jj git push -b <name>           # push branch
+jj git fetch && jj bookmark set main -r main@origin  # sync main
+gh-pr-create.main.kts --title "..." --body-file /tmp/... --owner cgruber --repo redistricting-sim
+gh-pr-merge.main.kts --pr N --owner cgruber --repo redistricting-sim
+```
+
+**Build/test**: `bazel test //game/web/src/pipeline:...` for pipeline unit tests. `bazel test //e2e:...` for e2e (Playwright). Always run locally before pushing.
+
+**§NOINLINE rule**: Never use heredocs, command substitution `$(...)`, or inline multi-line strings in Bash. Write bodies to `/tmp/<repo>-<branch>-<purpose>.md` via Write tool, then reference by path.
+
+**PR body required sections** (validated by `gh-pr-create.main.kts`):
+Summary | Affected machines / services | Validation performed | Deployment steps | Tickets addressed | Rollback
+
+**Scenario pipeline**: spec YAML → `runPipeline(spec)` → scenario JSON. The spec lives at `game/scenarios/<id>.spec.yaml`; the JSON output at `game/scenarios/<id>.json`. Only `scenario-002` has a spec file so far. The CLI entry point for re-generating is `generate-scenario` (wired in `pipeline-runner.ts`).
+
+## Open questions / deferred items
+
+- **GAME-084 closure**: ticket ACs need updating (see above). Is AC 6 ("existing scenarios migrated") in scope for S13, or filed as a separate ticket?
+- **scenario-002.spec.yaml note**: PR #265 description noted that settlement peaks (city=600, East Mills=200) were tuned conservatively to preserve e2e district balance. If GAME-079 (playability tuning) wants bigger population variance, the peaks may need adjustment in tandem with new e2e test strategies.
+- **GAME-087 GitHub issue #266**: still open; close manually once GAME-084 fully resolves and migration is complete (per §TICKETS: "close only at full DoD").
+- **HEX_DIRS duplication**: `HEX_DIRS` in `population-stage.ts` is duplicated verbatim from `terrain-generator.ts`. PR #265 thread noted this as a future hex-utils extraction ticket. Not filed yet.

--- a/thoughts/shared/plans/2026-06-22-generation-quality-overhaul.compressed.md
+++ b/thoughts/shared/plans/2026-06-22-generation-quality-overhaul.compressed.md
@@ -1,0 +1,87 @@
+<!--COMPRESSED v1; source:2026-06-22-generation-quality-overhaul.md-->
+§META
+date:2026-06-22 author:claude ticket:GAME-088,GAME-089,GAME-084(AC6) status:draft
+
+§ABBREV
+$pop=total_population $ff=priority-queue flood-fill $cty=county $ctr=settlement center
+$Ptot=total regional pop $cosmetic=dashed-border overlay,no gameplay effect
+$norm=normalize field to target total
+
+§GOAL
+Pipeline maps that LOOK demographically plausible game-wide. Fix 2 scenario-002 defects:
+(1) lumpy density (salt-and-pepper + tight central cluster + light precincts beside heavy);
+(2) $cty borders=parallel q/r slices ignoring $pop; real $cty wrap $ctr. Output need only
+broadly feel sane.
+
+§CONTEXT
+pipeline(GAME-084)=terrain→population→demographics→assembly; spec-driven(<id>.spec.yaml→
+runPipeline→<id>.json). only scenario-002 has spec; 003-009+tutorials=old gen-*.main.kts(to
+remove post-migrate). ROOT CAUSES(verified):
+- population-stage.ts uses INDEPENDENT per-precinct uniform jitter(±variance)→uncorrelated→
+  salt-pepper; settlement bumps=tight Gaussians(σ=radius/2); NO coherent-noise, NO contrast/
+  norm step. prior-art(2026-05-31) recommended fBm+pow but impl took "simplification off-ramp".
+- $cty assigned in demographics-stage.ts via county_labels=geometric q/r filters reused from
+  political zones, DECOUPLED from $pop. county_id=PURELY $cosmetic: drives only dashed overlay
+  (mapRenderer.ts computeCountySegments/setCountyBordersVisible); NOT contiguity/scoring/districting.
+county design grounded: 2026-06-22-us-county-formation-patterns. KEY=ONE algo(seeded $ff)+`model`
+flag expresses both models; borders bias to $pop troughs+river/feature edges→compact blobs snap to
+rivers=safe $cosmetic way to show river↔boundary assoc (per project_geography_cosmetic).
+
+§APPROACH
+2 impl PRs then gated per-scenario migration. CRITICAL CONSTRAINT: every scenario=tuned puzzle w/
+e2e solve test+teaching point; $pop feeds district balance AND seat outcomes. → change field SHAPE
+not magnitudes: $norm each regenerated scenario to its EXISTING total $pop; re-validate winnability
+per scenario.
+
+PR1 GAME-088 coherent population field (population-stage.ts):
+  - radial/gradient layer(optional,spec): monocentric falloff→dense core→rural fringe
+  - coherent value noise REPLACING independent jitter: cheapest=per-precinct jitter +1-2 neighbour-
+    averaging smoothing passes(seeded via prng.ts); upgrade to value-noise lattice if not organic
+  - contrast: pow(normalized,k≈2)→push low→0, sharpen centers (the missing step)
+  - $norm to target total(default=preserve current scenario total)=de-risk lever
+  - keep terrain suitability(L1)+named settlements; compose
+  - backward-compat: knobs unset→output close enough scenario-002 e2e still passes(or update deliberately)
+
+PR2 GAME-089 population-aware $cty stage (NEW step AFTER population so it reads field; replaces
+geometric county_labels):
+  STEP0 target count ≈precincts/14 (R5→~6,tut→~2); knob=catchment r=2
+  STEP1 classify $ctr by catchment pop(Σ within r,nearest wins): dominant≥40%$Ptot|anchor≥15-20%|
+        minor<15%(absorbed); always ≥1 anchor; cap anchors to target(top-k by catch pop) → 1 cty may
+        hold SEVERAL towns(Clark County WA case)
+  STEP2 grow: $ff 1 seed/anchor peak; cost=1+w_trough*(1-norm_pop_neighbor)+w_feature*crosses_feature
+        (w_trough≈0.5,w_feature≈1.0); fill all; orphans→nearest seat
+  STEP3 NAMED model preset(intuit-on-sight; owner reasons in city examples not knobs):
+        "seat_and_hinterland"(default,B)=each anchor=seat+rural surround |
+        "city_county"(A,SF/Denver)=carve dominant urban-core(pop≥core_density*peak,def 0.5)+split
+          remainder into ring_counties(auto) |
+        "split_metro"(C,Portland)=split_dense_center=true→multiple seeds in 1 city
+  STEP4 $cosmetic finish: dashed only; optional name-after-seat
+  all thresholds spec-overridable defaults; spec gains counties:{named model,overrides} EACH w/ inline
+  plain-English+real-city comment; plain-English→preset table in research doc (feedback-plain-english-
+  tooling-knobs: owner won't recall raw knobs). remove county_labels once scenario-002 migrated.
+  PRINCIPLES(hold across tuning): cty UNEQUAL by design(target=#seeds only,never balances;sanity
+  LOCAL not global) | REGION CLIPS cty(truncated edge cty=expected simplification not bug) | satellite
+  town(Vancouver-WA-like,same state)=just another settlement not a model | county_id stays $cosmetic.
+
+Phase3 GAME-084 AC6 migration (SEPARATE gated tickets, NOT folded into PR1/2): 1 ticket/scenario
+  (003-009 then tutorials); each=author spec.yaml reproducing political intent→regenerate→re-validate
+  e2e solve+teaching→visual sign-off. old gen-*.main.kts removed only after all migrate(AC7).
+
+§STEPS
+1. GAME-088 impl+unit tests; regen scenario-002; e2e green+visual sign-off; PR→merge.
+2. GAME-089 impl+unit tests; migrate scenario-002 spec to counties: block; remove county_labels;
+   verify overlay both models; PR→merge.
+3. Phase3 per-scenario migration tickets SEQUENTIAL (shared files→no parallel PRs).
+
+§RISKS
+winnability regression(shape flips solvable gerrymanders)→$norm + per-scenario e2e revalidation +
+  scenario-002 first | threshold churn(numbers=extrapolations)→spec-overridable, tune on scenario-002
+  first | spec authoring 003-009(no existing specs=real design work)→gated per-scenario | $cty visual
+  fights political zones→$cosmetic+off-by-default, low risk.
+
+§DONE
+[ ] scenario-002 pop=coherent gradient, no salt-pepper(visual)
+[ ] scenario-002 $cty overlay wraps center(s) sanely both models
+[ ] scenario-002 e2e solve test passes(or deliberately updated)
+[ ] new generator knobs spec-driven w/ documented defaults
+[ ] migration tracked as gated per-scenario tickets under GAME-084 AC6

--- a/thoughts/shared/plans/2026-06-22-generation-quality-overhaul.md
+++ b/thoughts/shared/plans/2026-06-22-generation-quality-overhaul.md
@@ -1,0 +1,144 @@
+---
+date: 2026-06-22
+author: claude
+ticket: GAME-088, GAME-089, GAME-084 (AC6 migration)
+status: draft
+---
+
+# Plan: Generation-quality overhaul — coherent population field + population-aware counties
+
+## Goal
+
+Make the pipeline produce maps that *look* demographically plausible across the whole
+game, fixing two concrete defects observed while playtesting scenario-002:
+
+1. **Lumpy density** — population reads as salt-and-pepper noise with a tight central
+   cluster and unexpectedly light precincts next to heavy ones.
+2. **Counties don't follow population** — county borders are parallel q/r slices that
+   ignore the population field; real counties wrap population centers.
+
+The output only has to *broadly feel sane*, not be perfect.
+
+## Context
+
+The pipeline (GAME-084) is `terrain → population → demographics → assembly`, spec-driven
+(`<id>.spec.yaml` → `runPipeline` → `<id>.json`). Today only `scenario-002` has a spec;
+003–009 + tutorials still come from the old per-scenario `gen-*.main.kts` generators,
+which are slated for removal once migrated.
+
+Root causes (verified in code):
+
+- `population-stage.ts` uses **independent per-precinct uniform jitter** (`±variance`),
+  so neighbours are uncorrelated → salt-and-pepper. Settlement bumps are tight Gaussians
+  (σ = radius/2). There is no coherent-noise layer, no contrast/normalization step. The
+  prior-art research (`2026-05-31-population-distribution-prior-art`) recommended fBm +
+  `pow` contrast but the implementation took the documented "simplification off-ramp".
+- Counties are assigned in `demographics-stage.ts` via `county_labels` — geometric q/r
+  filters reused from the political zones, **completely decoupled from population**.
+  `county_id` is **purely cosmetic**: it drives only the dashed county-border overlay
+  (`mapRenderer.ts` `computeCountySegments` / `setCountyBordersVisible`); it does not
+  affect contiguity, scoring, or districting.
+
+County design is grounded in new research: `2026-06-22-us-county-formation-patterns`.
+Key finding — **one algorithm (seeded priority-queue flood-fill) + a `model` flag**
+expresses both requested models. Borders biased toward population troughs + river/feature
+edges give compact blobs that snap to rivers, which is the safe cosmetic way to surface
+the river↔boundary association (per the `project_geography_cosmetic` principle).
+
+## Approach
+
+Two implementation PRs, then gated per-scenario migration. **Critical constraint:** every
+scenario is a tuned puzzle with an e2e solve test and a teaching point; `total_population`
+feeds both district balance and seat outcomes. So we change the *shape* of the field, not
+the magnitudes — **normalize each regenerated scenario back to its existing total
+population** — and re-validate winnability per scenario.
+
+### PR 1 — GAME-088: coherent population field
+
+Rework `population-stage.ts` so the base field has spatial structure instead of
+independent jitter:
+
+- **Radial / gradient layer** (optional, spec-driven): monocentric density falloff so the
+  macro shape is "dense core → rural fringe".
+- **Coherent value noise** replacing independent jitter: low-frequency noise sampled on
+  hex coords (seeded via existing `prng.ts`) so neighbours correlate. Cheapest viable
+  form: generate per-precinct jitter then run 1–2 neighbour-averaging smoothing passes;
+  upgrade to true value-noise lattice if smoothing isn't organic enough.
+- **Contrast step** (`pow(normalized, k)`, k≈2): pushes low density toward 0, sharpens
+  centers — the documented missing step.
+- **Normalize to target total**: scale the final field so `Σ total_population` equals a
+  spec target (default = preserve current scenario total). This is the de-risking lever.
+- Keep terrain suitability (Layer 1) and named settlements; they compose with the above.
+- Backward-compat: with the new knobs unset, output should stay close enough that
+  scenario-002's e2e solve test still passes (or update the test deliberately).
+
+### PR 2 — GAME-089: population-aware county stage
+
+New pipeline step **after** population (so it can read the field), before/within assembly.
+Replaces the geometric `county_labels` path. Algorithm (from the heuristic):
+
+```
+STEP0 target count   ≈ precincts / 14            (R5→~6, tutorial→~2); knob = catchment r=2
+STEP1 classify centers by catchment pop (Σ within r, nearest-center wins):
+        dominant ≥40% Ptot | anchor ≥15–20% Ptot | minor <15% (absorbed)
+        always keep ≥1 anchor; cap anchors to target count (top-k by catch pop)
+        → one county may hold several towns (Clark County WA case)
+STEP2 grow: priority-queue flood-fill, 1 seed per anchor peak
+        cost = 1 + w_trough*(1 - norm_pop_neighbor) + w_feature*crosses_feature
+        (w_trough≈0.5, w_feature≈1.0); fill until all claimed; orphans → nearest seat
+STEP3 named model preset (intuit-on-sight; owner reasons in city examples not knobs):
+        "seat_and_hinterland" (default, B): each anchor = seat + rural surround
+        "city_county" (A, SF/Denver): carve dominant center's urban-core (pop ≥
+              core_density*peak, default 0.5) + split remainder into ring_counties (auto)
+        "split_metro" (C, Portland): split_dense_center=true → multiple seeds in one city
+STEP4 cosmetic finish: dashed borders only; optional name-after-seat
+```
+
+All thresholds are spec-overridable defaults, tuned by eyeballing 1/2/3-center fields.
+Spec gains a `counties:` block (named `model` + optional overrides), **each knob carrying an
+inline plain-English + real-city comment**, plus a plain-English→preset table kept in the
+research doc (per [[feedback-plain-english-tooling-knobs]] — the owner won't recall raw
+knobs between sessions). The old `county_labels` path is removed once scenario-002 migrates.
+
+**Principles (hold across all tuning):** counties are *unequal by design* (target count
+sets seed count only, never balances; sanity is local not global); the *region clips
+counties* (truncated edge counties are an expected game simplification, not a bug); a
+satellite town (Vancouver-WA-like, same state) is just another settlement, not a model;
+`county_id` stays cosmetic-only.
+
+### Phase 3 — GAME-084 AC6: per-scenario migration (separate gated tickets)
+
+One ticket per scenario (003–009, then tutorials). Each: author a `spec.yaml` that
+reproduces the puzzle's political intent, regenerate, **re-validate the e2e solve test +
+teaching point**, get visual sign-off. This is the bulk of the effort and must not be
+folded into PR 1/2. Old `gen-*.main.kts` removed only after all migrate (AC7).
+
+## Steps
+
+1. GAME-088: implement coherent field in `population-stage.ts` + unit tests; regenerate
+   scenario-002; confirm e2e solve test green + visual sign-off. PR, review, merge.
+2. GAME-089: implement county stage + unit tests; migrate scenario-002 spec to the new
+   `counties:` block; remove geometric `county_labels` path; confirm county overlay looks
+   sane in both models. PR, review, merge.
+3. Phase 3: file + work per-scenario migration tickets sequentially (shared scenario files
+   → no parallel PRs).
+
+## Risks
+
+- **Winnability regression** — population shape change flips which gerrymanders solve.
+  Mitigation: normalize-to-existing-total; per-scenario e2e re-validation; scenario-002
+  proven first.
+- **Threshold tuning churn** — the heuristic numbers are extrapolations. Mitigation: all
+  spec-overridable; tune by eyeball on scenario-002 before generalizing.
+- **Spec authoring for 003–009** — no existing specs; reproducing intent is real design
+  work. Mitigation: gated per-scenario tickets, not batched.
+- **County visual fights political zones** — counties are cosmetic and off by default;
+  low risk.
+
+## Done (acceptance)
+
+- [ ] scenario-002 population reads as a coherent gradient, no salt-and-pepper (visual)
+- [ ] scenario-002 county overlay wraps the population center(s) sanely in both models
+- [ ] scenario-002 e2e solve test passes (or deliberately updated)
+- [ ] new generator knobs are spec-driven with documented defaults
+- [ ] migration tracked as gated per-scenario tickets under GAME-084 AC6

--- a/thoughts/shared/research/2026-06-22-us-county-formation-patterns.compressed.md
+++ b/thoughts/shared/research/2026-06-22-us-county-formation-patterns.compressed.md
@@ -1,0 +1,159 @@
+<!--COMPRESSED v1; source:2026-06-22-us-county-formation-patterns.md-->
+§META
+date:2026-06-22 researcher:claude(general-purpose subagent) git_commit:30662afea546 branch:main repo:cgruber/redistricting-sim
+topic:us-county-formation-patterns
+tags:counties map-generation procedural-generation heuristic GAME-084
+status:complete last_updated:2026-06-22 last_updated_by:claude
+
+§ABBREV
+$cty=county $ctr=settlement center $seat=county seat $catch=catchment(precincts within radius r of a center)
+$ff=priority-queue flood-fill $Ptot=total regional population $r=catchment radius(hexes)
+$cosmetic=dashed-border overlay, no gameplay effect
+
+§SUMMARY
+Heuristic for procedurally generating $cosmetic $cty boundaries on small hex grids. $cty purely
+visual; must only LOOK plausible. Core findings: (1) rural $cty size is AREA-driven via day's-ride-
+to-$seat rule (fixed geographic size → east/south small, west large). (2) a dominant $ctr OVERRIDES
+area logic & gets its own $cty (independent cities, consolidated city-counties: SF/Denver/NYC
+boroughs). (3) $cty = compact blobs radiating from $seat, borders snap to pop troughs + rivers/
+ridgelines. Recommendation: ONE region-grow ($ff) algo + a named `model` preset (seat_and_hinterland
+/city_county/split_metro) expresses the real city↔cty patterns. Calibrate to OUR map sizes (~4-7 cty
+@ 91hex, ~2-3 @ tutorial) via day's-ride→r≈2 hexes.
+
+§RQ1_SIZE (what sets count & size)
+Day's-ride rule = dominant driver of RURAL size: $cty sized so farmer rides to courthouse & back in
+1 day → roughly FIXED geographic radius, not fixed pop. Texas 254 cty b/c explicit "no one >1 day
+from courthouse." East/west gradient explained by: founding-era density (dense+slow=small;
+sparse+rail=large; N.Calif small cty predate railroads/Gold Rush) + area data (median 622 sqmi;
+west avg ~2427, Georgia ~343; range 12→145505 sqmi). Count: ~3143 cty+equiv, avg 62/state, Delaware
+3→Texas 254; South/Midwest more cty than West/NE.
+→TAKEAWAY: default size = AREA catchment, not pop quota; day's-ride = the size knob.
+
+§RQ2_CENTERS (cty vs pop center) — 3 regimes by city dominance
+1. DEFAULT(~most cty): dominant town = $seat + rural hinterland. single admin center, courthouse,
+   rest is rural surround. ← reproduce this most often.
+2. CONSOLIDATED city-cty (~40 natl): city dominates → city+cty govt merge, cty coterminous w/ city
+   (SF Denver Philly, 5 NYC boroughs=5 cty).
+3. INDEPENDENT city (41 natl, 38 in Virginia): city belongs to NO cty; primary admin division.
+Common thread: bigger $ctr rel. to surroundings → stops being INSIDE a rural cty, becomes own dense
+blob. = real-world basis for "urban core + rural ring": core=consolidated/independent-city case.
+
+§RQ3_RATIOS (atmosphere, not direct params)
+Avg cty pop(2019) 104435; median 25965 → mean≫median, pop heavily concentrated. >half US pop in 143
+cty(4.6%); 137 cty>500k; 709<10k; 35<1k. No clean national "center >X% → own cty" stat exists →
+that threshold is OUR extrapolation. County COUNT anchor must be geographic (area÷catchment), NOT
+national per-state avg (wrong scale). → most generated maps: 1 dominant + few secondary centers.
+
+§RQ4_SHAPE (what looks right)
+- compact blobs (≈equidimensional, not slivers) → $ff/Voronoi from $seat gives this free.
+- borders SNAP to natural features: rivers + ridgelines/watershed divides "often a basis for cty &
+  state boundaries" (Virginia: Blue Ridge, Rappahannock/Rapidan whole-length cty borders).
+- radiate from $seat (= seat + everything within a day's ride).
+- west/flat = arbitrary straight survey lines (minor concern for small hex grid).
+PROJECT TIE-IN(important): memory note project_geography_cosmetic says rivers ASSOCIATE w/ district
+borders b/c higher-order political features (state/CTY lines, municipal limits) follow them — no
+physical "can't cross river" rule. This research CONFIRMS mechanism: cty lines really follow rivers/
+divides. → biasing $cosmetic cty borders toward rivers/troughs is doubly justified, BUT must stay a
+SOFT visual bias, never a hard barrier. Cty overlay = the right place to SHOW river↔boundary
+association w/o baking a false rule into gameplay.
+
+§RQ5_PRIORART
+Azgaar Fantasy Map Generator = most transferable. States & Provinces via $ff over cell graph from
+seed burgs; cost favors cultural align, route access, land>ocean, unclaimed>contested; mountains/
+rivers RAISE cross-cost (=border-snapping). States: 1 seed per capital burg, flood out. Provinces:
+SUBDIVIDE a state — seeds at significant non-capital burgs above pop threshold, flood constrained to
+parent cells. KEY MAP: cty=states(1 region/seed, flood-grown); urban-core-vs-ring=province
+subdivision (dominant ctr subdivides own region). ONE algo, two behaviors via flag. (Reuses same
+$ff/scoring machinery as sibling 2026-05-31 population doc.) Lower-priority: O'Leary/Uncharted Atlas
+score-place-rescore (which ctrs anchor); Civ (rivers as attractors, no admin regions).
+refs: deepwiki.com/Azgaar/Fantasy-Map-Generator/3.3-states-and-provinces ;
+azgaar.wordpress.com/2017/11/21/settlements/
+
+§RECOMMENDED_HEURISTIC
+Inputs: per-precinct total_population field + list of settlement centers(local maxima) + map size.
+Output: cty id per precinct. ONE algo = seeded $ff, parametrized by `model` flag. Hex dist=grid-graph.
+
+STEP0 — target cty count from map size (day's-ride knob):
+  catchment radius r=2 hexes (r2 disc=19 cells; w/ competition real catch lands ~10-15 cells).
+  expected cty count ≈ total_precincts / ~14. → 91hex→~6 (band 4-7); 30hex→~2 (band 2-3).
+  r = sole size knob: smaller r→more/smaller cty(east feel); larger→fewer/bigger(west feel).
+  [EXTRAP: cell math sound, "~14 claimed" estimated. tune on output.]
+
+STEP1 — classify centers (which anchor own cty): Ptot=Σpop. per ctr catch pop=Σpop of precincts
+  within r (nearest-ctr wins ties).
+  DOMINANT: catch ≥40% Ptot → guaranteed anchor + eligible for core/ring subdivision.
+  ANCHOR:   catch ≥15-20% Ptot → own cty (town big enough to be a seat).
+  MINOR:    <~15% → no own seed; absorbed into nearest anchor (= small towns share a rural cty).
+  always keep ≥1 anchor (largest ctr). cap anchors to Step0 band: keep top-k by catch pop, k=target.
+  [EXTRAP: 15%/40% cuts chosen to read right on 1- vs 3-ctr fields; not sourced. defaults to tune.]
+
+STEP2 — grow cty ($ff; gives compactness+contiguity free): seed 1 cty per anchor's peak precinct.
+  priority-queue $ff: pop lowest-cost frontier precinct, assign, push unclaimed neighbors.
+  cost = 1 + w_trough*(1 - normalized_pop_neighbor) + w_feature*crosses_feature
+  suggested w_trough≈0.5, w_feature≈1.0. fill until ALL precincts claimed (NO area cap during fill;
+  r only set seed expectations; field troughs do real partition). → compact blobs radiating from
+  seats, breaking at troughs/rivers.
+  CONTIGUITY/ORPHANS: $ff contiguous by construction. post-fill sweep any unreachable straggler
+  (coastal/feature island) → assign to nearest seat by hex dist.
+
+STEP3 — apply NAMED `model` preset (real city↔cty patterns; share Steps0-2; differ only in #seeds
+  in dense area + whether dense core carved). names=intuit-on-sight (owner reasons in city examples
+  not raw knobs; see PLAIN_ENGLISH map + feedback-plain-english-tooling-knobs):
+  model="seat_and_hinterland" (DEFAULT, Pattern B): each anchor region=final cty=town/seat+rural
+    surround. minors absorbed Step1 → ONE cty can hold SEVERAL towns (Clark County WA=Vancouver+
+    Camas+Battle Ground+unincorporated). most common real pattern.
+  model="city_county" (Pattern A, =SF/Denver): for each DOMINANT ctr(≥40%) carve dense core own cty:
+    URBAN CORE=contiguous precincts around peak w/ pop ≥ core_density*peak_pop (default 0.5)="out to
+      certain density" cutoff; flood from peak (compact). raise core_density=tighter city; lower=eats
+      more suburb.
+    RING COUNTIES=remainder split into ring_counties cty (default auto from secondary towns/sectors;
+      scenario-002 wants 2=west+east). = consolidated/independent-city (dense core own unit) wrapped
+      by separate suburban/rural cty; mirrors Azgaar province subdiv. no dominant→degrade to seat_and_hinterland.
+  model="split_metro" (Pattern C, =Portland across Multnomah/Washington/Clackamas): split_dense_center=
+    true → place MULTIPLE seeds INSIDE one large ctr so cty lines cut THROUGH urban mass. use when 1
+    city outgrew 1 cty.
+  SATELLITE towns NOT a separate model: Vancouver-WA-like town (same state/region)=just another ctr,
+    gets own cty via Step1 like Gresham/Beaverton. cross-state metros (Portland↔Vancouver WA) NEVER
+    co-occur: map=single region, never crosses state line, no cross-border districting.
+
+PLAIN_ENGLISH→preset (breadcrumb; owner won't recall raw knobs):
+  "small town+rural around"→seat_and_hinterland | "cty w/ several towns(Vancouver/Camas/Battle
+  Ground)"→seat_and_hinterland(absorption) | "city IS its own cty, SF/Denver"→city_county(raise
+  core_density to tighten) | "city across several cty, Portland"→split_metro | "satellite town like
+  Vancouver WA(same state) gets own cty"→add a settlement(no model change).
+
+PRINCIPLES (don't violate when tuning):
+  - cty UNEQUAL by design: no equal pop/area/shape. target count=#seeds ONLY, never balances. sanity
+    is LOCAL("does cty wrap its seat?") never GLOBAL("are cty balanced across region?").
+  - REGION CLIPS cty: precincts exist only inside map; edge cty truncated by boundary, conceptually
+    continues off-map. few truncated edge cty=expected+fine, deliberate game simplification not a bug.
+  - ONE cty can hold SEVERAL towns (Clark County): not every settlement=seat; sub-anchors absorbed.
+
+STEP4 — cosmetic finish(optional,rec): dashed borders only, no gameplay. borders already prefer
+  troughs+feature hexes(Step2)→ visually align w/ rivers/ridgelines = "looks right" & SAFE way to
+  show river↔boundary assoc w/o making geography a rule (per project_geography_cosmetic). optionally
+  name cty after seat.
+
+DEFAULTS(all tunable): model=seat_and_hinterland(B; or city_county=A SF/Denver | split_metro=C
+  Portland) | r=2(day's-ride size knob) | target=precincts/14(4-7@r5,2-3@tut) | anchor=15-20% Ptot |
+  dominant=40% Ptot | core_density=0.5*peak | ring_counties=auto | split_dense_center=false |
+  w_trough=0.5 | w_feature=1.0.
+GROUNDED vs EXTRAP: STRUCTURE (area-catchment default, pop-override for dominant ctr, $ff from
+  seats, borders snap to troughs/features, one algo+named preset) directly grounded RQ1-5 + Azgaar.
+  NUMBERS (r=2, 15/40%, core_density, weights) = defensible extrapolations for small maps, NOT from a
+  source; tune by eyeballing 1/2/3-center generated fields.
+
+§REFS
+Texas cty/day's-ride: https://www.texastribune.org/2018/07/03/beto-orourke-visited-all-254-counties-texas-why-are-there-so-many/
+East/west size(Quora): https://www.quora.com/Why-are-counties-in-the-east-of-the-US-so-much-smaller-than-counties-in-the-west
+Size/Gold-Rush era: https://letsgola.wordpress.com/2015/12/23/county-size/
+Wikipedia County(US): https://en.wikipedia.org/wiki/County_(United_States)
+Wikipedia County statistics: https://en.wikipedia.org/wiki/County_statistics_of_the_United_States
+Census big/small counties: https://www.census.gov/library/stories/2017/10/big-and-small-counties.html
+Wikipedia consolidated city-county: https://en.wikipedia.org/wiki/Consolidated_city-county
+Wikipedia independent city(US): https://en.wikipedia.org/wiki/Independent_city_(United_States)
+NLC consolidations: https://www.nlc.org/resource/cities-101-consolidations/
+VirginiaPlaces watersheds/political: http://www.virginiaplaces.org/watersheds/3political.html
+Azgaar DeepWiki states/provinces: https://deepwiki.com/Azgaar/Fantasy-Map-Generator/3.3-states-and-provinces
+Azgaar settlements/regions: https://azgaar.wordpress.com/2017/11/21/settlements/
+Sibling prior-art(reused $ff machinery): thoughts/shared/research/2026-05-31-population-distribution-prior-art.md

--- a/thoughts/shared/research/2026-06-22-us-county-formation-patterns.md
+++ b/thoughts/shared/research/2026-06-22-us-county-formation-patterns.md
@@ -1,0 +1,355 @@
+---
+date: 2026-06-22
+researcher: claude (general-purpose subagent)
+git_commit: 30662afea546
+branch: main
+repository: cgruber/redistricting-sim
+topic: us-county-formation-patterns
+tags: [counties, map-generation, procedural-generation, heuristic, GAME-084]
+status: complete
+last_updated: 2026-06-22
+last_updated_by: claude
+---
+
+## Summary
+
+Research into how US counties actually got their count, size, and shape, distilled into a
+heuristic for procedurally generating **cosmetic** county boundaries (a dashed-border overlay)
+on small hex-grid maps in the redistricting game. Counties do not affect gameplay; they only
+need to *feel* plausible to a player who knows roughly what US county maps look like.
+
+The headline findings:
+
+1. **Rural county size is area-driven, set by the "day's ride to the county seat" rule** — a
+   county was historically sized so a farmer could ride to the courthouse and back in one day.
+   This makes rural counties roughly *fixed geographic size*, which is why eastern/southern
+   counties are small (dense, early-founded) and western counties are huge (sparse, late-founded).
+
+2. **A dominant population center overrides area logic.** The common pattern is "one dominant town
+   = county seat + rural hinterland." But when a city is big enough it gets *its own* county
+   (independent cities, consolidated city-counties like SF/Denver/NYC boroughs). So county size is
+   **area-driven by default, population-driven where a center dominates.**
+
+3. **Counties are compact blobs whose borders snap to population troughs and natural features**
+   (rivers, ridgelines/watershed divides). This dovetails with the project's existing
+   "geography is cosmetic" note: rivers *align* with real county/state lines because higher-order
+   political boundaries follow them — which is exactly why biasing cosmetic county borders toward
+   rivers/troughs reads as correct.
+
+The recommended heuristic (full spec in §RECOMMENDED_HEURISTIC) is **a single region-grow
+(priority-queue flood-fill) algorithm with a named `model` preset**, not separate algorithms. The
+real city↔county patterns fall out of one parameter: `seat_and_hinterland` (town + rural surround,
+the default), `city_county` (dense core is its own county — *San Francisco, Denver*), and
+`split_metro` (one city across several counties — *Portland*). Sizing is calibrated to *our* map
+sizes (≈4–7 counties on a radius-5 / 91-hex map, ≈2–3 on a 30-hex tutorial) by mapping "day's ride"
+to a catchment radius of ~2 hexes.
+
+---
+
+## RQ1 — What determines US county count and size?
+
+**The day's-ride rule is the dominant historical driver of rural county size.** Counties needed
+to be small enough that a resident could travel to the courthouse, conduct business, and return in
+a single day on horseback — because most farmers could not afford more than one day away. Texas
+followed an explicit guideline that no one should be more than a day's travel from their
+courthouse, which is a major reason it has 254 counties.
+([Texas Tribune](https://www.texastribune.org/2018/07/03/beto-orourke-visited-all-254-counties-texas-why-are-there-so-many/),
+[Quora: east vs west counties](https://www.quora.com/Why-are-counties-in-the-east-of-the-US-so-much-smaller-than-counties-in-the-west))
+
+This makes **rural county size roughly a fixed geographic radius** (a day's ride), not a fixed
+population. Two corollaries explain the famous east/west size gradient:
+
+- **Founding-era settlement density.** Counties drawn when an area was dense and travel was slow
+  (colonial/antebellum East and South) are small; counties drawn when an area was sparse and
+  railroads existed (the West, the Gold Rush) are large. Many of Northern California's small
+  counties date to the Gold Rush, *before* railroads.
+  ([Let's Go LA: County Size](https://letsgola.wordpress.com/2015/12/23/county-size/))
+- **Area numbers bear this out.** Median county land area is ~622 sq mi (2000 census). Western
+  counties average ~2,427 sq mi; Georgia's average ~343 sq mi. Range spans Kalawao County, HI
+  (12 sq mi) to Yukon-Koyukuk, AK (145,505 sq mi).
+  ([Wikipedia: County (United States)](https://en.wikipedia.org/wiki/County_(United_States)))
+
+**Count.** ~3,143 counties + equivalents across 50 states + DC; average 62 per state; range from
+Delaware (3) to Texas (254). Southern and Midwestern states tend to have *more* counties than
+Western or Northeastern states.
+([Wikipedia: County (United States)](https://en.wikipedia.org/wiki/County_(United_States)))
+
+**Takeaway for us:** default county size is an *area catchment*, not a population quota. The
+day's-ride rule is the knob: we map it to a small hex catchment radius (see §RECOMMENDED_HEURISTIC).
+
+---
+
+## RQ2 — How do counties relate to population centers?
+
+Three regimes, ordered by how dominant the city is:
+
+1. **Dominant town = county seat + rural surround (the default, ~most counties).** Each county has
+   a single administrative center, the *county seat*, usually the largest town, with the courthouse.
+   The rest of the county is its rural hinterland. This is the canonical "one center, one county"
+   shape and the one we should reproduce most often.
+   ([Wikipedia: County (United States)](https://en.wikipedia.org/wiki/County_(United_States)))
+
+2. **City gets its own county — consolidated city-county (~40 nationally).** When a city's
+   population dominates its surroundings, city and county governments merge: San Francisco, Denver,
+   Philadelphia, the five NYC boroughs (each a county). The county still nominally exists but is
+   coterminous with the city.
+   ([Wikipedia: Consolidated city-county](https://en.wikipedia.org/wiki/Consolidated_city-county),
+   [NLC: Consolidations](https://www.nlc.org/resource/cities-101-consolidations/))
+
+3. **Independent city — city carved out of any county (41 nationally, 38 in Virginia).** A primary
+   administrative division belonging to no county at all. Virginia's are a constitutional quirk
+   originally meant to centralize trade and legal matters.
+   ([Wikipedia: Independent city (US)](https://en.wikipedia.org/wiki/Independent_city_(United_States)))
+
+**The common thread:** the bigger a center relative to its surroundings, the more it stops being
+*inside* a rural county and becomes its *own* unit (and visually, a small dense blob). This is the
+real-world justification for the user's "urban core + rural ring" model: the urban core is the
+consolidated-city-county / independent-city case, and the ring is the rural hinterland the city
+would otherwise have been the seat of.
+
+---
+
+## RQ3 — Typical ratios and thresholds
+
+National statistics (atmosphere, not directly our parameters — we calibrate to map size in RQ-synthesis):
+
+- **Average county population (2019): 104,435; median: 25,965** (Nicholas County, WV). Mean ≫
+  median → a few huge counties pull the average up; most counties are small.
+- **Extreme concentration:** more than half the US population lives in just 143 counties (4.6% of
+  all counties). 137 counties exceed 500,000; 709 counties are under 10,000; 35 under 1,000.
+  ([Census: Big and Small Counties](https://www.census.gov/library/stories/2017/10/big-and-small-counties.html),
+  [Wikipedia: County statistics](https://en.wikipedia.org/wiki/County_statistics_of_the_United_States))
+
+**What transfers to a threshold:** the distribution says population is *heavily* concentrated — a
+small number of centers hold most people, the rest is thin rural fill. That maps to: most generated
+maps should have **one clearly dominant center** plus a couple of secondary centers, and the
+dominant one is a strong candidate for its own (or subdivided) county. There is no clean national
+"a center with >X% warrants its own county" statistic in the literature — that threshold is an
+extrapolation we make (see §RECOMMENDED_HEURISTIC) tuned to look right on 1-center vs 3-center
+generated fields, not a number lifted from a source.
+
+**County count vs region size:** the only defensible count anchor is geographic — region area ÷
+catchment area. For our maps that yields ~4–7 counties at radius-5 and ~2–3 at tutorial size
+(derivation in §RECOMMENDED_HEURISTIC). National per-state counts (avg 62) are at the wrong scale
+to use directly.
+
+---
+
+## RQ4 — Shape patterns: what makes a county map "look right"?
+
+- **Compact blobs.** Counties are roughly equidimensional regions around a seat, not long slivers.
+  A flood-fill / Voronoi-style growth from the seat produces this naturally.
+- **Borders snap to natural features — rivers and ridgelines/watershed divides.** Prominent
+  ridgelines break land into watersheds, and these were "often a basis for county and state
+  boundaries." Virginia's boundaries are a mix of natural features (rivers, divides) and straight
+  survey lines; e.g. the Blue Ridge and the Rappahannock/Rapidan form county boundaries along their
+  whole length.
+  ([VirginiaPlaces: Watersheds & political boundaries](http://www.virginiaplaces.org/watersheds/3political.html))
+- **Radiate from the seat.** Because size was set by travel time to the courthouse, a county tends
+  to be "the seat plus everything within a day's ride," i.e. a catchment centered on the seat.
+- **Straight survey lines in the flat/sparse West.** Out West where there were no settlements or
+  rivers to anchor on, boundaries are often arbitrary straight lines. For a small hex grid this is
+  a minor concern; compact blobs with feature-snapping read as correct.
+
+**Project tie-in (important).** The repo memory note "Geography is cosmetic by default"
+(`project_geography_cosmetic.md`) already states that rivers *associate* with district boundaries
+because higher-order political features (state lines, **county lines**, historic municipal limits)
+align with them — there is no physical rule that a district can't cross a river. This research
+*confirms the mechanism*: county lines really do follow rivers/divides. So biasing cosmetic county
+borders toward rivers and population troughs is doubly justified — but, per that note, it must stay
+a *soft visual bias*, never a hard barrier. The county overlay is in fact the perfect place to
+*show* the river/boundary association without baking a false rule into gameplay.
+
+---
+
+## RQ5 — Procedural-generation prior art
+
+**Azgaar's Fantasy Map Generator** is the most directly transferable. It generates *States* and
+*Provinces* with a **priority-queue flood-fill** over the cell graph, expanding outward from seed
+burgs. Cost function favors: cultural alignment, route accessibility, land over ocean, and
+unclaimed over contested cells; mountains/rivers raise cell-to-cell travel cost (which is exactly
+the "borders snap to features" behavior we want).
+- **States** seed one per capital burg, then flood-fill outward.
+- **Provinces** subdivide a state's territory: seeds placed at significant (non-capital) burgs
+  above a population threshold, then a flood-fill constrained to the parent's cells.
+([DeepWiki: States and Provinces](https://deepwiki.com/Azgaar/Fantasy-Map-Generator/3.3-states-and-provinces),
+[Azgaar: Settlements/Regions](https://azgaar.wordpress.com/2017/11/21/settlements/))
+
+This is the key structural insight, and it maps cleanly onto counties:
+**counties = states (one region per seed center, flood-grown), and the urban-core-vs-rural-ring
+split = the province subdivision step (a dominant center subdivides its own region).** One
+algorithm, two behaviors via a flag. (Our earlier `2026-05-31-population-distribution-prior-art`
+doc already adopted Azgaar's flood-fill/scoring patterns for population — we reuse the same machinery.)
+
+Other prior art (lower priority): Martin O'Leary / Uncharted Atlas uses iterative
+score-place-rescore for city spacing (relevant to *which* centers anchor counties, not to growing
+the regions); Civ-style generators treat rivers as attractors but don't draw admin regions.
+
+---
+
+## RECOMMENDED_HEURISTIC
+
+A single, implementable decision procedure. Inputs: the per-precinct `total_population` field, the
+list of settlement centers (local maxima from the population stage), and map size. Output: a county
+id per precinct. One algorithm — **seeded priority-queue flood-fill** — parametrized by a named
+`model` preset (`seat_and_hinterland` / `city_county` / `split_metro`; see Step 3) to express the
+real city↔county patterns. Hex distances are grid-graph distances.
+
+### Step 0 — Derive target county count from map size (the "day's ride" knob)
+
+Map the day's-ride rule to a **catchment radius `r`**. A radius-2 hex disc is 19 cells; with
+competition between centers, real claimed catchments land around 10–15 cells. So:
+
+- Default catchment radius `r = 2` hexes (the "day's ride").
+- Expected county count ≈ `total_precincts / ~14`.
+  - Radius-5 / 91 hex → ~6 counties (target band **4–7**).
+  - 30-hex tutorial → ~2 counties (target band **2–3**).
+
+`r` is the single size knob: smaller `r` → more, smaller counties (eastern/southern feel); larger
+`r` → fewer, bigger counties (western feel). *(Extrapolation: the cell-count math is sound but the
+"~14 claimed cells" figure is estimated, not sourced. Tune against generated output.)*
+
+### Step 1 — Classify centers (which centers anchor their own county)
+
+Let `P_total` = sum of `total_population`. For each settlement center, compute its **catchment
+population** = sum of population of precincts within `r` hexes (nearest-center wins on ties).
+
+- **Dominant center:** catchment population ≥ **40%** of `P_total` → guaranteed anchor; eligible
+  for core/ring subdivision.
+- **Anchor center:** catchment population ≥ **15–20%** of `P_total` → anchors its own county
+  (the "this town is big enough to be a seat" case).
+- **Minor center:** below ~15% → does **not** get its own seed; it will be absorbed into the
+  nearest anchor's county (this reproduces "several small towns share one rural county").
+
+Always keep at least one anchor (the single largest center) even if no center clears 15%.
+Cap anchors so the count stays in the Step-0 band: if too many centers qualify, keep the top-k by
+catchment population where k = target county count. *(Extrapolation: the 15% / 40% cut points are
+chosen to read right on 1-center vs 3-center fields, not lifted from a source — see RQ3. Treat as
+defaults to tune.)*
+
+### Step 2 — Grow counties (region-grow flood-fill; gives compactness + contiguity for free)
+
+Seed one county at each anchor center's peak precinct. Run a **priority-queue flood-fill** (Azgaar
+pattern): repeatedly pop the lowest-cost frontier precinct and assign it to that county, pushing its
+unclaimed neighbors. Cost to claim a neighbor:
+
+```
+cost = base_step
+     + slope_penalty   (steeper population drop between cells = cheaper to STOP here,
+                         i.e. higher cost to cross → borders settle in population troughs)
+     + feature_bias     (crossing a river or ridgeline hex adds cost → borders snap to features)
+```
+
+Concretely: `cost = 1 + w_trough * (1 - normalized_pop_of_neighbor) + w_feature * crosses_feature`.
+Suggested weights `w_trough ≈ 0.5`, `w_feature ≈ 1.0`. Flood-fill continues until **all** precincts
+are claimed (no area cap during fill — `r` only set seed expectations; the field's troughs do the
+real partitioning). This yields compact blobs that radiate from seats and break at troughs/rivers.
+
+**Contiguity & orphans:** flood-fill is contiguous by construction. After the fill, sweep for any
+unreachable straggler precinct (shouldn't happen on a connected grid, but coastal/feature islands
+could) and assign it to the nearest seat by hex distance.
+
+### Step 3 — Apply the named `model` preset
+
+This is where the real city↔county patterns diverge — they all share Steps 0–2 and differ only in
+(i) how many seeds land in the dense area and (ii) whether the dense core is carved out. The `model`
+field is a **named archetype** chosen to be intuited on sight; the raw knobs below sit underneath as
+optional overrides. (Naming rationale: the owner reasons in real-city examples, not raw parameters —
+see the plain-English mapping below and `project_geography_cosmetic` sibling note.)
+
+- **`model = "seat_and_hinterland"` (the default — Pattern B).** Every anchor's flood-grown region
+  is its final county: a town/seat plus its rural surround. Minor centers were already absorbed in
+  Step 1, so one county can legitimately contain **several towns** (e.g. Clark County WA = Vancouver
+  + Camas + Battle Ground + unincorporated land). This is the most common real pattern.
+
+- **`model = "city_county"` (Pattern A — *like San Francisco, Denver*).** For each **dominant**
+  center (≥40%, Step 1), carve its dense core into its own county:
+  - **Urban core county:** the contiguous precincts around the peak whose population ≥
+    `core_density * peak_population` (default `core_density = 0.5`) — the "out to a certain density"
+    cutoff — flood-grown from the peak so it stays compact. Raise `core_density` for a tighter
+    city-county, lower it to let the city-county eat more suburb.
+  - **Ring counties:** the remainder of that center's region, split into `ring_counties` counties
+    (default `auto` — derived from secondary towns/sectors; e.g. scenario-002 wants 2 = west + east).
+  This reproduces the consolidated-/independent-city pattern (dense core as its own unit) wrapped by
+  separate suburban/rural counties. Mirrors Azgaar's province subdivision. No dominant center →
+  degrades to `seat_and_hinterland`.
+
+- **`model = "split_metro"` (Pattern C — *like Portland across Multnomah/Washington/Clackamas*).**
+  Set `split_dense_center = true`: place **multiple seeds inside one large center** so county lines
+  cut *through* the urban mass. Use when a single city has outgrown one county.
+
+**Satellite towns are not a separate model.** A town like Vancouver WA (within the same state/region)
+is just another settlement center — it gets its own county via Step 1 exactly like Gresham or
+Beaverton would. Cross-state-line metros (Portland↔Vancouver WA) never co-occur here: a map is a
+single region that never crosses a state line, so there is no cross-border districting to model.
+
+### Step 4 — Cosmetic finish (optional, recommended)
+
+- Render counties as dashed borders only (no gameplay effect).
+- Because borders already prefer troughs and feature hexes (Step 2), they will visually align with
+  rivers/ridgelines — the desired "looks right" effect and the safe way to *show* the
+  river↔boundary association without making geography a rule (per `project_geography_cosmetic.md`).
+- Optionally name each county after its seat precinct/settlement.
+
+### Plain-English → preset mapping (breadcrumb for future tuning)
+
+The owner won't recall raw knobs between sessions. Translate descriptions to settings:
+
+| When the description is… | Set | Notes |
+|---|---|---|
+| "small town with rural land around it" | `model: seat_and_hinterland` | the default; minor towns share the county |
+| "a county with several towns in it (Vancouver/Camas/Battle Ground)" | `model: seat_and_hinterland` | absorption (Step 1) puts multiple centers in one county |
+| "the city *is* its own county, like San Francisco / Denver" | `model: city_county` | raise `core_density` to tighten the city-county |
+| "city spread across several counties, like Portland" | `model: split_metro` | sets `split_dense_center: true` |
+| "a satellite town like Vancouver WA (same state) gets its own county" | add a settlement | secondary anchors auto-get a county — no model change |
+
+### Defaults summary (all tunable)
+
+| Parameter | Default | Meaning / source |
+|---|---|---|
+| `model` | `seat_and_hinterland` | named preset: B (default) / `city_county` (A, SF/Denver) / `split_metro` (C, Portland) |
+| `r` (catchment radius) | 2 hexes | day's-ride → size knob (RQ1; cell-count extrapolated) |
+| target count | `precincts / 14` | ~4–7 @ r5, ~2–3 @ tutorial (extrapolated) |
+| anchor threshold | 15–20% of `P_total` | town big enough to be a seat (extrapolated) |
+| dominant threshold | 40% of `P_total` | triggers `city_county` core/ring split (extrapolated) |
+| `core_density` | 0.5 × peak pop | "out to a certain density" urban-core cutoff (extrapolated) |
+| `ring_counties` | `auto` | how many counties wrap a city-county's core (e.g. 2 for scenario-002) |
+| `split_dense_center` | `false` | `true` = `split_metro` (seats placed inside one city) |
+| `w_trough` | 0.5 | border bias toward population troughs |
+| `w_feature` | 1.0 | border bias toward rivers/ridgelines (RQ4) |
+
+### Principles (don't violate these when tuning)
+
+- **Counties are unequal by design.** No equal population, area, or shape. `target count` only
+  decides how many *seeds* to drop — it never balances them. Sanity is **local** ("does this county
+  sensibly wrap its seat?"), never global ("are the counties balanced across the region?").
+- **The region clips counties.** Precincts only exist inside the map; an edge county is simply
+  truncated by the boundary and conceptually "continues off-map." A few truncated edge counties are
+  expected and fine — a deliberate game simplification, not a bug to fix.
+- **One county can hold several towns** (the Clark County case): not every settlement is a seat;
+  sub-anchor centers are absorbed.
+
+**Where this is grounded vs extrapolated:** the *structure* (area-catchment default, population
+override for dominant centers, flood-fill from seats, borders snapping to troughs/features, one
+algorithm + subdivision flag) is directly grounded in RQ1–RQ5 and Azgaar. The *specific numbers*
+(`r=2`, 15%/40% cut points, `core_frac`, weights) are defensible extrapolations calibrated to our
+small map sizes, not values pulled from a source — they should be tuned by eyeballing generated
+1-center, 2-center, and 3-center fields.
+
+---
+
+## REFS
+
+- Texas county count / day's ride: https://www.texastribune.org/2018/07/03/beto-orourke-visited-all-254-counties-texas-why-are-there-so-many/
+- East vs west county size (Quora): https://www.quora.com/Why-are-counties-in-the-east-of-the-US-so-much-smaller-than-counties-in-the-west
+- County size / Gold Rush founding era: https://letsgola.wordpress.com/2015/12/23/county-size/
+- Wikipedia: County (United States): https://en.wikipedia.org/wiki/County_(United_States)
+- Wikipedia: County statistics of the United States: https://en.wikipedia.org/wiki/County_statistics_of_the_United_States
+- Census: Big and Small Counties: https://www.census.gov/library/stories/2017/10/big-and-small-counties.html
+- Wikipedia: Consolidated city-county: https://en.wikipedia.org/wiki/Consolidated_city-county
+- Wikipedia: Independent city (US): https://en.wikipedia.org/wiki/Independent_city_(United_States)
+- National League of Cities: Consolidations: https://www.nlc.org/resource/cities-101-consolidations/
+- VirginiaPlaces: Watersheds & political boundaries: http://www.virginiaplaces.org/watersheds/3political.html
+- Azgaar DeepWiki: States and Provinces: https://deepwiki.com/Azgaar/Fantasy-Map-Generator/3.3-states-and-provinces
+- Azgaar blog: Settlements/Regions: https://azgaar.wordpress.com/2017/11/21/settlements/
+- Sibling prior-art doc (population/flood-fill machinery we reuse): thoughts/shared/research/2026-05-31-population-distribution-prior-art.md

--- a/thoughts/shared/tickets/BUILD-010-release-script-clikt-import.md
+++ b/thoughts/shared/tickets/BUILD-010-release-script-clikt-import.md
@@ -1,0 +1,32 @@
+---
+id: BUILD-010
+title: release.main.kts fails to compile — missing clikt `default` import
+area: build, tooling
+status: resolved
+created: 2026-06-22
+---
+
+## Summary
+
+`game/release.main.kts` did not compile: the `Serve` subcommand calls clikt's
+`.default("58080")` on an option, but the script never imported
+`com.github.ajalt.clikt.parameters.options.default`. Because a `.main.kts` is
+compiled as a whole, this broke **every** subcommand — `prepare`, `deploy`, and
+`serve` all failed with `unresolved reference 'default'`, so the deploy tool was
+unusable for anyone.
+
+## Resolution
+
+Added the missing import:
+
+```kotlin
+import com.github.ajalt.clikt.parameters.options.default
+```
+
+Verified by running `release.main.kts -- prepare` (builds + stages) and
+`release.main.kts -- deploy --env dev` (deploys to dev.pastthepost.gg) successfully.
+
+## References
+
+- `game/release.main.kts` (Serve subcommand, line ~481)
+- Discovered while deploying GAME-088 to dev for visual review.

--- a/thoughts/shared/tickets/GAME-088-coherent-population-field.md
+++ b/thoughts/shared/tickets/GAME-088-coherent-population-field.md
@@ -1,0 +1,52 @@
+---
+id: GAME-088
+title: Coherent population field — spatial structure, contrast, normalize-to-total
+area: game, tooling
+status: open
+created: 2026-06-22
+---
+
+## Summary
+
+Rework the population stage so generated density forms coherent spatial gradients instead
+of salt-and-pepper noise. Observed in scenario-002 playtest: a tight central cluster with
+unexpectedly light precincts sitting next to heavy ones. Root cause is independent
+per-precinct uniform jitter (`±variance`) with no coherent-noise, contrast, or
+normalization layer — the pipeline took the "simplification off-ramp" documented in the
+prior-art research.
+
+## Current State
+
+`game/web/src/pipeline/population-stage.ts` computes
+`base × suitability + settlement_bump + jitter × suitability`, where `jitter` is
+`prng.nextInt(-variance, variance)` per precinct — uncorrelated between neighbours.
+Settlement bumps are tight Gaussians (σ = radius/2). Only `scenario-002` exercises this.
+
+## Goals / Acceptance Criteria
+
+- [ ] Replace independent jitter with a spatially-coherent field (neighbour-correlated):
+      minimum viable = 1–2 neighbour-averaging smoothing passes on the seeded jitter;
+      upgrade to a value-noise lattice if smoothing isn't organic enough
+- [ ] Optional spec-driven radial/gradient layer (monocentric dense-core → rural-fringe)
+- [ ] Contrast step `pow(normalized, k)` (k≈2 default) to sharpen centers / push low→0
+- [ ] Normalize final field to a spec target total (default = preserve current scenario
+      total) — this isolates shape change from magnitude change
+- [ ] Terrain suitability (Layer 1) and named settlements still compose with the new layers
+- [ ] All new behaviour is spec-driven with documented defaults; defaults keep output
+      close enough that scenario-002's e2e solve test still passes (or update deliberately)
+
+## Test Coverage
+
+- [ ] Unit tests for each new layer (smoothing, gradient, contrast, normalization) in
+      `population-stage_test.ts`
+- [ ] Regenerate `scenario-002.json`; e2e solve test stays green (or deliberately updated)
+- [ ] Manual: scenario-002 density reads as a coherent gradient, no salt-and-pepper
+
+## References
+
+- Plan: `thoughts/shared/plans/2026-06-22-generation-quality-overhaul.md`
+- Prior art: `thoughts/shared/research/2026-05-31-population-distribution-prior-art.md`
+  (fBm + `pow` contrast pipeline; the off-ramp this ticket walks back)
+- `game/web/src/pipeline/population-stage.ts`, `prng.ts`
+- `game/scenarios/scenario-002.spec.yaml`
+- Follows GAME-087 (the two-layer terrain-aware stage this extends)

--- a/thoughts/shared/tickets/GAME-088-coherent-population-field.md
+++ b/thoughts/shared/tickets/GAME-088-coherent-population-field.md
@@ -2,7 +2,7 @@
 id: GAME-088
 title: Coherent population field — spatial structure, contrast, normalize-to-total
 area: game, tooling
-status: open
+status: resolved
 created: 2026-06-22
 ---
 

--- a/thoughts/shared/tickets/GAME-089-population-aware-county-stage.md
+++ b/thoughts/shared/tickets/GAME-089-population-aware-county-stage.md
@@ -2,7 +2,7 @@
 id: GAME-089
 title: Population-aware county stage — flood-fill counties that wrap population centers
 area: game, tooling
-status: open
+status: resolved
 created: 2026-06-22
 ---
 

--- a/thoughts/shared/tickets/GAME-089-population-aware-county-stage.md
+++ b/thoughts/shared/tickets/GAME-089-population-aware-county-stage.md
@@ -1,0 +1,83 @@
+---
+id: GAME-089
+title: Population-aware county stage — flood-fill counties that wrap population centers
+area: game, tooling
+status: open
+created: 2026-06-22
+---
+
+## Summary
+
+Generate cosmetic county boundaries that follow the population field instead of arbitrary
+geometric slices. Today county borders are parallel q/r filters reused from the political
+zones, completely decoupled from population, so they don't wrap population centers the way
+real US counties do. Replace with a population-aware stage driven by the heuristic from the
+county-formation research.
+
+## Current State
+
+Counties are assigned in `demographics-stage.ts` via `county_labels` (geometric q/r filters)
+— decoupled from population. `county_id` is **purely cosmetic**: it drives only the dashed
+county-border overlay (`mapRenderer.ts`); it does NOT affect contiguity, scoring, or
+districting. So this stage can be reshaped freely without gameplay risk.
+
+## Design (from research)
+
+Single algorithm — seeded priority-queue flood-fill — parametrized by a **named `model`
+preset** (intuit-on-sight names; the owner reasons in real-city examples, not raw knobs —
+see [[feedback-plain-english-tooling-knobs]]). Full spec + plain-English mapping +
+principles in `thoughts/shared/research/2026-06-22-us-county-formation-patterns.md`
+§RECOMMENDED_HEURISTIC.
+
+```
+STEP0 target count ≈ precincts / 14   (R5→~6, tutorial→~2); knob = catchment radius r=2
+STEP1 classify centers by catchment pop (Σ within r, nearest-center wins):
+        dominant ≥40% Ptot | anchor ≥15–20% Ptot | minor <15% (absorbed into nearest)
+        always keep ≥1 anchor; cap anchors to target (top-k by catch pop)
+        → ONE county may hold SEVERAL towns (Clark County WA case): minors are absorbed
+STEP2 grow: 1 seed per anchor peak; pop-lowest-cost frontier; assign; push neighbours
+        cost = 1 + w_trough*(1 - norm_pop_neighbor) + w_feature*crosses_feature
+        (w_trough≈0.5, w_feature≈1.0); fill all; orphans → nearest seat by hex dist
+STEP3 named model preset:
+        "seat_and_hinterland" (default, Pattern B): done — each anchor = a seat + surround
+        "city_county" (Pattern A, SF/Denver): for each dominant center, carve urban-core
+            (pop ≥ core_density*peak, default 0.5) + split remainder into `ring_counties`
+            counties (default auto; scenario-002 = 2: west + east)
+        "split_metro" (Pattern C, Portland): split_dense_center=true → multiple seeds
+            inside one large center so county lines cut through the city
+```
+
+**Principles (must hold):** counties are UNEQUAL by design (target count = #seeds only,
+never balances them; sanity is local, not global); the REGION CLIPS counties (edge
+counties truncated by the map boundary is expected — a game simplification, not a bug);
+satellite towns (Vancouver-WA-like, same state) are just extra settlement centers, not a
+model. county_id stays cosmetic-only.
+
+## Goals / Acceptance Criteria
+
+- [ ] New county stage runs AFTER population (reads the field); replaces the geometric
+      `county_labels` path
+- [ ] Spec gains a `counties:` block: `model` (seat_and_hinterland | city_county |
+      split_metro) + optional overrides (r, anchor%, dominant%, core_density, ring_counties,
+      split_dense_center, weights), each with an inline plain-English + real-city comment
+- [ ] All three presets produce contiguous, compact counties that wrap population center(s)
+- [ ] Borders prefer population troughs + river/feature edges (soft bias, never a barrier)
+- [ ] All thresholds spec-overridable with documented defaults
+- [ ] Plain-English → preset mapping table kept current in the research doc (breadcrumb)
+- [ ] scenario-002 migrated to the `counties:` block; old `county_labels` path removed
+- [ ] county_id remains cosmetic-only (no gameplay coupling introduced)
+
+## Test Coverage
+
+- [ ] Unit tests: center classification, flood-fill contiguity, orphan reassignment, all
+      three model presets (incl. multi-town absorption), threshold overrides
+- [ ] Manual: scenario-002 county overlay reads as sane in both models
+
+## References
+
+- Plan: `thoughts/shared/plans/2026-06-22-generation-quality-overhaul.md`
+- Research: `thoughts/shared/research/2026-06-22-us-county-formation-patterns.md`
+- `game/web/src/pipeline/demographics-stage.ts` (current county_labels path),
+  `pipeline-runner.ts`, `assembler.ts`
+- `game/web/src/render/mapRenderer.ts` (cosmetic overlay consumer)
+- Depends on GAME-088 (consumes the improved population field)

--- a/thoughts/shared/tickets/GAME-090-settlement-density-realism.md
+++ b/thoughts/shared/tickets/GAME-090-settlement-density-realism.md
@@ -1,0 +1,43 @@
+---
+id: GAME-090
+title: Settlement density realism — plateau cores, non-circular shape, leapfrog developments
+area: game, tooling
+status: open
+created: 2026-06-23
+---
+
+## Summary
+
+Real settlement density is not a smooth monocentric cone — it's a **dense core
+plateau + a sharp urban edge + a low rural floor (5–10× ratio) + scattered
+leapfrog developments** beyond the edge. Captured from playtesting GAME-088:
+a pure radial gradient reads as artificial ("a stable slope"); the eye expects a
+core, established neighborhoods, a hard-ish boundary, and the odd new subdivision
+popping up a precinct or two past the edge.
+
+## Current State (what already landed in GAME-088)
+
+- `gradient` (macro tilt), `contrast` (dynamic-range / pow), `target_total`
+  (normalize) — gives the big urban/rural ratio (scenario-002 runs ~12×).
+- `profile: plateau` on settlements — flat top within the inner half-radius, then
+  a linear drop to a sharp edge (vs the smooth `gaussian`). Reads as a core.
+- **Non-circular cores** are achievable today by overlapping multiple plateau
+  settlements (scenario-002 = centre + a (1,-1) lobe → the core fans out).
+
+## Goals / Acceptance Criteria (remaining work)
+
+- [ ] **Leapfrog / exurban developments**: a spec feature that scatters N elevated
+      precincts just beyond the urban edge (stochastic, seeded), breaking the
+      clean boundary the way real new subdivisions do.
+- [ ] Optional: a sharper plateau edge knob (edge exponent) for steeper shoulders.
+- [ ] Optional: convenience for non-circular cores without hand-authoring multiple
+      settlements (e.g. an elongation / multi-anchor settlement).
+- [ ] Apply to the tutorial migrations and any scenario that wants a real city.
+
+## References
+
+- Plan: `thoughts/shared/plans/2026-06-22-generation-quality-overhaul.md`
+- Built on GAME-088 (population field) + GAME-089 (counties).
+- Philosophy: pipeline = initial-state generator, hand-tweaked for pedagogy.
+- Back-burner stretch: a transformer trained on real cities (deferred — needs
+  large training-data creation + validation).

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -117,14 +117,15 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-082-terrain-visual-treatment-refinement.md` | game, rendering, UX | Visual-tuning pass over GAME-075 terrain layer: thicker rivers, more prominent coast/lakeside edges, foothill rendering pickup, internal-lake validation |
 | `GAME-083-unassigned-precinct-visual-feedback.md` | game, rendering, UX | Unassigned precincts need a distinct neutral fill (white→dark-grey range); currently indistinguishable from assigned ones |
 | `GAME-084-map-generation-pipeline.md` | game, tooling | Spec-driven staged pipeline (terrain→population→demographics→assembler); single scenario JSON format throughout; requires loader validation split |
-| `GAME-088-coherent-population-field.md` | game, tooling | Coherent population field: neighbour-correlated noise (smoothing/value-noise) + optional radial gradient + pow contrast + normalize-to-existing-total; replaces salt-and-pepper independent jitter; extends GAME-087 |
-| `GAME-089-population-aware-county-stage.md` | game, tooling | Population-aware cosmetic counties: one seeded flood-fill algo + named model preset (seat_and_hinterland / city_county[SF] / split_metro[Portland]) from county-formation research; replaces geometric county_labels; borders wrap pop centers + snap to troughs/rivers; depends on GAME-088 |
+| `GAME-090-settlement-density-realism.md` | game, tooling | Settlement density realism follow-ons: leapfrog/exurban developments, sharper plateau edge, easier non-circular cores. Plateau profile + big urban/rural ratio already landed in GAME-088 |
 ---
 
 ## Resolved
 
 | Summary | Resolution |
 |---|---|
+| GAME-089: population-aware county stage | Replaced geometric `county_labels` with a population-aware flood-fill county stage (`county-stage.ts`); named model presets seat_and_hinterland / city_county / split_metro; counties wrap pop centers, borders bias to troughs/rivers; county display names plumbed to the precinct-info panel; darker/shorter-dash border overlay; county_id stays cosmetic. scenario-002 migrated to `counties:` block (city + west + east). Unit tests + e2e green |
+| GAME-088: coherent population field | Added opt-in field-shaping to the population stage: gradient, neighbour-smoothing, pow-contrast, normalize-to-target, plus a `plateau` settlement profile (flat core + sharp edge vs gaussian). scenario-002 reworked to a 3-cluster, ~12x urban/rural field with a non-circular city core; scenario-002 winnability e2e re-solved (pack dense east-core Ryu → Ken 3-1). Also fixed precinct-info lean showing real party names. Unit + e2e tests pass |
 | BUILD-010: release.main.kts missing clikt import | Added `import com.github.ajalt.clikt.parameters.options.default`; the `Serve` subcommand's `.default()` call broke compilation of the whole script (prepare/deploy/serve all failed). Verified via dev deploy of GAME-088 |
 | GAME-087: terrain-aware population stage | `populateScenario` rewritten with terrain suitability (lakeside 1.4×/riverside 1.3×/coastal 0.9×/mountain 0.5×), Gaussian settlement bumps, and all anchor types (center, cardinal, feature, exact coords); scenario-002 updated with Clearwater City + East Mills settlements; peaks tuned to keep e2e district balance within ±5% of mean; all 10 ACs met; merged PR #265 |
 | GAME-041: split loader.ts | `runtime-types.ts` extracted (requireString etc.); `validateScenarioInvariants()` named function in loader.ts; cartesianProduct at module level; all 8 model tests pass; no behavior change |

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -117,6 +117,8 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-082-terrain-visual-treatment-refinement.md` | game, rendering, UX | Visual-tuning pass over GAME-075 terrain layer: thicker rivers, more prominent coast/lakeside edges, foothill rendering pickup, internal-lake validation |
 | `GAME-083-unassigned-precinct-visual-feedback.md` | game, rendering, UX | Unassigned precincts need a distinct neutral fill (white→dark-grey range); currently indistinguishable from assigned ones |
 | `GAME-084-map-generation-pipeline.md` | game, tooling | Spec-driven staged pipeline (terrain→population→demographics→assembler); single scenario JSON format throughout; requires loader validation split |
+| `GAME-088-coherent-population-field.md` | game, tooling | Coherent population field: neighbour-correlated noise (smoothing/value-noise) + optional radial gradient + pow contrast + normalize-to-existing-total; replaces salt-and-pepper independent jitter; extends GAME-087 |
+| `GAME-089-population-aware-county-stage.md` | game, tooling | Population-aware cosmetic counties: one seeded flood-fill algo + named model preset (seat_and_hinterland / city_county[SF] / split_metro[Portland]) from county-formation research; replaces geometric county_labels; borders wrap pop centers + snap to troughs/rivers; depends on GAME-088 |
 ---
 
 ## Resolved

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -125,6 +125,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| BUILD-010: release.main.kts missing clikt import | Added `import com.github.ajalt.clikt.parameters.options.default`; the `Serve` subcommand's `.default()` call broke compilation of the whole script (prepare/deploy/serve all failed). Verified via dev deploy of GAME-088 |
 | GAME-087: terrain-aware population stage | `populateScenario` rewritten with terrain suitability (lakeside 1.4×/riverside 1.3×/coastal 0.9×/mountain 0.5×), Gaussian settlement bumps, and all anchor types (center, cardinal, feature, exact coords); scenario-002 updated with Clearwater City + East Mills settlements; peaks tuned to keep e2e district balance within ±5% of mean; all 10 ACs met; merged PR #265 |
 | GAME-041: split loader.ts | `runtime-types.ts` extracted (requireString etc.); `validateScenarioInvariants()` named function in loader.ts; cartesianProduct at module level; all 8 model tests pass; no behavior change |
 | GAME-086: lake rendering | `lakeside: boolean` derived in adapter from lake-tile adjacency; lake intrusion fill (smooth profile, `#4dd0e1`, depth 5px) rendered in `renderTerrainEdges` with corner caps; river stroke unified with lake colour; tutorial-003 lake tile moved to centre (-1,1); 6 lakeside precincts; e2e + unit tests; merged PR #253 |


### PR DESCRIPTION
## Summary

Generation-quality overhaul for the map pipeline — makes pipeline-generated maps
read like plausible places, demonstrated on scenario-002.

**GAME-088 — coherent population field.** Replaces the salt-and-pepper independent
jitter with opt-in field-shaping layers in the population stage:
- `gradient` (monocentric tilt), `smoothing` (neighbour-averaged coherent noise),
  `contrast` (pow on the normalized field, widens dynamic range), `target_total`
  (normalize the field so total population is preserved — change shape, not magnitude).
- `plateau` settlement profile (flat core + sharp edge) alongside `gaussian`.
- With no layers set, the formula reduces exactly to GAME-087's — existing scenarios
  and tests are unchanged.

**GAME-089 — population-aware counties.** Replaces the geometric `county_labels`
slices with a seeded flood-fill county stage that wraps population centers:
- Named model presets: `seat_and_hinterland` (default), `city_county` (SF/Denver —
  dense core carved out), `split_metro` (Portland — city across several counties).
- Borders bias toward population troughs and river edges. `county_id` stays purely
  cosmetic (drives only the dashed border overlay).
- County display **names** plumbed to the precinct-info panel; darker/shorter-dash
  border overlay so white district lines show through.

**scenario-002** migrated to the new field + `counties:` block: a 3-cluster city
(Clearwater City core + East Mills + West Bend), non-circular plateau core, ~12×
urban/rural ratio, and three counties (city + west + east). Its winnability e2e was
re-solved against the new field (pack the dense east-of-centre Ryu core into a sink,
split the Ken-leaning remainder into three balanced majority-Ken districts → Ken 3/1).

**Also included:**
- Fix: precinct-info lean now shows real party names (Ken/Ryu) instead of "Party 1/2".
- `fix(BUILD-010)`: missing clikt `default` import that broke `release.main.kts`
  compilation (prepare/deploy/serve all failed). Needed to deploy this work to dev.
- Planning + research docs (county-formation patterns), GAME-090 filed for realism
  follow-ons (leapfrog developments, sharper edges).

## Affected machines / services

- The browser game (`game/web`) only. No infra/hosts/secrets touched.
- Deploys to the static site (dev/staging/production via `game/release.main.kts`).

## Validation performed

- [x] Unit + typecheck suite: `bazel test //game/web/src/...` — 33/33 pass
- [x] Full Playwright e2e: `bazel test //game/web:e2e_test` — pass (incl. re-solved
      scenario-002 winnability)
- [x] scenario-002 re-solve verified offline against the sim's pop×partyShare vote
      model (Ken 3 / Ryu 1, all districts within ±10%)
- [x] Deployed to dev (dev.pastthepost.gg) and eyeballed
- [ ] sops decrypt verified (N/A — no secrets)
- [ ] kubectl dry-run (N/A — no manifests)

## Deployment steps (POST-MERGE)

- Static-site app; no automatic deploy on merge. Release via `game/release.main.kts`
  (`prepare` → `deploy --env staging`, then production with explicit sign-off).
- Already deployed to **dev** as a vTEST build for review; no prod action required by
  this PR.

## Tickets addressed

- GAME-088 (resolved), GAME-089 (resolved), BUILD-010 (resolved)
- GAME-090 filed (settlement-density realism follow-ons)
- Relates to GAME-084 (pipeline) and GAME-079 (scenario-002 playability)

## Rollback

- Revert the PR. `county_id`/`county_name` are cosmetic; the new population layers
  are opt-in, so reverting restores the prior generator behavior exactly.
- `scenario-002.json` is regenerable from its `.spec.yaml` via
  `generate_scenario`; no manual data to restore.
