### PR TITLE
feat: debug Restart button — restart a scenario including its guided tutorial

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -842,6 +842,36 @@ test("debug force-win button: hidden without ?debug param", async ({ page }) => 
   await expect(debugBtn).not.toBeVisible();
 });
 
+test("debug restart: re-runs the guided tutorial from scratch (clears the seen flag)", async ({ page }) => {
+  // The beforeEach marks tutorials complete, so the overlay is normally suppressed.
+  await page.goto("/?campaign=tutorial&s=tutorial-002&debug");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("#tutorial-panel")).toHaveCount(0); // suppressed
+
+  // Restart (debug) reloads with resetTutorial=1, which clears the "seen" flag.
+  const restart = page.locator("#btn-debug-restart");
+  await expect(restart).toBeVisible();
+  await restart.click();
+  await expect(page).toHaveURL(/resetTutorial=1/);
+
+  // After dismissing the (re-shown) intro, the guided overlay runs again.
+  const skip2 = page.locator("#btn-intro-skip");
+  await expect(skip2).toBeVisible({ timeout: 15_000 });
+  await skip2.click();
+  await expect(page.locator("#tutorial-panel")).toBeVisible({ timeout: 10_000 });
+});
+
+test("debug restart: hidden without ?debug param", async ({ page }) => {
+  await page.goto("/?s=tutorial-002");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("#btn-debug-restart")).not.toBeVisible();
+});
+
 test("lock gate: direct URL to locked scenario redirects to main menu", async ({ page }) => {
   // Ensure no progress — scenario-002 requires tutorial-002 completed
   await page.goto("/");

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -154,6 +154,7 @@
         <button id="btn-submit" disabled aria-label="Submit map for evaluation">Submit Map</button>
         <button id="btn-debug-win" style="display:none;background:#8b4513;color:#ffa;">⚡ Force Win (debug)</button>
         <button id="btn-debug-coords" style="display:none;background:#1e3a5f;color:#9ef;">⌖ Coords [C]</button>
+        <button id="btn-debug-restart" style="display:none;background:#5f1e3a;color:#f9e;" title="Restart this scenario from scratch, including the guided tutorial">↻ Restart (debug)</button>
         <button id="btn-reset" aria-label="Reset map to initial state">Reset</button>
         <span id="reset-confirm">
           Reset to start?

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -1496,6 +1496,21 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		btnDebugCoords.addEventListener("click", toggleCoordLabels);
 	}
 
+	// Debug: restart the scenario from scratch — including the guided tutorial. Reset alone
+	// only restores the map; once a tutorial's overlay is marked complete you can't re-watch it
+	// without this. Clears the saved WIP (so the map resets) and reloads with resetTutorial=1
+	// (so the intro re-shows and the guided overlay reruns).
+	const btnDebugRestart = document.getElementById("btn-debug-restart") as HTMLButtonElement | null;
+	if (btnDebugRestart && IS_DEBUG) {
+		btnDebugRestart.style.display = "";
+		btnDebugRestart.addEventListener("click", () => {
+			clearWip();
+			const url = new URL(window.location.href);
+			url.searchParams.set("resetTutorial", "1");
+			window.location.assign(url.toString());
+		});
+	}
+
 	btnKeepDrawing!.addEventListener("click", () => {
 		// Cancel any in-progress criteria reveal (timeouts + audio) before leaving.
 		if (skipClickHandler) {


### PR DESCRIPTION
## Summary

Playtest feedback (d): **Reset** only restores the map, and once a tutorial's guided overlay is
marked complete there's no way to re-watch it — force-win + replay doesn't reset the tutorial
bits. Adds a debug-only **"↻ Restart (debug)"** button that **restarts the scenario including
its guidance**: it clears the saved WIP (`clearWip()`) and reloads the current scenario with
`resetTutorial=1`, so the intro re-shows and the guided overlay reruns on a fresh map.

- `index.html` — `#btn-debug-restart`, hidden by default; shown in `IS_DEBUG` like the other
  debug buttons.
- `main.ts` — `clearWip()` + reload with `resetTutorial=1` (the existing overlay flag that
  clears the per-tutorial "seen" flags on load).

## Affected machines / services

- None. Game web UI (one debug-only button + handler) + e2e. No backend/build/deploy change.

## Validation performed

- [x] `bazel test //game/web:app_typecheck_test` — main.ts wiring typechecks (reuses the
      already-imported `clearWip`).
- [x] `bazel build //game/web:e2e_test` — specs wired + build green.
- [x] New e2e: with the overlay suppressed, clicking Restart reloads with `resetTutorial=1` and
      the guided overlay reruns; the button is hidden without `?debug`.
- [x] e2e (Playwright) is CI-only on the dev machine; it runs as the CI gate on this PR.

## Deployment steps

- None. Debug-only control (hidden unless `?debug`).

## Tickets addressed

- Playtest-feedback tooling (item d). No ticket; small debug control.

## Rollback

- Revert this PR; the Restart (debug) button disappears. No runtime/state impact (debug-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
