### PR TITLE
test: decouple generic e2e tests from tutorial-002 onto scenario-002 fixture

### DIFF
--- a/game/web/e2e/smoke.spec.ts
+++ b/game/web/e2e/smoke.spec.ts
@@ -22,7 +22,10 @@ test("app loads and renders hex map", async ({ page }) => {
     consoleErrors.push(`[pageerror] ${err.message}`);
   });
 
-  await page.goto("/?s=tutorial-002");
+  // &debug: scenario-002 is a campaign scenario (not the first), so it is locked
+  // until the prior one is completed; debug mode bypasses the unlock gate and loads
+  // it directly (otherwise the app redirects to the select screen).
+  await page.goto("/?s=scenario-002&debug");
 
   // Dismiss intro screen (GAME-016): skip button appears after scenario loads.
   const skipBtn = page.locator("#btn-intro-skip");

--- a/game/web/e2e/sprint1.spec.ts
+++ b/game/web/e2e/sprint1.spec.ts
@@ -4,17 +4,16 @@ import { test, expect } from "@playwright/test";
  * Sprint 1 behavioral tests — Phase 2 (CI-002).
  *
  * Covers the five interaction categories required for the Sprint 1 demo:
- *   1. Scenario load:        30 precincts rendered, no console errors
+ *   1. Scenario load:        precincts rendered, no console errors
  *   2. Paint interaction:    drag assigns a precinct to the active district
  *   3. Undo:                 undo restores prior assignment
  *   4. View toggle:          fill changes when switching between districts/lean modes
  *   5. Boundary rendering:   painting a precinct to a new district creates boundary lines
  *
