### PR TITLE
feat(tutorial): end T004 guidance with a read-only Done beat, not an in-overlay submit

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -1532,7 +1532,7 @@ test("tutorial-004 winnability: four balanced, connected districts pass (distric
 
 // ─── GAME-099: guided overlay (tutorial-004) — light orient (nothing hidden) ───
 
-test("guided overlay: tutorial-004 gives a light orient then steps back to submit", async ({ page }) => {
+test("guided overlay: tutorial-004 gives a light orient then a read-only Done beat that unlocks without submitting", async ({ page }) => {
   await page.goto("/?campaign=tutorial&s=tutorial-004&debug&resetTutorial=1");
   const skip = page.locator("#btn-intro-skip");
   await expect(skip).toBeVisible({ timeout: 15_000 });
@@ -1547,13 +1547,31 @@ test("guided overlay: tutorial-004 gives a light orient then steps back to submi
   await expect(page.locator("#tutorial-panel")).toContainText("capstone");
   await page.locator("#tutorial-panel .tutorial-next").click();
 
-  // Step 2 — paint; advance once 5 precincts are in District 2.
-  await expect(page.locator("#tutorial-panel")).toContainText("four districts");
-  await paintHexes(page, [[-3, 0], [-2, 0], [-1, 0], [0, 0], [1, 0]], 2);
+  // Step 2 — paint a full district's worth (32). The live counter shows the target and progress.
+  await expect(page.locator("#tutorial-panel")).toContainText("full district's worth");
+  await expect(page.locator("#tutorial-panel .tutorial-progress")).toBeVisible();
+  await expect(page.locator("#tutorial-panel .tutorial-progress")).toContainText("/ 32 painted");
+  // Paint 32 precincts into District 2 via the store (the overlay counts assignments live).
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, { getState: () => {
+      paintStroke: (ids: number[], d: number) => void;
+    } }>)["__gameStore"];
+    if (!store) throw new Error("__gameStore not found");
+    store.getState().paintStroke([...Array(32).keys()], 2);
+  });
 
-  // Step 3 — submit (terminal).
-  await expect(page.locator("#tutorial-panel")).toContainText("Submit");
-  await page.locator("#btn-submit").click();
+  // Step 3 — read-only "Done" beat: the map + painter are locked (no tutorial-interactive), so the
+  // only action is reading the coach and clicking Done. The button reads "Done", not "Next →".
+  await expect(page.locator("#tutorial-panel")).toContainText("the map is yours", { timeout: 10_000 });
+  await expect(page.locator("#map-svg")).not.toHaveClass(/tutorial-interactive/);
+  await expect(page.locator("#district-toolbar")).not.toHaveClass(/tutorial-interactive/);
+  const doneBtn = page.locator("#tutorial-panel .tutorial-next");
+  await expect(doneBtn).toHaveText("Done");
+  await doneBtn.click();
+
+  // Done ends the tutorial WITHOUT submitting: the overlay is gone, no result screen appeared,
+  // and the editor is unlocked (the player finishes — pan, inspect, submit — on their own).
   await expect(page.locator("#tutorial-panel")).toHaveCount(0);
-  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-screen")).toBeHidden();
+  await expect(page.locator("#main")).not.toHaveClass(/tutorial-paused/);
 });

--- a/game/web/src/tutorial/overlay.ts
+++ b/game/web/src/tutorial/overlay.ts
@@ -29,6 +29,14 @@ export interface TutorialStep {
   highlight?: string | string[];
   /** Selector(s) to un-hide for this step (start hidden on load). */
   reveal?: string | string[];
+  /**
+   * Read-only step: lock the map and painter too (the default leaves them interactive so the
+   * player can always paint). The player can only read the coach and click Done/Skip. Use it for
+   * a closing "you're on your own now" beat that ends the tutorial *before* any real action
+   * (drawing, panning, submitting) — so nothing is submitted while still inside the overlay, and
+   * when the step finishes everything unlocks at once.
+   */
+  readOnly?: boolean;
   advance: AdvanceTrigger;
 }
 
@@ -146,9 +154,12 @@ const TUTORIAL_003: TutorialStep[] = [
 
 /**
  * tutorial-004 — "Capstone" (DESIGN-012 / GAME-099). A light orientation over a fuller map
- * with every tool visible from the start (nothing hidden, no `reveal`): orient → paint →
- * submit, then step back. The player synthesises T1–T3 — draw connected districts, read the
- * lean + result — as the bridge to the real campaign scenarios.
+ * with every tool visible from the start (nothing hidden, no `reveal`): orient → paint → a
+ * closing read-only "Done" beat that releases the player. Unlike T1–T3, the capstone does NOT
+ * end on Submit inside the overlay — the final step locks the map, and clicking **Done** ends
+ * the tutorial and unlocks everything, so the player pans/inspects/submits on their own (the
+ * bridge to the real campaign). The player synthesises T1–T3 — connected districts, read the
+ * lean + result.
  */
 const TUTORIAL_004: TutorialStep[] = [
   {
@@ -156,14 +167,14 @@ const TUTORIAL_004: TutorialStep[] = [
     advance: { on: "next" },
   },
   {
-    text: "Draw your four districts the way you have all along. Keep each one connected, and glance at the result to see who your lines elect — there's no score to chase here.",
+    text: "Get going — pick **District 2** and paint a full district's worth of precincts into it, keeping it connected. Watch the counter; glance at the result to see who your lines elect.",
     highlight: ["#district-toolbar", "#map-svg"],
-    advance: { on: "paint-count", district: 2, n: 5 },
+    advance: { on: "paint-count", district: 2, n: 32 },
   },
   {
-    text: "When your map's done, hit **Submit**. Then on to the real thing.",
-    highlight: "#btn-submit",
-    advance: { on: "submit" },
+    text: "You've drawn a district — you've got this. Hit **Done** and the map is yours: pan around, watch the **Map Validity** panel, and **Submit** when your four districts are balanced and connected. Then on to the real thing.",
+    readOnly: true,
+    advance: { on: "next" },
   },
 ];
 
@@ -290,6 +301,10 @@ function runOverlay(id: string, script: TutorialStep[], store: StoreLike): void 
   panel.setAttribute("aria-label", "Tutorial");
   const textEl = document.createElement("div");
   textEl.className = "tutorial-text";
+  // Live progress line for paint-count steps ("District 2 — 4 / 32 painted"). Hidden otherwise.
+  const progressEl = document.createElement("div");
+  progressEl.className = "tutorial-progress";
+  progressEl.style.display = "none";
   const controls = document.createElement("div");
   controls.className = "tutorial-controls";
   const nextBtn = document.createElement("button");
@@ -299,7 +314,7 @@ function runOverlay(id: string, script: TutorialStep[], store: StoreLike): void 
   skipBtn.className = "tutorial-skip";
   skipBtn.textContent = "Skip tutorial";
   controls.append(nextBtn, skipBtn);
-  panel.append(textEl, controls);
+  panel.append(textEl, progressEl, controls);
   document.body.appendChild(panel);
 
   nextBtn.addEventListener("click", () => {
@@ -366,15 +381,30 @@ function runOverlay(id: string, script: TutorialStep[], store: StoreLike): void 
     // Input is always locked while the coach is up: only the highlighted target(s), the painter,
     // and the map stay clickable (the player can always paint), plus Next/Skip at body level.
     // Everything else — the view toolbar, undo/redo, reset, etc. — is inert, so the player can't
-    // wander off whatever the guidance is pointing at.
+    // wander off whatever the guidance is pointing at. A `readOnly` step locks the map + painter
+    // too: nothing but the coach is clickable (used for a closing "click Done" beat).
     editorRoots.forEach((r) => r.classList.add("tutorial-paused"));
-    [...targets, ...selectorsToElements(["#map-svg", "#district-toolbar"])].forEach((el) =>
+    const alwaysInteractive = step.readOnly ? [] : selectorsToElements(["#map-svg", "#district-toolbar"]);
+    [...targets, ...alwaysInteractive].forEach((el) =>
       el.classList.add("tutorial-interactive"),
     );
 
+    // On the final step the "Next" button reads "Done" — it finishes the tutorial (and unlocks
+    // the editor) rather than stepping forward.
+    nextBtn.textContent = stepIdx === script.length - 1 ? "Done" : "Next →";
     nextBtn.style.display = step.advance.on === "next" ? "" : "none";
 
-    stepCleanup = setupAdvance(step, targets, advance, store);
+    // Paint-count steps show a live "X / N painted" counter so the player can see the goal and
+    // their progress toward it (the step otherwise looks locked until the unseen threshold trips).
+    const isPaintCount = step.advance.on === "paint-count";
+    progressEl.style.display = isPaintCount ? "" : "none";
+    if (!isPaintCount) progressEl.classList.remove("tutorial-progress-complete");
+    const reportProgress = (text: string, done: boolean) => {
+      progressEl.textContent = text;
+      progressEl.classList.toggle("tutorial-progress-complete", done);
+    };
+
+    stepCleanup = setupAdvance(step, targets, advance, store, reportProgress);
   }
 
   renderStep();
@@ -386,6 +416,7 @@ function setupAdvance(
   targets: HTMLElement[],
   advance: () => void,
   store: StoreLike,
+  reportProgress: (text: string, done: boolean) => void,
 ): () => void {
   switch (step.advance.on) {
     case "next":
@@ -418,14 +449,27 @@ function setupAdvance(
         for (const d of store.getState().assignments.values()) if (d === district) c += 1;
         return c;
       };
-      // Already satisfied? (defensive) — advance on next tick.
-      const unsub = store.subscribe(() => {
-        if (count() >= n) {
+      let advanceTimer = 0;
+      let fired = false;
+      let unsub = () => {};
+      const tick = () => {
+        const c = count();
+        const done = c >= n;
+        reportProgress(`District ${district} — ${Math.min(c, n)} / ${n} painted`, done);
+        if (done && !fired) {
+          fired = true;
           unsub();
-          advance();
+          // A short beat so the player sees the count reach the target before painting freezes
+          // and the coach advances to the closing "Done" step.
+          advanceTimer = window.setTimeout(() => advance(), 450);
         }
-      });
-      return () => unsub();
+      };
+      unsub = store.subscribe(tick);
+      tick(); // initial count + display (also handles an already-satisfied step)
+      return () => {
+        unsub();
+        if (advanceTimer) window.clearTimeout(advanceTimer);
+      };
     }
     case "auto": {
       const t = window.setTimeout(() => advance(), step.advance.ms);

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -1374,6 +1374,24 @@ body {
 }
 #tutorial-panel .tutorial-text { margin-bottom: 12px; }
 #tutorial-panel .tutorial-text strong { color: #fff; }
+/* Live "X / N painted" counter for paint-count steps; turns green when the target is reached. */
+#tutorial-panel .tutorial-progress {
+  margin: -4px 0 12px;
+  padding: 5px 10px;
+  background: rgba(47, 111, 208, 0.16);
+  border: 1px solid #2a4a6c;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #9fc0e8;
+  letter-spacing: 0.01em;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+#tutorial-panel .tutorial-progress.tutorial-progress-complete {
+  color: #7fe0a0;
+  background: rgba(111, 207, 142, 0.18);
+  border-color: #3e7a55;
+}
 #tutorial-panel .tutorial-controls {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary

Fixes a rough edge at the end of the tutorial-004 guided walkthrough. The final guided step kept
the map in its paint-only locked state and advanced when the player hit **Submit** — so the player
submitted *while still inside the tutorial*, and during that step couldn't pan/scroll to inspect
the population balance (the guidance held the map locked).

Now the capstone ends on a read-only **Done** beat, and the paint step shows its progress:

- `overlay.ts`: new `readOnly` step flag locks the map + painter too (the default keeps them
  interactive so the player can always paint). On the final step the "Next →" button reads
  **Done** — clicking it finishes the tutorial and unlocks the whole editor at once.
- `overlay.ts`: paint-count steps now show a **live "District N — X / M painted" counter** in the
  coach panel (green when the target is hit), so the player can see the goal and their progress —
  the step previously looked locked until an unseen threshold tripped. A short beat lets them see
  the count reach the target before the map freezes and the coach advances to Done.
- T004 script: `orient → paint a full district's worth (32) → read-only "Done" beat`
  (was `orient → paint 5 → submit`). The player then pans, watches Map Validity, and submits on
  their own, outside the overlay.
- T001–T003 are unchanged: their terminal step still advances on Submit (the Done label only
  applies when the last step advances on `next`, which those don't).

## Affected machines / services

- Static browser game (`game/web`) only — the guided-overlay engine and the T004 step script.
  No server/infra services, no scenario-data change.

## Validation performed

- [x] `bazel test //game/web:app_typecheck_test //game/web:e2e_test` — green.
- [x] The tutorial-004 guided e2e test asserts: the paint counter is visible with its target
      (`/ 32 painted`); the final step is read-only on **both** the map and the painter (no
      `tutorial-interactive`); the button reads **Done**; and clicking Done removes the overlay and
      unlocks the editor (`#main` loses `tutorial-paused`) **without** routing through the result
      screen (no in-overlay submit).
- [x] T001–T003 guided e2e tests still pass (their submit-terminated flow is untouched).

## Deployment steps

- N/A — static web app; merge rebuilds the bundle. No migrations, no infra changes.

## Tickets addressed

- None — guided-overlay UX polish (follow-up to the T003/T004 tutorial arc, GAME-076/099).

## Rollback

- Revert this commit; T004 returns to the submit-terminated final step. No data migration to undo.
