### PR TITLE
feat(GAME-099): re-add the balance gate to tutorial-004 (wedge winning move)

### DIFF
--- a/game/scenarios/tutorial-004.json
+++ b/game/scenarios/tutorial-004.json
@@ -3230,6 +3230,14 @@
       "criterion": {
         "type": "district_count"
       }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All four districts have roughly equal population (within 15%).",
+      "criterion": {
+        "type": "population_balance"
+      }
     }
   ],
   "narrative": {
@@ -3244,11 +3252,11 @@
         "heading": "Everything You've Learned"
       },
       {
-        "body": "Draw four districts, each one connected. Keep them roughly even if you like — the Map Validity panel shows you how balanced they are — but there's no score to chase here. Read the result, get a feel for how the lines move it, and submit. The campaign scenarios are where it counts.\n",
+        "body": "A legal map is the same as ever: four districts, roughly equal in population, each one connected. The Map Validity panel tracks both — even the districts out and keep each whole until it's green. There's no seat target; read the result to see who your lines elect, then submit. The campaign scenarios are where that starts to count.\n",
         "heading": "Then the Real Thing"
       }
     ],
-    "objective": "Draw four connected districts — a complete map — and read the result your lines produce, then submit. (Keep them roughly even if you can; there's no target to hit. This is your last warm-up before the campaign.)\n",
+    "objective": "Draw four balanced, connected districts — a complete legal map — and read the result your lines produce, then submit. (No seat target; this is your last warm-up before the campaign.)\n",
     "epilogue": "That's everything: pick a district and paint it, keep the populations even and each district whole, and read the lean and the result to see who your lines elect. You've got the whole loop now.\nFrom here the maps come with a reason to draw them one way or another — a party to favor, a community to protect or split, a rule to satisfy. Same tools, real stakes. Good luck.\n"
   },
   "default_district_id": "d1",

--- a/game/scenarios/tutorial-004.spec.yaml
+++ b/game/scenarios/tutorial-004.spec.yaml
@@ -14,20 +14,18 @@
 #   then steps back.
 #
 #   JUDGMENT CALLS (flagged for review — iterate freely):
-#     - Objective kept MECHANICAL: gates district_count + contiguity. The election result is
-#       VISIBLE to read, but there is no seat goal — winning by seats was never taught here;
-#       that's what the real campaign scenarios are for. The result is the bridge, not the test.
-#     - Balance is NOT gated (it was strictly gated in T2). A hex circle with 4 districts has no
-#       clean balanced band/strip partition (the centre diagonal alone is ~11% of population), so
-#       gating balance would make the map either unwinnable-by-a-simple-move or require a
-#       hand-crafted partition the initial-assignment rule can't express. Instead the Map
-#       Validity panel stays VISIBLE so the player practises + sees balance — but the capstone
-#       gate is light (connected districts), keeping it low-pressure and winnable. Revisit if a
-#       balanced 4-partition becomes expressible (or drop to 3 districts).
+#     - The full LEGAL-MAP skill is gated: district_count + population_balance + contiguity (the
+#       cumulative T1-T2 skills). No seat goal — winning by seats was never taught here; that's
+#       the real campaign scenarios. The result is VISIBLE to read, the bridge, not the test.
+#     - Balance does NOT need a simple stripe: a hex circle has no clean balanced band split, but
+#       FOUR WEDGES around the centre balance within ±15% (each district gets an equal slice of
+#       the dense core + the sparse rim — verified contiguous). The player draws and evens the
+#       districts out using the Map Validity panel, exactly as in T2.
 #     - radius 6 (127 precincts), 4 districts — bigger and more districts than T3.
 #     - City view: the City overlay (GAME-096) still isn't built, so there's no #filter-city;
 #       the map carries an urban core for when it ships. Lean + County + result are all visible.
-#     - Coastline deferred (sea tiles must sit outside the precinct circle — visual pass).
+#     - Coastline: deferred to the owner's precinct picks — a sea tile can sit on a rim hex-edge
+#       (shared edge of the circle), it does not have to be fully outside the precinct set.
 
 format_version: "1"
 
@@ -130,16 +128,20 @@ assembly:
   hide_election_results: false       # capstone: everything is visible from the start...
   hide_view_toolbar: false           # ...nothing hidden, no reveal — all the tools at once
   rules:
