### PR TITLE
feat(GAME-091): scenario-002 reapportionment opener — narrative, debrief, old-map, river

### DIFF
--- a/game/scenarios/scenario-002.json
+++ b/game/scenarios/scenario-002.json
@@ -1,11 +1,11 @@
 {
   "format_version": "1",
   "id": "scenario-002",
-  "title": "Clearwater County: The Governor's Map",
+  "title": "Clearwater Valley: The Governor's Map",
   "election_type": "state_house",
   "region": {
-    "id": "clearwater_county",
-    "name": "Clearwater County"
+    "id": "clearwater_valley",
+    "name": "Clearwater Valley"
   },
   "geometry": {
     "type": "hex_axial"
@@ -64,7 +64,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (0,-5)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d2"
     },
     {
       "id": "p002",
@@ -89,7 +89,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (1,-5)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d2"
     },
     {
       "id": "p003",
@@ -114,7 +114,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (2,-5)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d2"
     },
     {
       "id": "p004",
@@ -189,7 +189,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (5,-5)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d2"
     },
     {
       "id": "p007",
@@ -214,7 +214,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-1,-4)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p008",
@@ -239,7 +239,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (0,-4)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d2"
     },
     {
       "id": "p009",
@@ -264,7 +264,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (1,-4)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d2"
     },
     {
       "id": "p010",
@@ -339,7 +339,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (4,-4)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d2"
     },
     {
       "id": "p013",
@@ -364,7 +364,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (5,-4)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d2"
     },
     {
       "id": "p014",
@@ -389,7 +389,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-2,-3)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p015",
@@ -414,7 +414,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-1,-3)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p016",
@@ -439,7 +439,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (0,-3)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p017",
@@ -514,7 +514,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (3,-3)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d2"
     },
     {
       "id": "p020",
@@ -539,7 +539,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (4,-3)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d2"
     },
     {
       "id": "p021",
@@ -564,7 +564,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (5,-3)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p022",
@@ -589,7 +589,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-3,-2)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p023",
@@ -614,7 +614,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-2,-2)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p024",
@@ -639,7 +639,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-1,-2)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p025",
@@ -664,7 +664,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (0,-2)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p026",
@@ -689,7 +689,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (1,-2)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d1"
     },
     {
       "id": "p027",
@@ -714,7 +714,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (2,-2)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d1"
     },
     {
       "id": "p028",
@@ -739,7 +739,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (3,-2)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d2"
     },
     {
       "id": "p029",
@@ -764,7 +764,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (4,-2)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p030",
@@ -789,7 +789,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (5,-2)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p031",
@@ -814,7 +814,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-4,-1)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p032",
@@ -839,7 +839,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-3,-1)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p033",
@@ -864,7 +864,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-2,-1)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p034",
@@ -889,7 +889,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-1,-1)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p035",
@@ -914,7 +914,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (0,-1)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d1"
     },
     {
       "id": "p036",
@@ -939,7 +939,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (1,-1)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d1"
     },
     {
       "id": "p037",
@@ -964,7 +964,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (2,-1)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d1"
     },
     {
       "id": "p038",
@@ -989,7 +989,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (3,-1)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p039",
@@ -1014,7 +1014,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (4,-1)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p040",
@@ -1039,7 +1039,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (5,-1)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p041",
@@ -1064,7 +1064,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-5,0)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p042",
@@ -1089,7 +1089,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-4,0)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p043",
@@ -1114,7 +1114,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-3,0)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p044",
@@ -1139,7 +1139,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-2,0)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p045",
@@ -1164,7 +1164,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (-1,0)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d1"
     },
     {
       "id": "p046",
@@ -1189,7 +1189,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (0,0)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d1"
     },
     {
       "id": "p047",
@@ -1214,7 +1214,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (1,0)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d1"
     },
     {
       "id": "p048",
@@ -1239,7 +1239,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (2,0)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p049",
@@ -1264,7 +1264,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (3,0)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p050",
@@ -1289,7 +1289,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (4,0)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p051",
@@ -1314,7 +1314,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (5,0)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p052",
@@ -1339,7 +1339,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-5,1)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p053",
@@ -1364,7 +1364,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-4,1)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p054",
@@ -1389,7 +1389,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-3,1)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p055",
@@ -1411,10 +1411,10 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_city",
-      "county_name": "Clearwater City",
+      "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "City (-2,1)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p056",
@@ -1439,7 +1439,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (-1,1)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d1"
     },
     {
       "id": "p057",
@@ -1464,7 +1464,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (0,1)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d1"
     },
     {
       "id": "p058",
@@ -1489,7 +1489,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (1,1)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p059",
@@ -1514,7 +1514,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (2,1)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p060",
@@ -1539,7 +1539,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (3,1)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p061",
@@ -1564,7 +1564,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (4,1)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p062",
@@ -1589,7 +1589,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-5,2)",
-      "initial_district_id": "d1"
+      "initial_district_id": "d3"
     },
     {
       "id": "p063",
@@ -1614,7 +1614,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-4,2)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p064",
@@ -1639,7 +1639,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-3,2)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p065",
@@ -1661,8 +1661,8 @@
           "name": "All voters"
         }
       ],
-      "county_id": "clearwater_city",
-      "county_name": "Clearwater City",
+      "county_id": "clearwater_west",
+      "county_name": "Clearwater West",
       "name": "City (-2,2)",
       "initial_district_id": "d3"
     },
