### PR TITLE
feat: tighten the guided overlay — lock input, gate the lean step, Reset restores the view

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -868,6 +868,28 @@ test("reset: does not start an overlay on a non-guided scenario", async ({ page 
   await expect(page.locator("#tutorial-panel")).toHaveCount(0);
 });
 
+test("reset: restores the initial view — districts colouring + county overlay off", async ({ page }) => {
+  // Reset zeroes the whole scenario including the vantage point: switch to lean + turn county
+  // borders on, then Reset should restore districts colouring + county off (not just the map).
+  await page.goto("/?s=scenario-002&debug");
+  const skip = page.locator("#btn-intro-skip");
+  await expect(skip).toBeVisible({ timeout: 15_000 });
+  await skip.click();
+  await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+
+  await page.locator("#filter-lean").click();
+  await page.locator("#filter-county").click();
+  await expect(page.locator("#filter-lean")).toHaveAttribute("aria-checked", "true");
+  await expect(page.locator("#filter-county")).toHaveAttribute("aria-pressed", "true");
+
+  await page.locator("#btn-reset").click();
+  await page.locator("#btn-reset-confirm").click();
+
+  await expect(page.locator("#filter-districts")).toHaveAttribute("aria-checked", "true");
+  await expect(page.locator("#filter-lean")).toHaveAttribute("aria-checked", "false");
+  await expect(page.locator("#filter-county")).toHaveAttribute("aria-pressed", "false");
+});
+
 test("lock gate: direct URL to locked scenario redirects to main menu", async ({ page }) => {
   // Ensure no progress — scenario-002 requires tutorial-002 completed
   await page.goto("/");
@@ -1427,11 +1449,12 @@ test("guided overlay: tutorial-003 reveals the result + lean, then county, then 
   await expect(page.locator("#tutorial-panel")).toContainText("geography");
   await page.locator("#tutorial-panel .tutorial-next").click();
 
-  // Step 2 — reveal the Lean view + the election result together.
+  // Step 2 — reveal the Lean button + the election result; advance only when Lean is clicked.
   await expect(page.locator("#tutorial-panel")).toContainText("election result");
   await expect(page.locator("#results-container")).toBeVisible();
   await expect(page.locator("#filter-lean")).toBeVisible();
-  await page.locator("#tutorial-panel .tutorial-next").click();
+  await page.locator("#filter-lean").click(); // the "thing" — Next is not offered on this step
+  await expect(page.locator("#filter-lean")).toHaveAttribute("aria-checked", "true");
 
   // Step 3 — paint and watch the result move; advance once 5 precincts are in District 2.
   await expect(page.locator("#tutorial-panel")).toContainText("watch the result");

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -818,9 +818,13 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		temporalStore.getState().clear();
 		resetConfirm!.classList.remove("visible");
 		btnReset!.disabled = false;
-		// Reset zeroes the whole scenario, not just the painted map: restart the guided tutorial
-		// from the top (no-op for non-guided scenarios). Guidance is skippable, so bringing it
-		// back on Reset is safe, useful production behavior.
+		// Reset zeroes the WHOLE scenario, not just the painted map: restore the initial view
+		// (districts colouring, overlays off, fitted vantage point) and restart the guided
+		// tutorial from the top (no-op for non-guided scenarios). Guidance is skippable, so
+		// bringing it back on Reset is safe, useful production behavior.
+		applyViewMode("districts");
+		applyCounty(false);
+		renderer.resetView();
 		restartTutorialOverlay(scenario, store);
 	});
 

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -50,6 +50,8 @@ export interface MapRenderer {
 	setCoordLabelsVisible(visible: boolean): void;
 	/** Provide scenario party display names for the precinct-info panel. */
 	setPartyLabels(labels: Partial<Record<PartyKey, string>>): void;
+	/** Reset the zoom/pan to the initial fitted vantage point (used by Reset). */
+	resetView(): void;
 }
 
 // ─── Internal types ───────────────────────────────────────────────────────────
@@ -401,6 +403,14 @@ export class SvgMapRenderer implements MapRenderer {
 	setViewMode(mode: ViewMode) {
 		this.viewMode = mode;
 		this.render();
+	}
+
+	resetView() {
+		// Snap the zoom/pan back to the initial fitted vantage point (same as the "0" shortcut).
+		this.svg
+			.transition()
+			.duration(SvgMapRenderer.ZOOM_DURATION_RESET)
+			.call(this.zoomBehavior.transform, this.initialTransform);
 	}
 
 	setCountyBordersVisible(visible: boolean) {

--- a/game/web/src/tutorial/overlay.ts
+++ b/game/web/src/tutorial/overlay.ts
@@ -29,8 +29,6 @@ export interface TutorialStep {
   highlight?: string | string[];
   /** Selector(s) to un-hide for this step (start hidden on load). */
   reveal?: string | string[];
-  /** Block all input except the highlight target(s) while this step is shown. */
-  pauseInput?: boolean;
   advance: AdvanceTrigger;
 }
 
@@ -50,13 +48,11 @@ const TUTORIAL_001: TutorialStep[] = [
   {
     text: "Pick **District 2** from the painter on the left.",
     highlight: '[data-district="2"]',
-    pauseInput: true,
     advance: { on: "click-target" },
   },
   {
     text: "Now click precincts on the map to paint them into District 2.",
     highlight: "#map-svg",
-    pauseInput: true,
     advance: { on: "paint-count", district: 2, n: 5 },
   },
   {
@@ -125,10 +121,10 @@ const TUTORIAL_003: TutorialStep[] = [
     advance: { on: "next" },
   },
   {
-    text: "Until now every voter was the same. They're not. **Lean** colors each precinct by who its voters favor — and this is what that produces: the **election result**, district by district.",
+    text: "Until now every voter was the same. They're not. Click **Lean** to colour each precinct by who its voters favour — and the **election result** panel (just appeared) shows what that produces, district by district.",
     reveal: ["#filter-lean", "#results-heading", "#results-container"],
-    highlight: ["#filter-lean", "#results-container"],
-    advance: { on: "next" },
+    highlight: "#filter-lean",
+    advance: { on: "click-target" },
   },
   {
     text: "Repaint a district and watch the result move. The lines you draw decide who wins.",
@@ -139,7 +135,6 @@ const TUTORIAL_003: TutorialStep[] = [
     text: "**County** borders are the old administrative lines. Like the river, they're **cosmetic** — they don't affect your districts at all; they just help you read the map and ground where things are.",
     reveal: "#filter-county",
     highlight: "#filter-county",
-    pauseInput: true,
     advance: { on: "click-target" },
   },
   {
@@ -368,10 +363,14 @@ function runOverlay(id: string, script: TutorialStep[], store: StoreLike): void 
     const targets = selectorsToElements(step.highlight);
     targets.forEach((el) => el.classList.add("tutorial-highlight"));
 
-    if (step.pauseInput) {
-      editorRoots.forEach((r) => r.classList.add("tutorial-paused"));
-      targets.forEach((el) => el.classList.add("tutorial-interactive"));
-    }
+    // Input is always locked while the coach is up: only the highlighted target(s), the painter,
+    // and the map stay clickable (the player can always paint), plus Next/Skip at body level.
+    // Everything else — the view toolbar, undo/redo, reset, etc. — is inert, so the player can't
+    // wander off whatever the guidance is pointing at.
+    editorRoots.forEach((r) => r.classList.add("tutorial-paused"));
+    [...targets, ...selectorsToElements(["#map-svg", "#district-toolbar"])].forEach((el) =>
+      el.classList.add("tutorial-interactive"),
+    );
 
     nextBtn.style.display = step.advance.on === "next" ? "" : "none";
 


### PR DESCRIPTION
## Summary

Three playtest fixes that make the guided tutorials feel tighter:

- **(1) Input is locked to the guidance.** While the coach panel is up, only the **highlighted
  target**, the **painter**, and the **map** are clickable (plus Next/Skip at body level).
  Everything else — the view toolbar, undo/redo, reset, coords — is inert, so the player can't
  wander off what the guidance is pointing at. `pauseInput` is no longer a per-step opt-in; it's
  the default for every step (the field was removed).
- **(2) The lean step gates on the action.** T3's "Lean / election result" step no longer offers
  a free **Next** — it advances only when the player **clicks the Lean button** (the thing it
  describes). The result panel still reveals for reading.
- **(3) Reset restores the view.** Reset now zeroes the whole scenario including the **vantage
  point**: districts colouring, county overlay **off**, and the zoom/pan snapped back to the
  initial fit (new `MapRenderer.resetView()`) — on top of the existing map + guidance restart.
  Previously a Reset in T3 could leave you in lean view with counties still on.

## Affected machines / services

- None. Game web UI (overlay engine, Reset handler, renderer) + e2e. No backend/build/deploy change.

## Validation performed

- [x] `bazel test //game/web:app_typecheck_test` — overlay.ts + main.ts + mapRenderer.ts typecheck
      (resetView added to the MapRenderer interface + SvgMapRenderer; only implementer).
- [x] `bazel build //game/web:e2e_test` — specs wired + build green.
- [x] Existing overlay walkthroughs (T1/T2/T4) paint via the store (bypassing pointer-events), so
      always-on pause doesn't break them; highlighted buttons + Next/Skip stay clickable.
- [x] New/updated e2e: T3 walkthrough advances the lean step by clicking Lean; a new test asserts
      Reset restores districts colouring + county overlay off.
- [x] e2e (Playwright) is CI-only on the dev machine; it runs as the CI gate on this PR.

## Deployment steps

- None.

## Tickets addressed

- Playtest feedback on the guided tutorials (input lock, action-gated Next, Reset view-reset).

## Rollback

- Revert this PR; the overlay returns to per-step pause, T3's lean step to a free Next, and Reset
  to map+guidance only (no view reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
