### PR TITLE
fix(GAME-098): tutorial-003 enforces a legal map (keeps the Map Validity panel visible)

### DIFF
--- a/game/scenarios/tutorial-003.json
+++ b/game/scenarios/tutorial-003.json
@@ -2316,7 +2316,7 @@
   "events": [],
   "rules": {
     "population_tolerance": 0.15,
-    "contiguity": "allowed"
+    "contiguity": "required"
   },
   "success_criteria": [
     {
@@ -2325,6 +2325,14 @@
       "description": "All three districts are in use and every precinct is assigned.",
       "criterion": {
         "type": "district_count"
+      }
+    },
+    {
+      "id": "sc-population-balance",
+      "required": true,
+      "description": "All three districts have roughly equal population (within 15%).",
+      "criterion": {
+        "type": "population_balance"
       }
     }
   ],
@@ -2344,7 +2352,7 @@
         "heading": "Lean, and the Result"
       }
     ],
-    "objective": "Draw three districts and read the result. There's no target to hit — repaint the lines and watch who wins change, then submit when you've had a look.\n",
+    "objective": "Draw three balanced, connected districts — a legal map, like before — and read the result. There's no seat to chase; repaint the lines, watch who wins change, and submit when it's legal and you've had a look.\n",
     "epilogue": "That's the whole picture: precincts lean, and the district lines you draw turn those leanings into seats. The same voters can hand one party a majority of seats or the other — nothing changed but the lines.\nYou've drawn a legal map and learned to read the vote. From here the campaign scenarios put it to work: real maps, real goals, and a reason to draw the lines the way you do.\n"
   },
   "default_district_id": "d1",

--- a/game/scenarios/tutorial-003.spec.yaml
+++ b/game/scenarios/tutorial-003.spec.yaml
@@ -10,18 +10,20 @@
 #   Tutorial 3 is the FIRST ELECTORAL LAYER. It unveils the election-result panel TOGETHER
 #   with the Lean view (lean = who each precinct favors; the result = who wins each district —
 #   a causal pair), then the county view. The result is shown to *read* ("repaint and watch it
-#   move"), NOT to exploit — strategy is the capstone + the real scenarios. So the objective
-#   stays MECHANICAL (gates on district_count only): nothing can fail the player for a rule this
-#   tutorial doesn't teach.
+#   move"), NOT to exploit — there is no SEAT goal; strategy is the capstone + the real scenarios.
+#
+#   T3 still draws a LEGAL map: it gates district_count + population_balance + contiguity (the
+#   cumulative skill from T2). That's also what keeps the Map Validity panel visible — panels
+#   accrete once revealed (owner rule, 2026-06-25); the applicable-aware hiding must not re-hide
+#   a panel an earlier tutorial introduced.
 #
 #   New since T2: a little geography (a river — cosmetic scenery, districts may cross it), a
 #   partisan east/west LEAN, and counties. The guided overlay REVEALS the result
 #   panel + Lean view in one step, then the County view.
 #
 #   JUDGMENT CALLS (flagged for review — iterate freely):
-#     - 3 districts; gates district_count only (no balance/contiguity gate — T2 taught those;
-#       T3 is about reading the result). rules.contiguity: allowed to keep winnability simple
-#       and terrain-proof.
+#     - 3 districts; gates district_count + population_balance + contiguity (legal map) but no
+#       seat goal. Winning move = three wedges around the centre (BFS-verified balanced).
 #     - The CITY view step is descoped from this draft: it needs the city-limits overlay
 #       (GAME-096), which isn't built yet. The map already carries an urban core so the city
 #       reveal can be added later without a map change. The overlay reveals lean+result, then
@@ -148,15 +150,21 @@ assembly:
   hide_election_results: false       # ELECTORAL: the result panel exists; the overlay reveals it
   hide_view_toolbar: false           # the view toolbar exists; the overlay reveals lean + county
   rules:
