### PR TITLE
feat(GAME-076): guided-overlay engine + tutorial-001 paint-only walkthrough

### DIFF
--- a/game/scenarios/tutorial-001.json
+++ b/game/scenarios/tutorial-001.json
@@ -962,5 +962,6 @@
   },
   "default_district_id": "d1",
   "hide_election_results": true,
-  "hide_view_toolbar": true
+  "hide_view_toolbar": true,
+  "guided": true
 }

--- a/game/scenarios/tutorial-001.spec.yaml
+++ b/game/scenarios/tutorial-001.spec.yaml
@@ -100,6 +100,7 @@ assembly:
   default_district_id: d1
   # No initial_district_rule → the loader fills every editable precinct with
   # default_district_id (d1), so the map opens as one district and the player carves d2.
+  guided: true                       # runs the paint-only guided overlay (GAME-076 / DESIGN-012)
   hide_election_results: true        # pre-electoral: hide the outcome prediction panel
   hide_view_toolbar: true            # paint-only: no lean/county/city views worth showing
   rules:

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -89,6 +89,16 @@ async function paintHexes(
   }, { hexes, district });
 }
 
+// GAME-076: tutorial-001 now runs a guided overlay (scenario.guided). Suppress it by
+// default so the existing tutorial-001 tests aren't intercepted by the coach panel /
+// input-pause. The overlay-specific tests below force it with `?resetTutorial=1`, which
+// clears this flag on load. (Harmless for non-guided scenarios — the flag is ignored.)
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    try { localStorage.setItem("tutorial-tutorial-001-complete", "1"); } catch { /* ignore */ }
+  });
+});
+
 // ─── scenario-002: "Give the Governor a Win" ─────────────────────────────────
 
 test("scenario-002 smoke: loads and renders 91 precincts", async ({ page }) => {
@@ -982,6 +992,62 @@ test("tutorial-001: a wildly imbalanced split still passes (balance not enforced
   await page.locator("#btn-submit").click();
   await expect(page.locator("#result-screen")).toBeVisible();
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+});
+
+// ─── GAME-076: guided overlay (tutorial-001 paint-only walkthrough) ──────────
+
+/** Force the guided overlay on tutorial-001, skip the intro, wait for the panel. */
+async function loadGuidedT1(page: import("@playwright/test").Page): Promise<void> {
+  // resetTutorial=1 clears the suppression flag the beforeEach set, so the overlay runs.
+  await page.goto("/?campaign=tutorial&s=tutorial-001&debug&resetTutorial=1");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("#tutorial-panel")).toBeVisible({ timeout: 10_000 });
+}
+
+test("guided overlay: walks the player from orient → pick D2 → paint → undo → submit", async ({ page }) => {
+  await loadGuidedT1(page);
+
+  // Step 1 — orient.
+  await expect(page.locator("#tutorial-panel")).toContainText("District 1");
+  await page.locator("#tutorial-panel .tutorial-next").click();
+
+  // Step 2 — pick District 2: the button is ringed, input is paused.
+  await expect(page.locator("#tutorial-panel")).toContainText("District 2");
+  await expect(page.locator('[data-district="2"]')).toHaveClass(/tutorial-highlight/);
+  await expect(page.locator("#main")).toHaveClass(/tutorial-paused/);
+  await page.locator('[data-district="2"]').click();
+
+  // Step 3 — paint: advance once 5 precincts are in District 2 (via the store, like other tests).
+  await expect(page.locator("#tutorial-panel")).toContainText("paint");
+  await expect(page.locator("#map-svg")).toHaveClass(/tutorial-highlight/);
+  await paintHexes(page, [[-3, 3], [-2, 3], [-1, 3], [0, 3], [-3, 2]], 2);
+
+  // Step 4 — undo.
+  await expect(page.locator("#tutorial-panel")).toContainText("Undo");
+  await page.locator("#tutorial-panel .tutorial-next").click();
+
+  // Step 5 — submit (terminal): clicking Submit ends the overlay and shows results.
+  await expect(page.locator("#tutorial-panel")).toContainText("Submit");
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#tutorial-panel")).toHaveCount(0);
+  await expect(page.locator("#result-screen")).toBeVisible();
+});
+
+test("guided overlay: Skip dismisses it", async ({ page }) => {
+  await loadGuidedT1(page);
+  await page.locator("#tutorial-panel .tutorial-skip").click();
+  await expect(page.locator("#tutorial-panel")).toHaveCount(0);
+});
+
+test("guided overlay: not shown on a non-guided scenario", async ({ page }) => {
+  await page.goto("/?s=scenario-002&debug");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("#tutorial-panel")).toHaveCount(0);
 });
 
 // ─── GAME-048: Campaign-driven scenario select ──────────────────────────────

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -16,6 +16,7 @@ import {
 	renderResults,
 	renderValidityPanel,
 } from "./render/panels.js";
