### PR TITLE
feat(GAME-098): tutorial-003 "Reading the Vote" — first electoral layer (guided reveal)

### DIFF
--- a/game/scenarios/tutorial-003.json
+++ b/game/scenarios/tutorial-003.json
@@ -1,2117 +1,2368 @@
 {
   "format_version": "1",
   "id": "tutorial-003",
-  "title": "Hawthorn Bend — A Tour of the Map",
+  "title": "Hawthorn Bend: Reading the Vote",
   "election_type": "state_house",
   "region": {
     "id": "hawthorn_bend",
     "name": "Hawthorn Bend"
   },
-  "geometry": { "type": "hex_axial" },
+  "geometry": {
+    "type": "hex_axial"
+  },
   "parties": [
-    { "id": "ash", "name": "Ash Party", "abbreviation": "ASH" },
-    { "id": "birch", "name": "Birch Party", "abbreviation": "BIR" }
-  ],
-  "districts": [
-    { "id": "d1", "name": "District 1" },
-    { "id": "d2", "name": "District 2" },
-    { "id": "d3", "name": "District 3" },
-    { "id": "d4", "name": "District 4" }
-  ],
-  "default_district_id": "d1",
-  "precincts": [
     {
-      "id": "p_0_n6",
-      "editable": true,
-      "position": { "q": 0, "r": -6 },
-      "total_population": 1082,
-      "initial_district_id": "d4",
-      "name": "(0,-6)",
-      "demographic_groups": [
-        {
-          "id": "p_0_n6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ash": 0.4886, "birch": 0.5114 }
-        }
-      ]
+      "id": "ken",
+      "name": "Ken Party",
+      "abbreviation": "KEN"
     },
     {
-      "id": "p_1_n6",
-      "editable": true,
-      "position": { "q": 1, "r": -6 },
-      "total_population": 906,
-      "initial_district_id": "d4",
-      "name": "(1,-6)",
-      "demographic_groups": [
-        {
-          "id": "p_1_n6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ash": 0.5565, "birch": 0.4435 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_n6",
-      "editable": true,
-      "position": { "q": 2, "r": -6 },
-      "total_population": 991,
-      "initial_district_id": "d4",
-      "name": "(2,-6)",
-      "demographic_groups": [
-        {
-          "id": "p_2_n6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.5207, "birch": 0.4793 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_n6",
-      "editable": true,
-      "position": { "q": 3, "r": -6 },
-      "total_population": 1066,
-      "initial_district_id": "d4",
-      "name": "(3,-6)",
-      "demographic_groups": [
-        {
-          "id": "p_3_n6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ash": 0.5112, "birch": 0.4888 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_n6",
-      "editable": true,
-      "position": { "q": 4, "r": -6 },
-      "total_population": 1086,
-      "initial_district_id": "d4",
-      "name": "(4,-6)",
-      "demographic_groups": [
-        {
-          "id": "p_4_n6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ash": 0.4977, "birch": 0.5023 }
-        }
-      ]
-    },
-    {
-      "id": "p_5_n6",
-      "editable": true,
-      "position": { "q": 5, "r": -6 },
-      "total_population": 1036,
-      "initial_district_id": "d4",
-      "name": "(5,-6)",
-      "demographic_groups": [
-        {
-          "id": "p_5_n6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ash": 0.4781, "birch": 0.5219 }
-        }
-      ]
-    },
-    {
-      "id": "p_6_n6",
-      "editable": true,
-      "position": { "q": 6, "r": -6 },
-      "total_population": 927,
-      "initial_district_id": "d4",
-      "name": "(6,-6)",
-      "demographic_groups": [
-        {
-          "id": "p_6_n6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ash": 0.4946, "birch": 0.5054 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_n5",
-      "editable": true,
-      "position": { "q": 0, "r": -5 },
-      "total_population": 930,
-      "initial_district_id": "d4",
-      "name": "(0,-5)",
-      "demographic_groups": [
-        {
-          "id": "p_0_n5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ash": 0.4665, "birch": 0.5335 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_n5",
-      "editable": true,
-      "position": { "q": 1, "r": -5 },
-      "total_population": 978,
-      "initial_district_id": "d4",
-      "name": "(1,-5)",
-      "demographic_groups": [
-        {
-          "id": "p_1_n5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.5334, "birch": 0.4666 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_n5",
-      "editable": true,
-      "position": { "q": 2, "r": -5 },
-      "total_population": 976,
-      "initial_district_id": "d4",
-      "name": "(2,-5)",
-      "demographic_groups": [
-        {
-          "id": "p_2_n5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.65,
-          "vote_shares": { "ash": 0.5114, "birch": 0.4886 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_n5",
-      "editable": true,
-      "position": { "q": 3, "r": -5 },
-      "total_population": 1010,
-      "initial_district_id": "d4",
-      "name": "(3,-5)",
-      "demographic_groups": [
-        {
-          "id": "p_3_n5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.64,
-          "vote_shares": { "ash": 0.5581, "birch": 0.4419 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_n5",
-      "editable": true,
-      "position": { "q": 4, "r": -5 },
-      "total_population": 961,
-      "initial_district_id": "d4",
-      "name": "(4,-5)",
-      "demographic_groups": [
-        {
-          "id": "p_4_n5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ash": 0.4867, "birch": 0.5133 }
-        }
-      ]
-    },
-    {
-      "id": "p_5_n5",
-      "editable": true,
-      "position": { "q": 5, "r": -5 },
-      "total_population": 916,
-      "initial_district_id": "d4",
-      "name": "(5,-5)",
-      "demographic_groups": [
-        {
-          "id": "p_5_n5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.4881, "birch": 0.5119 }
-        }
-      ]
-    },
-    {
-      "id": "p_6_n5",
-      "editable": true,
-      "position": { "q": 6, "r": -5 },
-      "total_population": 1053,
-      "initial_district_id": "d4",
-      "name": "(6,-5)",
-      "demographic_groups": [
-        {
-          "id": "p_6_n5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.67,
-          "vote_shares": { "ash": 0.5049, "birch": 0.4951 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_n4",
-      "editable": true,
-      "position": { "q": -1, "r": -4 },
-      "total_population": 1080,
-      "initial_district_id": "d4",
-      "name": "(-1,-4)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_n4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.4661, "birch": 0.5339 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_n4",
-      "editable": true,
-      "position": { "q": 0, "r": -4 },
-      "total_population": 985,
-      "initial_district_id": "d4",
-      "name": "(0,-4)",
-      "demographic_groups": [
-        {
-          "id": "p_0_n4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.63,
-          "vote_shares": { "ash": 0.4884, "birch": 0.5116 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_n4",
-      "editable": true,
-      "position": { "q": 1, "r": -4 },
-      "total_population": 917,
-      "initial_district_id": "d4",
-      "name": "(1,-4)",
-      "demographic_groups": [
-        {
-          "id": "p_1_n4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.5405, "birch": 0.4595 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_n4",
-      "editable": true,
-      "position": { "q": 2, "r": -4 },
-      "total_population": 1002,
-      "initial_district_id": "d4",
-      "name": "(2,-4)",
-      "demographic_groups": [
-        {
-          "id": "p_2_n4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.4951, "birch": 0.5049 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_n4",
-      "editable": true,
-      "position": { "q": 3, "r": -4 },
-      "total_population": 1052,
-      "initial_district_id": "d4",
-      "name": "(3,-4)",
-      "demographic_groups": [
-        {
-          "id": "p_3_n4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.5185, "birch": 0.4815 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_n4",
-      "editable": true,
-      "position": { "q": 4, "r": -4 },
-      "total_population": 1096,
-      "initial_district_id": "d4",
-      "name": "(4,-4)",
-      "demographic_groups": [
-        {
-          "id": "p_4_n4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.5162, "birch": 0.4838 }
-        }
-      ]
-    },
-    {
-      "id": "p_5_n4",
-      "editable": true,
-      "position": { "q": 5, "r": -4 },
-      "total_population": 1093,
-      "initial_district_id": "d4",
-      "name": "(5,-4)",
-      "demographic_groups": [
-        {
-          "id": "p_5_n4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ash": 0.5136, "birch": 0.4864 }
-        }
-      ]
-    },
-    {
-      "id": "p_6_n4",
-      "editable": true,
-      "position": { "q": 6, "r": -4 },
-      "total_population": 1065,
-      "initial_district_id": "d1",
-      "name": "(6,-4)",
-      "demographic_groups": [
-        {
-          "id": "p_6_n4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ash": 0.4749, "birch": 0.5251 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_n3",
-      "editable": true,
-      "position": { "q": -2, "r": -3 },
-      "total_population": 965,
-      "initial_district_id": "d3",
-      "name": "(-2,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ash": 0.5004, "birch": 0.4996 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_n3",
-      "editable": true,
-      "position": { "q": -1, "r": -3 },
-      "total_population": 942,
-      "initial_district_id": "d4",
-      "name": "(-1,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.4447, "birch": 0.5553 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_n3",
-      "editable": true,
-      "position": { "q": 0, "r": -3 },
-      "total_population": 1014,
-      "initial_district_id": "d4",
-      "name": "(0,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_0_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ash": 0.5565, "birch": 0.4435 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_n3",
-      "editable": true,
-      "position": { "q": 1, "r": -3 },
-      "total_population": 1089,
-      "initial_district_id": "d4",
-      "name": "(1,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_1_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.65,
-          "vote_shares": { "ash": 0.4698, "birch": 0.5302 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_n3",
-      "editable": true,
-      "position": { "q": 2, "r": -3 },
-      "total_population": 958,
-      "initial_district_id": "d4",
-      "name": "(2,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_2_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ash": 0.4957, "birch": 0.5043 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_n3",
-      "editable": true,
-      "position": { "q": 3, "r": -3 },
-      "total_population": 1050,
-      "initial_district_id": "d4",
-      "name": "(3,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_3_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.67,
-          "vote_shares": { "ash": 0.4947, "birch": 0.5053 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_n3",
-      "editable": true,
-      "position": { "q": 4, "r": -3 },
-      "total_population": 1048,
-      "initial_district_id": "d4",
-      "name": "(4,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_4_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.63,
-          "vote_shares": { "ash": 0.4496, "birch": 0.5504 }
-        }
-      ]
-    },
-    {
-      "id": "p_5_n3",
-      "editable": true,
-      "position": { "q": 5, "r": -3 },
-      "total_population": 1025,
-      "initial_district_id": "d1",
-      "name": "(5,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_5_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.64,
-          "vote_shares": { "ash": 0.4643, "birch": 0.5357 }
-        }
-      ]
-    },
-    {
-      "id": "p_6_n3",
-      "editable": true,
-      "position": { "q": 6, "r": -3 },
-      "total_population": 1042,
-      "initial_district_id": "d1",
-      "name": "(6,-3)",
-      "demographic_groups": [
-        {
-          "id": "p_6_n3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.4597, "birch": 0.5403 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_n2",
-      "editable": true,
-      "position": { "q": -4, "r": -2 },
-      "total_population": 984,
-      "initial_district_id": "d3",
-      "name": "(-4,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ash": 0.4865, "birch": 0.5135 }
-        }
-      ]
-    },
-    {
-      "id": "p_n3_n2",
-      "editable": true,
-      "position": { "q": -3, "r": -2 },
-      "total_population": 1085,
-      "initial_district_id": "d3",
-      "name": "(-3,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_n3_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ash": 0.5103, "birch": 0.4897 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_n2",
-      "editable": true,
-      "position": { "q": -2, "r": -2 },
-      "total_population": 1004,
-      "initial_district_id": "d3",
-      "name": "(-2,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ash": 0.5594, "birch": 0.4406 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_n2",
-      "editable": true,
-      "position": { "q": -1, "r": -2 },
-      "total_population": 901,
-      "initial_district_id": "d3",
-      "name": "(-1,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ash": 0.4699, "birch": 0.5301 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_n2",
-      "editable": true,
-      "position": { "q": 0, "r": -2 },
-      "total_population": 1087,
-      "initial_district_id": "d4",
-      "name": "(0,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_0_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.4853, "birch": 0.5147 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_n2",
-      "editable": true,
-      "position": { "q": 1, "r": -2 },
-      "total_population": 1022,
-      "initial_district_id": "d4",
-      "name": "(1,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_1_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ash": 0.4719, "birch": 0.5281 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_n2",
-      "editable": true,
-      "position": { "q": 2, "r": -2 },
-      "total_population": 940,
-      "initial_district_id": "d4",
-      "name": "(2,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_2_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.5294, "birch": 0.4706 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_n2",
-      "editable": true,
-      "position": { "q": 3, "r": -2 },
-      "total_population": 911,
-      "initial_district_id": "d1",
-      "name": "(3,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_3_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.5275, "birch": 0.4725 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_n2",
-      "editable": true,
-      "position": { "q": 4, "r": -2 },
-      "total_population": 1034,
-      "initial_district_id": "d1",
-      "name": "(4,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_4_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.4513, "birch": 0.5487 }
-        }
-      ]
-    },
-    {
-      "id": "p_5_n2",
-      "editable": true,
-      "position": { "q": 5, "r": -2 },
-      "total_population": 965,
-      "initial_district_id": "d1",
-      "name": "(5,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_5_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.5429, "birch": 0.4571 }
-        }
-      ]
-    },
-    {
-      "id": "p_6_n2",
-      "editable": true,
-      "position": { "q": 6, "r": -2 },
-      "total_population": 998,
-      "initial_district_id": "d1",
-      "name": "(6,-2)",
-      "demographic_groups": [
-        {
-          "id": "p_6_n2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.5276, "birch": 0.4724 }
-        }
-      ]
-    },
-    {
-      "id": "p_n5_n1",
-      "editable": true,
-      "position": { "q": -5, "r": -1 },
-      "total_population": 912,
-      "initial_district_id": "d3",
-      "name": "(-5,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_n5_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.64,
-          "vote_shares": { "ash": 0.4934, "birch": 0.5066 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_n1",
-      "editable": true,
-      "position": { "q": -4, "r": -1 },
-      "total_population": 969,
-      "initial_district_id": "d3",
-      "name": "(-4,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ash": 0.4442, "birch": 0.5558 }
-        }
-      ]
-    },
-    {
-      "id": "p_n3_n1",
-      "editable": true,
-      "position": { "q": -3, "r": -1 },
-      "total_population": 904,
-      "initial_district_id": "d3",
-      "name": "(-3,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_n3_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.4830, "birch": 0.5170 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_n1",
-      "editable": true,
-      "position": { "q": -2, "r": -1 },
-      "total_population": 917,
-      "initial_district_id": "d3",
-      "name": "(-2,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ash": 0.5059, "birch": 0.4941 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_n1",
-      "editable": true,
-      "position": { "q": -1, "r": -1 },
-      "total_population": 974,
-      "initial_district_id": "d3",
-      "name": "(-1,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ash": 0.4923, "birch": 0.5077 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_n1",
-      "editable": true,
-      "position": { "q": 0, "r": -1 },
-      "total_population": 1051,
-      "initial_district_id": "d4",
-      "name": "(0,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_0_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.4714, "birch": 0.5286 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_n1",
-      "editable": true,
-      "position": { "q": 1, "r": -1 },
-      "total_population": 951,
-      "initial_district_id": "d4",
-      "name": "(1,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_1_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.4780, "birch": 0.5220 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_n1",
-      "editable": true,
-      "position": { "q": 2, "r": -1 },
-      "total_population": 1076,
-      "initial_district_id": "d1",
-      "name": "(2,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_2_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.5390, "birch": 0.4610 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_n1",
-      "editable": true,
-      "position": { "q": 3, "r": -1 },
-      "total_population": 1037,
-      "initial_district_id": "d1",
-      "name": "(3,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_3_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ash": 0.5106, "birch": 0.4894 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_n1",
-      "editable": true,
-      "position": { "q": 4, "r": -1 },
-      "total_population": 1043,
-      "initial_district_id": "d1",
-      "name": "(4,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_4_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ash": 0.5029, "birch": 0.4971 }
-        }
-      ]
-    },
-    {
-      "id": "p_5_n1",
-      "editable": true,
-      "position": { "q": 5, "r": -1 },
-      "total_population": 969,
-      "initial_district_id": "d1",
-      "name": "(5,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_5_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.63,
-          "vote_shares": { "ash": 0.4816, "birch": 0.5184 }
-        }
-      ]
-    },
-    {
-      "id": "p_6_n1",
-      "editable": true,
-      "position": { "q": 6, "r": -1 },
-      "total_population": 1096,
-      "initial_district_id": "d1",
-      "name": "(6,-1)",
-      "demographic_groups": [
-        {
-          "id": "p_6_n1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ash": 0.5096, "birch": 0.4904 }
-        }
-      ]
-    },
-    {
-      "id": "p_n6_0",
-      "editable": true,
-      "position": { "q": -6, "r": 0 },
-      "total_population": 1096,
-      "initial_district_id": "d3",
-      "name": "(-6,0)",
-      "demographic_groups": [
-        {
-          "id": "p_n6_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.5432, "birch": 0.4568 }
-        }
-      ]
-    },
-    {
-      "id": "p_n5_0",
-      "editable": true,
-      "position": { "q": -5, "r": 0 },
-      "total_population": 943,
-      "initial_district_id": "d3",
-      "name": "(-5,0)",
-      "demographic_groups": [
-        {
-          "id": "p_n5_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.4607, "birch": 0.5393 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_0",
-      "editable": true,
-      "position": { "q": -4, "r": 0 },
-      "total_population": 1032,
-      "initial_district_id": "d3",
-      "name": "(-4,0)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ash": 0.5433, "birch": 0.4567 }
-        }
-      ]
-    },
-    {
-      "id": "p_n3_0",
-      "editable": true,
-      "position": { "q": -3, "r": 0 },
-      "total_population": 987,
-      "initial_district_id": "d3",
-      "name": "(-3,0)",
-      "demographic_groups": [
-        {
-          "id": "p_n3_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.5094, "birch": 0.4906 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_0",
-      "editable": true,
-      "position": { "q": -2, "r": 0 },
-      "total_population": 1031,
-      "initial_district_id": "d3",
-      "name": "(-2,0)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ash": 0.5479, "birch": 0.4521 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_0",
-      "editable": true,
-      "position": { "q": -1, "r": 0 },
-      "total_population": 903,
-      "initial_district_id": "d3",
-      "name": "(-1,0)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.5151, "birch": 0.4849 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_0",
-      "editable": true,
-      "position": { "q": 0, "r": 0 },
-      "total_population": 1044,
-      "initial_district_id": "d1",
-      "name": "(0,0)",
-      "demographic_groups": [
-        {
-          "id": "p_0_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.67,
-          "vote_shares": { "ash": 0.4563, "birch": 0.5437 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_0",
-      "editable": true,
-      "position": { "q": 1, "r": 0 },
-      "total_population": 1076,
-      "initial_district_id": "d1",
-      "name": "(1,0)",
-      "demographic_groups": [
-        {
-          "id": "p_1_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ash": 0.5025, "birch": 0.4975 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_0",
-      "editable": true,
-      "position": { "q": 2, "r": 0 },
-      "total_population": 980,
-      "initial_district_id": "d1",
-      "name": "(2,0)",
-      "demographic_groups": [
-        {
-          "id": "p_2_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.64,
-          "vote_shares": { "ash": 0.5371, "birch": 0.4629 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_0",
-      "editable": true,
-      "position": { "q": 3, "r": 0 },
-      "total_population": 1006,
-      "initial_district_id": "d1",
-      "name": "(3,0)",
-      "demographic_groups": [
-        {
-          "id": "p_3_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ash": 0.5361, "birch": 0.4639 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_0",
-      "editable": true,
-      "position": { "q": 4, "r": 0 },
-      "total_population": 989,
-      "initial_district_id": "d1",
-      "name": "(4,0)",
-      "demographic_groups": [
-        {
-          "id": "p_4_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.4436, "birch": 0.5564 }
-        }
-      ]
-    },
-    {
-      "id": "p_5_0",
-      "editable": true,
-      "position": { "q": 5, "r": 0 },
-      "total_population": 980,
-      "initial_district_id": "d1",
-      "name": "(5,0)",
-      "demographic_groups": [
-        {
-          "id": "p_5_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.4860, "birch": 0.5140 }
-        }
-      ]
-    },
-    {
-      "id": "p_6_0",
-      "editable": true,
-      "position": { "q": 6, "r": 0 },
-      "total_population": 1092,
-      "initial_district_id": "d1",
-      "name": "(6,0)",
-      "demographic_groups": [
-        {
-          "id": "p_6_0-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.5088, "birch": 0.4912 }
-        }
-      ]
-    },
-    {
-      "id": "p_n6_1",
-      "editable": true,
-      "position": { "q": -6, "r": 1 },
-      "total_population": 989,
-      "initial_district_id": "d3",
-      "name": "(-6,1)",
-      "demographic_groups": [
-        {
-          "id": "p_n6_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ash": 0.5439, "birch": 0.4561 }
-        }
-      ]
-    },
-    {
-      "id": "p_n5_1",
-      "editable": true,
-      "position": { "q": -5, "r": 1 },
-      "total_population": 1068,
-      "initial_district_id": "d3",
-      "name": "(-5,1)",
-      "demographic_groups": [
-        {
-          "id": "p_n5_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.5447, "birch": 0.4553 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_1",
-      "editable": true,
-      "position": { "q": -4, "r": 1 },
-      "total_population": 1021,
-      "initial_district_id": "d3",
-      "name": "(-4,1)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.65,
-          "vote_shares": { "ash": 0.5423, "birch": 0.4577 }
-        }
-      ]
-    },
-    {
-      "id": "p_n3_1",
-      "editable": true,
-      "position": { "q": -3, "r": 1 },
-      "total_population": 945,
-      "initial_district_id": "d3",
-      "name": "(-3,1)",
-      "demographic_groups": [
-        {
-          "id": "p_n3_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ash": 0.5420, "birch": 0.4580 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_1",
-      "editable": true,
-      "position": { "q": -2, "r": 1 },
-      "total_population": 928,
-      "initial_district_id": "d3",
-      "name": "(-2,1)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.4737, "birch": 0.5263 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_1",
-      "editable": true,
-      "position": { "q": 0, "r": 1 },
-      "total_population": 958,
-      "initial_district_id": "d2",
-      "name": "(0,1)",
-      "demographic_groups": [
-        {
-          "id": "p_0_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ash": 0.4734, "birch": 0.5266 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_1",
-      "editable": true,
-      "position": { "q": 1, "r": 1 },
-      "total_population": 923,
-      "initial_district_id": "d1",
-      "name": "(1,1)",
-      "demographic_groups": [
-        {
-          "id": "p_1_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.5292, "birch": 0.4708 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_1",
-      "editable": true,
-      "position": { "q": 2, "r": 1 },
-      "total_population": 904,
-      "initial_district_id": "d1",
-      "name": "(2,1)",
-      "demographic_groups": [
-        {
-          "id": "p_2_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ash": 0.5340, "birch": 0.4660 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_1",
-      "editable": true,
-      "position": { "q": 3, "r": 1 },
-      "total_population": 977,
-      "initial_district_id": "d1",
-      "name": "(3,1)",
-      "demographic_groups": [
-        {
-          "id": "p_3_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.5390, "birch": 0.4610 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_1",
-      "editable": true,
-      "position": { "q": 4, "r": 1 },
-      "total_population": 1055,
-      "initial_district_id": "d1",
-      "name": "(4,1)",
-      "demographic_groups": [
-        {
-          "id": "p_4_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ash": 0.5415, "birch": 0.4585 }
-        }
-      ]
-    },
-    {
-      "id": "p_5_1",
-      "editable": true,
-      "position": { "q": 5, "r": 1 },
-      "total_population": 1052,
-      "initial_district_id": "d1",
-      "name": "(5,1)",
-      "demographic_groups": [
-        {
-          "id": "p_5_1-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.4446, "birch": 0.5554 }
-        }
-      ]
-    },
-    {
-      "id": "p_n6_2",
-      "editable": true,
-      "position": { "q": -6, "r": 2 },
-      "total_population": 940,
-      "initial_district_id": "d3",
-      "name": "(-6,2)",
-      "demographic_groups": [
-        {
-          "id": "p_n6_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ash": 0.5499, "birch": 0.4501 }
-        }
-      ]
-    },
-    {
-      "id": "p_n5_2",
-      "editable": true,
-      "position": { "q": -5, "r": 2 },
-      "total_population": 958,
-      "initial_district_id": "d3",
-      "name": "(-5,2)",
-      "demographic_groups": [
-        {
-          "id": "p_n5_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ash": 0.5293, "birch": 0.4707 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_2",
-      "editable": true,
-      "position": { "q": -4, "r": 2 },
-      "total_population": 906,
-      "initial_district_id": "d3",
-      "name": "(-4,2)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.4501, "birch": 0.5499 }
-        }
-      ]
-    },
-    {
-      "id": "p_n3_2",
-      "editable": true,
-      "position": { "q": -3, "r": 2 },
-      "total_population": 1042,
-      "initial_district_id": "d3",
-      "name": "(-3,2)",
-      "demographic_groups": [
-        {
-          "id": "p_n3_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ash": 0.4760, "birch": 0.5240 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_2",
-      "editable": true,
-      "position": { "q": -2, "r": 2 },
-      "total_population": 939,
-      "initial_district_id": "d2",
-      "name": "(-2,2)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ash": 0.4952, "birch": 0.5048 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_2",
-      "editable": true,
-      "position": { "q": -1, "r": 2 },
-      "total_population": 1054,
-      "initial_district_id": "d2",
-      "name": "(-1,2)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ash": 0.5259, "birch": 0.4741 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_2",
-      "editable": true,
-      "position": { "q": 0, "r": 2 },
-      "total_population": 1084,
-      "initial_district_id": "d2",
-      "name": "(0,2)",
-      "demographic_groups": [
-        {
-          "id": "p_0_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.65,
-          "vote_shares": { "ash": 0.4769, "birch": 0.5231 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_2",
-      "editable": true,
-      "position": { "q": 1, "r": 2 },
-      "total_population": 1012,
-      "initial_district_id": "d1",
-      "name": "(1,2)",
-      "demographic_groups": [
-        {
-          "id": "p_1_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.4573, "birch": 0.5427 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_2",
-      "editable": true,
-      "position": { "q": 2, "r": 2 },
-      "total_population": 1018,
-      "initial_district_id": "d1",
-      "name": "(2,2)",
-      "demographic_groups": [
-        {
-          "id": "p_2_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.67,
-          "vote_shares": { "ash": 0.4955, "birch": 0.5045 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_2",
-      "editable": true,
-      "position": { "q": 3, "r": 2 },
-      "total_population": 1046,
-      "initial_district_id": "d1",
-      "name": "(3,2)",
-      "demographic_groups": [
-        {
-          "id": "p_3_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.65,
-          "vote_shares": { "ash": 0.5236, "birch": 0.4764 }
-        }
-      ]
-    },
-    {
-      "id": "p_4_2",
-      "editable": true,
-      "position": { "q": 4, "r": 2 },
-      "total_population": 1069,
-      "initial_district_id": "d1",
-      "name": "(4,2)",
-      "demographic_groups": [
-        {
-          "id": "p_4_2-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.63,
-          "vote_shares": { "ash": 0.5402, "birch": 0.4598 }
-        }
-      ]
-    },
-    {
-      "id": "p_n6_3",
-      "editable": true,
-      "position": { "q": -6, "r": 3 },
-      "total_population": 926,
-      "initial_district_id": "d3",
-      "name": "(-6,3)",
-      "demographic_groups": [
-        {
-          "id": "p_n6_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ash": 0.5157, "birch": 0.4843 }
-        }
-      ]
-    },
-    {
-      "id": "p_n5_3",
-      "editable": true,
-      "position": { "q": -5, "r": 3 },
-      "total_population": 1092,
-      "initial_district_id": "d3",
-      "name": "(-5,3)",
-      "demographic_groups": [
-        {
-          "id": "p_n5_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.5185, "birch": 0.4815 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_3",
-      "editable": true,
-      "position": { "q": -4, "r": 3 },
-      "total_population": 911,
-      "initial_district_id": "d2",
-      "name": "(-4,3)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.5244, "birch": 0.4756 }
-        }
-      ]
-    },
-    {
-      "id": "p_n3_3",
-      "editable": true,
-      "position": { "q": -3, "r": 3 },
-      "total_population": 957,
-      "initial_district_id": "d2",
-      "name": "(-3,3)",
-      "demographic_groups": [
-        {
-          "id": "p_n3_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.5398, "birch": 0.4602 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_3",
-      "editable": true,
-      "position": { "q": -2, "r": 3 },
-      "total_population": 1004,
-      "initial_district_id": "d2",
-      "name": "(-2,3)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ash": 0.5089, "birch": 0.4911 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_3",
-      "editable": true,
-      "position": { "q": -1, "r": 3 },
-      "total_population": 975,
-      "initial_district_id": "d2",
-      "name": "(-1,3)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.64,
-          "vote_shares": { "ash": 0.5557, "birch": 0.4443 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_3",
-      "editable": true,
-      "position": { "q": 0, "r": 3 },
-      "total_population": 1083,
-      "initial_district_id": "d2",
-      "name": "(0,3)",
-      "demographic_groups": [
-        {
-          "id": "p_0_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ash": 0.5430, "birch": 0.4570 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_3",
-      "editable": true,
-      "position": { "q": 1, "r": 3 },
-      "total_population": 908,
-      "initial_district_id": "d2",
-      "name": "(1,3)",
-      "demographic_groups": [
-        {
-          "id": "p_1_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.4707, "birch": 0.5293 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_3",
-      "editable": true,
-      "position": { "q": 2, "r": 3 },
-      "total_population": 1020,
-      "initial_district_id": "d1",
-      "name": "(2,3)",
-      "demographic_groups": [
-        {
-          "id": "p_2_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ash": 0.4717, "birch": 0.5283 }
-        }
-      ]
-    },
-    {
-      "id": "p_3_3",
-      "editable": true,
-      "position": { "q": 3, "r": 3 },
-      "total_population": 1054,
-      "initial_district_id": "d1",
-      "name": "(3,3)",
-      "demographic_groups": [
-        {
-          "id": "p_3_3-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.55,
-          "vote_shares": { "ash": 0.5417, "birch": 0.4583 }
-        }
-      ]
-    },
-    {
-      "id": "p_n6_4",
-      "editable": true,
-      "position": { "q": -6, "r": 4 },
-      "total_population": 925,
-      "initial_district_id": "d3",
-      "name": "(-6,4)",
-      "demographic_groups": [
-        {
-          "id": "p_n6_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ash": 0.5151, "birch": 0.4849 }
-        }
-      ]
-    },
-    {
-      "id": "p_n5_4",
-      "editable": true,
-      "position": { "q": -5, "r": 4 },
-      "total_population": 981,
-      "initial_district_id": "d2",
-      "name": "(-5,4)",
-      "demographic_groups": [
-        {
-          "id": "p_n5_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.57,
-          "vote_shares": { "ash": 0.5025, "birch": 0.4975 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_4",
-      "editable": true,
-      "position": { "q": -4, "r": 4 },
-      "total_population": 967,
-      "initial_district_id": "d2",
-      "name": "(-4,4)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.4422, "birch": 0.5578 }
-        }
-      ]
-    },
-    {
-      "id": "p_n3_4",
-      "editable": true,
-      "position": { "q": -3, "r": 4 },
-      "total_population": 956,
-      "initial_district_id": "d2",
-      "name": "(-3,4)",
-      "demographic_groups": [
-        {
-          "id": "p_n3_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.5303, "birch": 0.4697 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_4",
-      "editable": true,
-      "position": { "q": -2, "r": 4 },
-      "total_population": 1048,
-      "initial_district_id": "d2",
-      "name": "(-2,4)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.60,
-          "vote_shares": { "ash": 0.4572, "birch": 0.5428 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_4",
-      "editable": true,
-      "position": { "q": -1, "r": 4 },
-      "total_population": 1088,
-      "initial_district_id": "d2",
-      "name": "(-1,4)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.61,
-          "vote_shares": { "ash": 0.4519, "birch": 0.5481 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_4",
-      "editable": true,
-      "position": { "q": 0, "r": 4 },
-      "total_population": 979,
-      "initial_district_id": "d2",
-      "name": "(0,4)",
-      "demographic_groups": [
-        {
-          "id": "p_0_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.65,
-          "vote_shares": { "ash": 0.5203, "birch": 0.4797 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_4",
-      "editable": true,
-      "position": { "q": 1, "r": 4 },
-      "total_population": 958,
-      "initial_district_id": "d2",
-      "name": "(1,4)",
-      "demographic_groups": [
-        {
-          "id": "p_1_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ash": 0.5237, "birch": 0.4763 }
-        }
-      ]
-    },
-    {
-      "id": "p_2_4",
-      "editable": true,
-      "position": { "q": 2, "r": 4 },
-      "total_population": 1056,
-      "initial_district_id": "d1",
-      "name": "(2,4)",
-      "demographic_groups": [
-        {
-          "id": "p_2_4-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.66,
-          "vote_shares": { "ash": 0.5426, "birch": 0.4574 }
-        }
-      ]
-    },
-    {
-      "id": "p_n6_5",
-      "editable": true,
-      "position": { "q": -6, "r": 5 },
-      "total_population": 912,
-      "initial_district_id": "d2",
-      "name": "(-6,5)",
-      "demographic_groups": [
-        {
-          "id": "p_n6_5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.58,
-          "vote_shares": { "ash": 0.4952, "birch": 0.5048 }
-        }
-      ]
-    },
-    {
-      "id": "p_n5_5",
-      "editable": true,
-      "position": { "q": -5, "r": 5 },
-      "total_population": 951,
-      "initial_district_id": "d2",
-      "name": "(-5,5)",
-      "demographic_groups": [
-        {
-          "id": "p_n5_5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.63,
-          "vote_shares": { "ash": 0.5047, "birch": 0.4953 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_5",
-      "editable": true,
-      "position": { "q": -4, "r": 5 },
-      "total_population": 1004,
-      "initial_district_id": "d2",
-      "name": "(-4,5)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.65,
-          "vote_shares": { "ash": 0.5420, "birch": 0.4580 }
-        }
-      ]
-    },
-    {
-      "id": "p_n3_5",
-      "editable": true,
-      "position": { "q": -3, "r": 5 },
-      "total_population": 919,
-      "initial_district_id": "d2",
-      "name": "(-3,5)",
-      "demographic_groups": [
-        {
-          "id": "p_n3_5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ash": 0.5374, "birch": 0.4626 }
-        }
-      ]
-    },
-    {
-      "id": "p_n2_5",
-      "editable": true,
-      "position": { "q": -2, "r": 5 },
-      "total_population": 927,
-      "initial_district_id": "d2",
-      "name": "(-2,5)",
-      "demographic_groups": [
-        {
-          "id": "p_n2_5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.70,
-          "vote_shares": { "ash": 0.5491, "birch": 0.4509 }
-        }
-      ]
-    },
-    {
-      "id": "p_n1_5",
-      "editable": true,
-      "position": { "q": -1, "r": 5 },
-      "total_population": 998,
-      "initial_district_id": "d2",
-      "name": "(-1,5)",
-      "demographic_groups": [
-        {
-          "id": "p_n1_5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.56,
-          "vote_shares": { "ash": 0.4507, "birch": 0.5493 }
-        }
-      ]
-    },
-    {
-      "id": "p_0_5",
-      "editable": true,
-      "position": { "q": 0, "r": 5 },
-      "total_population": 995,
-      "initial_district_id": "d2",
-      "name": "(0,5)",
-      "demographic_groups": [
-        {
-          "id": "p_0_5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.69,
-          "vote_shares": { "ash": 0.5377, "birch": 0.4623 }
-        }
-      ]
-    },
-    {
-      "id": "p_1_5",
-      "editable": true,
-      "position": { "q": 1, "r": 5 },
-      "total_population": 1054,
-      "initial_district_id": "d2",
-      "name": "(1,5)",
-      "demographic_groups": [
-        {
-          "id": "p_1_5-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.68,
-          "vote_shares": { "ash": 0.4991, "birch": 0.5009 }
-        }
-      ]
-    },
-    {
-      "id": "p_n6_6",
-      "editable": true,
-      "position": { "q": -6, "r": 6 },
-      "total_population": 921,
-      "initial_district_id": "d2",
-      "name": "(-6,6)",
-      "demographic_groups": [
-        {
-          "id": "p_n6_6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.62,
-          "vote_shares": { "ash": 0.5355, "birch": 0.4645 }
-        }
-      ]
-    },
-    {
-      "id": "p_n5_6",
-      "editable": true,
-      "position": { "q": -5, "r": 6 },
-      "total_population": 1086,
-      "initial_district_id": "d2",
-      "name": "(-5,6)",
-      "demographic_groups": [
-        {
-          "id": "p_n5_6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ash": 0.5440, "birch": 0.4560 }
-        }
-      ]
-    },
-    {
-      "id": "p_n4_6",
-      "editable": true,
-      "position": { "q": -4, "r": 6 },
-      "total_population": 943,
-      "initial_district_id": "d2",
-      "name": "(-4,6)",
-      "demographic_groups": [
-        {
-          "id": "p_n4_6-all",
-          "name": "All voters",
-          "population_share": 1.0,
-          "turnout_rate": 0.59,
-          "vote_shares": { "ash": 0.4578, "birch": 0.5422 }
-        }
-      ]
+      "id": "ryu",
+      "name": "Ryu Party",
+      "abbreviation": "RYU"
     }
   ],
-  "terrain_tiles": [
-    { "position": { "q": -3, "r": -3 }, "type": "mountain" },
-    { "position": { "q": -2, "r": -4 }, "type": "mountain" },
-    { "position": { "q": -1, "r": -5 }, "type": "mountain" },
-    { "position": { "q": -3, "r": 6 }, "type": "sea" },
-    { "position": { "q": -2, "r": 6 }, "type": "sea" },
-    { "position": { "q": -1, "r": 6 }, "type": "sea" },
-    { "position": { "q": 0, "r": 6 }, "type": "sea" },
-    { "position": { "q": -1, "r": 1 }, "type": "lake" }
+  "districts": [
+    {
+      "id": "d1",
+      "name": "District 1"
+    },
+    {
+      "id": "d2",
+      "name": "District 2"
+    },
+    {
+      "id": "d3",
+      "name": "District 3"
+    }
   ],
-  "river_edges": [
-    ["p_n1_n4", "p_n2_n3"],
-    ["p_n2_n3", "p_n1_n3"],
-    ["p_n1_n3", "p_n2_n2"],
-    ["p_n2_n2", "p_n1_n2"],
-    ["p_n1_n2", "p_n2_n1"],
-    ["p_n2_n1", "p_n1_n1"],
-    ["p_n1_n1", "p_n2_0"],
-    ["p_n2_0", "p_n1_0"],
-    ["p_n1_0", "p_n2_1"],
-    ["p_n2_2", "p_n1_2"],
-    ["p_n1_2", "p_n2_3"],
-    ["p_n2_3", "p_n1_3"],
-    ["p_n1_3", "p_n2_4"],
-    ["p_n2_4", "p_n1_4"],
-    ["p_n1_4", "p_n2_5"],
-    ["p_n2_5", "p_n1_5"]
+  "precincts": [
+    {
+      "id": "p001",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": -5
+      },
+      "total_population": 3906,
+      "demographic_groups": [
+        {
+          "id": "p001-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5053058119490743,
+            "ryu": 0.4946941880509257
+          },
+          "turnout_rate": 0.6040175742469728,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,-5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p002",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": -5
+      },
+      "total_population": 3929,
+      "demographic_groups": [
+        {
+          "id": "p002-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.34564726762473585,
+            "ryu": 0.6543527323752641
+          },
+          "turnout_rate": 0.5572250277968124,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (1,-5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p003",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": -5
+      },
+      "total_population": 3929,
+      "demographic_groups": [
+        {
+          "id": "p003-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3429416694492102,
+            "ryu": 0.6570583305507898
+          },
+          "turnout_rate": 0.5510160588426516,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (2,-5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p004",
+      "editable": true,
+      "position": {
+        "q": 3,
+        "r": -5
+      },
+      "total_population": 3902,
+      "demographic_groups": [
+        {
+          "id": "p004-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3472965960763395,
+            "ryu": 0.6527034039236606
+          },
+          "turnout_rate": 0.6031260804389603,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (3,-5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p005",
+      "editable": true,
+      "position": {
+        "q": 4,
+        "r": -5
+      },
+      "total_population": 3881,
+      "demographic_groups": [
+        {
+          "id": "p005-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3846620431356132,
+            "ryu": 0.6153379568643869
+          },
+          "turnout_rate": 0.680589723365847,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (4,-5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p006",
+      "editable": true,
+      "position": {
+        "q": 5,
+        "r": -5
+      },
+      "total_population": 3864,
+      "demographic_groups": [
+        {
+          "id": "p006-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3924453490972519,
+            "ryu": 0.6075546509027481
+          },
+          "turnout_rate": 0.663901763537433,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (5,-5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p007",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": -4
+      },
+      "total_population": 3908,
+      "demographic_groups": [
+        {
+          "id": "p007-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6033014810644091,
+            "ryu": 0.39669851893559094
+          },
+          "turnout_rate": 0.5749593634624034,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,-4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p008",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": -4
+      },
+      "total_population": 3945,
+      "demographic_groups": [
+        {
+          "id": "p008-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5048573973588646,
+            "ryu": 0.4951426026411354
+          },
+          "turnout_rate": 0.6047889422508888,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,-4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p009",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": -4
+      },
+      "total_population": 3970,
+      "demographic_groups": [
+        {
+          "id": "p009-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3861849446594715,
+            "ryu": 0.6138150553405285
+          },
+          "turnout_rate": 0.6423248105798848,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (1,-4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p010",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": -4
+      },
+      "total_population": 3991,
+      "demographic_groups": [
+        {
+          "id": "p010-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3498137126863003,
+            "ryu": 0.6501862873136997
+          },
+          "turnout_rate": 0.6469714056001976,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (2,-4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p011",
+      "editable": true,
+      "position": {
+        "q": 3,
+        "r": -4
+      },
+      "total_population": 3966,
+      "demographic_groups": [
+        {
+          "id": "p011-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3747549327276647,
+            "ryu": 0.6252450672723353
+          },
+          "turnout_rate": 0.6483721209457144,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (3,-4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p012",
+      "editable": true,
+      "position": {
+        "q": 4,
+        "r": -4
+      },
+      "total_population": 3916,
+      "demographic_groups": [
+        {
+          "id": "p012-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.36713062427937987,
+            "ryu": 0.6328693757206201
+          },
+          "turnout_rate": 0.5654929414857179,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (4,-4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p013",
+      "editable": true,
+      "position": {
+        "q": 5,
+        "r": -4
+      },
+      "total_population": 3957,
+      "demographic_groups": [
+        {
+          "id": "p013-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.39966733710840346,
+            "ryu": 0.6003326628915966
+          },
+          "turnout_rate": 0.6105151803931221,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (5,-4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p014",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": -3
+      },
+      "total_population": 3917,
+      "demographic_groups": [
+        {
+          "id": "p014-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5871632305160165,
+            "ryu": 0.4128367694839835
+          },
+          "turnout_rate": 0.5972204012214206,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,-3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p015",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": -3
+      },
+      "total_population": 3869,
+      "demographic_groups": [
+        {
+          "id": "p015-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5832236292399466,
+            "ryu": 0.41677637076005336
+          },
+          "turnout_rate": 0.5592073300504126,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,-3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p016",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": -3
+      },
+      "total_population": 3980,
+      "demographic_groups": [
+        {
+          "id": "p016-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.48316059581935406,
+            "ryu": 0.5168394041806459
+          },
+          "turnout_rate": 0.6871966380858794,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,-3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p017",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": -3
+      },
+      "total_population": 4055,
+      "demographic_groups": [
+        {
+          "id": "p017-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3692182816937566,
+            "ryu": 0.6307817183062434
+          },
+          "turnout_rate": 0.6587316486402415,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (1,-3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p018",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": -3
+      },
+      "total_population": 3986,
+      "demographic_groups": [
+        {
+          "id": "p018-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.35763386089354754,
+            "ryu": 0.6423661391064525
+          },
+          "turnout_rate": 0.6047984126838856,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (2,-3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p019",
+      "editable": true,
+      "position": {
+        "q": 3,
+        "r": -3
+      },
+      "total_population": 3974,
+      "demographic_groups": [
+        {
+          "id": "p019-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3635302943922579,
+            "ryu": 0.6364697056077421
+          },
+          "turnout_rate": 0.655289015523158,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (3,-3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p020",
+      "editable": true,
+      "position": {
+        "q": 4,
+        "r": -3
+      },
+      "total_population": 3924,
+      "demographic_groups": [
+        {
+          "id": "p020-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3414927239902318,
+            "ryu": 0.6585072760097682
+          },
+          "turnout_rate": 0.6294742984347976,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (4,-3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p021",
+      "editable": true,
+      "position": {
+        "q": 5,
+        "r": -3
+      },
+      "total_population": 3877,
+      "demographic_groups": [
+        {
+          "id": "p021-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.34660360815003516,
+            "ryu": 0.6533963918499648
+          },
+          "turnout_rate": 0.5785146059468389,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (5,-3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p022",
+      "editable": true,
+      "position": {
+        "q": -3,
+        "r": -2
+      },
+      "total_population": 3984,
+      "demographic_groups": [
+        {
+          "id": "p022-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6131439528986812,
+            "ryu": 0.3868560471013188
+          },
+          "turnout_rate": 0.5677370664547198,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-3,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p023",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": -2
+      },
+      "total_population": 3966,
+      "demographic_groups": [
+        {
+          "id": "p023-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5937408154271543,
+            "ryu": 0.4062591845728457
+          },
+          "turnout_rate": 0.5893320111674257,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p024",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": -2
+      },
+      "total_population": 3975,
+      "demographic_groups": [
+        {
+          "id": "p024-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6538933295756578,
+            "ryu": 0.3461066704243422
+          },
+          "turnout_rate": 0.567436545714736,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p025",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": -2
+      },
+      "total_population": 3969,
+      "demographic_groups": [
+        {
+          "id": "p025-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.47355576261878013,
+            "ryu": 0.5264442373812199
+          },
+          "turnout_rate": 0.6638549737283028,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p026",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": -2
+      },
+      "total_population": 3958,
+      "demographic_groups": [
+        {
+          "id": "p026-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.35280013643205166,
+            "ryu": 0.6471998635679483
+          },
+          "turnout_rate": 0.5659126444370486,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (1,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p027",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": -2
+      },
+      "total_population": 3889,
+      "demographic_groups": [
+        {
+          "id": "p027-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3610617722198367,
+            "ryu": 0.6389382277801633
+          },
+          "turnout_rate": 0.6850401484989561,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (2,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p028",
+      "editable": true,
+      "position": {
+        "q": 3,
+        "r": -2
+      },
+      "total_population": 3889,
+      "demographic_groups": [
+        {
+          "id": "p028-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.4196551660820842,
+            "ryu": 0.5803448339179158
+          },
+          "turnout_rate": 0.6649249858339317,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (3,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p029",
+      "editable": true,
+      "position": {
+        "q": 4,
+        "r": -2
+      },
+      "total_population": 3890,
+      "demographic_groups": [
+        {
+          "id": "p029-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.35032881528139115,
+            "ryu": 0.6496711847186089
+          },
+          "turnout_rate": 0.6065305817988701,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (4,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p030",
+      "editable": true,
+      "position": {
+        "q": 5,
+        "r": -2
+      },
+      "total_population": 3830,
+      "demographic_groups": [
+        {
+          "id": "p030-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.34373225264251234,
+            "ryu": 0.6562677473574876
+          },
+          "turnout_rate": 0.6667913675890303,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (5,-2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p031",
+      "editable": true,
+      "position": {
+        "q": -4,
+        "r": -1
+      },
+      "total_population": 3956,
+      "demographic_groups": [
+        {
+          "id": "p031-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5919478052668273,
+            "ryu": 0.40805219473317267
+          },
+          "turnout_rate": 0.5864907047245652,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-4,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p032",
+      "editable": true,
+      "position": {
+        "q": -3,
+        "r": -1
+      },
+      "total_population": 3971,
+      "demographic_groups": [
+        {
+          "id": "p032-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5911093566194177,
+            "ryu": 0.40889064338058234
+          },
+          "turnout_rate": 0.6544001593952998,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-3,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p033",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": -1
+      },
+      "total_population": 3955,
+      "demographic_groups": [
+        {
+          "id": "p033-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6465382524579764,
+            "ryu": 0.35346174754202364
+          },
+          "turnout_rate": 0.695134210458491,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p034",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": -1
+      },
+      "total_population": 3910,
+      "demographic_groups": [
+        {
+          "id": "p034-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.609579965993762,
+            "ryu": 0.39042003400623804
+          },
+          "turnout_rate": 0.6106117340852506,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p035",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": -1
+      },
+      "total_population": 7948,
+      "demographic_groups": [
+        {
+          "id": "p035-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5157901692017913,
+            "ryu": 0.4842098307982087
+          },
+          "turnout_rate": 0.6856598873157054,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p036",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": -1
+      },
+      "total_population": 7919,
+      "demographic_groups": [
+        {
+          "id": "p036-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.39141374381259086,
+            "ryu": 0.6085862561874091
+          },
+          "turnout_rate": 0.655257795273792,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (1,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p037",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": -1
+      },
+      "total_population": 3940,
+      "demographic_groups": [
+        {
+          "id": "p037-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.39735424760729077,
+            "ryu": 0.6026457523927092
+          },
+          "turnout_rate": 0.6884932839660904,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (2,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p038",
+      "editable": true,
+      "position": {
+        "q": 3,
+        "r": -1
+      },
+      "total_population": 3842,
+      "demographic_groups": [
+        {
+          "id": "p038-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3829515208862722,
+            "ryu": 0.6170484791137278
+          },
+          "turnout_rate": 0.6663616319186986,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (3,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p039",
+      "editable": true,
+      "position": {
+        "q": 4,
+        "r": -1
+      },
+      "total_population": 3895,
+      "demographic_groups": [
+        {
+          "id": "p039-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3826728771068156,
+            "ryu": 0.6173271228931845
+          },
+          "turnout_rate": 0.6770163409761153,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (4,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p040",
+      "editable": true,
+      "position": {
+        "q": 5,
+        "r": -1
+      },
+      "total_population": 3883,
+      "demographic_groups": [
+        {
+          "id": "p040-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3616636220924556,
+            "ryu": 0.6383363779075444
+          },
+          "turnout_rate": 0.6470001933164895,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (5,-1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p041",
+      "editable": true,
+      "position": {
+        "q": -5,
+        "r": 0
+      },
+      "total_population": 3800,
+      "demographic_groups": [
+        {
+          "id": "p041-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5966621379368007,
+            "ryu": 0.4033378620631993
+          },
+          "turnout_rate": 0.5962858368991875,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-5,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p042",
+      "editable": true,
+      "position": {
+        "q": -4,
+        "r": 0
+      },
+      "total_population": 3893,
+      "demographic_groups": [
+        {
+          "id": "p042-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6300391770154238,
+            "ryu": 0.3699608229845762
+          },
+          "turnout_rate": 0.6105476806638762,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-4,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p043",
+      "editable": true,
+      "position": {
+        "q": -3,
+        "r": 0
+      },
+      "total_population": 3971,
+      "demographic_groups": [
+        {
+          "id": "p043-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.588989099599421,
+            "ryu": 0.41101090040057897
+          },
+          "turnout_rate": 0.5608681831741706,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-3,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p044",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": 0
+      },
+      "total_population": 4016,
+      "demographic_groups": [
+        {
+          "id": "p044-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6419899162836373,
+            "ryu": 0.35801008371636267
+          },
+          "turnout_rate": 0.5677682623965666,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p045",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": 0
+      },
+      "total_population": 7979,
+      "demographic_groups": [
+        {
+          "id": "p045-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6541187385097146,
+            "ryu": 0.3458812614902854
+          },
+          "turnout_rate": 0.668286394921597,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p046",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": 0
+      },
+      "total_population": 7943,
+      "demographic_groups": [
+        {
+          "id": "p046-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.4887368250451982,
+            "ryu": 0.5112631749548018
+          },
+          "turnout_rate": 0.6866344809881411,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p047",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": 0
+      },
+      "total_population": 7911,
+      "demographic_groups": [
+        {
+          "id": "p047-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.41224357556551694,
+            "ryu": 0.5877564244344831
+          },
+          "turnout_rate": 0.5720664052525536,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (1,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p048",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": 0
+      },
+      "total_population": 3925,
+      "demographic_groups": [
+        {
+          "id": "p048-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3678169579803944,
+            "ryu": 0.6321830420196056
+          },
+          "turnout_rate": 0.5703441788209602,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (2,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p049",
+      "editable": true,
+      "position": {
+        "q": 3,
+        "r": 0
+      },
+      "total_population": 3922,
+      "demographic_groups": [
+        {
+          "id": "p049-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3795511104166508,
+            "ryu": 0.6204488895833492
+          },
+          "turnout_rate": 0.599921706551686,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (3,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p050",
+      "editable": true,
+      "position": {
+        "q": 4,
+        "r": 0
+      },
+      "total_population": 3920,
+      "demographic_groups": [
+        {
+          "id": "p050-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.36999663660302756,
+            "ryu": 0.6300033633969724
+          },
+          "turnout_rate": 0.576135411427822,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (4,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p051",
+      "editable": true,
+      "position": {
+        "q": 5,
+        "r": 0
+      },
+      "total_population": 3940,
+      "demographic_groups": [
+        {
+          "id": "p051-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.39009894978255033,
+            "ryu": 0.6099010502174497
+          },
+          "turnout_rate": 0.6634701381321065,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (5,0)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p052",
+      "editable": true,
+      "position": {
+        "q": -5,
+        "r": 1
+      },
+      "total_population": 3806,
+      "demographic_groups": [
+        {
+          "id": "p052-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6058279548771679,
+            "ryu": 0.3941720451228321
+          },
+          "turnout_rate": 0.6764405668829567,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-5,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p053",
+      "editable": true,
+      "position": {
+        "q": -4,
+        "r": 1
+      },
+      "total_population": 3893,
+      "demographic_groups": [
+        {
+          "id": "p053-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6567664765007794,
+            "ryu": 0.34323352349922065
+          },
+          "turnout_rate": 0.6361133496160619,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-4,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p054",
+      "editable": true,
+      "position": {
+        "q": -3,
+        "r": 1
+      },
+      "total_population": 4002,
+      "demographic_groups": [
+        {
+          "id": "p054-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5831201609224081,
+            "ryu": 0.41687983907759185
+          },
+          "turnout_rate": 0.5640367951476947,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-3,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p055",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": 1
+      },
+      "total_population": 4084,
+      "demographic_groups": [
+        {
+          "id": "p055-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.620507898926735,
+            "ryu": 0.37949210107326503
+          },
+          "turnout_rate": 0.5803345354739576,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p056",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": 1
+      },
+      "total_population": 8054,
+      "demographic_groups": [
+        {
+          "id": "p056-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6473834357596934,
+            "ryu": 0.35261656424030663
+          },
+          "turnout_rate": 0.6370124400476925,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p057",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": 1
+      },
+      "total_population": 9233,
+      "demographic_groups": [
+        {
+          "id": "p057-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5292632918059826,
+            "ryu": 0.47073670819401736
+          },
+          "turnout_rate": 0.6629315311438404,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p058",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": 1
+      },
+      "total_population": 3903,
+      "demographic_groups": [
+        {
+          "id": "p058-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.41040687944740056,
+            "ryu": 0.5895931205525995
+          },
+          "turnout_rate": 0.681887343188282,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (1,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p059",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": 1
+      },
+      "total_population": 3922,
+      "demographic_groups": [
+        {
+          "id": "p059-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.34263891391456125,
+            "ryu": 0.6573610860854388
+          },
+          "turnout_rate": 0.6813205494312569,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (2,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p060",
+      "editable": true,
+      "position": {
+        "q": 3,
+        "r": 1
+      },
+      "total_population": 4000,
+      "demographic_groups": [
+        {
+          "id": "p060-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.39963071499019864,
+            "ryu": 0.6003692850098014
+          },
+          "turnout_rate": 0.5596533415257,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (3,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p061",
+      "editable": true,
+      "position": {
+        "q": 4,
+        "r": 1
+      },
+      "total_population": 4030,
+      "demographic_groups": [
+        {
+          "id": "p061-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3493368224240839,
+            "ryu": 0.6506631775759161
+          },
+          "turnout_rate": 0.5542654703021981,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (4,1)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p062",
+      "editable": true,
+      "position": {
+        "q": -5,
+        "r": 2
+      },
+      "total_population": 3867,
+      "demographic_groups": [
+        {
+          "id": "p062-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6447375842370093,
+            "ryu": 0.35526241576299067
+          },
+          "turnout_rate": 0.5725578236626462,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-5,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p063",
+      "editable": true,
+      "position": {
+        "q": -4,
+        "r": 2
+      },
+      "total_population": 4008,
+      "demographic_groups": [
+        {
+          "id": "p063-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6071773752011359,
+            "ryu": 0.3928226247988641
+          },
+          "turnout_rate": 0.5724428012152203,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-4,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p064",
+      "editable": true,
+      "position": {
+        "q": -3,
+        "r": 2
+      },
+      "total_population": 4127,
+      "demographic_groups": [
+        {
+          "id": "p064-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6103541999310255,
+            "ryu": 0.38964580006897453
+          },
+          "turnout_rate": 0.564119803684298,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-3,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p065",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": 2
+      },
+      "total_population": 4206,
+      "demographic_groups": [
+        {
+          "id": "p065-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6207892028056086,
+            "ryu": 0.37921079719439144
+          },
+          "turnout_rate": 0.6981394277769141,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p066",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": 2
+      },
+      "total_population": 4088,
+      "demographic_groups": [
+        {
+          "id": "p066-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.65795061647892,
+            "ryu": 0.34204938352108005
+          },
+          "turnout_rate": 0.6894861912936903,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p067",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": 2
+      },
+      "total_population": 5207,
+      "demographic_groups": [
+        {
+          "id": "p067-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5081325291655958,
+            "ryu": 0.4918674708344042
+          },
+          "turnout_rate": 0.674560887098778,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p068",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": 2
+      },
+      "total_population": 3975,
+      "demographic_groups": [
+        {
+          "id": "p068-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3408830546401441,
+            "ryu": 0.6591169453598559
+          },
+          "turnout_rate": 0.583707288315054,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (1,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p069",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": 2
+      },
+      "total_population": 4061,
+      "demographic_groups": [
+        {
+          "id": "p069-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.39443809710443023,
+            "ryu": 0.6055619028955698
+          },
+          "turnout_rate": 0.6672221300425007,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (2,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p070",
+      "editable": true,
+      "position": {
+        "q": 3,
+        "r": 2
+      },
+      "total_population": 4105,
+      "demographic_groups": [
+        {
+          "id": "p070-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3502964898571372,
+            "ryu": 0.6497035101428628
+          },
+          "turnout_rate": 0.6283688672352582,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (3,2)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p071",
+      "editable": true,
+      "position": {
+        "q": -5,
+        "r": 3
+      },
+      "total_population": 3940,
+      "demographic_groups": [
+        {
+          "id": "p071-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6299490517191588,
+            "ryu": 0.3700509482808412
+          },
+          "turnout_rate": 0.6639209776883944,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-5,3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p072",
+      "editable": true,
+      "position": {
+        "q": -4,
+        "r": 3
+      },
+      "total_population": 4027,
+      "demographic_groups": [
+        {
+          "id": "p072-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5933459560573101,
+            "ryu": 0.4066540439426899
+          },
+          "turnout_rate": 0.6732579563977197,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-4,3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p073",
+      "editable": true,
+      "position": {
+        "q": -3,
+        "r": 3
+      },
+      "total_population": 4105,
+      "demographic_groups": [
+        {
+          "id": "p073-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6401964820362628,
+            "ryu": 0.3598035179637372
+          },
+          "turnout_rate": 0.613562690874096,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-3,3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p074",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": 3
+      },
+      "total_population": 4085,
+      "demographic_groups": [
+        {
+          "id": "p074-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6588964271731674,
+            "ryu": 0.34110357282683257
+          },
+          "turnout_rate": 0.6288765277131461,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p075",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": 3
+      },
+      "total_population": 4086,
+      "demographic_groups": [
+        {
+          "id": "p075-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5910792603716254,
+            "ryu": 0.4089207396283746
+          },
+          "turnout_rate": 0.6500821900554001,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (-1,3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p076",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": 3
+      },
+      "total_population": 5217,
+      "demographic_groups": [
+        {
+          "id": "p076-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5218706489168108,
+            "ryu": 0.4781293510831892
+          },
+          "turnout_rate": 0.5953937924001366,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (0,3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p077",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": 3
+      },
+      "total_population": 4023,
+      "demographic_groups": [
+        {
+          "id": "p077-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.40648061826825144,
+            "ryu": 0.5935193817317486
+          },
+          "turnout_rate": 0.6023427072796039,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (1,3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p078",
+      "editable": true,
+      "position": {
+        "q": 2,
+        "r": 3
+      },
+      "total_population": 4071,
+      "demographic_groups": [
+        {
+          "id": "p078-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.3858691895380616,
+            "ryu": 0.6141308104619384
+          },
+          "turnout_rate": 0.5934965519001708,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (2,3)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p079",
+      "editable": true,
+      "position": {
+        "q": -5,
+        "r": 4
+      },
+      "total_population": 3980,
+      "demographic_groups": [
+        {
+          "id": "p079-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6392676852457225,
+            "ryu": 0.36073231475427747
+          },
+          "turnout_rate": 0.6934287487063556,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-5,4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p080",
+      "editable": true,
+      "position": {
+        "q": -4,
+        "r": 4
+      },
+      "total_population": 3991,
+      "demographic_groups": [
+        {
+          "id": "p080-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5945819167792797,
+            "ryu": 0.40541808322072026
+          },
+          "turnout_rate": 0.6639942443580367,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-4,4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p081",
+      "editable": true,
+      "position": {
+        "q": -3,
+        "r": 4
+      },
+      "total_population": 4017,
+      "demographic_groups": [
+        {
+          "id": "p081-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6378003415837884,
+            "ryu": 0.3621996584162116
+          },
+          "turnout_rate": 0.6736637991736643,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-3,4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p082",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": 4
+      },
+      "total_population": 4013,
+      "demographic_groups": [
+        {
+          "id": "p082-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6293722384050489,
+            "ryu": 0.37062776159495114
+          },
+          "turnout_rate": 0.5678121372242458,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (-2,4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p083",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": 4
+      },
+      "total_population": 4074,
+      "demographic_groups": [
+        {
+          "id": "p083-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5907081260718405,
+            "ryu": 0.40929187392815947
+          },
+          "turnout_rate": 0.6527216300251893,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (-1,4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p084",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": 4
+      },
+      "total_population": 5211,
+      "demographic_groups": [
+        {
+          "id": "p084-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5122939895279706,
+            "ryu": 0.48770601047202944
+          },
+          "turnout_rate": 0.5690018963767216,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (0,4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p085",
+      "editable": true,
+      "position": {
+        "q": 1,
+        "r": 4
+      },
+      "total_population": 3970,
+      "demographic_groups": [
+        {
+          "id": "p085-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.39785484347492456,
+            "ryu": 0.6021451565250755
+          },
+          "turnout_rate": 0.5545408094651066,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (1,4)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p086",
+      "editable": true,
+      "position": {
+        "q": -5,
+        "r": 5
+      },
+      "total_population": 3965,
+      "demographic_groups": [
+        {
+          "id": "p086-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6493291041627526,
+            "ryu": 0.3506708958372474
+          },
+          "turnout_rate": 0.6804829530417918,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-5,5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p087",
+      "editable": true,
+      "position": {
+        "q": -4,
+        "r": 5
+      },
+      "total_population": 3918,
+      "demographic_groups": [
+        {
+          "id": "p087-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6256893667764962,
+            "ryu": 0.3743106332235038
+          },
+          "turnout_rate": 0.5953932692296803,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-4,5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p088",
+      "editable": true,
+      "position": {
+        "q": -3,
+        "r": 5
+      },
+      "total_population": 3980,
+      "demographic_groups": [
+        {
+          "id": "p088-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5920063030533492,
+            "ryu": 0.4079936969466508
+          },
+          "turnout_rate": 0.666910684958566,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (-3,5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p089",
+      "editable": true,
+      "position": {
+        "q": -2,
+        "r": 5
+      },
+      "total_population": 4032,
+      "demographic_groups": [
+        {
+          "id": "p089-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6519125463813543,
+            "ryu": 0.3480874536186457
+          },
+          "turnout_rate": 0.6914643195341341,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (-2,5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p090",
+      "editable": true,
+      "position": {
+        "q": -1,
+        "r": 5
+      },
+      "total_population": 4072,
+      "demographic_groups": [
+        {
+          "id": "p090-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.6279194189421833,
+            "ryu": 0.3720805810578167
+          },
+          "turnout_rate": 0.5874609076417983,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (-1,5)",
+      "initial_district_id": "d1"
+    },
+    {
+      "id": "p091",
+      "editable": true,
+      "position": {
+        "q": 0,
+        "r": 5
+      },
+      "total_population": 3949,
+      "demographic_groups": [
+        {
+          "id": "p091-all",
+          "population_share": 1,
+          "vote_shares": {
+            "ken": 0.5002344448678195,
+            "ryu": 0.49976555513218046
+          },
+          "turnout_rate": 0.5741614397382364,
+          "name": "All voters"
+        }
+      ],
+      "county_id": "hawthorn_south",
+      "county_name": "Hawthorn South",
+      "name": "South (0,5)",
+      "initial_district_id": "d1"
+    }
   ],
-  "river_blocks_contiguity": false,
   "events": [],
   "rules": {
-    "population_tolerance": 0.10,
-    "contiguity": "required"
+    "population_tolerance": 0.15,
+    "contiguity": "allowed"
   },
   "success_criteria": [
     {
       "id": "sc-district-count",
       "required": true,
-      "description": "All four districts are in use and every precinct is assigned.",
-      "criterion": { "type": "district_count" }
-    },
-    {
-      "id": "sc-population-balance",
-      "required": true,
-      "description": "All four districts have roughly equal population (within 10%).",
-      "criterion": { "type": "population_balance" }
+      "description": "All three districts are in use and every precinct is assigned.",
+      "criterion": {
+        "type": "district_count"
+      }
     }
   ],
   "narrative": {
     "character": {
-      "name": "Tutorial Guide",
-      "role": "Tour Guide",
-      "motivation": "Welcome to Hawthorn Bend. This map shows every kind of terrain feature that you will see in the game."
+      "name": "You",
+      "role": "Mapmaker, Hawthorn Bend",
+      "motivation": "You can draw a legal map. Now for the part that makes redistricting matter: the voters aren't all the same, and where you draw the lines decides who wins. Let's learn to read the vote.\n"
     },
     "intro_slides": [
       {
-        "heading": "Reading the Map",
-        "body": "Maps can include geographic features alongside the precincts you draw districts from.\n\n- **Mountains** (grey tiles, northwest) — not assignable. Adjacent precincts are foothills with a soft grey fringe.\n- **Sea** (dark blue tiles, south) — not assignable. Adjacent precincts are coast with a blue shoreline.\n- **Lake** (aqua tile, centre) — not assignable. Adjacent precincts show a teal lakeside fringe.\n- **River** (teal line) — flows from the mountain area, through the lake, and down to the sea."
+        "body": "Hawthorn Bend has a river running through it — scenery only; your districts can cross it freely. What's new is underneath: the people. The west of the Bend leans one way, the east the other, and the centre is a tossup.\n",
+        "heading": "A New Kind of Map"
       },
       {
-        "heading": "Geography is Cosmetic",
-        "body": "These features are visual: they show what the region looks like, but **they do not constrain district-drawing**.\n\nReal redistricting often uses rivers and mountains as district boundaries — but that is because of political choices (state lines, county lines, historical municipal limits) that happen to follow geography, not because geography is a physical barrier. A district can cross a river or lake if the people on both sides share a community.\n\nThe initial map divides the region into four sectors. It is already a valid plan."
-      },
-      {
-        "heading": "Try It Out",
-        "body": "Click **Submit Map** to evaluate the starting districts. You can also repaint districts to experiment — drag across hexes to assign them, click district buttons to switch which district you are drawing.\n\nWhen you are done exploring, move on to the educational campaign."
+        "body": "Two new things will appear as we go. The **Lean** view colours each precinct by who its voters favour. And the **election result** shows who wins each district you draw. They go together: lean tells you the ground, the result tells you the outcome — and the lines you draw decide it.\n",
+        "heading": "Lean, and the Result"
       }
     ],
-    "objective": "Look around the map at the terrain features. Submit the initial four-district map, or repaint to experiment."
-  }
+    "objective": "Draw three districts and read the result. There's no target to hit — repaint the lines and watch who wins change, then submit when you've had a look.\n",
+    "epilogue": "That's the whole picture: precincts lean, and the district lines you draw turn those leanings into seats. The same voters can hand one party a majority of seats or the other — nothing changed but the lines.\nYou've drawn a legal map and learned to read the vote. From here the campaign scenarios put it to work: real maps, real goals, and a reason to draw the lines the way you do.\n"
+  },
+  "default_district_id": "d1",
+  "river_edges": [
+    [
+      "p057",
+      "p067"
+    ],
+    [
+      "p067",
+      "p076"
+    ],
+    [
+      "p076",
+      "p084"
+    ]
+  ],
+  "hide_election_results": false,
+  "hide_view_toolbar": false,
+  "guided": true
 }

--- a/game/scenarios/tutorial-003.spec.yaml
+++ b/game/scenarios/tutorial-003.spec.yaml
@@ -1,0 +1,179 @@
+# Spec file for tutorial-003: "Hawthorn Bend: Reading the Vote"
+# Source of truth for the map generation pipeline (GAME-098).
+# Generated output: game/scenarios/tutorial-003.json
+#
+# Regenerate:  bazel run //game/web/src/pipeline:generate_scenario -- \
+#                game/scenarios/tutorial-003.spec.yaml game/scenarios/tutorial-003.json
+#
+# PEDAGOGY (see plan thoughts/shared/plans/2026-06-24-tutorial-redesign-pipeline-migration.md
+# and DESIGN-012 / GAME-098):
+#   Tutorial 3 is the FIRST ELECTORAL LAYER. It unveils the election-result panel TOGETHER
+#   with the Lean view (lean = who each precinct favors; the result = who wins each district —
+#   a causal pair), then the county view. The result is shown to *read* ("repaint and watch it
+#   move"), NOT to exploit — strategy is the capstone + the real scenarios. So the objective
+#   stays MECHANICAL (gates on district_count only): nothing can fail the player for a rule this
+#   tutorial doesn't teach.
+#
+#   New since T2: a little geography (a river — cosmetic scenery, districts may cross it), a
+#   partisan east/west LEAN, and counties. The guided overlay REVEALS the result
+#   panel + Lean view in one step, then the County view.
+#
+#   JUDGMENT CALLS (flagged for review — iterate freely):
+#     - 3 districts; gates district_count only (no balance/contiguity gate — T2 taught those;
+#       T3 is about reading the result). rules.contiguity: allowed to keep winnability simple
+#       and terrain-proof.
+#     - The CITY view step is descoped from this draft: it needs the city-limits overlay
+#       (GAME-096), which isn't built yet. The map already carries an urban core so the city
+#       reveal can be added later without a map change. The overlay reveals lean+result, then
+#       county; the city step lands with GAME-096.
+#     - Terrain (coast + river) is a cosmetic draft for your visual pass.
+
+format_version: "1"
+
+# ── Scenario identity ─────────────────────────────────────────────────────────
+
+scenario:
+  id: tutorial-003
+  title: "Hawthorn Bend: Reading the Vote"
+  election_type: state_house
+  region:
+    id: hawthorn_bend
+    name: Hawthorn Bend
+
+# ── Stage 1a: Map layout ──────────────────────────────────────────────────────
+#
+# A step up again from T2's radius-4 (61). radius 5 = 91 precincts (no tiles carved out;
+# the planned coastline is deferred — see the terrain draft note below).
+
+map:
+  geometry: hex_axial
+  shape: hex_circle
+  radius: 5
+
+# ── Stage 1b: Terrain (COSMETIC scenery) ──────────────────────────────────────
+#
+# A short river running down the centre of the Bend. Geography is cosmetic — districts
+# may cross it freely.
+#
+# DRAFT NOTE: a coastline was planned too, but sea tiles must sit OUTSIDE the precinct
+# circle (the generator rejects tiles that overlap a precinct), so the coast needs
+# hand-placed outer-ring tiles best done during the visual pass. Deferred; the river
+# alone carries "some geography" for now. (Slide copy below matches: river only.)
+
+terrain:
+  river_edges:
+    - [ { q: 0, r: 1 }, { q: 0, r: 2 } ]
+    - [ { q: 0, r: 2 }, { q: 0, r: 3 } ]
+    - [ { q: 0, r: 3 }, { q: 0, r: 4 } ]
+
+# ── Stage 2: Population ───────────────────────────────────────────────────────
+#
+# A central city (Hawthorn) on a rural base — gives the county stage a dense seat to
+# form a county around (and an urban core for the future City view), without making
+# balance a factor (T3 doesn't gate on balance).
+
+population:
+  seed: 13
+  base: 4000
+  variance: 300
+  smoothing: 1
+  settlements:
+    - label: Hawthorn (city)
+      anchor: center
+      peak: 4000
+      radius: 2
+      profile: plateau
+
+# ── Stage 3: Demographics (PARTISAN — an east/west split) ─────────────────────
+#
+# The whole point of T3: voters are not uniform. The west of the Bend leans Ken, the
+# east leans Ryu, the centre is a tossup. This is what the Lean view colours and what
+# the election result reads — and it's why where you draw the lines changes who wins.
+
+demographics:
+  seed: 13
+  parties: [ken, ryu]
+  group:
+    id_suffix: all
+    name: All voters
+  turnout:
+    min: 0.55
+    max: 0.70
+  jitter: 0.04
+  zones:
+    - name: west
+      filter: { q_lte: -1 }
+      party_base: { ken: 0.62 }
+    - name: east
+      filter: { q_gte: 1 }
+      party_base: { ken: 0.38 }
+    - name: center
+      filter: { default: true }
+      party_base: { ken: 0.50 }
+
+# ── Stage 3b: Counties ────────────────────────────────────────────────────────
+#
+# A county seat (the city) plus its rural hinterland — gives the County view real
+# administrative lines to show. Cosmetic only (county_id drives the dashed border).
+
+counties:
+  model: seat_and_hinterland
+  target_count: 2
+  id_prefix: hawthorn
+
+# ── Stage 4: Assembly ─────────────────────────────────────────────────────────
+
+assembly:
+  parties:
+    - { id: ken, name: Ken Party, abbreviation: KEN }
+    - { id: ryu, name: Ryu Party, abbreviation: RYU }
+  districts:
+    - { id: d1, name: District 1 }
+    - { id: d2, name: District 2 }
+    - { id: d3, name: District 3 }
+  default_district_id: d1
+  # No initial_district_rule → opens as one district; the player carves three and watches
+  # the result update as the lines move.
+  guided: true                       # runs the guided overlay (GAME-076 / DESIGN-012, T3 script)
+  hide_election_results: false       # ELECTORAL: the result panel exists; the overlay reveals it
+  hide_view_toolbar: false           # the view toolbar exists; the overlay reveals lean + county
+  rules:
+    population_tolerance: 0.15        # unused (no balance criterion) — a sane default
+    contiguity: allowed              # not gated here — T3 is about reading the vote, not rules
+  success_criteria:
+    # Mechanical objective: three districts in use, every precinct assigned. The result is
+    # shown to read, not to win-by — so nothing here gates on the electoral outcome.
+    - id: sc-district-count
+      required: true
+      description: All three districts are in use and every precinct is assigned.
+      criterion: { type: district_count }
+  narrative:
+    character:
+      name: You
+      role: Mapmaker, Hawthorn Bend
+      motivation: >
+        You can draw a legal map. Now for the part that makes redistricting matter: the
+        voters aren't all the same, and where you draw the lines decides who wins. Let's
+        learn to read the vote.
+    intro_slides:
+      - heading: A New Kind of Map
+        body: >
+          Hawthorn Bend has a river running through it — scenery only; your districts can
+          cross it freely. What's new is underneath: the people. The west of the Bend leans
+          one way, the east the other, and the centre is a tossup.
+      - heading: Lean, and the Result
+        body: >
+          Two new things will appear as we go. The **Lean** view colours each precinct by
+          who its voters favour. And the **election result** shows who wins each district
+          you draw. They go together: lean tells you the ground, the result tells you the
+          outcome — and the lines you draw decide it.
+    objective: >
+      Draw three districts and read the result. There's no target to hit — repaint the lines
+      and watch who wins change, then submit when you've had a look.
+    epilogue: >
+      That's the whole picture: precincts lean, and the district lines you draw turn those
+      leanings into seats. The same voters can hand one party a majority of seats or the
+      other — nothing changed but the lines.
+
+      You've drawn a legal map and learned to read the vote. From here the campaign scenarios
+      put it to work: real maps, real goals, and a reason to draw the lines the way you do.

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -89,7 +89,7 @@ async function paintHexes(
   }, { hexes, district });
 }
 
-// GAME-076/077: tutorial-001 and tutorial-002 run a guided overlay (scenario.guided).
+// GAME-076/077/098: tutorial-001, -002, and -003 run a guided overlay (scenario.guided).
 // Suppress it by default so the existing tutorial tests aren't intercepted by the coach
 // panel / input-pause. The overlay-specific tests below force it with `?resetTutorial=1`,
 // which clears these flags on load. (Harmless for non-guided scenarios — the flags are ignored.)
@@ -98,6 +98,7 @@ test.beforeEach(async ({ page }) => {
     try {
       localStorage.setItem("tutorial-tutorial-001-complete", "1");
       localStorage.setItem("tutorial-tutorial-002-complete", "1");
+      localStorage.setItem("tutorial-tutorial-003-complete", "1");
     } catch { /* ignore */ }
   });
 });
@@ -882,14 +883,33 @@ test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", 
   await page.evaluate((ids) => {
     localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ids }));
   }, allButLast);
-  // Load tutorial-003. Its initial 4-quadrant assignment is already contiguous + balanced,
-  // so no paintStroke is needed — submit passes on the starting map.
+  // tutorial-003 ("Reading the Vote") opens as one district; carve three (by q-band) so the
+  // district_count objective passes — it gates on nothing else.
   await loadScenario(page, "tutorial-003");
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], d: number) => void;
+      precincts: { coord: { q: number; r: number } }[];
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found");
+    const state = store.getState();
+    const d2: number[] = [];
+    const d3: number[] = [];
+    state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
+      if (p.coord.q >= 2) d3.push(i);          // east → District 3
+      else if (p.coord.q >= -1) d2.push(i);    // centre → District 2
+      // q <= -2 (west) stays District 1
+    });
+    state.paintStroke(d2, 2);
+    state.paintStroke(d3, 3);
+  });
   await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
   await page.locator("#btn-submit").click();
   await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
-  // Click "Next Scenario" — should show wrap-up, not select screen
-  await page.locator("#btn-next-scenario").click();
+  // tutorial-003 has a teaching epilogue → the pass screen routes through "Continue →" to the
+  // debrief panel; its advance button (last scenario) leads to the wrap-up screen.
+  await page.locator("#btn-continue").click();
+  await page.locator("#btn-debrief-next").click();
   await expect(page.locator("#wrap-up-screen")).toBeVisible({ timeout: 5_000 });
   await expect(page.locator("#wrap-up-screen")).toContainText("Congratulations");
   // Select screen should NOT be visible
@@ -1095,7 +1115,7 @@ test("campaign select: ?campaign=tutorial shows tutorial-001, tutorial-002, and 
   await page.goto("/?campaign=tutorial");
   await expect(page.locator("#scenario-select")).toBeVisible({ timeout: 10_000 });
   const cards = page.locator(".scenario-card");
-  // GAME-082: tutorial-003 (geographic-features tour) is the third tutorial scenario.
+  // tutorial-003 ("Reading the Vote") is the third tutorial scenario; "Hawthorn Bend" is its region.
   await expect(cards).toHaveCount(3);
   await expect(cards.nth(0)).toContainText("Welcome to Redistricting");
   await expect(cards.nth(1)).toContainText("A Legal Map");
@@ -1275,85 +1295,111 @@ test.describe("GAME-068: animated reveal path (no reduced-motion)", () => {
   });
 });
 
-// ─── tutorial-003: "Hawthorn Bend — A Tour of the Map" (GAME-082 geo features tour) ───
+// ─── tutorial-003: "Hawthorn Bend: Reading the Vote" (GAME-098 — first electoral layer) ───
+// Redesigned from the old terrain tour: a 91-precinct map with an east/west partisan lean,
+// a cosmetic river, and counties. Guided overlay reveals the election result + Lean view
+// together, then the County view. Gates on district_count only (the result is shown to read).
 
-test("tutorial-003 smoke: loads and renders 119 precincts", async ({ page }) => {
-  await page.goto("/?s=tutorial-003&debug");
-  // 127 R=6 circle hexes minus 3 mountain tiles minus 4 sea tiles (now at r=6) minus 1 lake tile = 119.
-  await expect(page.locator("path.hex")).toHaveCount(119);
-});
-
-test("tutorial-003 terrain: 8 terrain tiles rendered (3 mountain + 4 sea + 1 lake)", async ({ page }) => {
-  await page.goto("/?s=tutorial-003&debug");
-  // Mountain tiles now at (-3,-3), (-2,-4), (-1,-5) — hexDist=6 boundary positions.
-  await expect(page.locator("g.terrain-tile")).toHaveCount(8);
-  await expect(page.locator("g.terrain-tile[data-terrain-type='mountain']")).toHaveCount(3);
-  await expect(page.locator("g.terrain-tile[data-terrain-type='sea']")).toHaveCount(4);
-  await expect(page.locator("g.terrain-tile[data-terrain-type='lake']")).toHaveCount(1);
-});
-
-test("tutorial-003 terrain: river rendered as two smoothed chains (split at lake tile)", async ({ page }) => {
-  await page.goto("/?s=tutorial-003&debug");
-  // 16 river edges split into two chains by the lake tile at (-1,1):
-  //   chain 1: NW foothill (-1,-4) → (-2,1)  [9 edges]
-  //   chain 2: (-2,2) → (-1,5) [7 edges] — downstream reach to coast area
-  // Smoothing uses d3.curveCardinal.tension(0.4).
-  await expect(page.locator("path.river-chain")).toHaveCount(2);
-  const d = await page.locator("path.river-chain").first().getAttribute("d");
-  expect(d).toBeTruthy();
-  expect(d!.startsWith("M")).toBe(true);
-  // curveCardinal on 3+ points emits cubic bezier (C).
-  expect(d!.includes("C")).toBe(true);
-});
-
-test("tutorial-003 terrain: terrain tiles are non-interactive (pointer-events: none)", async ({ page }) => {
-  await page.goto("/?s=tutorial-003&debug");
-  const pointerEvents = await page.locator("g.terrain-tile").first().evaluate(
-    (el) => getComputedStyle(el).pointerEvents,
-  );
-  expect(pointerEvents).toBe("none");
-});
-
-test("tutorial-003 terrain: coast edge strokes on precincts adjacent to sea", async ({ page }) => {
-  await page.goto("/?s=tutorial-003&debug");
-  // Sea tiles moved to r=6: (-3,6), (-2,6), (-1,6), (0,6). Coast precincts at r=5 / edge of map:
-  //   (-3,6): 3 precinct-facing edges → (-4,6), (-3,5), (-2,5)
-  //   (-2,6): 2 precinct-facing edges → (-2,5), (-1,5)
-  //   (-1,6): 2 precinct-facing edges → (-1,5), (0,5)
-  //   (0,6):  2 precinct-facing edges → (0,5), (1,5)
-  // Total: 3+2+2+2 = 9 sea-facing edges, each rendered as a curved <path> (GAME-082).
-  await expect(page.locator("path.terrain-edge-sea")).toHaveCount(9);
-});
-
-test("tutorial-003 terrain: lake edge strokes on precincts adjacent to lake tile", async ({ page }) => {
-  await page.goto("/?s=tutorial-003&debug");
-  // Lake tile at (-1,1). All 6 neighbours are valid precincts, each with 1 lake-facing edge:
-  //   (0,1), (-1,2), (-2,2), (-2,1), (-1,0), (0,0)
-  // Total: 6 lake-facing edges, each rendered as a curved <path>.
-  await expect(page.locator("path.terrain-edge-lake")).toHaveCount(6);
-});
-
-test("tutorial-003 terrain: foothill edge strokes on precincts adjacent to mountains", async ({ page }) => {
-  await page.goto("/?s=tutorial-003&debug");
-  // Mountain tiles at (-3,-3), (-2,-4), (-1,-5) are NOT precincts (terrain-position exclusion).
-  // Only positions with hexDist ≤ 6 are valid precincts. Foothill precincts are:
-  //   (-2,-3): 2 edges facing (-3,-3) and (-2,-4) [hexDist=5]
-  //   (-3,-2): 1 edge facing (-3,-3)              [hexDist=3]
-  //   (-4,-2): 1 edge facing (-3,-3)              [hexDist=4]
-  //   (-1,-4): 2 edges facing (-2,-4) and (-1,-5) [hexDist=5]
-  //   (0,-5):  1 edge facing (-1,-5)              [hexDist=5]
-  //   (0,-6):  1 edge facing (-1,-5)              [hexDist=6]
-  // Positions (-4,-3), (-3,-4), (-2,-5), (-1,-6) are hexDist=7 — outside the grid.
-  // Total: 2+1+1+2+1+1 = 8 mountain-facing edges, rendered as curved <path> (GAME-082).
-  await expect(page.locator("path.terrain-edge-mountain")).toHaveCount(8);
-});
-
-test("tutorial-003 contiguity: river is cosmetic, initial quadrant districts are contiguous", async ({ page }) => {
+test("tutorial-003 smoke: loads and renders 91 precincts", async ({ page }) => {
   await loadScenario(page, "tutorial-003");
-  // GAME-082: rivers are visual only — `river_blocks_contiguity: false`. The initial 4-quadrant
-  // assignment (3×3 blocks of precincts) is contiguous and population-balanced; no repainting needed.
-  await expect(page.locator("#validity-container")).toBeVisible();
-  const validityText = await page.locator("#validity-container").innerText();
-  expect(validityText).toMatch(/Connected/);
-  expect(validityText).not.toMatch(/Non-contiguous/);
+  await expect(page.locator("path.hex")).toHaveCount(91);
+});
+
+test("tutorial-003 terrain: the cosmetic river is rendered", async ({ page }) => {
+  await loadScenario(page, "tutorial-003");
+  // The river renders as an SVG <path class="river-chain">. It's a thin stroked line, so
+  // toBeVisible() (bounding-box based) is unreliable for SVG — assert it's attached instead.
+  await expect(page.locator("path.river-chain").first()).toBeAttached();
+});
+
+test("tutorial-003 electoral: the election-result panel is present (pre-electoral hiding is off)", async ({ page }) => {
+  // tutorial-003 sets hide_election_results: false — the first tutorial to surface the vote.
+  // With the guided overlay suppressed (beforeEach), the result panel shows normally.
+  await loadScenario(page, "tutorial-003");
+  await expect(page.locator("#results-container")).toBeVisible();
+});
+
+test("tutorial-003 lean view: switching to Lean recolors the map by partisanship", async ({ page }) => {
+  await loadScenario(page, "tutorial-003");
+  const hex0 = page.locator("path.hex").first();
+  const districtFill = await hex0.getAttribute("fill");
+  await page.locator("#filter-lean").click();
+  await expect(page.locator("#filter-lean")).toHaveAttribute("aria-checked", "true");
+  await expect(hex0).not.toHaveAttribute("fill", districtFill!);
+});
+
+test("tutorial-003 county view: the county overlay toggles on", async ({ page }) => {
+  await loadScenario(page, "tutorial-003");
+  const county = page.locator("#filter-county");
+  await county.click();
+  await expect(county).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator("svg g.county-borders")).toBeAttached();
+});
+
+test("tutorial-003 winnability: carving three districts passes (gates on district_count only)", async ({ page }) => {
+  await loadScenario(page, "tutorial-003");
+  // Mechanical objective: three districts in use, every precinct assigned. Carve three simple
+  // west / centre / east bands — no balance or contiguity gate to satisfy.
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], d: number) => void;
+      precincts: { coord: { q: number; r: number } }[];
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found");
+    const state = store.getState();
+    const d2: number[] = [];
+    const d3: number[] = [];
+    state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
+      if (p.coord.q >= 2) d3.push(i);          // east → District 3
+      else if (p.coord.q >= -1) d2.push(i);    // centre → District 2
+      // q <= -2 (west) stays District 1
+    });
+    state.paintStroke(d2, 2);
+    state.paintStroke(d3, 3);
+  });
+  await expect(page.locator("#btn-submit")).toBeEnabled({ timeout: 3_000 });
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-verdict")).toHaveText("Map Passed!");
+});
+
+// ─── GAME-098: guided overlay (tutorial-003) — first use of the `reveal` action ───
+
+test("guided overlay: tutorial-003 reveals the result + lean, then county, then submits", async ({ page }) => {
+  // resetTutorial=1 clears the suppression flag the beforeEach set, so the overlay runs.
+  await page.goto("/?campaign=tutorial&s=tutorial-003&debug&resetTutorial=1");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("#tutorial-panel")).toBeVisible({ timeout: 10_000 });
+
+  // The reveal targets start hidden — the overlay hides them on load.
+  await expect(page.locator("#results-container")).toBeHidden();
+  await expect(page.locator("#filter-lean")).toBeHidden();
+  await expect(page.locator("#filter-county")).toBeHidden();
+
+  // Step 1 — orient.
+  await expect(page.locator("#tutorial-panel")).toContainText("geography");
+  await page.locator("#tutorial-panel .tutorial-next").click();
+
+  // Step 2 — reveal the Lean view + the election result together.
+  await expect(page.locator("#tutorial-panel")).toContainText("election result");
+  await expect(page.locator("#results-container")).toBeVisible();
+  await expect(page.locator("#filter-lean")).toBeVisible();
+  await page.locator("#tutorial-panel .tutorial-next").click();
+
+  // Step 3 — paint and watch the result move; advance once 5 precincts are in District 2.
+  await expect(page.locator("#tutorial-panel")).toContainText("watch the result");
+  await paintHexes(page, [[-3, 0], [-2, 0], [-1, 0], [0, 0], [1, 0]], 2);
+
+  // Step 4 — reveal the County view (paused; advance on clicking the county toggle).
+  await expect(page.locator("#tutorial-panel")).toContainText("County");
+  await expect(page.locator("#filter-county")).toBeVisible();
+  await page.locator("#filter-county").click();
+
+  // Step 5 — submit (terminal): ends the overlay and shows results.
+  await expect(page.locator("#tutorial-panel")).toContainText("Submit");
+  await page.locator("#btn-submit").click();
+  await expect(page.locator("#tutorial-panel")).toHaveCount(0);
+  await expect(page.locator("#result-screen")).toBeVisible();
 });

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -56,7 +56,7 @@ const SCENARIO_MANIFEST = [
 	{ id: "scenario-007", title: "The Reform Map" },
 	{ id: "scenario-008", title: "Both Sides Unhappy" },
 	{ id: "scenario-009", title: "Cats vs. Dogs" },
-	{ id: "tutorial-003", title: "Hawthorn Bend — A Tour of the Map" },
+	{ id: "tutorial-003", title: "Hawthorn Bend: Reading the Vote" },
 ] as const;
 
 type ManifestEntry = (typeof SCENARIO_MANIFEST)[number];

--- a/game/web/src/model/campaigns_test.ts
+++ b/game/web/src/model/campaigns_test.ts
@@ -67,7 +67,7 @@ test("tutorial campaign scenarioIds are tutorial-001, tutorial-002, tutorial-003
 	assertNotNull(tutorial, "tutorial exists");
 	assertEqual(tutorial!.scenarioIds[0], "tutorial-001", "first scenario");
 	assertEqual(tutorial!.scenarioIds[1], "tutorial-002", "second scenario");
-	assertEqual(tutorial!.scenarioIds[2], "tutorial-003", "third scenario (geographic-features tour)");
+	assertEqual(tutorial!.scenarioIds[2], "tutorial-003", "third scenario (Reading the Vote)");
 });
 
 test("educational campaign has exactly 8 scenario IDs", () => {

--- a/game/web/src/model/loader_integration_test.ts
+++ b/game/web/src/model/loader_integration_test.ts
@@ -43,7 +43,7 @@ function loadJson(filename: string): unknown {
 const SCENARIOS: { file: string; id: string; precincts: number; districts: number }[] = [
   { file: "tutorial-001.json",  id: "tutorial-001",  precincts: 37,  districts: 2 },
   { file: "tutorial-002.json",  id: "tutorial-002",  precincts: 61,  districts: 3 },
-  { file: "tutorial-003.json",  id: "tutorial-003",  precincts: 119, districts: 4 },
+  { file: "tutorial-003.json",  id: "tutorial-003",  precincts: 91,  districts: 3 },
   { file: "scenario-002.json",  id: "scenario-002",  precincts: 91,  districts: 4 },
   { file: "scenario-003.json",  id: "scenario-003",  precincts: 127, districts: 5 },
   { file: "scenario-004.json",  id: "scenario-004",  precincts: 127, districts: 5 },

--- a/game/web/src/tutorial/overlay.ts
+++ b/game/web/src/tutorial/overlay.ts
@@ -102,9 +102,54 @@ const TUTORIAL_002: TutorialStep[] = [
   },
 ];
 
+/**
+ * tutorial-003 — "Reading the Vote" (DESIGN-012 / GAME-098). The first electoral layer:
+ * the engine's `reveal` action is used for the first time here. The election-result panel
+ * and the Lean view are revealed **together** (lean = who voters favor; the result = who
+ * wins — a causal pair), then the County view. The result is shown to *read* (repaint and
+ * watch it move), not to exploit — the objective stays mechanical (district_count).
+ *
+ * Reveal targets (start hidden on load, surfaced as their step fires): `#filter-lean`,
+ * `#results-heading` + `#results-container`, `#filter-county`.
+ *
+ * NOTE: the City view step (DESIGN-012 step 5) is descoped until the city-limits overlay
+ * (GAME-096) ships — there is no `#filter-city` yet. The map already carries an urban core,
+ * so that step can be added later without a map change.
+ */
+const TUTORIAL_003: TutorialStep[] = [
+  {
+    text: "A new map, with some geography — a river runs through the Bend. It's just scenery; your districts can cross it freely.",
+    advance: { on: "next" },
+  },
+  {
+    text: "Until now every voter was the same. They're not. **Lean** colors each precinct by who its voters favor — and this is what that produces: the **election result**, district by district.",
+    reveal: ["#filter-lean", "#results-heading", "#results-container"],
+    highlight: ["#filter-lean", "#results-container"],
+    advance: { on: "next" },
+  },
+  {
+    text: "Repaint a district and watch the result move. The lines you draw decide who wins.",
+    highlight: "#results-container",
+    advance: { on: "paint-count", district: 2, n: 5 },
+  },
+  {
+    text: "**County** borders show the old administrative lines — another way to read the map.",
+    reveal: "#filter-county",
+    highlight: "#filter-county",
+    pauseInput: true,
+    advance: { on: "click-target" },
+  },
+  {
+    text: "That's the whole picture. Draw your three districts and hit **Submit**.",
+    highlight: ["#district-toolbar", "#btn-submit"],
+    advance: { on: "submit" },
+  },
+];
+
 const SCRIPTS: Record<string, TutorialStep[]> = {
   "tutorial-001": TUTORIAL_001,
   "tutorial-002": TUTORIAL_002,
+  "tutorial-003": TUTORIAL_003,
 };
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────

--- a/thoughts/shared/tickets/GAME-098-tutorial-003-reading-the-vote.md
+++ b/thoughts/shared/tickets/GAME-098-tutorial-003-reading-the-vote.md
@@ -33,14 +33,33 @@ Arc + script: see DESIGN-012 (tutorial-003 step script) and
 
 ## Goals / Acceptance Criteria
 
-- [ ] `tutorial-003.spec.yaml` authored (terrain, lean split, counties + urban core);
-      `tutorial-003.json` generated.
-- [ ] `guided: true`; result panel + lean/county/city are `reveal` targets (hidden on load).
-- [ ] Guided script per DESIGN-012: lean + election result revealed in the same step, then
-      county, then city; the result updates live as districts are repainted.
-- [ ] Reuses GAME-076 engine + `reveal` action (no fork).
-- [ ] e2e: result panel + views hidden on load; each revealed as its step fires; result
-      reflects the painted map; winnable by drawing the required districts.
+- [x] `tutorial-003.spec.yaml` authored (river, lean split, counties + urban core);
+      `tutorial-003.json` generated. *(Coast deferred — see Progress.)*
+- [x] `guided: true`; result panel + lean/county are `reveal` targets (hidden on load).
+      *(City: pending GAME-096 — no `#filter-city` exists yet.)*
+- [x] Guided script per DESIGN-012: lean + election result revealed in the same step, then
+      county; the result updates live as districts are repainted. *(City step deferred.)*
+- [x] Reuses GAME-076 engine + `reveal` action (no fork) — first use of `reveal`.
+- [x] e2e: result panel + views hidden on load; each revealed as its step fires; result
+      reflects the painted map; winnable by drawing three districts.
+
+## Progress (2026-06-24) — DRAFT shipped, two deferrals
+
+Shipped as a complete draft: a 91-precinct radius-5 map with an east/west partisan lean
+(west 62% / centre 50% / east 37% Ken), a cosmetic river, two counties, and an urban core.
+`guided: true`, `hide_election_results: false`, `hide_view_toolbar: false`. The `TUTORIAL_003`
+overlay script (first use of `reveal`) hides the result panel + Lean + County on load and
+surfaces them in sequence: orient → reveal Lean + result together → paint & watch → reveal
+County → submit. Gates `district_count` only (result shown to read, not exploit); e2e covers
+load/reveal/lean/county/winnability + the overlay walkthrough.
+
+**Two deferrals (judgment calls, flagged for review):**
+1. **City-view step** — needs the city-limits overlay (GAME-096), which isn't built. The map
+   carries an urban core so the step slots in later without a map change. The overlay reveals
+   Lean+result then County; City follows with GAME-096. **This ticket stays open for that step.**
+2. **Coastline** — sea tiles must sit outside the precinct circle (the generator rejects
+   overlaps), so the coast needs hand-placed outer-ring tiles best done in the visual pass.
+   The river alone carries "some geography" for the draft.
 
 ## References
 


### PR DESCRIPTION
## Summary

Redesigns **tutorial-003** from the old "Hawthorn Bend" terrain tour into **"Reading the
Vote"** (GAME-098) — the first electoral layer of the tutorial arc. It unveils the
**election-result panel together with the Lean view** (lean = who voters favor; the result =
who wins each district — a causal pair), then the **County** view. This is the **first use of
the overlay engine's `reveal` action** (built in GAME-076, unexercised until now). The
objective stays mechanical (gates `district_count` only) — the result is shown to *read*
("repaint and watch it move"), not to exploit, keeping the "no untaught failure modes" rule.

**Map** (`tutorial-003.spec.yaml` → `tutorial-003.json`):
- radius-5 hex circle = **91 precincts**, **3 districts**.
- an **east/west partisan lean** (verified: west 62% / centre 50% / east 37% Ken) so the Lean
  view + result are meaningful; a **cosmetic river**; **two counties** + an urban core.
- `guided: true`, `hide_election_results: false`, `hide_view_toolbar: false`. The result panel
  + Lean + County are `reveal` targets (hidden on load, surfaced as their step fires).
- gates `district_count` only; `rules.contiguity: allowed` (T2 taught balance + contiguity).

**Engine:** `TUTORIAL_003` — a 5-step script (orient → reveal Lean+result → paint & watch →
reveal County → submit) in `overlay.ts`, reusing GAME-076 (no fork).

**Tests:** replaced the obsolete terrain-tour e2e (mountains/sea/lake at 119 precincts) with a
new T3 suite — smoke (91), river rendered, electoral panel present, Lean recolor, County
toggle, winnability (carve three → pass), and the guided-overlay reveal walkthrough.

### Judgment calls / deferrals (flagged for your review)

- **City-view step descoped** — it needs the city-limits overlay (GAME-096), which isn't
  built. The map keeps an urban core so the step slots in later without a map change; **GAME-098
  stays open** for it.
- **Coastline deferred** to the visual pass (sea tiles must sit outside the precinct circle;
  the river alone carries the "geography" for the draft).
- **Arc chaining confirmed:** finishing a tutorial returns to the campaign select screen (where
  the next unlocked scenario sits) — `goToNextScenario` is campaign-aware via `backUrl`, so the
  weird flat `SCENARIO_MANIFEST` order (used only for the all-complete → wrap-up check) does NOT
  skip T3.
- 3 districts; gates `district_count` only — see the spec header for the rationale.

## Affected machines / services

- None. Game web content (tutorial-003) + e2e/unit tests + manifest/campaign labels. No
  backend/build/deploy change.

## Validation performed

- [x] `bazel test //game/web:app_typecheck_test //game/web/src/model:loader_integration_test
      //game/web/src/model:campaigns_test` — all pass (overlay.ts + main.ts typecheck;
      tutorial-003.json loads at 91 precincts / 3 districts; campaign list intact).
- [x] `bazel build //game/web:e2e_test` — specs wired + build green.
- [x] Map verified via jq: 91 precincts, 3 districts, 2 counties, river present, east/west lean
      (62/50/37% Ken).
- [x] Overlay-step text assertions confirmed to be substrings of the authored `TUTORIAL_003` copy.
- [ ] e2e (Playwright) runs in **CI only** — not on the dev machine. The reveal walkthrough is
      the first exercise of the `reveal` action; the `toBeHidden()` reveal assertions are the
      most likely CI-iteration point. *(POST-MERGE: CI gate)*

## Deployment steps

- None.

## Tickets addressed

- **GAME-098** — tutorial-003 "Reading the Vote" (draft shipped; **stays open** for the
  City-view step, which is blocked on **GAME-096** city-limits overlay).

## Rollback

- Revert this PR; tutorial-003 returns to the terrain tour and its e2e suite reverts with it.
  No runtime/state migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