@@ -1689,7 +1689,7 @@
       "county_id": "clearwater_city",
       "county_name": "Clearwater City",
       "name": "City (-1,2)",
-      "initial_district_id": "d3"
+      "initial_district_id": "d1"
     },
     {
       "id": "p067",
@@ -1714,7 +1714,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (0,2)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p068",
@@ -1739,7 +1739,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (1,2)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p069",
@@ -1764,7 +1764,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (2,2)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p070",
@@ -1789,7 +1789,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (3,2)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p071",
@@ -1814,7 +1814,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-5,3)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p072",
@@ -1839,7 +1839,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-4,3)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p073",
@@ -1914,7 +1914,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-1,3)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d3"
     },
     {
       "id": "p076",
@@ -1939,7 +1939,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (0,3)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p077",
@@ -1964,7 +1964,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (1,3)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p078",
@@ -1989,7 +1989,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (2,3)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p079",
@@ -2014,7 +2014,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-5,4)",
-      "initial_district_id": "d2"
+      "initial_district_id": "d3"
     },
     {
       "id": "p080",
@@ -2089,7 +2089,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-2,4)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d3"
     },
     {
       "id": "p083",
@@ -2114,7 +2114,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-1,4)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d3"
     },
     {
       "id": "p084",
@@ -2139,7 +2139,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (0,4)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p085",
@@ -2164,7 +2164,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (1,4)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     },
     {
       "id": "p086",
@@ -2239,7 +2239,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-3,5)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d3"
     },
     {
       "id": "p089",
@@ -2264,7 +2264,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-2,5)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d3"
     },
     {
       "id": "p090",
@@ -2289,7 +2289,7 @@
       "county_id": "clearwater_west",
       "county_name": "Clearwater West",
       "name": "West (-1,5)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d3"
     },
     {
       "id": "p091",
@@ -2314,7 +2314,7 @@
       "county_id": "clearwater_east",
       "county_name": "Clearwater East",
       "name": "East (0,5)",
-      "initial_district_id": "d4"
+      "initial_district_id": "d2"
     }
   ],
   "events": [],
@@ -2365,24 +2365,33 @@
   "narrative": {
     "character": {
       "name": "You",
-      "role": "Ken Party Campaign Strategist, Clearwater County",
-      "motivation": "The governor wants a reliable majority in Clearwater County. The current map splits the vote evenly — two Ken, two Ryu. That's not good enough. You've been brought in to redraw the lines so Ken wins three of four seats.\n"
+      "role": "Ken Party Campaign Strategist, Clearwater Valley",
+      "motivation": "For a generation the Clearwater Valley voted by county — three counties, three seats, a steady two-to-one edge for the Ryu Party. Then the city outgrew its lines. Now the valley has a fourth seat to fill, and the governor — a Ken partisan — means to turn that two-to-one deficit into a three-to-one win.\n"
     },
     "intro_slides": [
       {
-        "body": "Clearwater County elects four representatives. Right now, the map gives each party two seats. The governor — a Ken partisan — wants three.\nThe population hasn't changed. The voters haven't changed. But the lines can change.\n",
-        "heading": "The Governor's Problem"
+        "body": "The Clearwater Valley has elected its representatives by county for as long as anyone can remember: Clearwater City in the center, the rural West, and the rural East. Three counties, three seats.\nThe counties were drawn roughly equal once. For years two of the three went to the Ryu Party.\n",
+        "heading": "Three Counties, Three Seats"
       },
       {
-        "body": "Every ten years, district boundaries are redrawn. The official reason is to reflect population changes. The real reason, often, is to change who wins.\nYou're looking at a map of precincts — small geographic units with known voting patterns. Your job is to group them into districts that favor the Ken Party.\n",
-        "heading": "How Redistricting Works"
+        "body": "Then a biotech firm planted its headquarters on the city's east bank, and the people followed. Clearwater City swelled while the rural counties held steady — a map once roughly equal is now badly lopsided.\nDistricts are supposed to hold near-equal population, so the valley is granted a fourth seat and the lines must be redrawn. That redraw is your opening.\n",
+        "heading": "A City That Grew"
       },
       {
-        "body": "Look at the map. The southeast corner votes heavily Ryu. The north and southwest lean Ken.\nIf you can contain the Ryu stronghold in one district and spread Ken voters across the other three, the governor gets the majority. The tools are simple — the consequences are not.\n",
-        "heading": "Your First Gerrymander"
+        "body": "Count every voter and Ryu is still ahead — but seats are won district by district, not valley-wide. A party can win a couple of districts in landslides, lose the rest by a hair, and take the most votes yet the fewest seats.\nThe lines decide which party that is — and they don't have to follow the old county borders. The voters haven't moved. The lines can.\n",
+        "heading": "Seats, Not Votes"
+      },
+      {
+        "body": "The countryside leans Ken. The east side of Clearwater City — newer, denser, where the boom landed — leans Ryu. But the city's Old Quarter to the west, its mills, its market, its weathered training halls, was settled generations ago by families who came in off the farms, and it kept their instincts. It leans Ken too.\nSo the politics don't follow the city limits: half the city votes like the farms that fed it, half votes the other way.\n",
+        "heading": "Know the Ground"
+      },
+      {
+        "body": "Pack the booming east-bank Ryu vote into a single district where they win in a landslide — every vote past a majority wasted. Spread Ken's voters — the rural counties and the Old Quarter alike — across the other three.\nThree slim wins beat one landslide. Same voters, same valley, a fourth seat, and lines that ignore the old county borders.\n",
+        "heading": "Your Move — Packing"
       }
     ],
-    "objective": "Redraw the map so the Ken Party wins at least 3 of 4 districts."
+    "objective": "Redraw the valley into four equal districts so the Ken Party wins at least 3 of 4 — turning the old 2–1 Ryu map into a 3–1 Ken one.\n",
+    "epilogue": "The old county map gave Ryu two of three seats. Handed a fourth seat and a free hand to ignore the county borders, you turned it into three of four for Ken — though Ryu still won more votes across the valley.\nBy packing the east-bank Ryu vote into a single district, you let them win it in a landslide while their extra votes piled up uselessly; Ken's voters, spread across the other three, carried each by a smaller but sufficient margin. That's \"packing\" — its mirror, \"cracking,\" splits a bloc so it never wins anywhere.\nPopulation shifts force redistricting; whoever controls the pen decides who benefits. Who draws the lines, and when, can matter as much as how people vote.\n"
   },
   "default_district_id": "d1",
   "instigator_character": "governor",