+import { startTutorialOverlay } from "./tutorial/overlay.js";
 import { createGameStore } from "./store/gameStore.js";
 import {
 	evaluateCriteria,
@@ -647,6 +648,9 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		document.getElementById("main-menu")?.classList.add("hidden");
 		appHeader!.style.display = "";
 		mainEl!.style.display = "";
+		// GAME-076: kick off the guided walkthrough (no-op unless scenario.guided + a script).
+		// rAF so the just-shown editor has laid out before the overlay highlights anything.
+		requestAnimationFrame(() => startTutorialOverlay(scenario, store));
 	}
 
 	function startScenarioIntro() {

--- a/game/web/src/model/loader.ts
+++ b/game/web/src/model/loader.ts
@@ -1075,6 +1075,11 @@ function parseAllFields(raw: Record<string, unknown>): PartialScenario {
     hide_view_toolbar = requireBoolean(raw["hide_view_toolbar"], "hide_view_toolbar");
   }
 
+  let guided: boolean | undefined;
+  if (raw["guided"] !== undefined) {
+    guided = requireBoolean(raw["guided"], "guided");
+  }
+
   const partial: PartialScenario = {
     format_version: "1", id, title, election_type, region, geometry,
     precincts: partialPrecincts,
@@ -1095,6 +1100,7 @@ function parseAllFields(raw: Record<string, unknown>): PartialScenario {
   if (river_blocks_contiguity !== undefined) partial.river_blocks_contiguity = river_blocks_contiguity;
   if (hide_election_results !== undefined) partial.hide_election_results = hide_election_results;
   if (hide_view_toolbar !== undefined) partial.hide_view_toolbar = hide_view_toolbar;
+  if (guided !== undefined) partial.guided = guided;
 
   return partial;
 }
@@ -1516,6 +1522,7 @@ function assembleScenario(
   if (partial.river_blocks_contiguity !== undefined) scenario.river_blocks_contiguity = partial.river_blocks_contiguity;
   if (partial.hide_election_results !== undefined) scenario.hide_election_results = partial.hide_election_results;
   if (partial.hide_view_toolbar !== undefined) scenario.hide_view_toolbar = partial.hide_view_toolbar;
+  if (partial.guided !== undefined) scenario.guided = partial.guided;
 
   return scenario;
 }

--- a/game/web/src/model/scenario.ts
+++ b/game/web/src/model/scenario.ts
@@ -306,6 +306,7 @@ export interface PartialScenario {
 	river_blocks_contiguity?: boolean;
 	hide_election_results?: boolean;
 	hide_view_toolbar?: boolean;
+	guided?: boolean;
 }
 
 // ─── Top-level Scenario ───────────────────────────────────────────────────────
@@ -349,4 +350,7 @@ export interface Scenario {
 	/** When true, the right-side map view toolbar (lean/county/city overlays) is hidden —
 	 *  the welcome tutorial has no alternate views worth showing (paint-only UI). */
 	hide_view_toolbar?: boolean;
+	/** When true, this scenario runs a guided walkthrough overlay (a registered step script
+	 *  keyed by scenario id drives the in-editor coaching). See DESIGN-012 / tutorial/overlay.ts. */
+	guided?: boolean;
 }

--- a/game/web/src/pipeline/assembler.ts
+++ b/game/web/src/pipeline/assembler.ts
@@ -154,5 +154,8 @@ export function assembleScenario(
     ...(spec.hide_view_toolbar !== undefined
       ? { hide_view_toolbar: spec.hide_view_toolbar }
       : {}),
+    ...(spec.guided !== undefined
+      ? { guided: spec.guided }
+      : {}),
   };
 }

--- a/game/web/src/pipeline/spec-types.ts
+++ b/game/web/src/pipeline/spec-types.ts
@@ -288,6 +288,8 @@ export interface AssemblySpec {
   hide_election_results?: boolean;
   /** Hide the right-side map view toolbar (lean/county/city) — paint-only tutorials. */
   hide_view_toolbar?: boolean;
+  /** Run the guided walkthrough overlay (a step script keyed by scenario id). */
+  guided?: boolean;
 }
 
 // ─── Pipeline spec (full file) ────────────────────────────────────────────────

--- a/game/web/src/render/panels.ts
+++ b/game/web/src/render/panels.ts
@@ -60,6 +60,7 @@ export function renderDistrictButtons(
 		btn.style.color = "#fff";
 		btn.setAttribute("aria-label", `Paint District ${i}`);
 		btn.setAttribute("data-tip", `District ${i}`);
+		btn.setAttribute("data-district", String(i)); // stable hook for the tutorial overlay (GAME-076)
 		// Number shows when the toolbar is collapsed; full label when expanded.
 		const num = document.createElement("span");
 		num.className = "district-num";

--- a/game/web/src/tutorial/overlay.ts
+++ b/game/web/src/tutorial/overlay.ts
@@ -1,0 +1,303 @@
+/**
+ * Guided-overlay engine (GAME-076, designed in DESIGN-012).
+ *
+ * Runs a registered step script for a `guided: true` scenario: shows a coach panel over
+ * the editor, highlights a control, optionally pauses input (pointer-events cascade), can
+ * `reveal` a control that started hidden, and advances through the script. Activation,
+ * skip/persist, and the T1 paint-only script live here.
+ *
+ * Input-pause uses the pointer-events cascade (NOT a z-index spotlight): the editor roots
+ * (#app-header + #main) get `pointer-events: none`, the highlight target gets
+ * `pointer-events: auto` (a descendant re-enables even under a disabled ancestor), and the
+ * panel/Skip live at <body> level so they're always clickable.
+ */
+
+import type { Scenario } from "../model/scenario.js";
+import type { GameStore } from "../store/gameStore.js";
+
+export type AdvanceTrigger =
+  | { on: "next" }
+  | { on: "click-target" }
+  | { on: "any-map-click" }
+  | { on: "paint-count"; district: number; n: number }
+  | { on: "submit" }
+  | { on: "auto"; ms: number };
+
+export interface TutorialStep {
+  text: string;
+  /** Selector(s) to ring + (when paused) keep interactive. */
+  highlight?: string | string[];
+  /** Selector(s) to un-hide for this step (start hidden on load). */
+  reveal?: string | string[];
+  /** Block all input except the highlight target(s) while this step is shown. */
+  pauseInput?: boolean;
+  advance: AdvanceTrigger;
+}
+
+const PANEL_ID = "tutorial-panel";
+
+// ─── Step scripts (keyed by scenario id) ──────────────────────────────────────
+
+/** tutorial-001 — paint-only welcome (DESIGN-012). Selectors are current as of GAME-097. */
+const TUTORIAL_001: TutorialStep[] = [
+  {
+    text: "Welcome. This whole county is **District 1** — your job is to split it into two.",
+    advance: { on: "next" },
+  },
+  {
+    text: "Pick **District 2** from the painter on the left.",
+    highlight: '[data-district="2"]',
+    pauseInput: true,
+    advance: { on: "click-target" },
+  },
+  {
+    text: "Now click precincts on the map to paint them into District 2.",
+    highlight: "#map-svg",
+    pauseInput: true,
+    advance: { on: "paint-count", district: 2, n: 5 },
+  },
+  {
+    text: "Changed your mind? **Undo** steps back.",
+    highlight: "#btn-undo",
+    advance: { on: "next" },
+  },
+  {
+    text: "When the county is split into two districts, hit **Submit**.",
+    highlight: "#btn-submit",
+    advance: { on: "submit" },
+  },
+];
+
+const SCRIPTS: Record<string, TutorialStep[]> = {
+  "tutorial-001": TUTORIAL_001,
+};
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function asArray(sel?: string | string[]): string[] {
+  if (sel === undefined) return [];
+  return Array.isArray(sel) ? sel : [sel];
+}
+
+function selectorsToElements(sel?: string | string[]): HTMLElement[] {
+  const out: HTMLElement[] = [];
+  for (const s of asArray(sel)) {
+    document.querySelectorAll<HTMLElement>(s).forEach((el) => out.push(el));
+  }
+  return out;
+}
+
+/** Minimal **bold** → <strong> for coach copy (author-controlled text). */
+function renderText(el: HTMLElement, text: string): void {
+  el.innerHTML = text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+}
+
+function completeKey(id: string): string {
+  return `tutorial-${id}-complete`;
+}
+
+// ─── Engine ──────────────────────────────────────────────────────────────────
+
+interface StoreLike {
+  getState(): GameStore;
+  subscribe(listener: () => void): () => void;
+}
+
+/**
+ * Start the guided overlay for a scenario, if it opts in (`guided: true`) and has a
+ * registered script. No-op otherwise. Respects the per-scenario "complete" flag so a
+ * returning player isn't re-coached; `?resetTutorial=1` forces it (and clears the flags).
+ */
+export function startTutorialOverlay(scenario: Scenario, store: StoreLike): void {
+  if (scenario.guided !== true) return;
+  const script = SCRIPTS[scenario.id];
+  if (!script || script.length === 0) return;
+
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("resetTutorial") === "1") {
+    clearTutorialFlags();
+  } else if (isComplete(scenario.id)) {
+    return;
+  }
+
+  runOverlay(scenario.id, script, store);
+}
+
+function isComplete(id: string): boolean {
+  try {
+    return localStorage.getItem(completeKey(id)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function clearTutorialFlags(): void {
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith("tutorial-") && k.endsWith("-complete")) keys.push(k);
+    }
+    keys.forEach((k) => localStorage.removeItem(k));
+  } catch {
+    /* ignore */
+  }
+}
+
+function runOverlay(id: string, script: TutorialStep[], store: StoreLike): void {
+  const overlayAc = new AbortController();
+  let stepIdx = 0;
+  let stepCleanup: (() => void) | null = null;
+
+  // Reveal targets start hidden; un-hidden as their step fires.
+  const revealEls = new Set<HTMLElement>();
+  for (const step of script) {
+    for (const el of selectorsToElements(step.reveal)) revealEls.add(el);
+  }
+  revealEls.forEach((el) => el.classList.add("tutorial-reveal-hidden"));
+
+  const editorRoots = [
+    document.getElementById("app-header"),
+    document.getElementById("main"),
+  ].filter((el): el is HTMLElement => el !== null);
+
+  // ── Panel (body-level coach bar) ─────────────────────────────────────────────
+  const panel = document.createElement("div");
+  panel.id = PANEL_ID;
+  panel.setAttribute("role", "dialog");
+  panel.setAttribute("aria-live", "polite");
+  panel.setAttribute("aria-label", "Tutorial");
+  const textEl = document.createElement("div");
+  textEl.className = "tutorial-text";
+  const controls = document.createElement("div");
+  controls.className = "tutorial-controls";
+  const nextBtn = document.createElement("button");
+  nextBtn.className = "tutorial-next";
+  nextBtn.textContent = "Next →";
+  const skipBtn = document.createElement("button");
+  skipBtn.className = "tutorial-skip";
+  skipBtn.textContent = "Skip tutorial";
+  controls.append(nextBtn, skipBtn);
+  panel.append(textEl, controls);
+  document.body.appendChild(panel);
+
+  nextBtn.addEventListener("click", () => {
+    if (script[stepIdx]?.advance.on === "next") advance();
+  }, { signal: overlayAc.signal });
+  skipBtn.addEventListener("click", () => finish(), { signal: overlayAc.signal });
+  document.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.key === "Escape") finish();
+  }, { signal: overlayAc.signal });
+
+  function clearStepDecorations(): void {
+    stepCleanup?.();
+    stepCleanup = null;
+    document.querySelectorAll(".tutorial-highlight").forEach((el) =>
+      el.classList.remove("tutorial-highlight"),
+    );
+    document.querySelectorAll(".tutorial-interactive").forEach((el) =>
+      el.classList.remove("tutorial-interactive"),
+    );
+    editorRoots.forEach((r) => r.classList.remove("tutorial-paused"));
+  }
+
+  function finish(): void {
+    clearStepDecorations();
+    overlayAc.abort();
+    panel.remove();
+    document.querySelectorAll(".tutorial-reveal-hidden").forEach((el) =>
+      el.classList.remove("tutorial-reveal-hidden"),
+    );
+    try {
+      localStorage.setItem(completeKey(id), "1");
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function advance(): void {
+    clearStepDecorations();
+    stepIdx += 1;
+    if (stepIdx >= script.length) {
+      finish();
+      return;
+    }
+    renderStep();
+  }
+
+  function renderStep(): void {
+    const step = script[stepIdx]!;
+    renderText(textEl, step.text);
+
+    // Reveal (un-hide) this step's targets.
+    selectorsToElements(step.reveal).forEach((el) => el.classList.remove("tutorial-reveal-hidden"));
+
+    const targets = selectorsToElements(step.highlight);
+    targets.forEach((el) => el.classList.add("tutorial-highlight"));
+
+    if (step.pauseInput) {
+      editorRoots.forEach((r) => r.classList.add("tutorial-paused"));
+      targets.forEach((el) => el.classList.add("tutorial-interactive"));
+    }
+
+    nextBtn.style.display = step.advance.on === "next" ? "" : "none";
+
+    stepCleanup = setupAdvance(step, targets, advance, store);
+  }
+
+  renderStep();
+}
+
+/** Wire the step's advance trigger; returns a cleanup that tears down its listeners. */
+function setupAdvance(
+  step: TutorialStep,
+  targets: HTMLElement[],
+  advance: () => void,
+  store: StoreLike,
+): () => void {
+  switch (step.advance.on) {
+    case "next":
+      return () => {};
+    case "click-target": {
+      const ac = new AbortController();
+      targets.forEach((el) =>
+        el.addEventListener("click", () => advance(), { signal: ac.signal, once: false }),
+      );
+      return () => ac.abort();
+    }
+    case "any-map-click": {
+      const ac = new AbortController();
+      document.getElementById("map-svg")?.addEventListener("click", () => advance(), {
+        signal: ac.signal,
+      });
+      return () => ac.abort();
+    }
+    case "submit": {
+      const ac = new AbortController();
+      document.getElementById("btn-submit")?.addEventListener("click", () => advance(), {
+        signal: ac.signal,
+      });
+      return () => ac.abort();
+    }
+    case "paint-count": {
+      const { district, n } = step.advance;
+      const count = () => {
+        let c = 0;
+        for (const d of store.getState().assignments.values()) if (d === district) c += 1;
+        return c;
+      };
+      // Already satisfied? (defensive) — advance on next tick.
+      const unsub = store.subscribe(() => {
+        if (count() >= n) {
+          unsub();
+          advance();
+        }
+      });
+      return () => unsub();
+    }
+    case "auto": {
+      const t = window.setTimeout(() => advance(), step.advance.ms);
+      return () => window.clearTimeout(t);
+    }
+  }
+}

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -1352,3 +1352,63 @@ body {
   z-index: 9999;
   user-select: none;
 }
+
+/* ── Tutorial guided overlay (GAME-076) ───────────────────────────────────── */
+#tutorial-panel {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 48px);
+  max-width: 440px;
+  box-sizing: border-box;
+  background: rgba(10, 20, 40, 0.97);
+  border: 1px solid #2a4a6c;
+  border-radius: 10px;
+  padding: 16px 18px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  z-index: 9500;
+  color: #e8eef6;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+#tutorial-panel .tutorial-text { margin-bottom: 12px; }
+#tutorial-panel .tutorial-text strong { color: #fff; }
+#tutorial-panel .tutorial-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+#tutorial-panel button {
+  padding: 6px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+}
+#tutorial-panel .tutorial-next { background: #2f6fd0; color: #fff; }
+#tutorial-panel .tutorial-skip { background: transparent; color: #8aa0b8; border-color: #2a4a6c; }
+
+/* Highlight ring on the active control. */
+.tutorial-highlight {
+  outline: 3px solid #ffd24a !important;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 6px rgba(255, 210, 74, 0.22) !important;
+  border-radius: 6px;
+  animation: tutorial-pulse 1.4s ease-in-out infinite;
+}
+@keyframes tutorial-pulse {
+  0%, 100% { box-shadow: 0 0 0 6px rgba(255, 210, 74, 0.18); }
+  50% { box-shadow: 0 0 0 10px rgba(255, 210, 74, 0.34); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tutorial-highlight { animation: none; }
+}
+
+/* Input pause: editor roots inert; the highlighted target stays interactive
+   (a descendant with pointer-events:auto receives events under a none ancestor). */
+.tutorial-paused { pointer-events: none; }
+.tutorial-interactive { pointer-events: auto !important; }
+
+/* Reveal targets start hidden until their step fires. */
+.tutorial-reveal-hidden { display: none !important; }


### PR DESCRIPTION
## Summary

Builds the **guided-overlay engine** (DESIGN-012) and wires **tutorial-001's paint-only
walkthrough** — the first interactive coaching in the game. The overlay walks a new player:
**orient → pick District 2 → paint → undo → submit**, highlighting each control and pausing
input where it matters.

- **Engine** (`game/web/src/tutorial/overlay.ts`): activates only for `scenario.guided` + a
  registered step script (keyed by scenario id). Step model = `text` / `highlight` / `reveal`
  / `pauseInput` / `advance` (`next` · `click-target` · `any-map-click` · `paint-count` ·
  `submit` · `auto`). Input-pause uses the **pointer-events cascade** (editor roots inert,
  the highlight target re-enabled; panel + Skip at `<body>` level) — no z-index spotlight.
  The `reveal` action (hide-on-load, un-hide per step) is built for T2/T3 and is unexercised
  by T1. Skip/Escape dismiss; a per-scenario `localStorage` "complete" flag means returning
  players aren't re-coached; `?resetTutorial=1` forces it.
- **`guided` flag** plumbed (spec → assembler → scenario → loader), set on tutorial-001.
  `startTutorialOverlay()` runs from `showEditor()`; `data-district="N"` hook added to paint
  buttons; coach-panel + highlight-ring + pause CSS.

**Scope:** GAME-076 — engine + T1 only. T2–T4 scripts come in GAME-077/098/099 on this engine.

## Affected machines / services

- None. Client-side game only (new TS module + CSS + tutorial-001.json regenerated with
  `guided: true`). No infra/services. The engine is a no-op for every non-guided scenario.

## Validation performed

- [x] `bazel test //game/web:app_typecheck_test` — app compiles (engine + wiring + flag).
- [x] `bazel test //game/web/src/model:loader_integration_test //game/web/src/pipeline:all` — pass.
- [x] `bazel build //game/web:e2e_test` — e2e specs compile (incl. new overlay tests).
- [x] Regenerated `tutorial-001.json` carries `guided: true` (+ existing paint-only flags).
- [x] Test-suppression wired: a file-level `beforeEach` sets the complete flag so the
      existing tutorial-001 tests aren't intercepted; overlay tests force it via `?resetTutorial=1`.
- [x] e2e (Playwright) — passed in CI (buildkite build 648; overlay walkthrough + suppression).
- [x] Owner playtest on `serve-local` — done; owner approved ("ship it, no notes").

## Deployment steps

- None. Ships with the next normal game deploy.

## Tickets addressed

- **GAME-076** — guided-overlay engine + tutorial-001 paint-only script *(implemented)*.
- DESIGN-012 (spec), GAME-077/098/099 (reuse this engine) — not in this PR.

## Rollback

- Revert this PR. `tutorial-001` loses its guided overlay (and `guided: true`); the map +
  paint-only chrome are unchanged. The engine is additive and no-op elsewhere — nothing else unwinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
