### PR TITLE
docs(GAME-100): ticket — terrain feature generation + river validity

### DIFF
--- a/thoughts/shared/tickets/GAME-100-terrain-feature-generation.md
+++ b/thoughts/shared/tickets/GAME-100-terrain-feature-generation.md
@@ -1,0 +1,92 @@
+---
+id: GAME-100
+title: Terrain feature generation — lay out rivers/coasts/mountains from intent, feed pop + demographics
+area: game, tooling
+status: open
+created: 2026-06-25
+---
+
+## Summary
+
+Make the pipeline's **terrain stage actually generate terrain features** — route rivers, place
+coastlines/mountains/lakes from high-level intent — instead of only passing through exact
+hand-authored coordinates. Generated terrain then feeds population suitability (already wired,
+GAME-087) and optionally informs demographics/lean. This is the capability the owner assumed
+existed; it does not.
+
+## Current state (verified in code, 2026-06-25)
+
+The GAME-084 pipeline is `terrain → population → demographics → counties → assembler`.
+Everything **downstream of terrain is generated**: population has a coherent field
+(gradient + noise + settlements + contrast, GAME-088), demographics has lean zones, counties
+flood-fill the population field (GAME-089). But the **terrain stage is pure passthrough**:
+
+- `terrain-generator.ts` generates the hex grid, then `buildTerrainTiles` / `buildRiverEdges`
+  only **validate + convert** the exact `tiles` and `river_edges` the spec hand-authors
+  (adjacency check, no-precinct-overlap check). There is **no routing, no placement, no
+  generation** of any feature.
+- Consequence: rivers must be authored as exact adjacent-precinct pairs whose **shared hex
+  edges** chain vertex-to-vertex. This is error-prone — the tutorial-003/004 rivers were
+  authored as vertically-adjacent pairs whose shared edges are disconnected horizontal stubs
+  (the "broken river"). The generator's adjacency check passed them because each pair *is*
+  adjacent; it has no notion of chain connectivity or valid endpoints.
+
+GAME-084's terrain AC was written as coordinate-driven ("produces ... terrain tiles + river
+edges" from the spec), so feature generation was never scoped — not abandoned, never built.
+
+## Goals / Acceptance Criteria
+
+### A. River-validity constraint (foundational guardrail — can land first)
+
+- [ ] Validate river edges at generation time (`buildRiverEdges` or a `validateScenario` pass):
+      a river is a set of shared-edge segments; reject any configuration where a river vertex
+      is a **loose end** — i.e. a degree-1 river vertex that is **not** (a) on the map boundary
+      (flows off-map), (b) adjacent to a water tile (sea/lake), or (c) shared with another river
+      vertex (part of a connected chain). Teeny disconnected segments are per-se invalid.
+- [ ] Clear error naming the offending vertex/edge so spec authoring fails fast.
+- [ ] Unit tests: a connected rim-to-rim chain passes; a single stub fails; a chain ending in a
+      lake passes; a chain with a mid-air loose end fails.
+
+### B. Terrain feature generation
+
+- [ ] **River routing:** from high-level intent (e.g. `river: { from: <anchor/feature>, to:
+      <sea|lake|off-map> }`), generate a **connected** river_edge chain that satisfies the
+      validity constraint by construction (walks the hex-edge graph; starts at the source —
+      which may be anywhere, incl. a mountain corner — and ends in water or off-map).
+- [ ] **Coastline:** from `coast: <side>` (or a sea region), place sea tiles along the chosen
+      rim. Note sea tiles may sit on a **rim hex-edge** (shared edge of the circle), not only
+      fully outside it (`buildTerrainTiles` already allows tiles outside the precinct set).
+- [ ] **Mountains / lakes:** place from intent (a range on a side; a lake at/near an anchor),
+      producing the foothill/lakeside fringes the renderer already supports.
+- [ ] Generated terrain feeds the population stage's suitability (riverside/coastal/lakeside/
+      mountain-adjacent weights — already consumed) so settlements/density respond to it.
+- [ ] Optionally let terrain inform demographics (e.g. coastal vs inland lean) — spec-driven,
+      off by default.
+- [ ] Hand-authored exact `tiles`/`river_edges` still supported (generation is opt-in via the
+      higher-level intent fields).
+
+## Design notes / principles (from owner)
+
+- **Rivers must start or end in a body of water, or off-screen.** A river can *start* anywhere
+  (including a mountain corner) but must *end* in a lake/sea or run off-map. (Not necessarily
+  both ends — one valid terminus suffices; the other can be off-map.)
+- Geography stays **cosmetic** (`project_geography_cosmetic`): generated features must not feed
+  contiguity/scoring/criteria — only rendering + (suitability) population + optional demographics.
+- Pipeline order matters: **terrain first**, so population + demographics can read it.
+- Keep spec knobs plain-English (`[[feedback-plain-english-tooling-knobs]]`): `coast: south`,
+  `river: { from: northwest-hills, to: sea }` — not raw coordinate lists.
+
+## Sequencing
+
+Owner's call (2026-06-25): do this **after** the tutorial-002/003 playtest fixes (done) and
+**before** the tutorial-004 capstone revisit. The broken tutorial-003/004 rivers are fixed as a
+by-product (regenerate with routed rivers) rather than hand-patched.
+
+## References
+
+- `game/web/src/pipeline/terrain-generator.ts` (passthrough today), `spec-types.ts` (`TerrainSpec`).
+- `game/web/src/render/mapRenderer.ts` `renderRivers` / `buildRiverChains` (shared-edge segments,
+  chained by shared vertex) — the geometry any generator/validator must match.
+- `game/web/src/model/hex-geometry.ts` (flat-top; `HEX_DIRECTIONS`, `hexCorners`).
+- GAME-084 (pipeline), GAME-087 (terrain→population suitability), GAME-088/089 (population +
+  county generation). GAME-098/099 (the tutorials whose rivers this fixes).

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -118,6 +118,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-090-settlement-density-realism.md` | game, tooling | Settlement density realism follow-ons: leapfrog/exurban developments, sharper plateau edge, easier non-circular cores. Plateau profile + big urban/rural ratio already landed in GAME-088 |
 | `GAME-096-city-limits-overlay.md` | game, rendering, UX | Basic cosmetic city-limits overlay (reuse county border mechanism); third View-toolbar Overlays entry; no gameplay effect. Prerequisite for tutorial-003's (GAME-098) lean/county/city view set |
 | `GAME-098-tutorial-003-reading-the-vote.md` | game, UX, tutorial, content | Tutorial-003 "Reading the Vote": first electoral layer — reveal the election-result panel together with the lean view, then county/city; terrain + partisan lean + counties/urban core. Reuses overlay engine + reveal action; needs GAME-096. See plan 2026-06-24-tutorial-redesign |
+| `GAME-100-terrain-feature-generation.md` | game, tooling | Make the terrain stage GENERATE features (route rivers, place coasts/mountains/lakes from intent) instead of passthrough of hand-authored coordinates; feeds population suitability + optional demographics. Incl. river-validity constraint (loose-ended segments invalid). Fixes the broken tutorial-003/004 rivers. Do after T2/T3 playtest fixes, before T4 capstone revisit |
 ---
 
 ## Resolved


### PR DESCRIPTION
## Summary

Files **GAME-100** — terrain feature generation — capturing the gap the owner surfaced in
playtest. The pipeline's terrain stage is **passthrough-only**: it lays out the hex grid and
validates/converts the exact `tiles` and `river_edges` authored in the spec, but **generates no
features**. Everything downstream (population field, demographics lean, county flood-fill) *is*
generated. So terrain is the one hand-authored, un-generated stage — which is why the
tutorial-003/004 rivers (vertically-adjacent precinct pairs whose shared edges don't chain) came
out broken, and why hand-authoring rivers is error-prone.

The ticket proposes:
- **A. A river-validity constraint** (foundational guardrail): reject river configurations with
  loose-ended segments — a river vertex must flow off-map, end in water, or join another river
  vertex. Would have caught the broken rivers at generation time.
- **B. Terrain feature generation**: route connected rivers from intent (`river: { from, to }`),
  place coastlines (`coast: south` — sea tiles may sit on a rim hex-edge), mountains/lakes; feed
  population suitability (already wired) + optionally demographics.

Sequenced (owner's call) after the T2/T3 playtest fixes (shipped: #282 texture/copy, #283
restart) and before the T4 capstone revisit.

## Affected machines / services

- None. A new ticket + TICKETS.md index entry. No code/build/deploy change.

## Validation performed

- [x] Grounded in code: `terrain-generator.ts` (`buildTerrainTiles`/`buildRiverEdges` are
      passthrough + validation only); `renderRivers`/`buildRiverChains` (shared-edge chaining);
      `hex-geometry.ts` (flat-top geometry). GAME-084 terrain AC was coordinate-driven.
- [x] TICKETS.md index updated in the same change.

## Deployment steps

- None.

## Tickets addressed

- Creates **GAME-100**. Related: GAME-084 (pipeline), GAME-087 (terrain→population),
  GAME-098/099 (the tutorials whose rivers it fixes).

## Rollback

- Revert this PR; the ticket is removed. No runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