@@ -2390,5 +2399,95 @@
     "governor": "bm",
     "commissioner": "bf",
     "judge": "lm"
-  }
+  },
+  "river_edges": [
+    [
+      "p007",
+      "p001"
+    ],
+    [
+      "p007",
+      "p008"
+    ],
+    [
+      "p008",
+      "p016"
+    ],
+    [
+      "p015",
+      "p008"
+    ],
+    [
+      "p016",
+      "p009"
+    ],
+    [
+      "p016",
+      "p017"
+    ],
+    [
+      "p025",
+      "p017"
+    ],
+    [
+      "p025",
+      "p026"
+    ],
+    [
+      "p035",
+      "p026"
+    ],
+    [
+      "p035",
+      "p036"
+    ],
+    [
+      "p046",
+      "p036"
+    ],
+    [
+      "p046",
+      "p047"
+    ],
+    [
+      "p057",
+      "p047"
+    ],
+    [
+      "p057",
+      "p058"
+    ],
+    [
+      "p057",
+      "p067"
+    ],
+    [
+      "p066",
+      "p067"
+    ],
+    [
+      "p075",
+      "p067"
+    ],
+    [
+      "p075",
+      "p076"
+    ],
+    [
+      "p083",
+      "p076"
+    ],
+    [
+      "p083",
+      "p084"
+    ],
+    [
+      "p090",
+      "p084"
+    ],
+    [
+      "p090",
+      "p091"
+    ]
+  ]
 }

--- a/game/scenarios/scenario-002.overlay.jq
+++ b/game/scenarios/scenario-002.overlay.jq
@@ -1,0 +1,40 @@
+# Manual finishing overlay for scenario-002 (GAME-091).
+#
+# The generator produces the base scenario (terrain, population, demographics,
+# counties, assembly) from scenario-002.spec.yaml. This overlay then applies the
+# hand pedagogical tweaks the generator does not produce — keeping scenario-002
+# fully reproducible (regenerate, then re-apply this overlay).
+#
+# Apply:
+#   bazel run //game/web/src/pipeline:generate_scenario -- game/scenarios/scenario-002.spec.yaml
+#   jq --slurpfile o game/scenarios/scenario-002.overlay.json \
+#      -f game/scenarios/scenario-002.overlay.jq \
+#      game/scenarios/scenario-002.json > /tmp/s2 && mv /tmp/s2 game/scenarios/scenario-002.json
+#
+# It does three things:
+#   1. Reassign the two west-edge city precincts (city_to_west) into Clearwater
+#      West county, so the county split reads ~West 41k / City 64k / East 40k —
+#      "the old map was 40/40/40 until the east-bank boom grew the city".
+#   2. Set the "old map" initial assignment: districts = the three counties
+#      (City->d1, East->d2, West->d3), leaving d4 empty for the player to carve.
+#   3. Add the cosmetic river (river_edges) that traces the W/E county border and
+#      the Ken/Ryu split through the city centre.
+
+($o[0]) as $ov
+| ($ov.river_edges) as $edges
+| ($ov.city_to_west | map("\(.[0]),\(.[1])")) as $toWest
+| (reduce .precincts[] as $p ({}; .["\($p.position.q),\($p.position.r)"] = $p.id)) as $id
+| .precincts |= map(
+    ("\(.position.q),\(.position.r)") as $k
+    | (if ($toWest | index($k))
+       then .county_id = "clearwater_west" | .county_name = "Clearwater West"
+       else . end)
+    | .initial_district_id = (
+        if .county_name == "Clearwater City" then "d1"
+        elif .county_name == "Clearwater East" then "d2"
+        else "d3" end)
+  )
+| .river_edges = ($edges | map([
+    $id["\(.[0][0]),\(.[0][1])"],
+    $id["\(.[1][0]),\(.[1][1])"]
+  ]))