-    population_tolerance: 0.15        # unused (no balance criterion) — the panel still shows it
-    contiguity: required             # the capstone gate: every district one connected piece
+    population_tolerance: 0.15        # generous — the player evens the districts out to pass
+    contiguity: required             # a legal map: every district one connected piece
   success_criteria:
-    # Light capstone gate: four districts, all assigned, each connected. Balance is shown in the
-    # (visible) Map Validity panel but not gated; no seat goal — the result is shown to read, not
-    # to hit. See the judgment note in the header for why balance isn't gated here.
+    # The full legal-map skill: four districts, all assigned, balanced, each connected. No seat
+    # goal — the result is shown to read, not to hit. Balanceable: four wedges around the centre
+    # land all four districts within ±15% (verified), and the player evens them out with the panel.
     - id: sc-district-count
       required: true
       description: All four districts are in use and every precinct is assigned.
       criterion: { type: district_count }
+    - id: sc-population-balance
+      required: true
+      description: All four districts have roughly equal population (within 15%).
+      criterion: { type: population_balance }
   narrative:
     character:
       name: You
@@ -155,14 +157,13 @@ assembly:
           are all here from the start. Draw a legal map and watch what it produces.
       - heading: Then the Real Thing
         body: >
-          Draw four districts, each one connected. Keep them roughly even if you like — the Map
-          Validity panel shows you how balanced they are — but there's no score to chase here.
-          Read the result, get a feel for how the lines move it, and submit. The campaign
-          scenarios are where it counts.
+          A legal map is the same as ever: four districts, roughly equal in population, each one
+          connected. The Map Validity panel tracks both — even the districts out and keep each
+          whole until it's green. There's no seat target; read the result to see who your lines
+          elect, then submit. The campaign scenarios are where that starts to count.
     objective: >
-      Draw four connected districts — a complete map — and read the result your lines produce,
-      then submit. (Keep them roughly even if you can; there's no target to hit. This is your
-      last warm-up before the campaign.)
+      Draw four balanced, connected districts — a complete legal map — and read the result your
+      lines produce, then submit. (No seat target; this is your last warm-up before the campaign.)
     epilogue: >
       That's everything: pick a district and paint it, keep the populations even and each
       district whole, and read the lean and the result to see who your lines elect. You've got

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -884,8 +884,8 @@ test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", 
   await page.evaluate((ids) => {
     localStorage.setItem("redistricting-sim-progress", JSON.stringify({ completed: ids }));
   }, allButLast);