-    population_tolerance: 0.15        # unused (no balance criterion) — a sane default
-    contiguity: allowed              # not gated here — T3 is about reading the vote, not rules
+    population_tolerance: 0.15        # generous — the player evens the districts out
+    contiguity: required             # carry T2's legal-map skill forward; keeps the validity panel up
   success_criteria:
-    # Mechanical objective: three districts in use, every precinct assigned. The result is
-    # shown to read, not to win-by — so nothing here gates on the electoral outcome.
+    # T3 still draws a LEGAL map (balanced + connected — the cumulative skill from T2) AND
+    # reads the vote. Gating balance + contiguity is what keeps the Map Validity panel visible
+    # (panels accrete once revealed). There is still no SEAT goal — the result is shown to read,
+    # not to win-by.
     - id: sc-district-count
       required: true
       description: All three districts are in use and every precinct is assigned.
       criterion: { type: district_count }
+    - id: sc-population-balance
+      required: true
+      description: All three districts have roughly equal population (within 15%).
+      criterion: { type: population_balance }
   narrative:
     character:
       name: You
@@ -178,8 +186,9 @@ assembly:
           you draw. They go together: lean tells you the ground, the result tells you the
           outcome — and the lines you draw decide it.
     objective: >
-      Draw three districts and read the result. There's no target to hit — repaint the lines
-      and watch who wins change, then submit when you've had a look.
+      Draw three balanced, connected districts — a legal map, like before — and read the result.
+      There's no seat to chase; repaint the lines, watch who wins change, and submit when it's
+      legal and you've had a look.
     epilogue: >
       That's the whole picture: precincts lean, and the district lines you draw turn those
       leanings into seats. The same voters can hand one party a majority of seats or the

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -1348,11 +1348,13 @@ test("tutorial-003 terrain: the cosmetic river is rendered", async ({ page }) =>
   await expect(page.locator("path.river-chain").first()).toBeAttached();
 });
 
