### PR TITLE
fix(GAME-098): tutorial-003 playtest polish — rural texture + county-view copy

### DIFF
--- a/game/scenarios/tutorial-003.json
+++ b/game/scenarios/tutorial-003.json
@@ -44,7 +44,7 @@
         "q": 0,
         "r": -5
       },
-      "total_population": 3906,
+      "total_population": 4086,
       "demographic_groups": [
         {
           "id": "p001-all",
@@ -69,7 +69,7 @@
         "q": 1,
         "r": -5
       },
-      "total_population": 3929,
+      "total_population": 3819,
       "demographic_groups": [
         {
           "id": "p002-all",
@@ -94,7 +94,7 @@
         "q": 2,
         "r": -5
       },
-      "total_population": 3929,
+      "total_population": 3458,
       "demographic_groups": [
         {
           "id": "p003-all",
@@ -119,7 +119,7 @@
         "q": 3,
         "r": -5
       },
-      "total_population": 3902,
+      "total_population": 3615,
       "demographic_groups": [
         {
           "id": "p004-all",
@@ -144,7 +144,7 @@
         "q": 4,
         "r": -5
       },
-      "total_population": 3881,
+      "total_population": 4307,
       "demographic_groups": [
         {
           "id": "p005-all",
@@ -169,7 +169,7 @@
         "q": 5,
         "r": -5
       },
-      "total_population": 3864,
+      "total_population": 4858,
       "demographic_groups": [
         {
           "id": "p006-all",
@@ -194,7 +194,7 @@
         "q": -1,
         "r": -4
       },
-      "total_population": 3908,
+      "total_population": 3469,
       "demographic_groups": [
         {
           "id": "p007-all",
@@ -219,7 +219,7 @@
         "q": 0,
         "r": -4
       },
-      "total_population": 3945,
+      "total_population": 3810,
       "demographic_groups": [
         {
           "id": "p008-all",
@@ -244,7 +244,7 @@
         "q": 1,
         "r": -4
       },
-      "total_population": 3970,
+      "total_population": 4077,
       "demographic_groups": [
         {
           "id": "p009-all",
@@ -269,7 +269,7 @@
         "q": 2,
         "r": -4
       },
-      "total_population": 3991,
+      "total_population": 4499,
       "demographic_groups": [
         {
           "id": "p010-all",
@@ -294,7 +294,7 @@
         "q": 3,
         "r": -4
       },
-      "total_population": 3966,
+      "total_population": 4405,
       "demographic_groups": [
         {
           "id": "p011-all",
@@ -319,7 +319,7 @@
         "q": 4,
         "r": -4
       },
-      "total_population": 3916,
+      "total_population": 5247,
       "demographic_groups": [
         {
           "id": "p012-all",
@@ -344,7 +344,7 @@
         "q": 5,
         "r": -4
       },
-      "total_population": 3957,
+      "total_population": 4638,
       "demographic_groups": [
         {
           "id": "p013-all",
@@ -369,7 +369,7 @@
         "q": -2,
         "r": -3
       },
-      "total_population": 3917,
+      "total_population": 3583,
       "demographic_groups": [
         {
           "id": "p014-all",
@@ -394,7 +394,7 @@
         "q": -1,
         "r": -3
       },
-      "total_population": 3869,
+      "total_population": 4080,
       "demographic_groups": [
         {
           "id": "p015-all",
@@ -419,7 +419,7 @@
         "q": 0,
         "r": -3
       },
-      "total_population": 3980,
+      "total_population": 3825,
       "demographic_groups": [
         {
           "id": "p016-all",
@@ -444,7 +444,7 @@
         "q": 1,
         "r": -3
       },
-      "total_population": 4055,
+      "total_population": 4102,
       "demographic_groups": [
         {
           "id": "p017-all",
@@ -469,7 +469,7 @@
         "q": 2,
         "r": -3
       },
-      "total_population": 3986,
+      "total_population": 4167,
       "demographic_groups": [
         {
           "id": "p018-all",
@@ -494,7 +494,7 @@
         "q": 3,
         "r": -3
       },
-      "total_population": 3974,
+      "total_population": 3712,
       "demographic_groups": [
         {
           "id": "p019-all",
@@ -519,7 +519,7 @@
         "q": 4,
         "r": -3
       },
-      "total_population": 3924,
+      "total_population": 4394,
       "demographic_groups": [
         {
           "id": "p020-all",
@@ -544,7 +544,7 @@
         "q": 5,
         "r": -3
       },
-      "total_population": 3877,
+      "total_population": 4118,
       "demographic_groups": [
         {
           "id": "p021-all",
@@ -569,7 +569,7 @@
         "q": -3,
         "r": -2
       },
-      "total_population": 3984,
+      "total_population": 4406,
       "demographic_groups": [
         {
           "id": "p022-all",
@@ -594,7 +594,7 @@
         "q": -2,
         "r": -2
       },
-      "total_population": 3966,
+      "total_population": 3808,
       "demographic_groups": [
         {
           "id": "p023-all",
@@ -619,7 +619,7 @@
         "q": -1,
         "r": -2
       },
-      "total_population": 3975,
+      "total_population": 3485,
       "demographic_groups": [
         {
           "id": "p024-all",
@@ -644,7 +644,7 @@
         "q": 0,
         "r": -2
       },
-      "total_population": 3969,
+      "total_population": 4320,
       "demographic_groups": [
         {
           "id": "p025-all",
@@ -669,7 +669,7 @@
         "q": 1,
         "r": -2
       },
-      "total_population": 3958,
+      "total_population": 3875,
       "demographic_groups": [
         {
           "id": "p026-all",
@@ -694,7 +694,7 @@
         "q": 2,
         "r": -2
       },
-      "total_population": 3889,
+      "total_population": 3483,
       "demographic_groups": [
         {
           "id": "p027-all",
@@ -719,7 +719,7 @@
         "q": 3,
         "r": -2
       },
-      "total_population": 3889,
+      "total_population": 3776,
       "demographic_groups": [
         {
           "id": "p028-all",
@@ -744,7 +744,7 @@
         "q": 4,
         "r": -2
       },
-      "total_population": 3890,
+      "total_population": 3419,
       "demographic_groups": [
         {
           "id": "p029-all",
@@ -769,7 +769,7 @@
         "q": 5,
         "r": -2
       },
-      "total_population": 3830,
+      "total_population": 3446,
       "demographic_groups": [
         {
           "id": "p030-all",
@@ -794,7 +794,7 @@
         "q": -4,
         "r": -1
       },
-      "total_population": 3956,
+      "total_population": 4636,
       "demographic_groups": [
         {
           "id": "p031-all",
@@ -819,7 +819,7 @@
         "q": -3,
         "r": -1
       },
-      "total_population": 3971,
+      "total_population": 4742,
       "demographic_groups": [
         {
           "id": "p032-all",
@@ -844,7 +844,7 @@
         "q": -2,
         "r": -1
       },
-      "total_population": 3955,
+      "total_population": 3842,
       "demographic_groups": [
         {
           "id": "p033-all",
@@ -869,7 +869,7 @@
         "q": -1,
         "r": -1
       },
-      "total_population": 3910,
+      "total_population": 4294,
       "demographic_groups": [
         {
           "id": "p034-all",
@@ -894,7 +894,7 @@
         "q": 0,
         "r": -1
       },
-      "total_population": 7948,
+      "total_population": 6836,
       "demographic_groups": [
         {
           "id": "p035-all",
@@ -919,7 +919,7 @@
         "q": 1,
         "r": -1
       },
-      "total_population": 7919,
+      "total_population": 7026,
       "demographic_groups": [
         {
           "id": "p036-all",
@@ -944,7 +944,7 @@
         "q": 2,
         "r": -1
       },
-      "total_population": 3940,
+      "total_population": 3733,
       "demographic_groups": [
         {
           "id": "p037-all",
@@ -969,7 +969,7 @@
         "q": 3,
         "r": -1
       },
-      "total_population": 3842,
+      "total_population": 4264,
       "demographic_groups": [
         {
           "id": "p038-all",
@@ -994,7 +994,7 @@
         "q": 4,
         "r": -1
       },
-      "total_population": 3895,
+      "total_population": 3375,
       "demographic_groups": [
         {
           "id": "p039-all",
@@ -1019,7 +1019,7 @@
         "q": 5,
         "r": -1
       },
-      "total_population": 3883,
+      "total_population": 4040,
       "demographic_groups": [
         {
           "id": "p040-all",
@@ -1044,7 +1044,7 @@
         "q": -5,
         "r": 0
       },
-      "total_population": 3800,
+      "total_population": 4957,
       "demographic_groups": [
         {
           "id": "p041-all",
@@ -1069,7 +1069,7 @@
         "q": -4,
         "r": 0
       },
-      "total_population": 3893,
+      "total_population": 4507,
       "demographic_groups": [
         {
           "id": "p042-all",
@@ -1094,7 +1094,7 @@
         "q": -3,
         "r": 0
       },
-      "total_population": 3971,
+      "total_population": 4092,
       "demographic_groups": [
         {
           "id": "p043-all",
@@ -1119,7 +1119,7 @@
         "q": -2,
         "r": 0
       },
-      "total_population": 4016,
+      "total_population": 3520,
       "demographic_groups": [
         {
           "id": "p044-all",
@@ -1144,7 +1144,7 @@
         "q": -1,
         "r": 0
       },
-      "total_population": 7979,
+      "total_population": 6774,
       "demographic_groups": [
         {
           "id": "p045-all",
@@ -1169,7 +1169,7 @@
         "q": 0,
         "r": 0
       },
-      "total_population": 7943,
+      "total_population": 6891,
       "demographic_groups": [
         {
           "id": "p046-all",
@@ -1194,7 +1194,7 @@
         "q": 1,
         "r": 0
       },
-      "total_population": 7911,
+      "total_population": 7751,
       "demographic_groups": [
         {
           "id": "p047-all",
@@ -1219,7 +1219,7 @@
         "q": 2,
         "r": 0
       },
-      "total_population": 3925,
+      "total_population": 3501,
       "demographic_groups": [
         {
           "id": "p048-all",
@@ -1244,7 +1244,7 @@
         "q": 3,
         "r": 0
       },
-      "total_population": 3922,
+      "total_population": 3570,
       "demographic_groups": [
         {
           "id": "p049-all",
@@ -1269,7 +1269,7 @@
         "q": 4,
         "r": 0
       },
-      "total_population": 3920,
+      "total_population": 4337,
       "demographic_groups": [
         {
           "id": "p050-all",
@@ -1294,7 +1294,7 @@
         "q": 5,
         "r": 0
       },
-      "total_population": 3940,
+      "total_population": 3558,
       "demographic_groups": [
         {
           "id": "p051-all",
@@ -1319,7 +1319,7 @@
         "q": -5,
         "r": 1
       },
-      "total_population": 3806,
+      "total_population": 4398,
       "demographic_groups": [
         {
           "id": "p052-all",
@@ -1344,7 +1344,7 @@
         "q": -4,
         "r": 1
       },
-      "total_population": 3893,
+      "total_population": 3895,
       "demographic_groups": [
         {
           "id": "p053-all",
@@ -1369,7 +1369,7 @@
         "q": -3,
         "r": 1
       },
-      "total_population": 4002,
+      "total_population": 4538,
       "demographic_groups": [
         {
           "id": "p054-all",
@@ -1394,7 +1394,7 @@
         "q": -2,
         "r": 1
       },
-      "total_population": 4084,
+      "total_population": 4646,
       "demographic_groups": [
         {
           "id": "p055-all",
@@ -1419,7 +1419,7 @@
         "q": -1,
         "r": 1
       },
-      "total_population": 8054,
+      "total_population": 7546,
       "demographic_groups": [
         {
           "id": "p056-all",
@@ -1444,7 +1444,7 @@
         "q": 0,
         "r": 1
       },
-      "total_population": 9233,
+      "total_population": 7772,
       "demographic_groups": [
         {
           "id": "p057-all",
@@ -1469,7 +1469,7 @@
         "q": 1,
         "r": 1
       },
-      "total_population": 3903,
+      "total_population": 3840,
       "demographic_groups": [
         {
           "id": "p058-all",
@@ -1494,7 +1494,7 @@
         "q": 2,
         "r": 1
       },
-      "total_population": 3922,
+      "total_population": 3410,
       "demographic_groups": [
         {
           "id": "p059-all",
@@ -1519,7 +1519,7 @@
         "q": 3,
         "r": 1
       },
-      "total_population": 4000,
+      "total_population": 4362,
       "demographic_groups": [
         {
           "id": "p060-all",
@@ -1544,7 +1544,7 @@
         "q": 4,
         "r": 1
       },
-      "total_population": 4030,
+      "total_population": 3544,
       "demographic_groups": [
         {
           "id": "p061-all",
@@ -1569,7 +1569,7 @@
         "q": -5,
         "r": 2
       },
-      "total_population": 3867,
+      "total_population": 3869,
       "demographic_groups": [
         {
           "id": "p062-all",
@@ -1594,7 +1594,7 @@
         "q": -4,
         "r": 2
       },
-      "total_population": 4008,
+      "total_population": 3547,
       "demographic_groups": [
         {
           "id": "p063-all",
@@ -1619,7 +1619,7 @@
         "q": -3,
         "r": 2
       },
-      "total_population": 4127,
+      "total_population": 4256,
       "demographic_groups": [
         {
           "id": "p064-all",
@@ -1644,7 +1644,7 @@
         "q": -2,
         "r": 2
       },
-      "total_population": 4206,
+      "total_population": 4432,
       "demographic_groups": [
         {
           "id": "p065-all",
@@ -1669,7 +1669,7 @@
         "q": -1,
         "r": 2
       },
-      "total_population": 4088,
+      "total_population": 4608,
       "demographic_groups": [
         {
           "id": "p066-all",
@@ -1694,7 +1694,7 @@
         "q": 0,
         "r": 2
       },
-      "total_population": 5207,
+      "total_population": 4980,
       "demographic_groups": [
         {
           "id": "p067-all",
@@ -1719,7 +1719,7 @@
         "q": 1,
         "r": 2
       },
-      "total_population": 3975,
+      "total_population": 3875,
       "demographic_groups": [
         {
           "id": "p068-all",
@@ -1744,7 +1744,7 @@
         "q": 2,
         "r": 2
       },
-      "total_population": 4061,
+      "total_population": 4257,
       "demographic_groups": [
         {
           "id": "p069-all",
@@ -1769,7 +1769,7 @@
         "q": 3,
         "r": 2
       },
-      "total_population": 4105,
+      "total_population": 4526,
       "demographic_groups": [
         {
           "id": "p070-all",
@@ -1794,7 +1794,7 @@
         "q": -5,
         "r": 3
       },
-      "total_population": 3940,
+      "total_population": 4203,
       "demographic_groups": [
         {
           "id": "p071-all",
@@ -1819,7 +1819,7 @@
         "q": -4,
         "r": 3
       },
-      "total_population": 4027,
+      "total_population": 4263,
       "demographic_groups": [
         {
           "id": "p072-all",
@@ -1844,7 +1844,7 @@
         "q": -3,
         "r": 3
       },
-      "total_population": 4105,
+      "total_population": 4282,
       "demographic_groups": [
         {
           "id": "p073-all",
@@ -1869,7 +1869,7 @@
         "q": -2,
         "r": 3
       },
-      "total_population": 4085,
+      "total_population": 4551,
       "demographic_groups": [
         {
           "id": "p074-all",
@@ -1894,7 +1894,7 @@
         "q": -1,
         "r": 3
       },
-      "total_population": 4086,
+      "total_population": 4048,
       "demographic_groups": [
         {
           "id": "p075-all",
@@ -1919,7 +1919,7 @@
         "q": 0,
         "r": 3
       },
-      "total_population": 5217,
+      "total_population": 5667,
       "demographic_groups": [
         {
           "id": "p076-all",
@@ -1944,7 +1944,7 @@
         "q": 1,
         "r": 3
       },
-      "total_population": 4023,
+      "total_population": 4043,
       "demographic_groups": [
         {
           "id": "p077-all",
@@ -1969,7 +1969,7 @@
         "q": 2,
         "r": 3
       },
-      "total_population": 4071,
+      "total_population": 4451,
       "demographic_groups": [
         {
           "id": "p078-all",
@@ -1994,7 +1994,7 @@
         "q": -5,
         "r": 4
       },
-      "total_population": 3980,
+      "total_population": 3703,
       "demographic_groups": [
         {
           "id": "p079-all",
@@ -2019,7 +2019,7 @@
         "q": -4,
         "r": 4
       },
-      "total_population": 3991,
+      "total_population": 4191,
       "demographic_groups": [
         {
           "id": "p080-all",
@@ -2044,7 +2044,7 @@
         "q": -3,
         "r": 4
       },
-      "total_population": 4017,
+      "total_population": 3620,
       "demographic_groups": [
         {
           "id": "p081-all",
@@ -2069,7 +2069,7 @@
         "q": -2,
         "r": 4
       },
-      "total_population": 4013,
+      "total_population": 3751,
       "demographic_groups": [
         {
           "id": "p082-all",
@@ -2094,7 +2094,7 @@
         "q": -1,
         "r": 4
       },
-      "total_population": 4074,
+      "total_population": 4163,
       "demographic_groups": [
         {
           "id": "p083-all",
@@ -2119,7 +2119,7 @@
         "q": 0,
         "r": 4
       },
-      "total_population": 5211,
+      "total_population": 5038,
       "demographic_groups": [
         {
           "id": "p084-all",
@@ -2144,7 +2144,7 @@
         "q": 1,
         "r": 4
       },
-      "total_population": 3970,
+      "total_population": 3496,
       "demographic_groups": [
         {
           "id": "p085-all",
@@ -2169,7 +2169,7 @@
         "q": -5,
         "r": 5
       },
-      "total_population": 3965,
+      "total_population": 3444,
       "demographic_groups": [
         {
           "id": "p086-all",
@@ -2194,7 +2194,7 @@
         "q": -4,
         "r": 5
       },
-      "total_population": 3918,
+      "total_population": 4358,
       "demographic_groups": [
         {
           "id": "p087-all",
@@ -2219,7 +2219,7 @@
         "q": -3,
         "r": 5
       },
-      "total_population": 3980,
+      "total_population": 3504,
       "demographic_groups": [
         {
           "id": "p088-all",
@@ -2244,7 +2244,7 @@
         "q": -2,
         "r": 5
       },
-      "total_population": 4032,
+      "total_population": 4555,
       "demographic_groups": [
         {
           "id": "p089-all",
@@ -2269,7 +2269,7 @@
         "q": -1,
         "r": 5
       },
-      "total_population": 4072,
+      "total_population": 4375,
       "demographic_groups": [
         {
           "id": "p090-all",
@@ -2294,7 +2294,7 @@
         "q": 0,
         "r": 5
       },
-      "total_population": 3949,
+      "total_population": 3817,
       "demographic_groups": [
         {
           "id": "p091-all",

--- a/game/scenarios/tutorial-003.spec.yaml
+++ b/game/scenarios/tutorial-003.spec.yaml
@@ -75,14 +75,24 @@ terrain:
 population:
   seed: 13
   base: 4000
-  variance: 300
-  smoothing: 1
+  variance: 650         # rural noise so the countryside reads as varied, not flat
+  smoothing: 0          # keep the texture — don't average the noise away
   settlements:
     - label: Hawthorn (city)
       anchor: center
-      peak: 4000
+      peak: 3200         # the county seat: dense, but not so stark it flattens everything else
       radius: 2
       profile: plateau
+    - label: East Hollow  # a couple of mild village peaks to break up the rurals
+      anchor: east
+      peak: 1500
+      radius: 2
+      profile: gaussian
+    - label: Westford
+      anchor: west
+      peak: 1500
+      radius: 2
+      profile: gaussian
 
 # ── Stage 3: Demographics (PARTISAN — an east/west split) ─────────────────────
 #

--- a/game/web/src/tutorial/overlay.ts
+++ b/game/web/src/tutorial/overlay.ts
@@ -133,7 +133,7 @@ const TUTORIAL_003: TutorialStep[] = [
     advance: { on: "paint-count", district: 2, n: 5 },
   },
   {
-    text: "**County** borders show the old administrative lines — another way to read the map.",
+    text: "**County** borders are the old administrative lines. Like the river, they're **cosmetic** — they don't affect your districts at all; they just help you read the map and ground where things are.",
     reveal: "#filter-county",
     highlight: "#filter-county",
     pauseInput: true,


### PR DESCRIPTION
## Summary

Two playtest-feedback fixes for **tutorial-003 "Reading the Vote"** (no generator dependency):

- **(g) Rural population texture** — the countryside read as flat. Added two mild village peaks
  (East Hollow east, Westford west), raised `variance` (300 → 650), dropped `smoothing` (1 → 0),
  and lowered the central city peak (4000 → 3200). The rurals now vary (~3.4k–7.8k, mean ~4.3k)
  instead of "dense centre, uniform rural." Lean is q-based and counties still form (2) — both
  unchanged. T3 gates `district_count` only, so population is purely visual here.
- **(h) County-view copy** — the guided step now says county borders are **cosmetic, like the
  river**: they don't affect districts, they just help read the map and ground the scenario.

**Not touched here:** the broken T3 river. Per the owner's steer, the river fix rides on the
**terrain-generation stage** (the pipeline's terrain stage is currently passthrough-only — it
validates hand-authored tiles/rivers but generates nothing). That's the next piece after the
T2/T3 playtest fixes, before T4.

## Affected machines / services

- None. tutorial-003 spec/json + the guided-overlay copy. No backend/build/deploy change.

## Validation performed

- [x] `bazel test //game/web:app_typecheck_test //game/web/src/model:loader_integration_test` —
      pass (overlay copy typechecks; tutorial-003.json loads at 91 precincts / 3 districts).
- [x] `bazel build //game/web:e2e_test` — specs wired + build green.
- [x] Verified via jq: rural population spread restored (min 3375 / max 7772 / mean 4333);
      counties still form (hawthorn_central + hawthorn_south); lean unchanged.
- [x] The county overlay step still contains "County" (the e2e overlay assertion substring).
- [x] e2e (Playwright) is CI-only on the dev machine; it runs as the CI gate on this PR.

## Deployment steps

- None.

## Tickets addressed

- **GAME-098** (tutorial-003) — playtest polish. Ticket stays open (city view + river/generator).

## Rollback

- Revert this PR; tutorial-003 returns to the flat-rural population + prior county copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