--- a/game/scenarios/scenario-002.overlay.json
+++ b/game/scenarios/scenario-002.overlay.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Manual finishing overlay for scenario-002 (GAME-091). Applied AFTER generate_scenario, since these are hand pedagogical tweaks the generator does not produce. Apply: jq --slurpfile o scenario-002.overlay.json -f scenario-002.overlay.jq scenario-002.json > tmp && mv tmp scenario-002.json. See scenario-002.overlay.jq.",
+  "river_edges": [
+    [[-1,-4],[0,-5]],
+    [[-1,-4],[0,-4]],
+    [[0,-4],[0,-3]],
+    [[-1,-3],[0,-4]],
+    [[0,-3],[1,-4]],
+    [[0,-3],[1,-3]],
+    [[0,-2],[1,-3]],
+    [[0,-2],[1,-2]],
+    [[0,-1],[1,-2]],
+    [[0,-1],[1,-1]],
+    [[0,0],[1,-1]],
+    [[0,0],[1,0]],
+    [[0,1],[1,0]],
+    [[0,1],[1,1]],
+    [[0,1],[0,2]],
+    [[-1,2],[0,2]],
+    [[-1,3],[0,2]],
+    [[-1,3],[0,3]],
+    [[-1,4],[0,3]],
+    [[-1,4],[0,4]],
+    [[-1,5],[0,4]],
+    [[-1,5],[0,5]]
+  ],
+  "city_to_west": [[-2,1],[-2,2]]
+}

--- a/game/scenarios/scenario-002.spec.yaml
+++ b/game/scenarios/scenario-002.spec.yaml
@@ -1,4 +1,4 @@
-# Spec file for scenario-002: "Clearwater County: The Governor's Map"
+# Spec file for scenario-002: "Clearwater Valley: The Governor's Map"
 # Source of truth for the map generation pipeline (GAME-084).
 # Generated output: game/scenarios/scenario-002.json
 #
@@ -7,6 +7,12 @@
 #   [x] Stage 2: population     (population-stage.ts)
 #   [x] Stage 3: demographics   (demographics-stage.ts)
 #   [x] Stage 4: assembly       (assembler.ts)
+#
+# MANUAL FINISHING OVERLAY (GAME-091): after generate_scenario, run the overlay to
+# apply hand pedagogical tweaks the generator does not produce — a cosmetic river,
+# the two-precinct county tidy, and the "old map" 3-county initial assignment.
+# Regenerating WITHOUT re-applying the overlay drops these. See:
+#   game/scenarios/scenario-002.overlay.jq  (+ scenario-002.overlay.json)
 
 format_version: "1"
 
@@ -14,11 +20,11 @@ format_version: "1"
 
 scenario:
   id: scenario-002
-  title: "Clearwater County: The Governor's Map"
+  title: "Clearwater Valley: The Governor's Map"
   election_type: state_house
   region:
-    id: clearwater_county
-    name: Clearwater County
+    id: clearwater_valley
+    name: Clearwater Valley
 
 # ── Stage 1a: Map layout ──────────────────────────────────────────────────────
 
@@ -36,7 +42,7 @@ terrain: {}
 
 # ── Stage 2: Population ───────────────────────────────────────────────────────
 #
-# Clearwater County urban/suburban mix — three density clusters so the field is
+# Clearwater Valley urban/rural mix — three density clusters so the field is
 # non-monotonic (not a single cone) and the county stage gets clean seeds:
 #   Clearwater City: the county seat, in the centre (dominant).
 #   East Mills:      a mill town to the east.
@@ -161,37 +167,73 @@ assembly:
   narrative:
     character:
       name: You
-      role: Ken Party Campaign Strategist, Clearwater County
+      role: Ken Party Campaign Strategist, Clearwater Valley
       motivation: >
-        The governor wants a reliable majority in Clearwater County. The current
-        map splits the vote evenly — two Ken, two Ryu. That's not good enough.
-        You've been brought in to redraw the lines so Ken wins three of four seats.
+        For a generation the Clearwater Valley voted by county — three counties,
+        three seats, a steady two-to-one edge for the Ryu Party. Then the city
+        outgrew its lines. Now the valley has a fourth seat to fill, and the
+        governor — a Ken partisan — means to turn that two-to-one deficit into a
+        three-to-one win.
     intro_slides:
-      - heading: The Governor's Problem
+      - heading: Three Counties, Three Seats
         body: >
-          Clearwater County elects four representatives. Right now, the map gives
-          each party two seats. The governor — a Ken partisan — wants three.
+          The Clearwater Valley has elected its representatives by county for as long
+          as anyone can remember: Clearwater City in the center, the rural West, and
+          the rural East. Three counties, three seats.
 
-          The population hasn't changed. The voters haven't changed. But the lines
-          can change.
-      - heading: How Redistricting Works
+          The counties were drawn roughly equal once. For years two of the three went
+          to the Ryu Party.
+      - heading: A City That Grew
         body: >
-          Every ten years, district boundaries are redrawn. The official reason is
-          to reflect population changes. The real reason, often, is to change who
-          wins.
+          Then a biotech firm planted its headquarters on the city's east bank, and
+          the people followed. Clearwater City swelled while the rural counties held
+          steady — a map once roughly equal is now badly lopsided.
 
-          You're looking at a map of precincts — small geographic units with known
-          voting patterns. Your job is to group them into districts that favor the
-          Ken Party.
-      - heading: Your First Gerrymander
+          Districts are supposed to hold near-equal population, so the valley is
+          granted a fourth seat and the lines must be redrawn. That redraw is your
+          opening.
+      - heading: Seats, Not Votes
         body: >
-          Look at the map. The southeast corner votes heavily Ryu. The north and
-          southwest lean Ken.
+          Count every voter and Ryu is still ahead — but seats are won district by
+          district, not valley-wide. A party can win a couple of districts in
+          landslides, lose the rest by a hair, and take the most votes yet the fewest
+          seats.
 
