### PR TITLE
feat: Reset also restarts the guided tutorial (replaces the debug Restart button)

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -842,34 +842,30 @@ test("debug force-win button: hidden without ?debug param", async ({ page }) => 
   await expect(debugBtn).not.toBeVisible();
 });
 
-test("debug restart: re-runs the guided tutorial from scratch (clears the seen flag)", async ({ page }) => {
+test("reset: also restarts the guided tutorial in place (zeroes the whole scenario)", async ({ page }) => {
   // The beforeEach marks tutorials complete, so the overlay is normally suppressed.
-  await page.goto("/?campaign=tutorial&s=tutorial-002&debug");
+  await page.goto("/?s=tutorial-002&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
   await expect(page.locator("#tutorial-panel")).toHaveCount(0); // suppressed
 
-  // Restart (debug) reloads with resetTutorial=1, which clears the "seen" flag.
-  const restart = page.locator("#btn-debug-restart");
-  await expect(restart).toBeVisible();
-  await restart.click();
-  await expect(page).toHaveURL(/resetTutorial=1/);
-
-  // After dismissing the (re-shown) intro, the guided overlay runs again.
-  const skip2 = page.locator("#btn-intro-skip");
-  await expect(skip2).toBeVisible({ timeout: 15_000 });
-  await skip2.click();
+  // Reset → confirm: resets the map AND restarts the guided overlay in place (no reload).
+  await page.locator("#btn-reset").click();
+  await page.locator("#btn-reset-confirm").click();
   await expect(page.locator("#tutorial-panel")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#tutorial-panel")).toContainText("rules"); // T2 step 1
 });
 
-test("debug restart: hidden without ?debug param", async ({ page }) => {
-  await page.goto("/?s=tutorial-002");
+test("reset: does not start an overlay on a non-guided scenario", async ({ page }) => {
+  await page.goto("/?s=scenario-002&debug");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
   await skip.click();
   await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
-  await expect(page.locator("#btn-debug-restart")).not.toBeVisible();
+  await page.locator("#btn-reset").click();
+  await page.locator("#btn-reset-confirm").click();
+  await expect(page.locator("#tutorial-panel")).toHaveCount(0);
 });
 
 test("lock gate: direct URL to locked scenario redirects to main menu", async ({ page }) => {

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -154,7 +154,6 @@
         <button id="btn-submit" disabled aria-label="Submit map for evaluation">Submit Map</button>
         <button id="btn-debug-win" style="display:none;background:#8b4513;color:#ffa;">⚡ Force Win (debug)</button>
         <button id="btn-debug-coords" style="display:none;background:#1e3a5f;color:#9ef;">⌖ Coords [C]</button>
-        <button id="btn-debug-restart" style="display:none;background:#5f1e3a;color:#f9e;" title="Restart this scenario from scratch, including the guided tutorial">↻ Restart (debug)</button>
         <button id="btn-reset" aria-label="Reset map to initial state">Reset</button>
         <span id="reset-confirm">
           Reset to start?

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -16,7 +16,7 @@ import {
 	renderResults,
 	renderValidityPanel,
 } from "./render/panels.js";
-import { startTutorialOverlay } from "./tutorial/overlay.js";
+import { restartTutorialOverlay, startTutorialOverlay } from "./tutorial/overlay.js";
 import { createGameStore } from "./store/gameStore.js";
 import {
 	evaluateCriteria,
@@ -818,6 +818,10 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		temporalStore.getState().clear();
 		resetConfirm!.classList.remove("visible");
 		btnReset!.disabled = false;
+		// Reset zeroes the whole scenario, not just the painted map: restart the guided tutorial
+		// from the top (no-op for non-guided scenarios). Guidance is skippable, so bringing it
+		// back on Reset is safe, useful production behavior.
+		restartTutorialOverlay(scenario, store);
 	});
 
 	// ── Submit / Evaluation (GAME-017) ────────────────────────────────────────
@@ -1494,21 +1498,6 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 	if (btnDebugCoords && IS_DEBUG) {
 		btnDebugCoords.style.display = "";
 		btnDebugCoords.addEventListener("click", toggleCoordLabels);
-	}
-
-	// Debug: restart the scenario from scratch — including the guided tutorial. Reset alone
-	// only restores the map; once a tutorial's overlay is marked complete you can't re-watch it
-	// without this. Clears the saved WIP (so the map resets) and reloads with resetTutorial=1
-	// (so the intro re-shows and the guided overlay reruns).
-	const btnDebugRestart = document.getElementById("btn-debug-restart") as HTMLButtonElement | null;
-	if (btnDebugRestart && IS_DEBUG) {
-		btnDebugRestart.style.display = "";
-		btnDebugRestart.addEventListener("click", () => {
-			clearWip();
-			const url = new URL(window.location.href);
-			url.searchParams.set("resetTutorial", "1");
-			window.location.assign(url.toString());
-		});
 	}
 
 	btnKeepDrawing!.addEventListener("click", () => {

--- a/game/web/src/tutorial/overlay.ts
+++ b/game/web/src/tutorial/overlay.ts
@@ -36,6 +36,9 @@ export interface TutorialStep {
 
 const PANEL_ID = "tutorial-panel";
 
+/** Teardown of the currently-running overlay (if any), so Reset can restart it in place. */
+let activeOverlayTeardown: (() => void) | null = null;
+
 // ─── Step scripts (keyed by scenario id) ──────────────────────────────────────
 
 /** tutorial-001 — paint-only welcome (DESIGN-012). Selectors are current as of GAME-097. */
@@ -227,6 +230,25 @@ export function startTutorialOverlay(scenario: Scenario, store: StoreLike): void
   runOverlay(scenario.id, script, store);
 }
 
+/**
+ * Restart the guided overlay from step 1, in place — used by Reset, so resetting a tutorial
+ * zeroes the whole scenario (map *and* guidance), not just the painted map. No-op for
+ * non-guided scenarios or those without a script. Tears down any running overlay first and
+ * clears the per-scenario "complete" flag so the coach reappears.
+ */
+export function restartTutorialOverlay(scenario: Scenario, store: StoreLike): void {
+  if (scenario.guided !== true) return;
+  const script = SCRIPTS[scenario.id];
+  if (!script || script.length === 0) return;
+  activeOverlayTeardown?.();
+  try {
+    localStorage.removeItem(completeKey(scenario.id));
+  } catch {
+    /* ignore */
+  }
+  runOverlay(scenario.id, script, store);
+}
+
 function isComplete(id: string): boolean {
   try {
     return localStorage.getItem(completeKey(id)) === "1";
@@ -305,13 +327,20 @@ function runOverlay(id: string, script: TutorialStep[], store: StoreLike): void 
     editorRoots.forEach((r) => r.classList.remove("tutorial-paused"));
   }
 
-  function finish(): void {
+  // Tear down the overlay DOM/listeners WITHOUT marking it complete (used by restart).
+  function teardown(): void {
     clearStepDecorations();
     overlayAc.abort();
     panel.remove();
     document.querySelectorAll(".tutorial-reveal-hidden").forEach((el) =>
       el.classList.remove("tutorial-reveal-hidden"),
     );
+    if (activeOverlayTeardown === teardown) activeOverlayTeardown = null;
+  }
+  activeOverlayTeardown = teardown;
+
+  function finish(): void {
+    teardown();
     try {
       localStorage.setItem(completeKey(id), "1");
     } catch {


### PR DESCRIPTION
## Summary

Reworks the tutorial-restart behavior per the owner's reconsideration of #283: instead of a
separate **debug-only** Restart button, the existing **Reset** button now zeroes the *whole*
scenario — the painted map **and** the guided tutorial — not just the map. Guidance is
skippable, so bringing it back on Reset is useful production behavior, and it drops an extra
debug control.

- **`overlay.ts`** — new `restartTutorialOverlay()`: tears down any running overlay, clears the
  per-scenario "complete" flag, and re-runs the coach from step 1, **in place** (no page
  reload, no intro re-show). No-op for non-guided scenarios. `finish()` refactored into a
  `teardown()` (DOM/listener cleanup) + the complete-flag write, so a restart can tear down
  without marking complete.
- **`main.ts`** — Reset-confirm calls `restartTutorialOverlay(scenario, store)` after resetting
  the map; the `#btn-debug-restart` button and wiring are removed.
- **`index.html`** — `#btn-debug-restart` removed.

## Affected machines / services

- None. Game web UI (Reset behavior + overlay engine) + e2e. No backend/build/deploy change.

## Validation performed

- [x] `bazel test //game/web:app_typecheck_test` — overlay.ts + main.ts typecheck.
- [x] `bazel build //game/web:e2e_test` — specs wired + build green.
- [x] New e2e: on a guided scenario, Reset re-runs the overlay in place (panel reappears at
      step 1); on a non-guided scenario (scenario-002), Reset starts no overlay. The existing
      sprint2 reset tests run on the non-guided scenario-002, so they're unaffected.
- [x] e2e (Playwright) is CI-only on the dev machine; it runs as the CI gate on this PR.

## Deployment steps

- None.

## Tickets addressed

- Supersedes the #283 approach (debug Restart) with production Reset behavior. Playtest item (d).

## Rollback

- Revert this PR; Reset returns to map-only and the debug Restart button is gone (it was removed
  here). If the old debug button is wanted back, re-revert #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
