### PR TITLE
docs: file GAME-094 (result-screen overflow) + scenario-002 acceptance

### DIFF
--- a/thoughts/shared/handoffs/2026-06-23-playtest-log.md
+++ b/thoughts/shared/handoffs/2026-06-23-playtest-log.md
@@ -20,19 +20,21 @@ Serve locally: `bazel run //game:serve-local` → http://localhost:58080
   unattended). Mark "Ready for review" + merge once it looks right.
 - Paused all further scenario generation/tuning per your instruction.
 
-## ⚠️ Awaiting your eyeball
+## Status update (2026-06-24, user back)
 
-1. **Filter toolbar (PR #269)** — top-right over the map, vertical stack of 3 icon
-   buttons (district view / partisan lean / county borders), beside the info panel.
-   Icons are THROWAWAY placeholders. Tests confirm the buttons work and stay in sync
-   with the old header buttons, but I couldn't check the look. The old header buttons
-   ("Switch to Partisan Lean" / "Show County Borders") are still present — decide later
-   whether to retire them.
+- ✅ **scenario-002 ACCEPTED** — played through, map/instructions correct; difficulty is
+  fine ("not even terribly hard with the instructions"). GAME-091 confirmed accepted.
+- 🐛 **Result screen overflows** the viewport with no scroll (the epilogue lengthened
+  the card) — affects desktop. Filed **GAME-094** (preferred fix: epilogue on a second
+  "Continue →" panel after the reveal).
+- 🔎 **Filter toolbar (PR #269)** served for visual review.
+
+## ⚠️ Still awaiting your call
+
+1. **Filter toolbar (PR #269)** — vertical icon buttons top-right over the map. Placeholder
+   icons. Decide if placement/look is right → mark "Ready" + merge; real icons later.
 2. **West "suburb ring"** — moving (−2,1)/(−2,2) into West county made West's inner edge
-   read as suburbs-in-a-different-county (you flagged this; NOT acted on). Decide:
-   keep / lean into narratively / reshape.
-3. **scenario-002 full playthrough** — old-3-county start + 5-slide reapportionment
-   intro + river + win debrief were built and e2e-verified but not eyeballed by you.
+   read as suburbs-in-a-different-county. Decide: keep / lean into narratively / reshape.
 
 ## What to playtest (checklist)
 

--- a/thoughts/shared/tickets/GAME-091-scenario-002-teaching-narrative.md
+++ b/thoughts/shared/tickets/GAME-091-scenario-002-teaching-narrative.md
@@ -14,6 +14,11 @@ vote (~51%) yet Ken can take 3 of 4 seats by packing — the clearest possible
 demonstration of votes ≠ seats. The old intro was also factually stale for the new
 field (it referenced a "southeast corner" Ryu bloc that no longer exists).
 
+**Playtested + accepted (2026-06-24):** owner played scenario-002 through to a win;
+map, intro, and instructions are correct and the difficulty reads fine ("not even
+terribly hard with the instructions"). One follow-up surfaced: the result screen
+overflows the viewport once the epilogue is shown → filed GAME-094.
+
 ## Resolution
 
 - New schema field `narrative.epilogue` (plain text), plumbed through spec-types →

--- a/thoughts/shared/tickets/GAME-094-result-screen-overflow-epilogue-panel.md
+++ b/thoughts/shared/tickets/GAME-094-result-screen-overflow-epilogue-panel.md
@@ -1,0 +1,41 @@
+---
+id: GAME-094
+title: Result screen overflows on smaller screens — move epilogue to a second "Continue" panel
+area: game, UX
+status: open
+created: 2026-06-24
+---
+
+## Summary
+
+The result screen can run taller than the viewport (verdict + subtitle + stars +
+criteria list + epilogue), with no way to scroll — so the bottom (including the
+teaching debrief) gets cut off. Observed on **desktop**, not just mobile. The GAME-091
+epilogue made the card noticeably longer and surfaced this.
+
+## Goals / Acceptance Criteria
+
+- [ ] The result screen stays within the viewport on a reasonably small desktop window
+      (and degrades gracefully toward mobile, though full mobile is a separate pass).
+- [ ] **Preferred fix:** move the epilogue to a **second panel**. After the result
+      reveal, the primary action becomes **"Continue →"** (in place of / before
+      "Next Scenario →"); clicking it swaps the result card for an epilogue/debrief
+      panel, which then offers "Next Scenario →".
+- [ ] If a single panel is kept instead, it must use available width better and/or be
+      scrollable — but the second-panel approach is preferred.
+- [ ] Keyboard + screen-reader friendly (the "Continue" step is focusable; epilogue is
+      announced).
+
+## Notes
+
+- This is the natural home for the result-screen "reveal → debrief" flow; the epilogue
+  is the teaching payoff and reads better with its own space.
+- Mobile layout is a larger, separate effort — but this fix should already keep the UI
+  usable on a smaller screen.
+
+## References
+
+- `game/web/index.html` (#result-screen / #result-card / #result-epilogue),
+  `game/web/src/main.ts` (result reveal, #btn-next-scenario), `game/web/styles.css`.
+- Introduced the overflow: GAME-091 (`narrative.epilogue` on the result screen).
+- Relates to DESIGN-015 (information-density redesign), GAME-008 (accessibility).

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -118,6 +118,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-083-unassigned-precinct-visual-feedback.md` | game, rendering, UX | Unassigned precincts need a distinct neutral fill (white→dark-grey range); currently indistinguishable from assigned ones |
 | `GAME-084-map-generation-pipeline.md` | game, tooling | Spec-driven staged pipeline (terrain→population→demographics→assembler); single scenario JSON format throughout; requires loader validation split |
 | `GAME-092-scenario-map-editor.md` | game, tooling, UX | Visual editor to hand-tweak generated scenarios — click hex edges for rivers, place terrain tiles, export to JSON. Motivated by hand-injecting scenario-002's river via jq. Design-first |
+| `GAME-094-result-screen-overflow-epilogue-panel.md` | game, UX | Result screen overflows the viewport (no scroll) once the epilogue is added — even on desktop. Preferred fix: move epilogue to a second "Continue →" panel after the reveal. Keep usable on smaller screens |
 | `GAME-090-settlement-density-realism.md` | game, tooling | Settlement density realism follow-ons: leapfrog/exurban developments, sharper plateau edge, easier non-circular cores. Plateau profile + big urban/rural ratio already landed in GAME-088 |
 ---
 


### PR DESCRIPTION
## Summary

Docs only:
- Files **GAME-094** — the result screen overflows the viewport (no scroll) once the
  epilogue is shown, even on desktop. Preferred fix: move the epilogue to a second
  "Continue →" panel after the reveal.
- Records **scenario-002 acceptance** (played through, correct, difficulty fine) on the
  GAME-091 ticket and the playtest log.

## Affected machines / services

- None — documentation/tickets only.

## Validation performed

- [x] Docs only; no code/build impact
- [ ] kubectl dry-run — N/A (docs)
- [ ] sops decrypt — N/A (docs)

## Deployment steps (POST-MERGE)

- None.

## Tickets addressed

- Files GAME-094; updates GAME-091 (accepted) + playtest log.

## Rollback

- Revert the PR (docs only).