-test("tutorial-003 electoral: the election-result panel is present (pre-electoral hiding is off)", async ({ page }) => {
-  // tutorial-003 sets hide_election_results: false — the first tutorial to surface the vote.
-  // With the guided overlay suppressed (beforeEach), the result panel shows normally.
+test("tutorial-003 chrome: the result panel AND the Map Validity panel are both visible", async ({ page }) => {
+  // hide_election_results: false → the result panel shows (first electoral tutorial). And T3
+  // gates balance + contiguity, so the Map Validity panel stays visible — panels accrete once
+  // revealed (it was introduced in T2; the applicable-aware hiding must not re-hide it here).
   await loadScenario(page, "tutorial-003");
   await expect(page.locator("#results-container")).toBeVisible();
+  await expect(page.locator("#validity-container")).toBeVisible();
 });
 
 test("tutorial-003 lean view: switching to Lean recolors the map by partisanship", async ({ page }) => {
@@ -1372,10 +1374,11 @@ test("tutorial-003 county view: the county overlay toggles on", async ({ page })
   await expect(page.locator("svg g.county-borders")).toBeAttached();
 });
 
-test("tutorial-003 winnability: carving three districts passes (gates on district_count only)", async ({ page }) => {
+test("tutorial-003 winnability: three balanced, connected wedges pass (district_count + balance + contiguity)", async ({ page }) => {
   await loadScenario(page, "tutorial-003");
-  // Mechanical objective: three districts in use, every precinct assigned. Carve three simple
-  // west / centre / east bands — no balance or contiguity gate to satisfy.
+  // T3 draws a LEGAL map: three districts balanced (±15%) + connected, plus reading the vote.
+  // Carve three wedges around the centre — each gets a slice of the dense core + sparse rim, so
+  // all three balance (BFS-verified; a 45° rotation is best: +1 / -3 / +2%).
   await page.evaluate(() => {
     const store = (window as unknown as Record<string, { getState: () => {
       paintStroke: (ids: number[], d: number) => void;
@@ -1385,10 +1388,16 @@ test("tutorial-003 winnability: carving three districts passes (gates on distric
     const state = store.getState();
     const d2: number[] = [];
     const d3: number[] = [];
+    const off = Math.PI / 4; // 45° rotation — best-balanced wedge orientation
     state.precincts.forEach((p: { coord: { q: number; r: number } }, i: number) => {
-      if (p.coord.q >= 2) d3.push(i);          // east → District 3
-      else if (p.coord.q >= -1) d2.push(i);    // centre → District 2
-      // q <= -2 (west) stays District 1
+      const x = Math.sqrt(3) * (p.coord.q + p.coord.r / 2);
+      const y = 1.5 * p.coord.r;
+      let a = Math.atan2(y, x);
+      if (a < 0) a += 2 * Math.PI;
+      const wedge = Math.min(2, Math.floor(((a - off + 2 * Math.PI) % (2 * Math.PI)) / (2 * Math.PI / 3)));
+      if (wedge === 1) d2.push(i);
+      else if (wedge === 2) d3.push(i);
+      // wedge 0 stays District 1
     });
     state.paintStroke(d2, 2);
     state.paintStroke(d3, 3);

--- a/game/web/src/tutorial/overlay.ts
+++ b/game/web/src/tutorial/overlay.ts
@@ -143,7 +143,7 @@ const TUTORIAL_003: TutorialStep[] = [
     advance: { on: "click-target" },
   },
   {
-    text: "That's the whole picture. Draw your three districts and hit **Submit**.",
+    text: "That's the whole picture. Draw your three districts — keep them balanced and connected, like before — then hit **Submit**.",
     highlight: ["#district-toolbar", "#btn-submit"],
     advance: { on: "submit" },
   },


### PR DESCRIPTION
## Summary

Playtest fix: **tutorial-003 was hiding the Map Validity panel.** The panel is "applicable-aware"
(`main.ts` shows it only when a scenario gates balance/contiguity), and T3 gated `district_count`
only — so it auto-hid. Per the owner's arc rule (**panels accrete once revealed** — T2 introduced
the validity panel), T3 now draws a **legal map**: it gates `district_count` +
`population_balance` (±15%) + `contiguity: required`. The panel shows naturally and is meaningful,
the player carries T2's legal-map skill forward, and there's still **no seat goal** (the result is
shown to read).

- `tutorial-003.spec.yaml` — add the `population_balance` criterion + `contiguity: required`;
  objective + header pedagogy updated.
- `overlay.ts` — T3 step 5 now reminds "keep them balanced and connected, like before."
- e2e — chrome test asserts the **result panel AND the Map Validity panel** are both visible;
  the winnability test carves **three balanced wedges** (the old q-band move no longer balances).

## Affected machines / services

- None. tutorial-003 spec/json + the guided-overlay copy + e2e. No backend/build/deploy change.

## Validation performed

- [x] `bazel test //game/web:app_typecheck_test //game/web/src/model:loader_integration_test` —
      pass (overlay copy typechecks; tutorial-003.json loads at 91 precincts / 3 districts).
- [x] `bazel build //game/web:e2e_test` — specs wired + build green.
- [x] Confirmed via jq the regenerated JSON gates `district_count` + `population_balance` with
      `contiguity: required`.
- [x] Re-verified the winning move on the regenerated JSON via BFS: three 45°-rotated wedges land
      at +1 / -3 / +2% (within ±15%) and contiguous — exactly what the winnability test carves.
- [x] e2e (Playwright) is CI-only on the dev machine; it runs as the CI gate on this PR.

## Deployment steps

- None.

## Tickets addressed

- **GAME-098** (tutorial-003). Ticket stays open (city view + GAME-100 river/generator).

## Rollback

- Revert this PR; T3 returns to district_count-only (and the validity panel auto-hides again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