-          If you can contain the Ryu stronghold in one district and spread Ken
-          voters across the other three, the governor gets the majority. The tools
-          are simple — the consequences are not.
-    objective: Redraw the map so the Ken Party wins at least 3 of 4 districts.
+          The lines decide which party that is — and they don't have to follow the
+          old county borders. The voters haven't moved. The lines can.
+      - heading: Know the Ground
+        body: >
+          The countryside leans Ken. The east side of Clearwater City — newer,
+          denser, where the boom landed — leans Ryu. But the city's Old Quarter to
+          the west, its mills, its market, its weathered training halls, was settled
+          generations ago by families who came in off the farms, and it kept their
+          instincts. It leans Ken too.
+
+          So the politics don't follow the city limits: half the city votes like the
+          farms that fed it, half votes the other way.
+      - heading: Your Move — Packing
+        body: >
+          Pack the booming east-bank Ryu vote into a single district where they win
+          in a landslide — every vote past a majority wasted. Spread Ken's voters —
+          the rural counties and the Old Quarter alike — across the other three.
+
+          Three slim wins beat one landslide. Same voters, same valley, a fourth seat,
+          and lines that ignore the old county borders.
+    objective: >
+      Redraw the valley into four equal districts so the Ken Party wins at least 3 of
+      4 — turning the old 2–1 Ryu map into a 3–1 Ken one.
+    epilogue: >
+      The old county map gave Ryu two of three seats. Handed a fourth seat and a free
+      hand to ignore the county borders, you turned it into three of four for Ken —
+      though Ryu still won more votes across the valley.
+
+      By packing the east-bank Ryu vote into a single district, you let them win it in
+      a landslide while their extra votes piled up uselessly; Ken's voters, spread
+      across the other three, carried each by a smaller but sufficient margin. That's
+      "packing" — its mirror, "cracking," splits a bloc so it never wins anywhere.
+
+      Population shifts force redistricting; whoever controls the pen decides who
+      benefits. Who draws the lines, and when, can matter as much as how people vote.
   instigator_character: governor
   character_demographics:
     governor: bm

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -177,6 +177,9 @@ test("scenario-002 winnability: packing east Ryu bloc into one district passes",
   await page.locator("#btn-submit").click();
   await expect(page.locator("#result-screen")).toBeVisible();
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+  // GAME-091: the teaching debrief is revealed on a win.
+  await expect(page.locator("#result-epilogue")).toBeVisible();
+  await expect(page.locator("#result-epilogue")).toContainText("packing");
 });
 
 // ─── scenario-003: "The Packing Problem" ─────────────────────────────────────

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -77,6 +77,7 @@
         <div id="result-subtitle"></div>
         <div id="result-stars" class="hidden" aria-label="Star rating"></div>
         <div id="result-criteria-list"></div>