- * Initial app state (tutorial-001.json):
- *   - The loader auto-fills null initial_district_id with districts[0].id ("d1").
- *   - All 30 precincts therefore start assigned to District 1.
- *   - Initial hex fills are HSL-adjusted District 1 blue (not #2a2a3e).
- *   - No interior boundaries (all same district); only outer grid edges.
+ * Fixture: these run against scenario-002 (the educational campaign opener) — a stable,
+ * play-relevant editor fixture shared by the generic e2e tests (decoupled from the
+ * tutorials, which are now guided). scenario-002 has 91 precincts, 4 districts, and a
+ * fully-assigned diagonal-strip initial state.
  *
  * Mouse interaction note:
  *   page.mouse coordinates are unreliable for SVG paths in headless Chromium
@@ -43,7 +42,9 @@ async function paintHex(
 
 /** Navigate, dismiss the intro screen, and wait for the hex grid to be ready. */
 async function loadApp(page: import("@playwright/test").Page): Promise<void> {
-	await page.goto("/?s=tutorial-002");
+	await page.goto("/?s=scenario-002&debug");
+	// Force the instant result-screen path (the sandbox ignores config reducedMotion).
+	await page.emulateMedia({ reducedMotion: "reduce" });
 	// Dismiss intro screen (GAME-016)
 	const skip = page.locator("#btn-intro-skip");
 	await expect(skip).toBeVisible({ timeout: 10_000 });
@@ -54,7 +55,7 @@ async function loadApp(page: import("@playwright/test").Page): Promise<void> {
 
 // ─── Test 1: Scenario load ────────────────────────────────────────────────────
 
-test("scenario load: 196 precincts rendered with no console errors", async ({ page }) => {
+test("scenario load: 91 precincts rendered with no console errors", async ({ page }) => {
 	const consoleErrors: string[] = [];
 	page.on("console", (msg) => {
 		if (msg.type() === "error") consoleErrors.push(msg.text());
@@ -66,7 +67,7 @@ test("scenario load: 196 precincts rendered with no console errors", async ({ pa
 	await loadApp(page);
 
 	const hexCount = await page.locator("path.hex").count();
-	expect(hexCount).toBe(196);
+	expect(hexCount).toBe(91);
 
 	expect(consoleErrors).toHaveLength(0);
 });
@@ -81,21 +82,22 @@ test("paint interaction: painting a precinct changes its fill and enables undo",
 	const hex0 = page.locator("path.hex[data-precinct-id='0']");
 	const btnUndo = page.locator("#btn-undo");
 
-	// Capture initial fill (District 1 blue — all precincts start as D1 due to
-	// loader auto-fill). Undo is disabled because no strokes have been made yet.
+	// Capture initial fill (precinct 0 starts in District 2 per scenario-002's
+	// initial assignment). Undo is disabled because no strokes have been made yet.
 	const initialFill = await hex0.getAttribute("fill");
 	await expect(btnUndo).toBeDisabled();
 
-	// Switch to District 2 so this stroke actually changes the assignment
-	await page.locator("button.district-btn").nth(1).click();
+	// Switch to District 4 (unused in scenario-002's initial state) so this stroke
+	// actually changes precinct 0's assignment (it starts in District 2).
+	await page.locator("button.district-btn").nth(3).click();
 
-	// Paint precinct 0 to District 2
+	// Paint precinct 0 to District 4
 	await paintHex(page, "path.hex[data-precinct-id='0']");
 
 	// Wait for the stroke to commit (undo button becomes enabled)
 	await expect(btnUndo).toBeEnabled();
 
-	// Fill must have changed from the District 1 color
+	// Fill must have changed from the District 2 color
 	const fillAfter = await hex0.getAttribute("fill");
 	expect(fillAfter).not.toBe(initialFill);
 });
@@ -111,8 +113,8 @@ test("undo: restores fill to previous assignment and disables undo button", asyn
 	// Capture the initial fill before any painting
 	const initialFill = await hex0.getAttribute("fill");
 
-	// Switch to District 2 and paint precinct 0
-	await page.locator("button.district-btn").nth(1).click();
+	// Switch to District 4 (unused initially) and paint precinct 0 (starts in District 2)
+	await page.locator("button.district-btn").nth(3).click();
 	await paintHex(page, "path.hex[data-precinct-id='0']");
 	await expect(btnUndo).toBeEnabled();
 
@@ -153,14 +155,14 @@ test("boundary rendering: painting a precinct to a new district creates boundary
 
 	const btnUndo = page.locator("#btn-undo");
 
-	// All precincts start as District 1 → no interior boundaries (same district
-	// everywhere). Only outer grid edges exist at this point.
+	// scenario-002 starts with a fully-assigned initial map (d1/d2/d3), so some
+	// interior boundaries already exist. Capture the baseline count.
 	const initialBoundaryCount = await page.locator("line.boundary").count();
 
-	// Switch to District 2 and paint precinct 0.
-	// Precinct 0 becomes D2; its neighbors remain D1 → interior boundaries appear
-	// between D2 (precinct 0) and each D1 neighbor.
-	await page.locator("button.district-btn").nth(1).click();
+	// Switch to District 4 (unused initially) and paint precinct 0 (starts in D2).
+	// Precinct 0 becomes D4; its two same-district (D2) neighbors each gain a new
+	// boundary with it → the interior boundary count strictly increases.
+	await page.locator("button.district-btn").nth(3).click();
 	await paintHex(page, "path.hex[data-precinct-id='0']");
 	await expect(btnUndo).toBeEnabled();
 

--- a/game/web/e2e/sprint2.spec.ts
+++ b/game/web/e2e/sprint2.spec.ts
@@ -13,9 +13,14 @@ import { test, expect } from "@playwright/test";
  * (same approach as sprint1.spec.ts) to avoid coordinate-mapping issues.
  */
 
-/** Navigate, dismiss the intro screen, and wait for the hex grid to be ready. */
+/**
+ * Navigate, dismiss the intro screen, and wait for the hex grid to be ready.
+ * Fixture: scenario-002 (educational opener) — the shared, play-relevant editor fixture
+ * with the full view toolbar (the tutorials are now guided / paint-only).
+ */
 async function loadApp(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/?s=tutorial-002");
+  await page.goto("/?s=scenario-002&debug");
+  await page.emulateMedia({ reducedMotion: "reduce" });
   // Dismiss intro screen (GAME-016)
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });
@@ -70,8 +75,8 @@ test("validity panel: updates after painting a precinct to a new district", asyn
   // Capture initial validity panel HTML
   const before = await page.locator("#validity-container").innerHTML();
 
-  // Switch to District 2 and paint precinct 0
-  await page.locator("button.district-btn").nth(1).click();
+  // Switch to District 4 (unused initially) and paint precinct 0 (starts in District 2)
+  await page.locator("button.district-btn").nth(3).click();
   await paintHex(page, "path.hex[data-precinct-id='0']");
   await expect(page.locator("#btn-undo")).toBeEnabled();
 
@@ -206,8 +211,8 @@ test("reset: Cancel hides confirm row and preserves undo state", async ({ page }
   await loadApp(page);
   const btnUndo = page.locator("#btn-undo");
 
-  // Paint first so undo is enabled
-  await page.locator("button.district-btn").nth(1).click();
+  // Paint first so undo is enabled (District 4 is unused initially; precinct 0 starts in D2)
+  await page.locator("button.district-btn").nth(3).click();
   await paintHex(page, "path.hex[data-precinct-id='0']");
   await expect(btnUndo).toBeEnabled();
 
@@ -230,8 +235,8 @@ test("reset: full flow — paint, confirm reset, fills restored, undo disabled",
 
   const initialFill = await hex0.getAttribute("fill");
 
-  // Paint precinct 0 to District 2
-  await page.locator("button.district-btn").nth(1).click();
+  // Paint precinct 0 (starts in District 2) to District 4 (unused initially)
+  await page.locator("button.district-btn").nth(3).click();
   await paintHex(page, "path.hex[data-precinct-id='0']");
   await expect(btnUndo).toBeEnabled();
   expect(await hex0.getAttribute("fill")).not.toBe(initialFill);

--- a/game/web/e2e/sprint3.spec.ts
+++ b/game/web/e2e/sprint3.spec.ts
@@ -4,8 +4,10 @@ import { test, expect } from "@playwright/test";
  * Sprint 3 behavioral tests:
  *   GAME-014 (scenario scale), GAME-016 (intro), GAME-017 (evaluation), GAME-018 (progression).
  *
- * NOTE: The app loads tutorial-002.json (196-precinct three-county map) as the primary scenario.
- * tutorial-001.json is retained for loader unit tests only.
+ * NOTE: Generic editor/submit/wip mechanics run against scenario-002 (the shared, play-
+ * relevant fixture). The intro-narrative, winnability, and scale tests still use tutorial-002
+ * because they assert its specific content; they're updated/replaced when tutorial-002 becomes
+ * "A Legal Map" (GAME-077). Progress/select tests reference tutorial-002 by id (no editor load).
  *
  * GAME-016: Intro slide flow:
  *   1. Intro screen is visible on initial load (before map editor) — new player
@@ -34,7 +36,11 @@ import { test, expect } from "@playwright/test";
 
 /** Navigate, dismiss intro, wait for hex grid. */
 async function loadEditor(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/?s=tutorial-002");
+  // Fixture: scenario-002 (educational opener) for the generic submit/editor-mechanics tests.
+  // (The intro-narrative + winnability/scale tests below stay on tutorial-002 — they assert
+  // its specific content — and are updated/replaced when tutorial-002 becomes "A Legal Map".)
+  await page.goto("/?s=scenario-002&debug");
+  await page.emulateMedia({ reducedMotion: "reduce" });
   // playwright.config reducedMotion:'reduce' is ignored in the Bazel-sandboxed Chromium;
   // explicit emulation ensures the instant result path runs so verdict is visible immediately.
   await page.emulateMedia({ reducedMotion: "reduce" });
@@ -297,11 +303,11 @@ test("wip: saved assignment map is restored on scenario load", async ({ page }) 
   // Pre-paint precinct 0 → district 2, precinct 1 → district 3 in the WIP
   // Then load tutorial-002 and verify via window.__gameStore that assignments match
   const wipAssignments: Record<string, number> = {};
-  // tutorial-002 has 196 precincts; build a complete assignment with index 0 → 2 (district 2)
-  for (let i = 0; i < 196; i++) wipAssignments[String(i)] = i === 0 ? 2 : 1;
+  // scenario-002 has 91 precincts; build a complete assignment with index 0 → 2 (district 2)
+  for (let i = 0; i < 91; i++) wipAssignments[String(i)] = i === 0 ? 2 : 1;
 
-  await seedWip(page, "tutorial-002", wipAssignments, 2);
-  await page.goto("/?s=tutorial-002");
+  await seedWip(page, "scenario-002", wipAssignments, 2);
+  await page.goto("/?s=scenario-002&debug");
 
   // Wait for editor to be ready (intro appears because it's a fresh load without completed state)
   const skip = page.locator("#btn-intro-skip");
@@ -320,9 +326,9 @@ test("wip: saved assignment map is restored on scenario load", async ({ page }) 
 });
 
 test("wip: painting precincts triggers a debounced WIP save to localStorage", async ({ page }) => {
-  // Load tutorial-002, skip intro, paint precinct 0 → district 2 via store shortcut,
+  // Load scenario-002, skip intro, paint precinct 0 → district 2 via store shortcut,
   // then wait > 800ms and confirm the WIP key was written with the expected assignment.
-  await page.goto("/?s=tutorial-002");
+  await page.goto("/?s=scenario-002&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });
   await skip.click();
@@ -347,7 +353,7 @@ test("wip: painting precincts triggers a debounced WIP save to localStorage", as
 
   // Precinct 0 must be stored as district 2.
   const wip = JSON.parse(wipRaw!) as { scenarioId: string; assignments: Record<string, number>; activeDistrict: number };
-  expect(wip.scenarioId).toBe("tutorial-002");
+  expect(wip.scenarioId).toBe("scenario-002");
   expect(wip.assignments["0"]).toBe(2);
   expect(wip.activeDistrict).toBe(2);
 });
@@ -407,7 +413,16 @@ test("winnability: painting boundary precincts enables submit and produces a pas
    * Winning move: paint 7 hexes at r=-2, q=-6..0 from d2 → d1.
    * This transfers ~21k population, bringing all three districts within ±3%.
    */
-  await loadEditor(page);
+  // Asserts old tutorial-002's specific 3-county 196-precinct balance map; stays on
+  // tutorial-002 and is replaced when tutorial-002 becomes "A Legal Map" (GAME-077).
+  await page.goto("/?s=tutorial-002");
+  // Force the instant result-screen path (the sandbox ignores config reducedMotion);
+  // without this the animated criteria reveal leaves #result-verdict empty past the timeout.
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 10_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 10_000 });
 
   // GAME-059: Submit is always enabled; initial state is unbalanced but submittable.
   await expect(page.locator("#btn-submit")).toBeEnabled();

--- a/game/web/e2e/sprint4.spec.ts
+++ b/game/web/e2e/sprint4.spec.ts
@@ -11,9 +11,9 @@ import { test, expect } from "@playwright/test";
  *   4. Final visible state matches expected criteria count (regression)
  */
 
-/** Navigate, dismiss intro, wait for hex grid. */
+/** Navigate, dismiss intro, wait for hex grid. Fixture: scenario-002 (educational opener). */
 async function loadEditor(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/?s=tutorial-002");
+  await page.goto("/?s=scenario-002&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });
   await skip.click();
@@ -89,7 +89,7 @@ test("GAME-069: every criterion row has a character slot (.rc-char)", async ({ p
 });
 
 // GAME-062: commissioner rows use real sprite sheets (not placeholder SVG) after wiring.
-// scenario-002 (tutorial-002) has commissioner criteria with demo "bf".
+// scenario-002 has commissioner criteria with demo "bf".
 test("GAME-062: commissioner criterion rows render a character sprite", async ({ page }) => {
   await loadEditor(page);
   await openResultScreen(page);
@@ -163,14 +163,14 @@ test("GAME-052: final state has correct criteria count after skip (regression)",
 test("GAME-073: failure banner shown immediately in reduced-motion mode", async ({ page }) => {
   await loadEditor(page);
   await openResultScreen(page); // already emulates reducedMotion:'reduce'
-  // Unsolved tutorial-002 has required-failing criteria.
+  // scenario-002 default map has required-failing criteria.
   await expect(page.locator("#result-verdict")).toHaveText("Map Failed");
   await expect(page.locator("#result-stars")).toBeHidden();
 });
 
 // Reduced-motion path: success banner + stars shown immediately on a force-win.
 test("GAME-073: success banner and stars shown immediately in reduced-motion mode (force-win)", async ({ page }) => {
-  await page.goto("/?s=tutorial-002&debug");
+  await page.goto("/?s=scenario-002&debug");
   await page.emulateMedia({ reducedMotion: "reduce" });
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });
@@ -182,14 +182,14 @@ test("GAME-073: success banner and stars shown immediately in reduced-motion mod
 
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
   await expect(page.locator("#result-stars")).toBeVisible();
-  // tutorial-002: 2 required + 1 optional → max 2 stars; force-win passes all → 2 stars
+  // scenario-002: 3 required + 1 optional → max 2 stars; force-win passes all → 2 stars
   const starCount = await page.locator("#result-stars .result-star").count();
   expect(starCount).toBe(2);
 });
 
 // Animated path: verdict starts empty, skip button reveals it with stars.
 test("GAME-073: skip reveals verdict and stars (animated mode, force-win)", async ({ page }) => {
-  await page.goto("/?s=tutorial-002&debug");
+  await page.goto("/?s=scenario-002&debug");
   // Do NOT emulate reduced-motion — use animated path.
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 10_000 });

--- a/game/web/e2e/submit-on-invalid.spec.ts
+++ b/game/web/e2e/submit-on-invalid.spec.ts
@@ -12,9 +12,13 @@ import { test, expect } from "@playwright/test";
  *   6. Validity sidebar panel updates live during drawing (regression guard)
  */
 
-/** Navigate, dismiss intro, wait for hex grid. */
+/**
+ * Navigate, dismiss intro, wait for hex grid. Fixture: scenario-002 (educational opener),
+ * the shared play-relevant editor fixture; `&debug` exposes the force-win button used to
+ * exercise the pass-result UI.
+ */
 async function loadEditor(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/?s=tutorial-002");
+  await page.goto("/?s=scenario-002&debug");
   // playwright.config reducedMotion:'reduce' is ignored in the Bazel-sandboxed Chromium;
   // explicit emulation ensures the instant result path runs so verdict is visible immediately.
   await page.emulateMedia({ reducedMotion: "reduce" });
@@ -33,29 +37,7 @@ async function paintAllIntoDistrictOne(page: import("@playwright/test").Page): P
     if (!store) throw new Error("__gameStore not exposed");
     const state = store.getState();
     const allIds = Array.from(state.assignments.keys());
-    state.paintStroke(allIds, 1); // All precincts → district 1; districts 2 and 3 empty
-  });
-}
-
-/** Paint the winning move: move boundary precincts at r=-2, q=-6..0 from d2 to d1. */
-async function paintWinningMove(page: import("@playwright/test").Page): Promise<void> {
-  await page.evaluate(() => {
-    const store = (window as unknown as Record<string, unknown>)["__gameStore"] as
-      | { getState: () => { paintStroke: (ids: number[], d: number) => void; precincts: { coord: { q: number; r: number } }[] } }
-      | undefined;
-    if (!store) throw new Error("__gameStore not exposed");
-    const state = store.getState();
-    const coordToIdx = new Map<string, number>();
-    state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
-      coordToIdx.set(`${p.coord.q},${p.coord.r}`, i);
-    });
-    // Move 7 hexes at r=-2, q=-6..0 from central (d2) → north (d1)
-    const ids: number[] = [];
-    for (let q = -6; q <= 0; q++) {
-      const idx = coordToIdx.get(`${q},-2`);
-      if (idx !== undefined) ids.push(idx);
-    }
-    state.paintStroke(ids, 1);
+    state.paintStroke(allIds, 1); // All precincts → district 1; the other districts left empty (invalid)
   });
 }
 
@@ -129,8 +111,8 @@ test("submit-on-invalid: Fix It button returns to editor from invalid map result
 // ─── Any non-passing result ───────────────────────────────────────────────────
 
 test("submit-on-invalid: any non-passing result hides Next Scenario and shows the back button", async ({ page }) => {
-  // The initial state of tutorial-002 has population imbalance (invalid map).
-  // Submitting it produces a non-passing result — the result screen shows a
+  // scenario-002's default (diagonal-strip) map doesn't meet the criteria (district d4 is
+  // unused). Submitting it produces a non-passing result — the result screen shows a
   // failure verdict, the back button (Keep Drawing / Fix It), and hides Next Scenario.
   // Note: the "Fix It" vs "Keep Drawing" label distinction is covered separately:
   //   - "Fix It" for invalid maps: see "invalid map shows Fix It button, not Next Scenario"
@@ -146,25 +128,29 @@ test("submit-on-invalid: any non-passing result hides Next Scenario and shows th
 
 // ─── Winning (passing) map result screen ─────────────────────────────────────
 
-test("submit-on-invalid: passing map shows pass screen with Next Scenario", async ({ page }) => {
+test("submit-on-invalid: passing map shows pass screen routing to the next scenario", async ({ page }) => {
   await loadEditor(page);
-  // Paint the winning move to satisfy all required criteria
-  await paintWinningMove(page);
-
-  await page.locator("#btn-submit").click();
+  // Force-win to exercise the pass-result UI without replicating scenario-002's full
+  // winning move (its real winnability is covered in scenarios.spec.ts).
+  await page.locator("#btn-debug-win").click();
 
   await expect(page.locator("#result-screen")).toBeVisible();
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
-  // Both buttons shown on pass
+  // scenario-002 has a teaching epilogue (narrative.epilogue), so the pass screen routes
+  // through "Continue →" to a debrief panel rather than showing "Next Scenario" directly
+  // (GAME-094). Keep Drawing + Continue are shown; Next Scenario is deferred to the debrief.
   await expect(page.locator("#btn-keep-drawing")).toBeVisible();
-  await expect(page.locator("#btn-next-scenario")).toBeVisible();
+  await expect(page.locator("#btn-continue")).toBeVisible();
+  await expect(page.locator("#btn-next-scenario")).not.toBeVisible();
+
+  // Continue → debrief panel, which carries the advance-to-next-scenario button.
+  await page.locator("#btn-continue").click();
+  await expect(page.locator("#btn-debrief-next")).toBeVisible();
 });
 
 test("submit-on-invalid: passing map shows Keep Drawing (not Fix It) label", async ({ page }) => {
   await loadEditor(page);
-  await paintWinningMove(page);
-
-  await page.locator("#btn-submit").click();
+  await page.locator("#btn-debug-win").click();
 
   await expect(page.locator("#result-screen")).toBeVisible();
   // Label must be "Keep Drawing" on a passing map, not "Fix It"

--- a/thoughts/shared/tickets/GAME-076-tutorial-001-walkthrough.md
+++ b/thoughts/shared/tickets/GAME-076-tutorial-001-walkthrough.md
@@ -2,9 +2,21 @@
 id: GAME-076
 title: Guided-overlay engine + tutorial-001 paint-only walkthrough
 area: game, UX, tutorial
-status: open
+status: resolved
 created: 2026-05-18
 ---
+
+## Resolution
+
+Shipped in **PR #275** (squash-merged to main). `game/web/src/tutorial/overlay.ts` implements
+the guided-overlay engine per DESIGN-012 (step model; `next`/`click-target`/`any-map-click`/
+`paint-count`/`submit`/`auto` advance; input-pause via the pointer-events cascade; `reveal`
+action built but unexercised until T3; Skip/Escape + per-scenario `localStorage` complete flag;
+`?resetTutorial=1`). `guided: true` plumbed (spec → assembler → scenario → loader) and set on
+tutorial-001; `startTutorialOverlay()` runs from `showEditor()`; `data-district="N"` hook on
+paint buttons; coach-panel + ring + pause CSS. e2e covers the walkthrough + suppression; a
+file-level `beforeEach` keeps the overlay out of the other tutorial-001 tests. Owner playtested
+and approved.
 
 ## Summary
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -107,7 +107,6 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `DESIGN-013-vra-scenario-design.md` | design, content | VRA scenario design: "The 55% Problem" (Bethune-Hill dual-failure zone) and proxy-only redistricting post-Callais |
 | `DESIGN-014-nonpartisan-content-framing.md` | design, content | Non-partisan content guidelines: source standards, narrative language, naming conventions, about-page audit; prerequisite for VRA scenario authoring |
 | `DESIGN-015-information-density-redesign.md` | design, UX | Layout redesign for 5+ districts: evaluate map overlays, HUD strip, tabbed sidebar; specify where GAME-080 demographic stat lives; DESIGN-004 fate |
-| `GAME-076-tutorial-001-walkthrough.md` | game, UX, tutorial | Guided-overlay engine (`guided:true` activation, step model, highlight/pause/skip, reveal action) + tutorial-001 paint-only 5-step script (orient → pick D2 → paint → undo → submit). Per revised DESIGN-012 |
 | `GAME-077-tutorial-002-guided-mode.md` | game, UX, tutorial, content | Tutorial-002 "A Legal Map": contiguity + balanced population + the validity panel; gates balance/contiguity; pre-electoral (hide_election_results+hide_view_toolbar). Re-scoped 2026-06-24 (views moved to GAME-098). See plan 2026-06-24-tutorial-redesign |
 | `GAME-078-vra-scenarios-implementation.md` | game, content | Implement VRA scenarios: Scenario A + Scenario B; terrain features; proxy-data mechanic; hides race demographics; result-screen reveal |
 | `GAME-079-scenario-002-playability-tuning.md` | game, content | Tighten scenario-002 — trivially-easy first educational campaign scenario requires genuine engagement |
@@ -127,6 +126,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 
 | Summary | Resolution |
 |---|---|
+| GAME-076: guided-overlay engine + tutorial-001 | Built the guided walkthrough engine (`src/tutorial/overlay.ts`): step model, `guided:true` activation, highlight/pause (pointer-events cascade)/skip/persist, reveal action (for T2/T3), `?resetTutorial=1`. tutorial-001 5-step paint script (orient→D2→paint→undo→submit). e2e + suppression beforeEach. PR #275 |
 | DESIGN-004: legend layout | Obsolete — won't do. Legend removed game-wide in GAME-097 (#273); the paint toolbar is the legend, so there's nothing to relocate |
 | GAME-097: tutorial pipeline migration + tutorial-001 | tutorial-001 now pipeline-generated (`tutorial-001.spec.yaml`→json): 37-precinct hex circle, paint-and-submit welcome. Pre-electoral/paint-only conventions: `hide_election_results`+`hide_view_toolbar` flags, applicable-aware validity panel, balance opt-in via `isMapSubmittable`, legend removed game-wide (paint toolbar=legend). Gates on `district_count` only (no untaught failure modes). Overlay-activation convention deferred to GAME-076. PR #273 |
 | GAME-091: scenario-002 teaching narrative | Rewrote scenario-002 intro to teach votes≠seats + packing (old text was stale for the new field); added `narrative.epilogue` (schema→assembler→loader→result screen) — a teaching debrief revealed on a win explaining packing/cracking neutrally. e2e asserts the debrief shows |


### PR DESCRIPTION
## Summary

**Test-only.** Decouples the generic e2e tests from `tutorial-002`, which has been the
de-facto generic editor-test fixture across the suite. With GAME-077 about to repurpose
`tutorial-002` as the guided "A Legal Map" (61 precincts, view toolbar hidden), the
content-agnostic tests move onto **scenario-002** (the educational campaign opener) — a
stable, play-relevant fixture, so the tests double as a smoke test for real content (the
owner's explicit preference over a synthetic test-only scenario).

**scenario-002 fixture facts (verified against the JSON):** 91 precincts, 4 districts; the
initial map assigns precincts to **d1/d2/d3** (d1=11, d2=41, d3=39) and leaves **d4 unused**;
**precinct index 0 (p001) starts in d2**; the default map fails the success criteria (so
invalid-map tests still see a failing default); scenario-002 carries a teaching epilogue
(`narrative.epilogue`).

- **sprint1 / sprint2:** `loadApp` → `scenario-002&debug` (+ `emulateMedia({reducedMotion:'reduce'})`
  for the result-screen path); `196 precincts` → `91`. Generic paint tests now paint precinct 0
  into **District 4** (`nth(3)`, unused initially) rather than District 2 — precinct 0 already
  starts in d2, so the old `nth(1)` paint was a no-op (undo never enabled). Painting into the
  unused d4 guarantees the assignment changes (and adds interior boundaries).
- **smoke:** → `scenario-002&debug`. scenario-002 is a locked campaign scenario (not the first),
  so debug bypasses the unlock gate; without it the app redirects to the select screen and the
  intro-skip button never appears.
- **sprint4:** `loadEditor` + force-win gotos → scenario-002; criteria counts are dynamic
  (adapt to 4 criteria); star count unchanged (1 optional → 2 stars).
- **submit-on-invalid:** `loadEditor` → `scenario-002&debug`; passing-map tests use
  `#btn-debug-win` (force-win) rather than a map-specific winning move; `paintWinningMove` removed.
  The passing-map test follows scenario-002's epilogue flow (GAME-094): the pass screen shows
  **"Continue →"** (not "Next Scenario" directly) → debrief panel → advance button (`#btn-debrief-next`).
- **sprint3:** generic submit + wip-restore/save → scenario-002; the **intro-narrative,
  winnability, and scale** tests stay on (unchanged) tutorial-002 — they assert its specific
  content and are updated/replaced in GAME-077. The winnability test keeps its inline
  tutorial-002 goto and now also emulates reduced-motion so the animated verdict reveal resolves.

**This PR does not change `tutorial-002.json` or the loader integration test** — those move
in GAME-077. So this is a pure test refactor, verifiable against the unchanged tutorial-002.

## Affected machines / services

- None. e2e test files only (+ GAME-076 ticket marked resolved). No source, build, or runtime change.

## Validation performed

- [x] `bazel build //game/web:e2e_test` — target builds (specs are transpiled by Playwright at
      run time, not Bazel-typechecked).
- [x] Pinned scenario-002 numbers via jq: 91 precincts, 4 districts; initial d1=11/d2=41/d3=39,
      d4 unused; precinct 0 (p001) starts in d2 → paint into d4 always registers a change.
- [x] Reduced-motion emulate added to every repointed result-screen path (scenario-002 has
      4 criteria; the animated reveal would otherwise exceed the 10s timeout).
- [x] Diagnosed all 9 CI failures from build 650 logs (no-op paints, locked-scenario redirect,
      lost emulate, epilogue Continue-flow) and fixed each at the root cause.
- [ ] e2e (Playwright) runs in **CI only** — not installed on the dev machine. *(POST-MERGE: CI gate)*

## Deployment steps

- None.

## Tickets addressed

- Test infrastructure prep for **GAME-077** (tutorial-002 "A Legal Map").
- **GAME-076** — marked resolved (shipped in #275).

## Rollback

- Revert this PR; the generic tests return to tutorial-002. No runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