-  // tutorial-004 ("Capstone") opens as one district; carve four contiguous diagonal strips
-  // (by k = q+r) so the district_count objective passes — contiguity holds and nothing else gates.
+  // tutorial-004 ("Capstone") opens as one district; carve four wedges around the centre so the
+  // map is balanced (±15%) + contiguous and passes (same winning move as the winnability test).
   await loadScenario(page, "tutorial-004");
   await page.evaluate(() => {
     const store = (window as unknown as Record<string, { getState: () => {
@@ -897,12 +897,17 @@ test("wrap-up screen: completing last scenario shows wrap-up on Next Scenario", 
     const d2: number[] = [];
     const d3: number[] = [];
     const d4: number[] = [];
+    const off = Math.PI / 4;
     state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
-      const k = p.coord.q + p.coord.r;
-      if (k > 1) d4.push(i);
-      else if (k > -1) d3.push(i);
-      else if (k > -3) d2.push(i);
-      // k <= -3 stays District 1
+      const x = Math.sqrt(3) * (p.coord.q + p.coord.r / 2);
+      const y = 1.5 * p.coord.r;
+      let a = Math.atan2(y, x);
+      if (a < 0) a += 2 * Math.PI;
+      const wedge = Math.min(3, Math.floor(((a - off + 2 * Math.PI) % (2 * Math.PI)) / (Math.PI / 2)));
+      if (wedge === 1) d2.push(i);
+      else if (wedge === 2) d3.push(i);
+      else if (wedge === 3) d4.push(i);
+      // wedge 0 stays District 1
     });
     state.paintStroke(d2, 2);
     state.paintStroke(d3, 3);
@@ -1411,7 +1416,8 @@ test("guided overlay: tutorial-003 reveals the result + lean, then county, then 
 
 // ─── tutorial-004: "Fairhaven: Putting It Together" (GAME-099 — capstone) ───
 // A fuller map (127 precincts, 4 districts) with every tool visible from the start (nothing
-// hidden, no reveal). Light guided orientation; gates district_count + contiguity only.
+// hidden, no reveal). Light guided orientation; gates the full legal-map skill —
+// district_count + population_balance (±15%) + contiguity.
 
 test("tutorial-004 smoke: loads and renders 127 precincts", async ({ page }) => {
   await loadScenario(page, "tutorial-004");
@@ -1427,10 +1433,12 @@ test("tutorial-004 capstone chrome: validity panel, view toolbar, and result are
   await expect(page.locator("#results-container")).toBeVisible();
 });
 
-test("tutorial-004 winnability: carving four connected districts passes (district_count + contiguity)", async ({ page }) => {
+test("tutorial-004 winnability: four balanced, connected districts pass (district_count + balance + contiguity)", async ({ page }) => {
   await loadScenario(page, "tutorial-004");
-  // Carve four contiguous diagonal strips (by k = q+r). Contiguity holds by construction and
-  // nothing else gates, so the map passes.
+  // Carve four wedges around the centre — each district gets an equal slice of the dense core
+  // and the sparse rim, so all four land within ±15% (BFS-verified balanced + contiguous;
+  // a 45° rotation is the best-balanced). This is the "give the dense centre to everyone" move
+  // a player arrives at by evening out the panel.
   await page.evaluate(() => {
     const store = (window as unknown as Record<string, { getState: () => {
       paintStroke: (ids: number[], d: number) => void;
@@ -1441,12 +1449,17 @@ test("tutorial-004 winnability: carving four connected districts passes (distric
     const d2: number[] = [];
     const d3: number[] = [];
     const d4: number[] = [];
+    const off = Math.PI / 4; // 45° rotation — best-balanced wedge orientation
     state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
-      const k = p.coord.q + p.coord.r;
-      if (k > 1) d4.push(i);
-      else if (k > -1) d3.push(i);
-      else if (k > -3) d2.push(i);
-      // k <= -3 stays District 1
+      const x = Math.sqrt(3) * (p.coord.q + p.coord.r / 2);
+      const y = 1.5 * p.coord.r;
+      let a = Math.atan2(y, x);
+      if (a < 0) a += 2 * Math.PI;
+      const wedge = Math.min(3, Math.floor(((a - off + 2 * Math.PI) % (2 * Math.PI)) / (Math.PI / 2)));
+      if (wedge === 1) d2.push(i);
+      else if (wedge === 2) d3.push(i);
+      else if (wedge === 3) d4.push(i);
+      // wedge 0 stays District 1
     });
     state.paintStroke(d2, 2);
     state.paintStroke(d3, 3);

--- a/thoughts/shared/tickets/GAME-099-tutorial-004-capstone.md
+++ b/thoughts/shared/tickets/GAME-099-tutorial-004-capstone.md
@@ -26,14 +26,14 @@ Detailed pedagogy refined when reached. See the arc in
 
 ## Goals / Acceptance Criteria
 
-- [x] Pedagogy + objective finalized — **mechanical** (gates district_count + contiguity; result
-      visible to read, no seat goal). See Resolution for the balance-gate judgment.
+- [x] Pedagogy + objective finalized — the full legal-map skill (gates district_count +
+      **population_balance** + contiguity); result visible to read, no seat goal.
 - [x] `tutorial-004.spec.yaml` authored; `tutorial-004.json` generated (127 precincts, 4 districts).
 - [x] Light guided script (orient → paint → submit); reuses GAME-076 engine (no fork).
 - [x] Campaign wiring: tutorial-004 added to the tutorial campaign + SCENARIO_MANIFEST, in order.
-- [x] e2e: loads (127), all chrome visible, winnable (4 contiguous diagonal strips), + overlay.
+- [x] e2e: loads (127), all chrome visible, winnable (4 balanced wedges, BFS-verified), + overlay.
 
-## Resolution (2026-06-25) — DRAFT shipped
+## Resolution (2026-06-25) — shipped
 
 Shipped: "Fairhaven: Putting It Together" — a radius-6 (127-precinct) 4-district map with a
 river, east/west lean (west 60% / east 40% Ken), and three counties. `guided: true`, **nothing
@@ -42,17 +42,19 @@ visible from load. Light 3-step `TUTORIAL_004` script (orient → paint → subm
 tutorial campaign (now 4 scenarios) + SCENARIO_MANIFEST; wrap-up + campaign-select + campaigns
 tests updated.
 
-**Judgment calls (flagged for review):**
-- **Balance is NOT gated** (district_count + contiguity only). A hex circle with 4 districts has
-  no clean balanced band/strip partition (the centre diagonal alone is ~11% of population), and
-  the initial-assignment rule can only express diagonal strips — so gating balance would make the
-  map unwinnable-by-a-simple-move. The Map Validity panel stays **visible** (the player practises
-  + sees balance), but the gate is light to keep the capstone low-pressure + winnable. Revisit if
-  a balanced 4-partition becomes expressible, or drop to 3 districts.
+Initial draft (#280) gated district_count + contiguity only; the owner asked to keep **balance**
+gated, noting the player fixes the districts (no simple stripe needed). Follow-up: re-added the
+`population_balance` criterion (±15%). The winning move is **four wedges around the centre** —
+each district gets an equal slice of the dense core + sparse rim, landing all four within ±15%
+(BFS-verified balanced + contiguous; a 45° rotation gives the best margin). e2e winnability +
+wrap-up carve those wedges.
+
+**Remaining judgment calls / deferrals:**
 - **Objective kept mechanical** (no seat goal) — winning by seats was never taught; that's the
   campaign scenarios. The result is the bridge, shown to read.
-- **City view + coastline deferred** (same as T3): City needs GAME-096; the coast needs
-  outer-ring sea tiles (visual pass). The map carries an urban core for the City view later.
+- **City view** deferred — needs GAME-096; the map carries an urban core for when it ships.
+- **Coastline** deferred to the owner's precinct picks (a sea tile can sit on a rim hex-edge, not
+  only fully outside the circle).
 
 ## References
 


### PR DESCRIPTION
## Summary

Follow-up to #280 (the T4 capstone). The owner asked to **keep population_balance gated** in the
capstone. My earlier reasoning — that a hex circle with 4 districts has no balanced partition —
conflated "no simple *stripe* balances" with "unwinnable." The player **fixes the districts**
(as in T2), so balance just needs an achievable partition.

- Re-adds the **`population_balance` criterion (±15%)** to tutorial-004; restores the
  "balanced, connected" narrative. `tutorial-004.json` regenerated (population unchanged).
- The winning move is now **four wedges around the centre** — each district gets an equal slice
  of the dense core and the sparse rim, so all four land within ±15% (BFS-verified balanced +
  contiguous; a 45° rotation is best: **+6 / −8 / +4 / −2%**). The e2e winnability and wrap-up
  tests carve those wedges (the diagonal strips they used don't balance).

**Still deferred (your call):** the **coastline** — you'll recommend the rim precincts; a sea
tile can sit on a rim hex-edge (shared edge of the circle), not only fully outside it. The
**city view** still waits on GAME-096.

## Affected machines / services

- None. Game content (tutorial-004 spec/json) + e2e tests + the GAME-099 ticket. No backend/
  build/deploy change.

## Validation performed

- [x] `bazel test //game/web/src/model:loader_integration_test` — tutorial-004.json loads (127
      precincts, 4 districts), invariants pass.
- [x] `bazel build //game/web:e2e_test` — specs wired + build green.
- [x] Re-verified the wedge partition on the regenerated JSON via BFS: off=45° → all four
      districts +6/−8/+4/−2% (within ±15%) and contiguous; this is exactly what the tests carve.
- [x] Confirmed the regenerated JSON gates `district_count` + `population_balance`.
- [x] e2e (Playwright) is CI-only on the dev machine; it runs as the CI gate on this PR.

## Deployment steps

- None.

## Tickets addressed

- **GAME-099** — capstone balance gate (resolution updated; ticket remains resolved).

## Rollback

- Revert this PR; tutorial-004 returns to district_count + contiguity only. No runtime/state
  migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