+        <div id="result-epilogue" class="hidden"></div>
         <div id="result-reveal-controls" style="display:none">
           <button id="btn-reveal-skip">Skip →</button>
         </div>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -48,7 +48,7 @@ import { preload, play, setMuted, isMuted } from "./audio/audioPlayer.js";
 
 const SCENARIO_MANIFEST = [
 	{ id: "tutorial-002", title: "Millbrook County: Three-District Challenge" },
-	{ id: "scenario-002", title: "Clearwater County: The Governor's Map" },
+	{ id: "scenario-002", title: "Clearwater Valley: The Governor's Map" },
 	{ id: "scenario-003", title: "Riverport: The Packing Problem" },
 	{ id: "scenario-004", title: "Lakeview: Cracking the Opposition" },
 	{ id: "scenario-005", title: "Valle Verde: A Voice for the Valley" },
@@ -101,6 +101,7 @@ let skipClickHandler: (() => void) | null = null;
 const resultVerdict = document.getElementById("result-verdict") as HTMLElement | null;
 const resultSubtitle = document.getElementById("result-subtitle") as HTMLElement | null;
 const resultCriteriaList = document.getElementById("result-criteria-list") as HTMLElement | null;
+const resultEpilogue = document.getElementById("result-epilogue") as HTMLElement | null;
 const btnKeepDrawing = document.getElementById("btn-keep-drawing") as HTMLButtonElement | null;
 const btnNextScenario = document.getElementById("btn-next-scenario") as HTMLButtonElement | null;
 const resultStars = document.getElementById("result-stars") as HTMLElement | null;
@@ -955,6 +956,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		resultVerdict.style.opacity = "0";
 		resultSubtitle.textContent = "";
 		resultSubtitle.style.opacity = "0";
+		if (resultEpilogue) { resultEpilogue.textContent = ""; resultEpilogue.classList.add("hidden"); }
 		if (resultStars) { resultStars.innerHTML = ""; resultStars.classList.add("hidden"); }
 		// maxStars based on scenario structure (not forced-pass); stars computed from actual results.
 		const maxStars = 1 + evalResult.criterionResults.filter(cr => !cr.required).length;
@@ -1037,6 +1039,14 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			if (pass && resultStars) {
 				renderStars(resultStars, starCount, maxStars);
 				resultStars.classList.remove("hidden");
+			}
+			// GAME-091: reveal the teaching debrief on a win.
+			if (pass && resultEpilogue) {
+				const epilogue = scenario.narrative?.epilogue;
+				if (epilogue) {
+					resultEpilogue.textContent = epilogue;
+					resultEpilogue.classList.remove("hidden");
+				}
 			}
 			if (pass) {
 				play("tada");

--- a/game/web/src/model/loader.ts
+++ b/game/web/src/model/loader.ts
@@ -414,6 +414,9 @@ function parseNarrative(raw: unknown): Narrative {
   if (r["flavor_text"] !== undefined) {
     narrative.flavor_text = requireString(r["flavor_text"], "narrative.flavor_text");
   }
+  if (r["epilogue"] !== undefined) {
+    narrative.epilogue = requireString(r["epilogue"], "narrative.epilogue");
+  }
   if (r["instigator"] !== undefined) {
     throw new Error("narrative.instigator removed; use instigator_character at the scenario root level instead");
   }

--- a/game/web/src/model/scenario.ts
+++ b/game/web/src/model/scenario.ts
@@ -230,6 +230,11 @@ export interface Narrative {
 	/** Shown on the map screen */
 	objective: string;
 	flavor_text?: string;
+	/**
+	 * Teaching debrief shown on the result screen after a winning map is revealed
+	 * (GAME-091). Plain text; explains the lesson the scenario demonstrates.
+	 */
+	epilogue?: string;
 }
 
 // ─── State context ────────────────────────────────────────────────────────────

--- a/game/web/src/pipeline/assembler.ts
+++ b/game/web/src/pipeline/assembler.ts
@@ -127,6 +127,7 @@ export function assembleScenario(
     intro_slides: spec.narrative.intro_slides,
     objective: spec.narrative.objective,
     ...(spec.narrative.flavor_text !== undefined ? { flavor_text: spec.narrative.flavor_text } : {}),
+    ...(spec.narrative.epilogue !== undefined ? { epilogue: spec.narrative.epilogue } : {}),
   };
 
   return {

--- a/game/web/src/pipeline/spec-types.ts
+++ b/game/web/src/pipeline/spec-types.ts
@@ -270,6 +270,8 @@ export interface NarrativeSpec {
   intro_slides: SlideSpec[];
   objective: string;
   flavor_text?: string;
+  /** Teaching debrief shown on the result screen after a win (GAME-091). */
+  epilogue?: string;
 }
 
 export interface AssemblySpec {

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -360,22 +360,23 @@ export class SvgMapRenderer implements MapRenderer {
 		//   borderGroup         — committed district boundaries (solid white)
 		//   hexGroup            — precinct fills
 		//   terrainOverlayGroup — coast/foothill intrusion fills + lake blobs (above hex fills)
-		//   countyBorderGroup   — county boundary overlay (dashed gray; off by default)
-		//   riverGroup          — blue river strokes along hex edges (above precincts + county borders)
+		//   riverGroup          — blue river strokes along hex edges (above precincts)
+		//   countyBorderGroup   — county boundary overlay (dashed gray; off by default; over rivers)
 		//   previewBorderGroup  — in-stroke boundary preview (top)
 		// Note on riverGroup placement: DESIGN-008 describes rivers as "above hex fills but
 		// below district outlines". In this renderer borderGroup is *below* hexGroup (district
 		// boundaries shine through semi-transparent hex fills), so the spec's two constraints
 		// are mutually exclusive. We choose "above hex fills" because rivers must be visible
-		// as natural geographic boundaries; they sit above district outlines as a result.
+		// as natural geographic boundaries. County borders sit above rivers so administrative
+		// lines read as drawn over the geography (county lines often follow rivers).
 		this.zoomGroup = this.svg.append("g").attr("class", "zoom-layer");
 		this.terrainGroup = this.zoomGroup.append("g").attr("class", "terrain");
 		this.borderGroup = this.zoomGroup.append("g").attr("class", "borders");
 		this.hexGroup = this.zoomGroup.append("g").attr("class", "hexes");
 		this.terrainOverlayGroup = this.zoomGroup.append("g").attr("class", "terrain-overlay");
 		this.hoverHighlightGroup = this.zoomGroup.append("g").attr("class", "hover-highlight");
-		this.countyBorderGroup = this.zoomGroup.append("g").attr("class", "county-borders");
 		this.riverGroup = this.zoomGroup.append("g").attr("class", "rivers");
+		this.countyBorderGroup = this.zoomGroup.append("g").attr("class", "county-borders");
 		this.previewBorderGroup = this.zoomGroup.append("g").attr("class", "preview-borders");
 		this.coordLabelGroup = this.zoomGroup.append("g").attr("class", "coord-labels").attr("display", "none");
 

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -594,6 +594,25 @@ body {
   transition: opacity 0.3s ease;
 }
 
+/* GAME-091: teaching debrief shown after a winning map is revealed. */
+#result-epilogue {
+  margin: 14px auto 4px;
+  max-width: 46ch;
+  padding: 12px 14px;
+  border-left: 3px solid #5a7fb0;
+  background: rgba(90, 127, 176, 0.10);
+  border-radius: 4px;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: #c2cce0;
+  white-space: pre-wrap;
+  text-align: left;
+}
+
+#result-epilogue.hidden {
+  display: none;
+}
+
 #result-stars {
   display: flex;
   justify-content: center;

--- a/thoughts/shared/handoffs/2026-06-23-playtest-log.md
+++ b/thoughts/shared/handoffs/2026-06-23-playtest-log.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-23
+session: unattended run (user AFK) — review/merge + filter toolbar
+status: in-progress
+---
+
+# Playtest log — what to verify when you're back
+
+This log captures everything done during the unattended run so you know what to
+eyeball/playtest. Serve locally with `bazel run //game:serve-local`
+(http://localhost:58080).
+
+## ⚠️ Awaiting your eyeball (paused, NOT acted on)
+
+- **West "suburb ring" around the city** — moving (−2,1)/(−2,2) into West county made
+  West's inner edge read as suburbs-in-a-different-county (Portland/Vancouver pattern).
+  You flagged this; I did NOT change it further. Decide on return whether to keep,
+  lean into it (narrative nod), or reshape.
+- **scenario-002 overall** — the old-3-county start + reapportionment narrative +
+  river + rename were built and merged but you have not done a full visual playthrough.
+
+## What changed (merged work)
+
+(filled in as PRs land — see sections below)
+
+## What to playtest
+
+(checklist filled in below)

--- a/thoughts/shared/tickets/GAME-091-scenario-002-teaching-narrative.md
+++ b/thoughts/shared/tickets/GAME-091-scenario-002-teaching-narrative.md
@@ -1,0 +1,43 @@
+---
+id: GAME-091
+title: Scenario-002 reframed as the campaign's reapportionment opener (narrative + debrief + old-map + river)
+area: game, content, UX
+status: resolved
+created: 2026-06-23
+---
+
+## Summary
+
+Massage scenario-002's intro and result screens to actually teach the gerrymandering
+lesson. The GAME-088 field made the lesson stronger: Ryu now wins the county popular
+vote (~51%) yet Ken can take 3 of 4 seats by packing — the clearest possible
+demonstration of votes ≠ seats. The old intro was also factually stale for the new
+field (it referenced a "southeast corner" Ryu bloc that no longer exists).
+
+## Resolution
+
+- New schema field `narrative.epilogue` (plain text), plumbed through spec-types →
+  assembler → scenario schema → loader, and rendered on the result screen as a
+  teaching debrief revealed after a winning verdict (`#result-epilogue`, styled).
+- scenario-002 intro slides rewritten to teach: votes-vs-seats, then packing (with
+  cracking named). Motivation/objective updated to the new field (Ryu leads votes).
+- Epilogue debrief explains packing/cracking neutrally (education, not advocacy —
+  fictional Ken/Ryu parties; per DESIGN-014 framing intent).
+- e2e: scenario-002 winnability test asserts the debrief appears on a win.
+- **Reapportionment framing** (differentiates 002 from 003, which also taught packing):
+  region renamed "Clearwater County" → "Clearwater Valley" (it holds three counties);
+  intro tells the old-3-county-map → east-bank boom → 4th seat → flip 2-1 to 3-1 story.
+- **"Old map" start**: initial assignment = the three counties (City→d1/East→d2/West→d3),
+  d4 empty for the player to carve. Two west-edge city precincts moved to West county so
+  the split reads ~West 41k / City 64k / East 40k.
+- **Cosmetic river** tracing the W/E county border + the Ken/Ryu split through the city;
+  county borders render over rivers.
+- Manual finishing lives in `scenario-002.overlay.{json,jq}`, applied after
+  generate_scenario — scenario-002 stays reproducible (regenerate → re-apply overlay).
+
+## References
+
+- `game/scenarios/scenario-002.spec.yaml` (narrative block)
+- `game/web/src/model/scenario.ts`, `loader.ts`, `pipeline/assembler.ts`, `spec-types.ts`
+- `game/web/index.html`, `game/web/src/main.ts`, `game/web/styles.css`
+- Built on GAME-088/089 (PR #267). Relates to DESIGN-014 (non-partisan framing).

--- a/thoughts/shared/tickets/GAME-092-scenario-map-editor.md
+++ b/thoughts/shared/tickets/GAME-092-scenario-map-editor.md
@@ -1,0 +1,40 @@
+---
+id: GAME-092
+title: Scenario map editor — hand-tweak generated scenarios (rivers, terrain) in-browser
+area: game, tooling, UX
+status: open
+created: 2026-06-23
+---
+
+## Summary
+
+A visual editor for hand-tweaking pipeline-generated scenarios, so pedagogical
+adjustments don't require editing JSON by hand. Motivated directly by placing a
+river on scenario-002: the river is a list of `[precinctId, precinctId]` edge
+pairs, which is tedious and error-prone to author by hand (had to trace a path,
+map positions → ids, and inject via jq).
+
+This is the tooling half of the project philosophy: the pipeline generates the
+initial state; a human tweaks it for pedagogy. Right now the "tweak" step has no
+UI.
+
+## Goals / Acceptance Criteria (rough; design first)
+
+- [ ] Click hex edges to add/remove **river** segments (cosmetic; `river_edges`).
+- [ ] Place/remove **terrain tiles** (lake / sea / mountain) by clicking hexes.
+- [ ] Optional: nudge per-precinct population / reassign county for fine-tuning.
+- [ ] Export the edited scenario back to JSON (and ideally a diff vs the generated
+      JSON, so manual tweaks are reviewable / re-appliable after regeneration).
+- [ ] Reuses the existing SVG map renderer + hex-edge geometry.
+
+## Open questions
+
+- Edit the generated JSON directly, or maintain a "manual overlay" layered on top
+  of regeneration (so regen + overlay = final, surviving generator changes)?
+- Standalone debug route (e.g. `?edit`) vs a separate tool build.
+
+## References
+
+- Hand-edit precedent: scenario-002 river (20 `river_edges` injected via jq).
+- `game/web/src/render/mapRenderer.ts` (edge geometry, river/terrain layers).
+- Philosophy: pipeline = initial-state generator, hand-tweaked for pedagogy.

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -117,6 +117,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-082-terrain-visual-treatment-refinement.md` | game, rendering, UX | Visual-tuning pass over GAME-075 terrain layer: thicker rivers, more prominent coast/lakeside edges, foothill rendering pickup, internal-lake validation |
 | `GAME-083-unassigned-precinct-visual-feedback.md` | game, rendering, UX | Unassigned precincts need a distinct neutral fill (white→dark-grey range); currently indistinguishable from assigned ones |
 | `GAME-084-map-generation-pipeline.md` | game, tooling | Spec-driven staged pipeline (terrain→population→demographics→assembler); single scenario JSON format throughout; requires loader validation split |
+| `GAME-092-scenario-map-editor.md` | game, tooling, UX | Visual editor to hand-tweak generated scenarios — click hex edges for rivers, place terrain tiles, export to JSON. Motivated by hand-injecting scenario-002's river via jq. Design-first |
 | `GAME-090-settlement-density-realism.md` | game, tooling | Settlement density realism follow-ons: leapfrog/exurban developments, sharper plateau edge, easier non-circular cores. Plateau profile + big urban/rural ratio already landed in GAME-088 |
 ---
 
@@ -124,6 +125,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| GAME-091: scenario-002 teaching narrative | Rewrote scenario-002 intro to teach votes≠seats + packing (old text was stale for the new field); added `narrative.epilogue` (schema→assembler→loader→result screen) — a teaching debrief revealed on a win explaining packing/cracking neutrally. e2e asserts the debrief shows |
 | GAME-089: population-aware county stage | Replaced geometric `county_labels` with a population-aware flood-fill county stage (`county-stage.ts`); named model presets seat_and_hinterland / city_county / split_metro; counties wrap pop centers, borders bias to troughs/rivers; county display names plumbed to the precinct-info panel; darker/shorter-dash border overlay; county_id stays cosmetic. scenario-002 migrated to `counties:` block (city + west + east). Unit tests + e2e green |
 | GAME-088: coherent population field | Added opt-in field-shaping to the population stage: gradient, neighbour-smoothing, pow-contrast, normalize-to-target, plus a `plateau` settlement profile (flat core + sharp edge vs gaussian). scenario-002 reworked to a 3-cluster, ~12x urban/rural field with a non-circular city core; scenario-002 winnability e2e re-solved (pack dense east-core Ryu → Ken 3-1). Also fixed precinct-info lean showing real party names. Unit + e2e tests pass |
 | BUILD-010: release.main.kts missing clikt import | Added `import com.github.ajalt.clikt.parameters.options.default`; the `Serve` subcommand's `.default()` call broke compilation of the whole script (prepare/deploy/serve all failed). Verified via dev deploy of GAME-088 |


### PR DESCRIPTION
## Summary

Reframes **scenario-002** as the campaign's "why redistricting happens" opener and
gives it real teaching surfaces. Previously 002 and 003 both taught packing; this
differentiates 002 around **reapportionment** (population change forces a redraw) with
packing as the tool.

- **Result-screen debrief:** new `narrative.epilogue` field (spec-types → assembler →
  scenario schema → loader), rendered after a winning verdict (`#result-epilogue`).
- **Intro rewritten** around the story: an old 3-county map (2-1 Ryu) → a biotech boom
  on the city's east bank → reapportionment grants a 4th seat → the governor flips it to
  3-1 Ken. Teaches votes≠seats, packing/cracking, and "district lines don't follow
  county lines." Non-partisan framing (fictional Ken/Ryu; per DESIGN-014).
- **"Old Quarter" story** explains the west-city Ken lean (farm-migrant neighborhoods).
- **Region renamed** "Clearwater County" → "Clearwater Valley" (it holds three counties).
- **"Old map" start:** initial assignment = the three counties (d4 empty for the player
  to carve); two west-edge city precincts moved to West county so the split reads
  ~West 41k / City 64k / East 40k.
- **Cosmetic river** tracing the W/E county border + the Ken/Ryu city split; county
  borders now render over rivers.
- **Precinct-info lean** now shows real party names (Ken/Ryu) instead of "Party 1/2".
- Manual finishing lives in `scenario-002.overlay.{json,jq}`, applied after
  `generate_scenario` so scenario-002 stays reproducible (regenerate → re-apply overlay).

## Affected machines / services

- The browser game (`game/web`) + the scenario-002 data only. No infra/hosts/secrets.

## Validation performed

- [x] Full unit + typecheck suite: `bazel test //game/web/src/...` — pass
- [x] Playwright e2e: `bazel test //game/web:e2e_test` — pass (winnability re-confirmed;
      result-debrief assertion added)
- [x] Old-map start verified: counties-as-districts = 2 Ryu / 1 Ken (City RYU, East RYU,
      West KEN), computed against the sim's pop×partyShare model
- [ ] Manual visual playthrough (N/A — author AFK; see playtest log
      `thoughts/shared/handoffs/2026-06-23-playtest-log.md`)
- [ ] sops decrypt (N/A — no secrets)
- [ ] kubectl dry-run (N/A — no manifests)

## Deployment steps (POST-MERGE)

- Static-site app; no auto-deploy on merge. Release via `game/release.main.kts`
  (`prepare` → `deploy --env staging`, prod with explicit sign-off). No prod action here.

## Tickets addressed

- GAME-091 (resolved). GAME-092 (scenario map editor) filed.
- Builds on GAME-088/089 (#267). Relates to DESIGN-014 (framing), GAME-079 (playability).

## Rollback

- Revert the PR. The epilogue field is additive/optional; the river + old-map +
  county-move are confined to scenario-002.json (regenerable from spec + overlay).
