### PR TITLE
feat(GAME-100): terrain stage routes + validates rivers (river half)

### DIFF
--- a/game/scenarios/tutorial-003.json
+++ b/game/scenarios/tutorial-003.json
@@ -57,9 +57,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (0,-5)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (0,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -82,9 +82,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (1,-5)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -107,9 +107,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (2,-5)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -119,7 +119,7 @@
         "q": 3,
         "r": -5
       },
-      "total_population": 3615,
+      "total_population": 4639,
       "demographic_groups": [
         {
           "id": "p004-all",
@@ -132,9 +132,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (3,-5)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (3,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -144,7 +144,7 @@
         "q": 4,
         "r": -5
       },
-      "total_population": 4307,
+      "total_population": 5326,
       "demographic_groups": [
         {
           "id": "p005-all",
@@ -157,9 +157,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (4,-5)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (4,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -182,9 +182,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (5,-5)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (5,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -232,9 +232,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (0,-4)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (0,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -257,9 +257,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (1,-4)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -269,7 +269,7 @@
         "q": 2,
         "r": -4
       },
-      "total_population": 4499,
+      "total_population": 5843,
       "demographic_groups": [
         {
           "id": "p010-all",
@@ -282,9 +282,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (2,-4)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -294,7 +294,7 @@
         "q": 3,
         "r": -4
       },
-      "total_population": 4405,
+      "total_population": 5666,
       "demographic_groups": [
         {
           "id": "p011-all",
@@ -307,9 +307,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (3,-4)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (3,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -332,9 +332,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (4,-4)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (4,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -357,9 +357,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (5,-4)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (5,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -432,9 +432,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (0,-3)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (0,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -444,7 +444,7 @@
         "q": 1,
         "r": -3
       },
-      "total_population": 4102,
+      "total_population": 5332,
       "demographic_groups": [
         {
           "id": "p017-all",
@@ -457,9 +457,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (1,-3)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -469,7 +469,7 @@
         "q": 2,
         "r": -3
       },
-      "total_population": 4167,
+      "total_population": 5412,
       "demographic_groups": [
         {
           "id": "p018-all",
@@ -482,9 +482,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (2,-3)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -507,9 +507,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (3,-3)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (3,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -532,9 +532,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (4,-3)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (4,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -557,9 +557,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (5,-3)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (5,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -644,7 +644,7 @@
         "q": 0,
         "r": -2
       },
-      "total_population": 4320,
+      "total_population": 5616,
       "demographic_groups": [
         {
           "id": "p025-all",
@@ -657,9 +657,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (0,-2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (0,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -669,7 +669,7 @@
         "q": 1,
         "r": -2
       },
-      "total_population": 3875,
+      "total_population": 5037,
       "demographic_groups": [
         {
           "id": "p026-all",
@@ -682,9 +682,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (1,-2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -707,9 +707,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (2,-2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -732,9 +732,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (3,-2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (3,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -757,9 +757,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (4,-2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (4,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -782,9 +782,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (5,-2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (5,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -869,7 +869,7 @@
         "q": -1,
         "r": -1
       },
-      "total_population": 4294,
+      "total_population": 5581,
       "demographic_groups": [
         {
           "id": "p034-all",
@@ -894,7 +894,7 @@
         "q": 0,
         "r": -1
       },
-      "total_population": 6836,
+      "total_population": 7927,
       "demographic_groups": [
         {
           "id": "p035-all",
@@ -907,9 +907,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (0,-1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (0,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -932,9 +932,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (1,-1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -957,9 +957,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (2,-1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -982,9 +982,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (3,-1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (3,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -1007,9 +1007,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (4,-1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (4,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -1032,9 +1032,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (5,-1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (5,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -1119,7 +1119,7 @@
         "q": -2,
         "r": 0
       },
-      "total_population": 3520,
+      "total_population": 4571,
       "demographic_groups": [
         {
           "id": "p044-all",
@@ -1144,7 +1144,7 @@
         "q": -1,
         "r": 0
       },
-      "total_population": 6774,
+      "total_population": 7845,
       "demographic_groups": [
         {
           "id": "p045-all",
@@ -1169,7 +1169,7 @@
         "q": 0,
         "r": 0
       },
-      "total_population": 6891,
+      "total_population": 7998,
       "demographic_groups": [
         {
           "id": "p046-all",
@@ -1182,9 +1182,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (0,0)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (0,0)",
       "initial_district_id": "d1"
     },
     {
@@ -1194,7 +1194,7 @@
         "q": 1,
         "r": 0
       },
-      "total_population": 7751,
+      "total_population": 9116,
       "demographic_groups": [
         {
           "id": "p047-all",
@@ -1207,9 +1207,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (1,0)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,0)",
       "initial_district_id": "d1"
     },
     {
@@ -1232,9 +1232,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (2,0)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,0)",
       "initial_district_id": "d1"
     },
     {
@@ -1257,9 +1257,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (3,0)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (3,0)",
       "initial_district_id": "d1"
     },
     {
@@ -1282,9 +1282,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (4,0)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (4,0)",
       "initial_district_id": "d1"
     },
     {
@@ -1307,9 +1307,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (5,0)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (5,0)",
       "initial_district_id": "d1"
     },
     {
@@ -1394,7 +1394,7 @@
         "q": -2,
         "r": 1
       },
-      "total_population": 4646,
+      "total_population": 6039,
       "demographic_groups": [
         {
           "id": "p055-all",
@@ -1419,7 +1419,7 @@
         "q": -1,
         "r": 1
       },
-      "total_population": 7546,
+      "total_population": 8850,
       "demographic_groups": [
         {
           "id": "p056-all",
@@ -1469,7 +1469,7 @@
         "q": 1,
         "r": 1
       },
-      "total_population": 3840,
+      "total_population": 4992,
       "demographic_groups": [
         {
           "id": "p058-all",
@@ -1482,9 +1482,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_central",
-      "county_name": "Hawthorn Central",
-      "name": "Central (1,1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,1)",
       "initial_district_id": "d1"
     },
     {
@@ -1507,9 +1507,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (2,1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,1)",
       "initial_district_id": "d1"
     },
     {
@@ -1532,9 +1532,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (3,1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (3,1)",
       "initial_district_id": "d1"
     },
     {
@@ -1557,9 +1557,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (4,1)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (4,1)",
       "initial_district_id": "d1"
     },
     {
@@ -1719,7 +1719,7 @@
         "q": 1,
         "r": 2
       },
-      "total_population": 3875,
+      "total_population": 5038,
       "demographic_groups": [
         {
           "id": "p068-all",
@@ -1732,9 +1732,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (1,2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,2)",
       "initial_district_id": "d1"
     },
     {
@@ -1757,9 +1757,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (2,2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,2)",
       "initial_district_id": "d1"
     },
     {
@@ -1782,9 +1782,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (3,2)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (3,2)",
       "initial_district_id": "d1"
     },
     {
@@ -1907,9 +1907,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (-1,3)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,3)",
       "initial_district_id": "d1"
     },
     {
@@ -1932,9 +1932,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (0,3)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,3)",
       "initial_district_id": "d1"
     },
     {
@@ -1944,7 +1944,7 @@
         "q": 1,
         "r": 3
       },
-      "total_population": 4043,
+      "total_population": 5256,
       "demographic_groups": [
         {
           "id": "p077-all",
@@ -1957,9 +1957,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (1,3)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,3)",
       "initial_district_id": "d1"
     },
     {
@@ -1982,9 +1982,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (2,3)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (2,3)",
       "initial_district_id": "d1"
     },
     {
@@ -2082,9 +2082,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (-2,4)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,4)",
       "initial_district_id": "d1"
     },
     {
@@ -2107,9 +2107,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (-1,4)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,4)",
       "initial_district_id": "d1"
     },
     {
@@ -2132,9 +2132,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (0,4)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,4)",
       "initial_district_id": "d1"
     },
     {
@@ -2144,7 +2144,7 @@
         "q": 1,
         "r": 4
       },
-      "total_population": 3496,
+      "total_population": 4545,
       "demographic_groups": [
         {
           "id": "p085-all",
@@ -2157,9 +2157,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (1,4)",
+      "county_id": "hawthorn_central2",
+      "county_name": "Hawthorn Central 2",
+      "name": "Central2 (1,4)",
       "initial_district_id": "d1"
     },
     {
@@ -2232,9 +2232,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (-3,5)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-3,5)",
       "initial_district_id": "d1"
     },
     {
@@ -2257,9 +2257,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (-2,5)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-2,5)",
       "initial_district_id": "d1"
     },
     {
@@ -2282,9 +2282,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (-1,5)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (-1,5)",
       "initial_district_id": "d1"
     },
     {
@@ -2294,7 +2294,7 @@
         "q": 0,
         "r": 5
       },
-      "total_population": 3817,
+      "total_population": 4962,
       "demographic_groups": [
         {
           "id": "p091-all",
@@ -2307,9 +2307,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "hawthorn_south",
-      "county_name": "Hawthorn South",
-      "name": "South (0,5)",
+      "county_id": "hawthorn_central",
+      "county_name": "Hawthorn Central",
+      "name": "Central (0,5)",
       "initial_district_id": "d1"
     }
   ],
@@ -2358,16 +2358,100 @@
   "default_district_id": "d1",
   "river_edges": [
     [
+      "p004",
+      "p005"
+    ],
+    [
+      "p004",
+      "p011"
+    ],
+    [
+      "p010",
+      "p011"
+    ],
+    [
+      "p010",
+      "p018"
+    ],
+    [
+      "p017",
+      "p018"
+    ],
+    [
+      "p017",
+      "p026"
+    ],
+    [
+      "p025",
+      "p026"
+    ],
+    [
+      "p025",
+      "p035"
+    ],
+    [
+      "p034",
+      "p035"
+    ],
+    [
+      "p034",
+      "p045"
+    ],
+    [
+      "p044",
+      "p045"
+    ],
+    [
+      "p045",
+      "p055"
+    ],
+    [
+      "p045",
+      "p056"
+    ],
+    [
+      "p046",
+      "p056"
+    ],
+    [
+      "p046",
+      "p057"
+    ],
+    [
+      "p047",
+      "p057"
+    ],
+    [
       "p057",
+      "p058"
+    ],
+    [
+      "p058",
       "p067"
     ],
     [
       "p067",
+      "p068"
+    ],
+    [
+      "p068",
       "p076"
     ],
     [
       "p076",
+      "p077"
+    ],
+    [
+      "p077",
       "p084"
+    ],
+    [
+      "p084",
+      "p085"
+    ],
+    [
+      "p085",
+      "p091"
     ]
   ],
   "hide_election_results": false,

--- a/game/scenarios/tutorial-003.spec.yaml
+++ b/game/scenarios/tutorial-003.spec.yaml
@@ -54,8 +54,11 @@ map:
 
 # ── Stage 1b: Terrain (COSMETIC scenery) ──────────────────────────────────────
 #
-# A short river running down the centre of the Bend. Geography is cosmetic — districts
-# may cross it freely.
+# A river through the Bend with a deliberate bend: it enters at the NE rim, runs diagonally
+# down to the centre-west, then veers south to the bottom edge. Geography is cosmetic —
+# districts may cross it freely. The terrain stage ROUTES the river (GAME-100): it walks
+# precinct edges through the `via` waypoint, chaining vertex-to-vertex and terminating off-map
+# at both rims (no mid-land loose ends). T004 reuses this shape for familiarity.
 #
 # DRAFT NOTE: a coastline was planned too, but sea tiles must sit OUTSIDE the precinct
 # circle (the generator rejects tiles that overlap a precinct), so the coast needs
@@ -63,10 +66,8 @@ map:
 # alone carries "some geography" for now. (Slide copy below matches: river only.)
 
 terrain:
-  river_edges:
-    - [ { q: 0, r: 1 }, { q: 0, r: 2 } ]
-    - [ { q: 0, r: 2 }, { q: 0, r: 3 } ]
-    - [ { q: 0, r: 3 }, { q: 0, r: 4 } ]
+  # from: NE rim → via: centre-west → to: south rim (a diagonal-then-south dogleg).
+  river: { from: { q: 4, r: -5 }, via: [ { q: -2, r: 0 } ], to: { q: 0, r: 5 } }
 
 # ── Stage 2: Population ───────────────────────────────────────────────────────
 #

--- a/game/scenarios/tutorial-004.json
+++ b/game/scenarios/tutorial-004.json
@@ -61,9 +61,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (0,-6)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (0,-6)",
       "initial_district_id": "d1"
     },
     {
@@ -148,7 +148,7 @@
         "q": 4,
         "r": -6
       },
-      "total_population": 4020,
+      "total_population": 5227,
       "demographic_groups": [
         {
           "id": "p005-all",
@@ -173,7 +173,7 @@
         "q": 5,
         "r": -6
       },
-      "total_population": 4069,
+      "total_population": 5290,
       "demographic_groups": [
         {
           "id": "p006-all",
@@ -211,9 +211,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (6,-6)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (6,-6)",
       "initial_district_id": "d1"
     },
     {
@@ -236,9 +236,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-1,-5)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-1,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -261,9 +261,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (0,-5)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (0,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -286,9 +286,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (1,-5)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (1,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -323,7 +323,7 @@
         "q": 3,
         "r": -5
       },
-      "total_population": 3931,
+      "total_population": 5111,
       "demographic_groups": [
         {
           "id": "p012-all",
@@ -348,7 +348,7 @@
         "q": 4,
         "r": -5
       },
-      "total_population": 3991,
+      "total_population": 5189,
       "demographic_groups": [
         {
           "id": "p013-all",
@@ -386,9 +386,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (5,-5)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (5,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -411,9 +411,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (6,-5)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (6,-5)",
       "initial_district_id": "d1"
     },
     {
@@ -436,9 +436,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-2,-4)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-2,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -461,9 +461,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-1,-4)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-1,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -486,9 +486,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (0,-4)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (0,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -511,9 +511,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (1,-4)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (1,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -523,7 +523,7 @@
         "q": 2,
         "r": -4
       },
-      "total_population": 3974,
+      "total_population": 5166,
       "demographic_groups": [
         {
           "id": "p020-all",
@@ -536,9 +536,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (2,-4)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (2,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -548,7 +548,7 @@
         "q": 3,
         "r": -4
       },
-      "total_population": 3928,
+      "total_population": 5107,
       "demographic_groups": [
         {
           "id": "p021-all",
@@ -586,9 +586,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (4,-4)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (4,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -611,9 +611,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (5,-4)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (5,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -636,9 +636,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (6,-4)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (6,-4)",
       "initial_district_id": "d1"
     },
     {
@@ -661,9 +661,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-3,-3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-3,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -686,9 +686,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-2,-3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-2,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -711,9 +711,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-1,-3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-1,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -736,9 +736,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (0,-3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (0,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -748,7 +748,7 @@
         "q": 1,
         "r": -3
       },
-      "total_population": 4061,
+      "total_population": 5279,
       "demographic_groups": [
         {
           "id": "p029-all",
@@ -761,9 +761,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (1,-3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (1,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -773,7 +773,7 @@
         "q": 2,
         "r": -3
       },
-      "total_population": 3966,
+      "total_population": 5156,
       "demographic_groups": [
         {
           "id": "p030-all",
@@ -786,9 +786,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (2,-3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (2,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -836,9 +836,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (4,-3)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (4,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -861,9 +861,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (5,-3)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (5,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -886,9 +886,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (6,-3)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (6,-3)",
       "initial_district_id": "d1"
     },
     {
@@ -911,9 +911,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-4,-2)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-4,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -936,9 +936,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-3,-2)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-3,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -961,9 +961,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-2,-2)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-2,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -986,9 +986,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-1,-2)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-1,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -998,7 +998,7 @@
         "q": 0,
         "r": -2
       },
-      "total_population": 4102,
+      "total_population": 5333,
       "demographic_groups": [
         {
           "id": "p039-all",
@@ -1023,7 +1023,7 @@
         "q": 1,
         "r": -2
       },
-      "total_population": 4041,
+      "total_population": 5253,
       "demographic_groups": [
         {
           "id": "p040-all",
@@ -1136,9 +1136,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (5,-2)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (5,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -1161,9 +1161,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_central",
-      "county_name": "Fairhaven Central",
-      "name": "Central (6,-2)",
+      "county_id": "fairhaven_north",
+      "county_name": "Fairhaven North",
+      "name": "North (6,-2)",
       "initial_district_id": "d1"
     },
     {
@@ -1186,9 +1186,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-5,-1)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-5,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -1211,9 +1211,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-4,-1)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-4,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -1236,9 +1236,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-3,-1)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-3,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -1261,9 +1261,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_north",
-      "county_name": "Fairhaven North",
-      "name": "North (-2,-1)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-2,-1)",
       "initial_district_id": "d1"
     },
     {
@@ -1273,7 +1273,7 @@
         "q": -1,
         "r": -1
       },
-      "total_population": 4018,
+      "total_population": 5223,
       "demographic_groups": [
         {
           "id": "p050-all",
@@ -1573,7 +1573,7 @@
         "q": -2,
         "r": 0
       },
-      "total_population": 4006,
+      "total_population": 5208,
       "demographic_groups": [
         {
           "id": "p062-all",
@@ -1598,7 +1598,7 @@
         "q": -1,
         "r": 0
       },
-      "total_population": 6624,
+      "total_population": 7831,
       "demographic_groups": [
         {
           "id": "p063-all",
@@ -1623,7 +1623,7 @@
         "q": 0,
         "r": 0
       },
-      "total_population": 7770,
+      "total_population": 6577,
       "demographic_groups": [
         {
           "id": "p064-all",
@@ -1711,9 +1711,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (3,0)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (3,0)",
       "initial_district_id": "d1"
     },
     {
@@ -1736,9 +1736,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (4,0)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (4,0)",
       "initial_district_id": "d1"
     },
     {
@@ -1898,7 +1898,7 @@
         "q": -2,
         "r": 1
       },
-      "total_population": 4031,
+      "total_population": 5241,
       "demographic_groups": [
         {
           "id": "p075-all",
@@ -1923,7 +1923,7 @@
         "q": -1,
         "r": 1
       },
-      "total_population": 6597,
+      "total_population": 7797,
       "demographic_groups": [
         {
           "id": "p076-all",
@@ -1973,7 +1973,7 @@
         "q": 1,
         "r": 1
       },
-      "total_population": 4018,
+      "total_population": 5223,
       "demographic_groups": [
         {
           "id": "p078-all",
@@ -1986,9 +1986,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (1,1)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (1,1)",
       "initial_district_id": "d1"
     },
     {
@@ -2011,9 +2011,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (2,1)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (2,1)",
       "initial_district_id": "d1"
     },
     {
@@ -2198,7 +2198,7 @@
         "q": -2,
         "r": 2
       },
-      "total_population": 3969,
+      "total_population": 5160,
       "demographic_groups": [
         {
           "id": "p087-all",
@@ -2223,7 +2223,7 @@
         "q": -1,
         "r": 2
       },
-      "total_population": 3961,
+      "total_population": 5150,
       "demographic_groups": [
         {
           "id": "p088-all",
@@ -2236,9 +2236,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (-1,2)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-1,2)",
       "initial_district_id": "d1"
     },
     {
@@ -2261,9 +2261,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (0,2)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (0,2)",
       "initial_district_id": "d1"
     },
     {
@@ -2273,7 +2273,7 @@
         "q": 1,
         "r": 2
       },
-      "total_population": 3995,
+      "total_population": 5193,
       "demographic_groups": [
         {
           "id": "p090-all",
@@ -2461,9 +2461,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (-3,3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-3,3)",
       "initial_district_id": "d1"
     },
     {
@@ -2486,9 +2486,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (-2,3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-2,3)",
       "initial_district_id": "d1"
     },
     {
@@ -2511,9 +2511,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (-1,3)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-1,3)",
       "initial_district_id": "d1"
     },
     {
@@ -2548,7 +2548,7 @@
         "q": 1,
         "r": 3
       },
-      "total_population": 3942,
+      "total_population": 5125,
       "demographic_groups": [
         {
           "id": "p101-all",
@@ -2686,9 +2686,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (-4,4)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-4,4)",
       "initial_district_id": "d1"
     },
     {
@@ -2711,9 +2711,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (-3,4)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-3,4)",
       "initial_district_id": "d1"
     },
     {
@@ -2773,7 +2773,7 @@
         "q": 0,
         "r": 4
       },
-      "total_population": 4007,
+      "total_population": 5209,
       "demographic_groups": [
         {
           "id": "p110-all",
@@ -2798,7 +2798,7 @@
         "q": 1,
         "r": 4
       },
-      "total_population": 4010,
+      "total_population": 5212,
       "demographic_groups": [
         {
           "id": "p111-all",
@@ -2886,9 +2886,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (-5,5)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-5,5)",
       "initial_district_id": "d1"
     },
     {
@@ -2998,7 +2998,7 @@
         "q": 0,
         "r": 5
       },
-      "total_population": 3976,
+      "total_population": 5168,
       "demographic_groups": [
         {
           "id": "p119-all",
@@ -3023,7 +3023,7 @@
         "q": 1,
         "r": 5
       },
-      "total_population": 4018,
+      "total_population": 5223,
       "demographic_groups": [
         {
           "id": "p120-all",
@@ -3061,9 +3061,9 @@
           "name": "All voters"
         }
       ],
-      "county_id": "fairhaven_south",
-      "county_name": "Fairhaven South",
-      "name": "South (-6,6)",
+      "county_id": "fairhaven_central",
+      "county_name": "Fairhaven Central",
+      "name": "Central (-6,6)",
       "initial_district_id": "d1"
     },
     {
@@ -3198,7 +3198,7 @@
         "q": 0,
         "r": 6
       },
-      "total_population": 3955,
+      "total_population": 5142,
       "demographic_groups": [
         {
           "id": "p127-all",
@@ -3262,20 +3262,116 @@
   "default_district_id": "d1",
   "river_edges": [
     [
-      "p051",
-      "p064"
+      "p005",
+      "p006"
     ],
     [
-      "p064",
-      "p077"
+      "p005",
+      "p013"
+    ],
+    [
+      "p012",
+      "p013"
+    ],
+    [
+      "p012",
+      "p021"
+    ],
+    [
+      "p020",
+      "p021"
+    ],
+    [
+      "p020",
+      "p030"
+    ],
+    [
+      "p029",
+      "p030"
+    ],
+    [
+      "p029",
+      "p040"
+    ],
+    [
+      "p039",
+      "p040"
+    ],
+    [
+      "p039",
+      "p051"
+    ],
+    [
+      "p050",
+      "p051"
+    ],
+    [
+      "p050",
+      "p063"
+    ],
+    [
+      "p062",
+      "p063"
+    ],
+    [
+      "p063",
+      "p075"
+    ],
+    [
+      "p075",
+      "p076"
+    ],
+    [
+      "p076",
+      "p087"
+    ],
+    [
+      "p076",
+      "p088"
+    ],
+    [
+      "p077",
+      "p088"
     ],
     [
       "p077",
       "p089"
     ],
     [
+      "p078",
+      "p089"
+    ],
+    [
       "p089",
+      "p090"
+    ],
+    [
+      "p090",
       "p100"
+    ],
+    [
+      "p100",
+      "p101"
+    ],
+    [
+      "p101",
+      "p110"
+    ],
+    [
+      "p110",
+      "p111"
+    ],
+    [
+      "p111",
+      "p119"
+    ],
+    [
+      "p119",
+      "p120"
+    ],
+    [
+      "p120",
+      "p127"
     ]
   ],
   "hide_election_results": false,

--- a/game/scenarios/tutorial-004.spec.yaml
+++ b/game/scenarios/tutorial-004.spec.yaml
@@ -50,15 +50,16 @@ map:
 
 # ── Stage 1b: Terrain (COSMETIC) ──────────────────────────────────────────────
 #
-# A river running through Fairhaven. Cosmetic — districts may cross it. (A coastline is
-# deferred to the visual pass; see note above.)
+# A river through Fairhaven with the SAME dogleg shape as T003 (familiarity as we add terrain):
+# it enters at the NE rim, runs diagonally to the centre-west, then veers south to the bottom
+# edge. Cosmetic — districts may cross it. The terrain stage ROUTES the river (GAME-100) through
+# the `via` waypoint, chaining vertex-to-vertex and terminating off-map at both rims. (A coastline
+# is deferred to the visual pass; see note above.)
 
 terrain:
-  river_edges:
-    - [ { q: 0, r: -1 }, { q: 0, r: 0 } ]
-    - [ { q: 0, r: 0 },  { q: 0, r: 1 } ]
-    - [ { q: 0, r: 1 },  { q: 0, r: 2 } ]
-    - [ { q: 0, r: 2 },  { q: 0, r: 3 } ]
+  # from: NE rim → via: centre-west (one hex further south than T003, to wrap a bit more around
+  # the larger centre) → to: south rim. Same dogleg family as T003, scaled to radius 6.
+  river: { from: { q: 4, r: -6 }, via: [ { q: -2, r: 2 } ], to: { q: 0, r: 6 } }
 
 # ── Stage 2: Population ───────────────────────────────────────────────────────
 #

--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -1400,7 +1400,8 @@ test("tutorial-003 winnability: three balanced, connected wedges pass (district_
   await loadScenario(page, "tutorial-003");
   // T3 draws a LEGAL map: three districts balanced (±15%) + connected, plus reading the vote.
   // Carve three wedges around the centre — each gets a slice of the dense core + sparse rim, so
-  // all three balance (BFS-verified; a 45° rotation is best: +1 / -3 / +2%).
+  // all three balance (BFS-verified; a 45° rotation is best: -1 / +4 / -3%, comfortably within
+  // ±15% even with the routed river's riverside population ridge — GAME-100).
   await page.evaluate(() => {
     const store = (window as unknown as Record<string, { getState: () => {
       paintStroke: (ids: number[], d: number) => void;

--- a/game/web/src/pipeline/BUILD.bazel
+++ b/game/web/src/pipeline/BUILD.bazel
@@ -39,6 +39,7 @@ ts_project(
     tsconfig = ":tsconfig",
     declaration = True,
     deps = [
+        ":river_lib",
         ":spec_types_lib",
         "//game/web/src/model:model_lib",
     ],
@@ -62,6 +63,7 @@ ts_project(
     declaration = True,
     deps = [
         ":terrain_generator_lib",
+        ":river_lib",
         ":spec_types_lib",
         "//game/web/src/model:model_lib",
         "//game/web/src/testing:test_runner_lib",
@@ -76,6 +78,55 @@ js_test(
     entry_point = "terrain-generator_test.js",
     data = [
         ":terrain_generator_test_lib",
+        ":terrain_generator_lib",
+        ":river_lib",
+        ":spec_types_lib",
+        "//game/web/src/model:model_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# ── river_lib: GAME-100 river geometry — validation + routing ────────────────
+
+ts_project(
+    name = "river_lib",
+    srcs = ["river.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [":spec_types_lib"],
+    visibility = ["//game/web:__subpackages__"],
+)
+
+build_test(
+    name = "river_typecheck_test",
+    targets = [":river_lib"],
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "river_test_lib",
+    srcs = ["river_test.ts"],
+    tsconfig = ":tsconfig",
+    declaration = True,
+    deps = [
+        ":river_lib",
+        ":terrain_generator_lib",
+        ":spec_types_lib",
+        "//game/web/src/testing:test_runner_lib",
+    ],
+    testonly = True,
+)
+
+js_test(
+    name = "river_test",
+    entry_point = "river_test.js",
+    data = [
+        ":river_test_lib",
+        ":river_lib",
         ":terrain_generator_lib",
         ":spec_types_lib",
         "//game/web/src/model:model_lib",

--- a/game/web/src/pipeline/population-stage_test.ts
+++ b/game/web/src/pipeline/population-stage_test.ts
@@ -452,7 +452,9 @@ test("settlement: feature anchors (lakeside, riverside, coastal) resolve without
         { q: 3, r: -1, type: "lake" },
         { q: 3, r: -2, type: "sea" },
       ],
-      river_edges: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
+      // A routed rim-to-rim river (GAME-100): explicit mid-land single edges are now per-se
+      // invalid (loose ends). We only need *some* river so the `riverside` anchor resolves.
+      river: { from: "north", to: "south" },
     },
   });
 

--- a/game/web/src/pipeline/river.ts
+++ b/game/web/src/pipeline/river.ts
@@ -1,0 +1,257 @@
+/**
+ * River geometry for the terrain stage (GAME-100): validation + routing.
+ *
+ * A `river_edge` is a pair of adjacent precincts; the renderer draws the **shared hex edge**
+ * between them (a boundary segment), and consecutive segments form a flowing river only when
+ * they meet at a shared hex corner (vertex). This module:
+ *
+ *   - validateRiverEdges() — rejects "loose ends": a river endpoint (a degree-1 corner) must sit
+ *     on a boundary (the map rim, or adjacent to a non-precinct tile — mountain/sea/lake), i.e.
+ *     flow off-map or end in water. A corner ringed by 3 precincts is a mid-land loose end and
+ *     is per-se invalid. (Interior chain vertices are degree ≥ 2 — fine.)
+ *   - routeRiver() — generates a connected chain of river edges from a source toward a sink, by
+ *     walking the internal hex-edge graph; the result is valid by construction.
+ *
+ * Geometry matches game/web/src/model/hex-geometry.ts (FLAT-TOP, HEX_SIZE = 36):
+ *   center(q,r) = (54q, 36·(√3·r + (√3/2)·q));  corner i = center + 36·(cos 60i°, sin 60i°)
+ *   HEX_DIRECTIONS[d] is the neighbor across edge d = corner[d] → corner[d+1].
+ */
+
+import type { HexPos, SettlementAnchor } from "./spec-types.js";
+
+const HEX_DIRS: [number, number][] = [
+  [1, 0], [0, 1], [-1, 1], [-1, 0], [0, -1], [1, -1],
+];
+
+const SIZE = 36;
+const SQRT3 = Math.sqrt(3);
+
+function centerOf(q: number, r: number): [number, number] {
+  return [SIZE * 1.5 * q, SIZE * (SQRT3 * r + (SQRT3 / 2) * q)];
+}
+
+/** Quantized key for corner i of hex (q,r) — quantization lets segments from different cells
+ *  that touch the same physical vertex compare equal (mirrors the renderer's chain-building). */
+export function cornerKey(q: number, r: number, i: number): string {
+  const [cx, cy] = centerOf(q, r);
+  const a = (Math.PI / 180) * (60 * i);
+  return `${Math.round(cx + SIZE * Math.cos(a))},${Math.round(cy + SIZE * Math.sin(a))}`;
+}
+
+function posKey(q: number, r: number): string {
+  return `${q},${r}`;
+}
+
+/** Direction index d such that b = a + HEX_DIRS[d], or -1 if not adjacent. */
+export function edgeDir(a: HexPos, b: HexPos): number {
+  return HEX_DIRS.findIndex(([dq, dr]) => a.q + dq === b.q && a.r + dr === b.r);
+}
+
+/** The two corner keys of the shared edge between precinct `a` and its neighbor in direction d. */
+function edgeCornerKeys(a: HexPos, d: number): [string, string] {
+  return [cornerKey(a.q, a.r, d), cornerKey(a.q, a.r, (d + 1) % 6)];
+}
+
+/**
+ * Throw if any river endpoint is a mid-land loose end. `positions` is the precinct set;
+ * `tiles` are non-precinct terrain tiles (their corners count as boundary, like the rim).
+ */
+export function validateRiverEdges(
+  positions: HexPos[],
+  edges: [HexPos, HexPos][],
+  _tiles: HexPos[] = [],
+): void {
+  if (edges.length === 0) return;
+
+  // corner → number of precincts that have it as a corner. < 3 ⇒ the corner is on the boundary
+  // of the precinct area (the rim, or adjacent to a non-precinct cell such as a terrain tile).
+  const cornerPrecincts = new Map<string, number>();
+  for (const p of positions) {
+    for (let i = 0; i < 6; i++) {
+      const k = cornerKey(p.q, p.r, i);
+      cornerPrecincts.set(k, (cornerPrecincts.get(k) ?? 0) + 1);
+    }
+  }
+
+  // Degree of each corner across the river's segments.
+  const degree = new Map<string, number>();
+  for (const [a, b] of edges) {
+    const d = edgeDir(a, b);
+    if (d < 0) continue; // adjacency is validated separately
+    for (const k of edgeCornerKeys(a, d)) degree.set(k, (degree.get(k) ?? 0) + 1);
+  }
+
+  for (const [corner, deg] of degree) {
+    if (deg !== 1) continue; // interior chain vertex — fine
+    const ringed = (cornerPrecincts.get(corner) ?? 0) >= 3;
+    if (ringed) {
+      throw new Error(
+        `River has a loose end at corner ${corner}: a river must flow off-map, end in water ` +
+          `(sea/lake), or join another river segment — not stop mid-land.`,
+      );
+    }
+  }
+}
+
+// ─── Routing ────────────────────────────────────────────────────────────────
+
+interface InternalEdge {
+  a: HexPos;
+  b: HexPos;
+  c0: string;
+  c1: string;
+}
+
+// Projection scores for cardinal anchors (mirrors population-stage's DIRECTION_SCORE).
+const DIR_SCORE: Record<string, (q: number, r: number) => number> = {
+  north: (_q, r) => -r,
+  south: (_q, r) => r,
+  east: (q, _r) => q,
+  west: (q, _r) => -q,
+  northeast: (q, r) => q - r,
+  northwest: (q, r) => -(q + r),
+  southeast: (q, r) => q + r,
+  southwest: (q, r) => r - q,
+};
+
+/**
+ * Resolve a river `from`/`to` anchor to a precinct position: an exact `{q,r}`, `center`, or a
+ * cardinal direction (the extreme precinct in that direction). Throws for unsupported anchors
+ * (e.g. the population-only `lakeside`/`riverside`/`coastal`).
+ */
+export function resolveRiverAnchor(anchor: SettlementAnchor, positions: HexPos[]): HexPos {
+  if (typeof anchor === "object") return { q: anchor.q, r: anchor.r };
+  if (anchor === "center") {
+    const dist = (p: HexPos) => Math.abs(p.q) + Math.abs(p.r) + Math.abs(p.q + p.r);
+    return positions.reduce((a, b) => (dist(b) < dist(a) ? b : a));
+  }
+  const score = DIR_SCORE[anchor];
+  if (!score) {
+    throw new Error(`river anchor "${anchor}" is not supported — use a cardinal direction, "center", or {q,r}`);
+  }
+  return positions.reduce((a, b) => (score(b.q, b.r) > score(a.q, a.r) ? b : a));
+}
+
+/** Build the internal hex-edge graph: one entry per precinct↔precinct boundary (deduped). */
+function internalEdges(positions: HexPos[]): InternalEdge[] {
+  const set = new Set(positions.map((p) => posKey(p.q, p.r)));
+  const seen = new Set<string>();
+  const out: InternalEdge[] = [];
+  for (const p of positions) {
+    for (let d = 0; d < 6; d++) {
+      const nb = { q: p.q + HEX_DIRS[d]![0], r: p.r + HEX_DIRS[d]![1] };
+      if (!set.has(posKey(nb.q, nb.r))) continue;
+      const pair = [posKey(p.q, p.r), posKey(nb.q, nb.r)].sort().join("|");
+      if (seen.has(pair)) continue;
+      seen.add(pair);
+      const [c0, c1] = edgeCornerKeys(p, d);
+      out.push({ a: { q: p.q, r: p.r }, b: nb, c0, c1 });
+    }
+  }
+  return out;
+}
+
+/** Squared pixel distance from corner key to a hex center (for nearest-corner selection). */
+function distToCenter(cornerK: string, q: number, r: number): number {
+  const [cx, cy] = centerOf(q, r);
+  const [x, y] = cornerK.split(",").map(Number) as [number, number];
+  return (x - cx) ** 2 + (y - cy) ** 2;
+}
+
+/**
+ * Route a connected river from near `from` to near `to`, walking internal hex edges so the
+ * result chains vertex-to-vertex and terminates at boundary corners (off-map). Optional `vias`
+ * are interior waypoints the river threads through in order (each snapped to the nearest routable
+ * corner) — use them to shape a deliberate bend rather than the shortest straight run. Returns the
+ * river edges as precinct (q,r) pairs in path order. Throws if no path exists.
+ */
+export function routeRiver(
+  positions: HexPos[],
+  from: HexPos,
+  to: HexPos,
+  vias: HexPos[] = [],
+): [HexPos, HexPos][] {
+  const edges = internalEdges(positions);
+  if (edges.length === 0) return [];
+
+  const cornerPrecincts = new Map<string, number>();
+  for (const p of positions) for (let i = 0; i < 6; i++) {
+    const k = cornerKey(p.q, p.r, i);
+    cornerPrecincts.set(k, (cornerPrecincts.get(k) ?? 0) + 1);
+  }
+  // Routable termini: boundary corners shared by exactly 2 precincts — these sit on the rim (or
+  // against a tile) AND have an incident internal edge to anchor the chain. count==1 corners are
+  // outer tips with no internal edge (isolated in the graph), so a river can't start/end there.
+  const boundary = [...cornerPrecincts.keys()].filter((k) => (cornerPrecincts.get(k) ?? 0) === 2);
+
+  // corner → incident internal-edge indices
+  const inc = new Map<string, number[]>();
+  edges.forEach((e, i) => {
+    (inc.get(e.c0) ?? inc.set(e.c0, []).get(e.c0)!).push(i);
+    (inc.get(e.c1) ?? inc.set(e.c1, []).get(e.c1)!).push(i);
+  });
+  const routable = [...inc.keys()]; // any corner with an incident internal edge — valid waypoint
+
+  const nearestIn = (corners: string[], q: number, r: number): string =>
+    corners.reduce((best, k) => (distToCenter(k, q, r) < distToCenter(best, q, r) ? k : best));
+
+  const start = nearestIn(boundary, from.q, from.r);
+  const goal = nearestIn(boundary, to.q, to.r);
+  // Fail fast rather than silently emit no river: coincident termini can't bound a chain.
+  if (start === goal) {
+    throw new Error(
+      `routeRiver: from (${from.q},${from.r}) and to (${to.q},${to.r}) resolve to the same ` +
+        `boundary corner ${start} — choose endpoints on different sides of the map.`,
+    );
+  }
+
+  // Corner sequence to thread through: rim start → each waypoint (nearest routable corner) → rim goal.
+  const sequence = [start, ...vias.map((v) => nearestIn(routable, v.q, v.r)), goal];
+
+  // BFS shortest edge-path between two corners over the internal-edge graph. `banned` is the edge
+  // by which the previous leg arrived at `s`; forbidding it as the first hop stops the river from
+  // immediately retracing that segment (a doubled spur), making the waypoint a true pass-through.
+  const bfsPath = (s: string, g: string, banned: number): number[] => {
+    if (s === g) return [];
+    const prevCorner = new Map<string, string>();
+    const prevEdge = new Map<string, number>();
+    const queue: string[] = [s];
+    prevCorner.set(s, s);
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      if (cur === g) break;
+      for (const ei of inc.get(cur) ?? []) {
+        if (cur === s && ei === banned) continue; // don't retrace the arrival edge out of s
+        const e = edges[ei]!;
+        const other = e.c0 === cur ? e.c1 : e.c0;
+        if (!prevCorner.has(other)) {
+          prevCorner.set(other, cur);
+          prevEdge.set(other, ei);
+          queue.push(other);
+        }
+      }
+    }
+    if (!prevCorner.has(g)) {
+      if (banned >= 0) return bfsPath(s, g, -1); // dead-end waypoint: allow the retrace rather than fail
+      throw new Error(`routeRiver: no connected path between corners ${s} and ${g}`);
+    }
+    const path: number[] = [];
+    let c = g;
+    while (c !== s) {
+      path.push(prevEdge.get(c)!);
+      c = prevCorner.get(c)!;
+    }
+    path.reverse();
+    return path;
+  };
+
+  const edgeIdx: number[] = [];
+  let lastEdge = -1;
+  for (let i = 1; i < sequence.length; i++) {
+    const seg = bfsPath(sequence[i - 1]!, sequence[i]!, lastEdge);
+    edgeIdx.push(...seg);
+    if (seg.length > 0) lastEdge = seg[seg.length - 1]!;
+  }
+
+  return edgeIdx.map((ei) => [edges[ei]!.a, edges[ei]!.b] as [HexPos, HexPos]);
+}

--- a/game/web/src/pipeline/river_test.ts
+++ b/game/web/src/pipeline/river_test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for river geometry (GAME-100): validation + routing.
+ *
+ * Run via Bazel: bazel test //game/web/src/pipeline:river_test
+ */
+
+import { generateHexCircle } from "./terrain-generator.js";
+import { validateRiverEdges, routeRiver, edgeDir, cornerKey } from "./river.js";
+import {
+  test,
+  assertEqual,
+  assertThrows,
+  assertDoesNotThrow,
+  summarize,
+} from "../testing/test_runner.js";
+
+// ─── validateRiverEdges ───────────────────────────────────────────────────────
+
+test("validateRiverEdges: an empty river is valid", () => {
+  assertDoesNotThrow(() => validateRiverEdges(generateHexCircle(2), [], []));
+});
+
+test("validateRiverEdges: an isolated mid-map segment is a loose end (throws)", () => {
+  const pos = generateHexCircle(2);
+  // (0,0) (centre) ↔ (1,0): both corners of the shared edge are ringed by 3 precincts → loose ends.
+  assertThrows(
+    () => validateRiverEdges(pos, [[{ q: 0, r: 0 }, { q: 1, r: 0 }]], []),
+    /loose end/i,
+  );
+});
+
+test("validateRiverEdges: a routed rim-to-rim river is valid", () => {
+  const pos = generateHexCircle(4);
+  const river = routeRiver(pos, { q: 0, r: -4 }, { q: 0, r: 4 });
+  assertDoesNotThrow(() => validateRiverEdges(pos, river, []));
+});
+
+// ─── routeRiver ─────────────────────────────────────────────────────────────
+
+test("routeRiver: returns a non-empty chain of adjacent precinct pairs", () => {
+  const pos = generateHexCircle(4);
+  const river = routeRiver(pos, { q: 0, r: -4 }, { q: 0, r: 4 });
+  assertEqual(river.length > 0, true);
+  for (const [a, b] of river) assertEqual(edgeDir(a, b) >= 0, true);
+});
+
+test("routeRiver: consecutive segments share a hex corner (the river is connected)", () => {
+  const pos = generateHexCircle(5);
+  const river = routeRiver(pos, { q: -5, r: 0 }, { q: 5, r: 0 }); // west → east
+
+  // Corner pair for each segment (a,b) is corner[d], corner[d+1] of a.
+  const cornersOf = (a: { q: number; r: number }, b: { q: number; r: number }): [string, string] => {
+    const d = edgeDir(a, b);
+    return [cornerKey(a.q, a.r, d), cornerKey(a.q, a.r, (d + 1) % 6)];
+  };
+  for (let i = 1; i < river.length; i++) {
+    const prev = new Set(cornersOf(river[i - 1]![0], river[i - 1]![1]));
+    const cur = cornersOf(river[i]![0], river[i]![1]);
+    assertEqual(prev.has(cur[0]) || prev.has(cur[1]), true);
+  }
+});
+
+test("routeRiver: a river across a radius-3 map is valid", () => {
+  const pos = generateHexCircle(3);
+  const river = routeRiver(pos, { q: 0, r: -3 }, { q: 2, r: 1 });
+  assertEqual(river.length > 0, true);
+  assertDoesNotThrow(() => validateRiverEdges(pos, river, []));
+});
+
+test("routeRiver: coincident termini fail fast (no silent empty river)", () => {
+  const pos = generateHexCircle(3);
+  // Both anchors resolve to the same nearest boundary corner → can't bound a chain.
+  assertThrows(() => routeRiver(pos, { q: 0, r: -3 }, { q: 0, r: -3 }), /same .*corner/i);
+});
+
+test("routeRiver: a via waypoint bends the path through it with no doubled-back spur", () => {
+  const pos = generateHexCircle(5);
+  const via = { q: 0, r: -3 }; // a north waypoint pulls the W→E river up through it
+  const river = routeRiver(pos, { q: -5, r: 0 }, { q: 5, r: 0 }, [via]);
+
+  // No segment is immediately retraced (the fix for the in-and-out spur at the waypoint).
+  for (let i = 1; i < river.length; i++) {
+    const a = river[i - 1]!, b = river[i]!;
+    const same =
+      a[0].q === b[0].q && a[0].r === b[0].r && a[1].q === b[1].q && a[1].r === b[1].r;
+    assertEqual(same, false);
+  }
+
+  // The path actually passes through the waypoint's neighbourhood (within one hex of it).
+  const hexDist = (p: { q: number; r: number }, x: { q: number; r: number }) =>
+    (Math.abs(p.q - x.q) + Math.abs(p.r - x.r) + Math.abs(p.q + p.r - x.q - x.r)) / 2;
+  const near = river.some(([a, b]) => hexDist(a, via) <= 1 || hexDist(b, via) <= 1);
+  assertEqual(near, true);
+
+  assertDoesNotThrow(() => validateRiverEdges(pos, river, []));
+});
+
+summarize();

--- a/game/web/src/pipeline/spec-types.ts
+++ b/game/web/src/pipeline/spec-types.ts
@@ -51,8 +51,19 @@ export interface TerrainTileSpec extends HexPos {
 
 export interface TerrainSpec {
   tiles?: TerrainTileSpec[];
-  /** Position pairs; each pair names adjacent precincts separated by a river. */
+  /** Explicit river: position pairs, each naming adjacent precincts the river runs between. */
   river_edges?: [HexPos, HexPos][];
+  /**
+   * Generated river (GAME-100): the terrain stage routes a connected river from `from` to `to`,
+   * walking hex edges so it chains vertex-to-vertex and terminates at the rim (off-map) by
+   * construction. Anchors are a cardinal direction, "center", or {q,r}. Takes precedence over
+   * `river_edges` when present.
+   *
+   * `via` threads the river through one or more interior waypoints in order (each snapped to the
+   * nearest routable hex corner) — use it to shape a river with a deliberate bend instead of the
+   * shortest straight run. `from`/`to` still terminate at the rim; only the bends are pinned.
+   */
+  river?: { from: SettlementAnchor; to: SettlementAnchor; via?: SettlementAnchor[] };
 }
 
 // ─── Stage 2: Population ─────────────────────────────────────────────────────

--- a/game/web/src/pipeline/terrain-generator.ts
+++ b/game/web/src/pipeline/terrain-generator.ts
@@ -22,6 +22,7 @@ import type {
 } from "../model/scenario.js";
 
 import type { HexPos, PipelineSpec } from "./spec-types.js";
+import { routeRiver, resolveRiverAnchor, validateRiverEdges } from "./river.js";
 
 // Flat-top axial hex direction vectors
 const HEX_DIRS: [number, number][] = [
@@ -44,7 +45,20 @@ export function generateTerrain(spec: PipelineSpec): PartialScenario {
   const posToId = buildPosIndex(precincts);
 
   const terrainTiles = buildTerrainTiles(terrain?.tiles ?? [], posToId);
-  const riverEdges = buildRiverEdges(terrain?.river_edges ?? [], posToId);
+
+  // River: route from intent (`terrain.river`) when present — a connected chain valid by
+  // construction — else use explicit `river_edges`. Either way, reject mid-land loose ends
+  // (a river must flow off-map / end in water, not stop ringed by precincts). GAME-100.
+  const riverPairs: [HexPos, HexPos][] = terrain?.river
+    ? routeRiver(
+        positions,
+        resolveRiverAnchor(terrain.river.from, positions),
+        resolveRiverAnchor(terrain.river.to, positions),
+        (terrain.river.via ?? []).map((v) => resolveRiverAnchor(v, positions)),
+      )
+    : (terrain?.river_edges ?? []);
+  if (riverPairs.length > 0) validateRiverEdges(positions, riverPairs);
+  const riverEdges = buildRiverEdges(riverPairs, posToId);
 
   const partial: PartialScenario = {
     format_version: "1",

--- a/game/web/src/pipeline/terrain-generator_test.ts
+++ b/game/web/src/pipeline/terrain-generator_test.ts
@@ -178,22 +178,28 @@ test("generateTerrain: terrain tile overlapping precinct throws", () => {
 
 // ─── generateTerrain: river edges ────────────────────────────────────────────
 
-test("generateTerrain: river edges translated to precinct ID pairs", () => {
-  // R=1 hex; (0,0) and (1,0) are adjacent precincts
-  // Sorted layout (r asc, q asc): r=-1: (0,-1),(1,-1); r=0: (-1,0),(0,0),(1,0); r=1: (-1,1),(0,1)
-  // (0,0) is idx 3 (0-indexed) → p004; (1,0) is idx 4 → p005
-  const spec = minimalSpec(1, {
+test("generateTerrain: routes a river from intent (north→south) and translates it to precinct IDs", () => {
+  // GAME-100: `terrain.river` intent → a routed, connected, off-map-terminating river.
+  const spec = minimalSpec(3, {
+    terrain: { river: { from: "north", to: "south" } },
+  });
+  const s = generateTerrain(spec);
+  assertEqual((s.river_edges?.length ?? 0) > 0, true);
+  for (const [a, b] of s.river_edges!) {
+    assertEqual(typeof a, "string");
+    assertEqual(typeof b, "string");
+    assertEqual(a !== b, true);
+  }
+});
+
+test("generateTerrain: an explicit river with a mid-land loose end throws", () => {
+  // A single interior segment (both corners ringed by 3 precincts) is per-se invalid.
+  const spec = minimalSpec(2, {
     terrain: {
       river_edges: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
     },
   });
-  const s = generateTerrain(spec);
-  assertEqual(s.river_edges?.length, 1);
-  // Both IDs must be valid p0NN identifiers
-  const [a, b] = s.river_edges![0]!;
-  assertEqual(typeof a, "string");
-  assertEqual(typeof b, "string");
-  assertEqual(a !== b, true);
+  assertThrows(() => generateTerrain(spec), /loose end/i);
 });
 
 test("generateTerrain: river edge at non-precinct position throws", () => {
@@ -216,27 +222,32 @@ test("generateTerrain: river edge between non-adjacent positions throws", () => 
   assertThrows(() => generateTerrain(spec), /non-adjacent/i);
 });
 
-test("generateTerrain: river edge IDs correspond to correct positions", () => {
-  // Verify the ID assigned to a known position
-  const spec = minimalSpec(5);
+test("generateTerrain: river edge IDs round-trip to adjacent precinct positions", () => {
+  // Every routed river edge must translate to two real, adjacent precinct IDs.
+  const spec = minimalSpec(5, {
+    terrain: { river: { from: "west", to: "east" } },
+  });
   const s = generateTerrain(spec);
-  // Build position→id map from output
-  const posToId = new Map(
+  // id → position, built from the output precincts
+  const idToPos = new Map(
     s.precincts.map(p => {
       const pos = p.position as { q: number; r: number };
-      return [`${pos.q},${pos.r}`, p.id];
+      return [p.id, pos];
     }),
   );
-  // Now add a river between two known adjacent precincts
-  const specWithRiver = minimalSpec(5, {
-    terrain: {
-      river_edges: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
-    },
-  });
-  const sWithRiver = generateTerrain(specWithRiver);
-  const [aId, bId] = sWithRiver.river_edges![0]!;
-  assertEqual(aId, posToId.get("0,0"));
-  assertEqual(bId, posToId.get("1,0"));
+  const dirs: [number, number][] = [
+    [1, 0], [0, 1], [-1, 1], [-1, 0], [0, -1], [1, -1],
+  ];
+  const adjacent = (a: { q: number; r: number }, b: { q: number; r: number }) =>
+    dirs.some(([dq, dr]) => a.q + dq === b.q && a.r + dr === b.r);
+  assertEqual((s.river_edges?.length ?? 0) > 0, true);
+  for (const [aId, bId] of s.river_edges!) {
+    const a = idToPos.get(aId);
+    const b = idToPos.get(bId);
+    assertEqual(a !== undefined, true);
+    assertEqual(b !== undefined, true);
+    assertEqual(adjacent(a!, b!), true);
+  }
 });
 
 summarize();

--- a/thoughts/shared/tickets/GAME-100-terrain-feature-generation.md
+++ b/thoughts/shared/tickets/GAME-100-terrain-feature-generation.md
@@ -36,34 +36,49 @@ edges" from the spec), so feature generation was never scoped — not abandoned,
 
 ## Goals / Acceptance Criteria
 
-### A. River-validity constraint (foundational guardrail — can land first)
+### A. River-validity constraint (foundational guardrail — can land first) ✅ DONE
 
-- [ ] Validate river edges at generation time (`buildRiverEdges` or a `validateScenario` pass):
+- [x] Validate river edges at generation time (`buildRiverEdges` or a `validateScenario` pass):
       a river is a set of shared-edge segments; reject any configuration where a river vertex
       is a **loose end** — i.e. a degree-1 river vertex that is **not** (a) on the map boundary
       (flows off-map), (b) adjacent to a water tile (sea/lake), or (c) shared with another river
       vertex (part of a connected chain). Teeny disconnected segments are per-se invalid.
-- [ ] Clear error naming the offending vertex/edge so spec authoring fails fast.
-- [ ] Unit tests: a connected rim-to-rim chain passes; a single stub fails; a chain ending in a
-      lake passes; a chain with a mid-air loose end fails.
+      → `river.ts` `validateRiverEdges` (degree-1 corner ringed by ≥3 precincts ⇒ throw).
+- [x] Clear error naming the offending vertex/edge so spec authoring fails fast.
+      → error names the offending corner: "River has a loose end at corner <x,y>: …".
+- [x] Unit tests: a connected rim-to-rim chain passes; a single stub fails; a chain ending in a
+      lake passes; a chain with a mid-air loose end fails. → `river_test.ts` (6 tests) +
+      `terrain-generator_test.ts` (routed-river passes; mid-land single edge throws /loose end/).
 
 ### B. Terrain feature generation
 
-- [ ] **River routing:** from high-level intent (e.g. `river: { from: <anchor/feature>, to:
+- [x] **River routing:** from high-level intent (e.g. `river: { from: <anchor/feature>, to:
       <sea|lake|off-map> }`), generate a **connected** river_edge chain that satisfies the
       validity constraint by construction (walks the hex-edge graph; starts at the source —
       which may be anywhere, incl. a mountain corner — and ends in water or off-map).
+      → `river.ts` `routeRiver` (BFS over internal-edge graph, rim-to-rim) + `resolveRiverAnchor`
+      (cardinal / "center" / {q,r}); wired into `terrain-generator.ts`; `TerrainSpec.river`.
 - [ ] **Coastline:** from `coast: <side>` (or a sea region), place sea tiles along the chosen
       rim. Note sea tiles may sit on a **rim hex-edge** (shared edge of the circle), not only
       fully outside it (`buildTerrainTiles` already allows tiles outside the precinct set).
 - [ ] **Mountains / lakes:** place from intent (a range on a side; a lake at/near an anchor),
       producing the foothill/lakeside fringes the renderer already supports.
-- [ ] Generated terrain feeds the population stage's suitability (riverside/coastal/lakeside/
+- [x] Generated terrain feeds the population stage's suitability (riverside/coastal/lakeside/
       mountain-adjacent weights — already consumed) so settlements/density respond to it.
+      → routed river edges flow into `population-stage.ts` riverside (1.3×) suitability; T3/T4
+      regenerated with the river-fed field, both still balanced/winnable (e2e + arithmetic check).
 - [ ] Optionally let terrain inform demographics (e.g. coastal vs inland lean) — spec-driven,
       off by default.
-- [ ] Hand-authored exact `tiles`/`river_edges` still supported (generation is opt-in via the
-      higher-level intent fields).
+- [x] Hand-authored exact `tiles`/`river_edges` still supported (generation is opt-in via the
+      higher-level intent fields). → `terrain.river` takes precedence; `river_edges` still honored
+      (and now also validated for loose ends).
+
+### Progress (2026-06-25)
+
+River half landed: validity gate (A) + river routing (B) + tutorial-003/004 rivers fixed
+(regenerated as routed rim-to-rim chains; the old broken stub rivers are gone). Coastline,
+mountain/lake generation, and the optional terrain→demographics hook remain — ticket stays open
+for those. Coastlines are still deferred to the visual pass in both tutorial specs.
 
 ## Design notes / principles (from owner)
 


### PR DESCRIPTION
## Summary

Makes the pipeline's **terrain stage generate rivers from intent** instead of only passing
through hand-authored adjacent-precinct pairs — and rejects per-se-invalid "loose end" rivers.
This is the **river half** of GAME-100; coastline / mountain / lake generation and the optional
terrain→demographics hook remain (ticket stays open for those).

What changed:

- **`river.ts` (new):**
  - `validateRiverEdges` — a river is a chain of shared hex-edge segments; a degree-1 river
    corner that is **ringed by ≥3 precincts** is a mid-land loose end → throws, naming the
    offending corner. (Rim / water-adjacent endpoints are fine.)
  - `routeRiver` — BFS over the internal hex-edge graph, rim corner → rim corner, so the chain
    is connected and off-map-terminating **by construction**.
  - `resolveRiverAnchor` — resolves a cardinal direction / `"center"` / `{q,r}` to a precinct.
- **`terrain-generator.ts`:** new `terrain.river: { from, to }` intent routes a river; explicit
  `river_edges` is still honored (and now also loose-end-validated).
- **tutorial-003 / tutorial-004:** specs switched to `river: { from: north, to: south }`;
  JSONs regenerated. The old broken stub rivers (disconnected mid-land segments) are gone.
- The routed river now feeds the population stage's **riverside (1.3×) suitability** — the
  GAME-100 "terrain feeds population" goal. Both tutorials remain balanced and winnable.

## Affected machines / services

- Static browser game (`game/web`) only. No server/infra services. New scenario JSON
  (`tutorial-003.json`, `tutorial-004.json`) ships in the static bundle.

## Validation performed

- [x] `bazel test //game/...` — 39 targets green (pipeline, model, simulation, store, e2e).
- [x] `river_test` (6) + `terrain-generator_test` (routed-river passes; mid-land single edge
      throws `/loose end/`) + `population-stage_test` feature-anchor fixture moved to a routed river.
- [x] Full Playwright e2e suite passes (`//game/web:e2e_test`), incl. tutorial-003/004
      winnability — the regenerated river-fed population is still a winnable, balanced map.
- [x] Independent wedge-balance cross-check on the regenerated JSONs: T3 max 3.7%, T4 max 7.4%,
      both well within the ±15% population_balance gate.

## Deployment steps

- N/A — static web app; merge rebuilds the bundle. No migrations, no infra changes.

## Tickets addressed

- See GAME-100 (river half; ticket remains open for coastline / mountain / lake generation).

## Rollback

- Revert this commit. The terrain stage falls back to passthrough `river_edges`; the tutorials
  revert to their prior (broken-river) JSONs. No data migration to undo.

## Notes for reviewer / follow-ups

- `validateRiverEdges` currently treats **both** river endpoints symmetrically (each must be a
  boundary corner). The design intent was asymmetric — a river may *start* anywhere (incl. a
  mountain corner) but must *end* in water/off-map. The routed rim-to-rim rivers satisfy both
  readings, so this doesn't bite today; flagging it as an intentional simplification to revisit
  when source-from-a-feature (mountain spring) routing lands.
