### PR TITLE
fix(tutorial): freeze UI until guided, Done-beat terminals, result-screen next/back

### DIFF
--- a/game/web/e2e/scenarios.spec.ts
+++ b/game/web/e2e/scenarios.spec.ts
@@ -1135,7 +1135,7 @@ test("guided overlay: not shown on a non-guided scenario", async ({ page }) => {
 
 // ─── GAME-077: guided overlay (tutorial-002 "A Legal Map") ───────────────────
 
-test("guided overlay: tutorial-002 runs the legal-map script (orient → paint → validity → submit)", async ({ page }) => {
+test("guided overlay: tutorial-002 runs the legal-map script (orient → paint → validity → Done)", async ({ page }) => {
   // resetTutorial=1 clears the suppression flag the beforeEach set, so the overlay runs.
   await page.goto("/?campaign=tutorial&s=tutorial-002&debug&resetTutorial=1");
   const skip = page.locator("#btn-intro-skip");
@@ -1156,15 +1156,16 @@ test("guided overlay: tutorial-002 runs the legal-map script (orient → paint �
   await expect(page.locator("#validity-container")).toHaveClass(/tutorial-highlight/);
   await page.locator("#tutorial-panel .tutorial-next").click();
 
-  // Step 4 — even out + keep connected.
-  await expect(page.locator("#tutorial-panel")).toContainText("green");
-  await page.locator("#tutorial-panel .tutorial-next").click();
-
-  // Step 5 — submit (terminal): clicking Submit ends the overlay and shows results.
-  await expect(page.locator("#tutorial-panel")).toContainText("Submit");
-  await page.locator("#btn-submit").click();
+  // Step 4 — read-only "Done" beat: no in-overlay submit. The map is frozen (no tutorial-interactive);
+  // clicking Done ends the tutorial and unlocks the editor so the player evens out + submits on their own.
+  await expect(page.locator("#tutorial-panel")).toContainText("the map's yours");
+  await expect(page.locator("#map-svg")).not.toHaveClass(/tutorial-interactive/);
+  const doneBtn = page.locator("#tutorial-panel .tutorial-next");
+  await expect(doneBtn).toHaveText("Done");
+  await doneBtn.click();
   await expect(page.locator("#tutorial-panel")).toHaveCount(0);
-  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-screen")).toBeHidden();
+  await expect(page.locator("#main")).not.toHaveClass(/tutorial-paused/);
 });
 
 // ─── GAME-048: Campaign-driven scenario select ──────────────────────────────
@@ -1433,7 +1434,7 @@ test("tutorial-003 winnability: three balanced, connected wedges pass (district_
 
 // ─── GAME-098: guided overlay (tutorial-003) — first use of the `reveal` action ───
 
-test("guided overlay: tutorial-003 reveals the result + lean, then county, then submits", async ({ page }) => {
+test("guided overlay: tutorial-003 reveals the result + lean, then county, then a Done beat", async ({ page }) => {
   // resetTutorial=1 clears the suppression flag the beforeEach set, so the overlay runs.
   await page.goto("/?campaign=tutorial&s=tutorial-003&debug&resetTutorial=1");
   const skip = page.locator("#btn-intro-skip");
@@ -1466,11 +1467,16 @@ test("guided overlay: tutorial-003 reveals the result + lean, then county, then 
   await expect(page.locator("#filter-county")).toBeVisible();
   await page.locator("#filter-county").click();
 
-  // Step 5 — submit (terminal): ends the overlay and shows results.
-  await expect(page.locator("#tutorial-panel")).toContainText("Submit");
-  await page.locator("#btn-submit").click();
+  // Step 5 — read-only "Done" beat: no in-overlay submit. The map is frozen; clicking Done ends
+  // the tutorial and unlocks the editor so the player draws + submits on their own.
+  await expect(page.locator("#tutorial-panel")).toContainText("whole picture");
+  await expect(page.locator("#map-svg")).not.toHaveClass(/tutorial-interactive/);
+  const doneBtn = page.locator("#tutorial-panel .tutorial-next");
+  await expect(doneBtn).toHaveText("Done");
+  await doneBtn.click();
   await expect(page.locator("#tutorial-panel")).toHaveCount(0);
-  await expect(page.locator("#result-screen")).toBeVisible();
+  await expect(page.locator("#result-screen")).toBeHidden();
+  await expect(page.locator("#main")).not.toHaveClass(/tutorial-paused/);
 });
 
 // ─── tutorial-004: "Fairhaven: Putting It Together" (GAME-099 — capstone) ───

--- a/game/web/index.html
+++ b/game/web/index.html
@@ -107,6 +107,7 @@
           <div id="result-actions">
             <button id="btn-keep-drawing">← Keep Drawing</button>
             <button id="btn-continue" style="display:none">Continue →</button>
+            <button id="btn-back-to-menu" style="display:none">Back to Menu</button>
             <button id="btn-next-scenario" style="display:none">Next Scenario →</button>
             <button id="btn-mute-audio" aria-pressed="false">Mute</button>
           </div>
@@ -117,6 +118,7 @@
           <div id="result-epilogue"></div>
           <div id="result-debrief-actions">
             <button id="btn-debrief-back">← Back to results</button>
+            <button id="btn-debrief-menu">Back to Menu</button>
             <button id="btn-debrief-next">Next Scenario →</button>
           </div>
         </div>

--- a/game/web/src/main.ts
+++ b/game/web/src/main.ts
@@ -107,6 +107,8 @@ const btnDebriefBack = document.getElementById("btn-debrief-back") as HTMLButton
 const btnDebriefNext = document.getElementById("btn-debrief-next") as HTMLButtonElement | null;
 const btnKeepDrawing = document.getElementById("btn-keep-drawing") as HTMLButtonElement | null;
 const btnNextScenario = document.getElementById("btn-next-scenario") as HTMLButtonElement | null;
+const btnBackToMenu = document.getElementById("btn-back-to-menu") as HTMLButtonElement | null;
+const btnDebriefMenu = document.getElementById("btn-debrief-menu") as HTMLButtonElement | null;
 const resultStars = document.getElementById("result-stars") as HTMLElement | null;
 const resultRevealControls = document.getElementById("result-reveal-controls") as HTMLElement | null;
 const btnRevealSkip = document.getElementById("btn-reveal-skip") as HTMLButtonElement | null;
@@ -1129,6 +1131,9 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 			}
 			if (btnContinue) btnContinue.style.display = pass && epilogue ? "" : "none";
 			btnNextScenario!.style.display = pass && !epilogue ? "" : "none";
+			// "Back to Menu" sits beside "Next Scenario" on a direct win; on a win with an epilogue
+			// it lives in the debrief panel (btn-debrief-menu) instead.
+			if (btnBackToMenu) btnBackToMenu.style.display = pass && !epilogue ? "" : "none";
 		}
 
 		function revealVerdict(pass: boolean, starCount: number): void {
@@ -1373,6 +1378,7 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		btnKeepDrawing!.textContent = mapIsValid ? "← Keep Drawing" : "← Fix It";
 		btnKeepDrawing!.style.display = "";
 		btnNextScenario!.style.display = "none";
+		if (btnBackToMenu) btnBackToMenu.style.display = "none";
 
 		if (reducedMotion) {
 			// Instant path: all rows in final state with verdict character poses immediately.
@@ -1564,18 +1570,28 @@ const IS_DEBUG = (debugParam !== null && debugParam !== "off") ||
 		});
 	}
 
-	// "Next Scenario" → if all scenarios complete, show wrap-up; else select screen.
+	// "Next Scenario" → load the next scenario in the active list; if this is the last one,
+	// show the wrap-up. "Back to Menu" → the scenario-select / menu screen.
 	function goToNextScenario() {
-		const allComplete = SCENARIO_MANIFEST.every((e) => isCompleted(progress, e.id));
-		if (allComplete) {
+		const curIdx = activeList.findIndex((e) => e.id === entryToLoad.id);
+		const next = curIdx >= 0 ? activeList[curIdx + 1] : undefined;
+		if (next) {
+			const dest = campaignParam !== ""
+				? `./?s=${next.id}&campaign=${campaignParam}`
+				: `./?s=${next.id}`;
+			window.location.assign(dest);
+		} else {
 			resultScreen!.classList.add("hidden");
 			document.getElementById("wrap-up-screen")?.classList.remove("hidden");
-		} else {
-			window.location.assign(backUrl);
 		}
+	}
+	function goToMenu() {
+		window.location.assign(backUrl);
 	}
 	btnNextScenario!.addEventListener("click", goToNextScenario);
 	btnDebriefNext?.addEventListener("click", goToNextScenario);
+	btnBackToMenu?.addEventListener("click", goToMenu);
+	btnDebriefMenu?.addEventListener("click", goToMenu);
 
 	// GAME-094: "Continue →" swaps the results view for the teaching debrief panel.
 	btnContinue?.addEventListener("click", () => {

--- a/game/web/src/tutorial/overlay.ts
+++ b/game/web/src/tutorial/overlay.ts
@@ -25,18 +25,10 @@ export type AdvanceTrigger =
 
 export interface TutorialStep {
   text: string;
-  /** Selector(s) to ring + (when paused) keep interactive. */
+  /** Selector(s) to ring + keep interactive this step. */
   highlight?: string | string[];
   /** Selector(s) to un-hide for this step (start hidden on load). */
   reveal?: string | string[];
-  /**
-   * Read-only step: lock the map and painter too (the default leaves them interactive so the
-   * player can always paint). The player can only read the coach and click Done/Skip. Use it for
-   * a closing "you're on your own now" beat that ends the tutorial *before* any real action
-   * (drawing, panning, submitting) — so nothing is submitted while still inside the overlay, and
-   * when the step finishes everything unlocks at once.
-   */
-  readOnly?: boolean;
   advance: AdvanceTrigger;
 }
 
@@ -93,19 +85,13 @@ const TUTORIAL_002: TutorialStep[] = [
     advance: { on: "paint-count", district: 2, n: 5 },
   },
   {
-    text: "Watch the **Map Validity** panel — it flags a district that's too big, too small, or split in two.",
+    text: "Watch the **Map Validity** panel — it flags a district that's too big, too small, or split in two, and turns all green when the map is **legal**.",
     highlight: "#validity-container",
     advance: { on: "next" },
   },
   {
-    text: "Even out the populations and keep each district connected until the panel's all green.",
-    highlight: "#validity-container",
+    text: "That's the goal. Hit **Done**, then the map's yours: even the districts out until the **Map Validity** panel is all green, and **Submit** once it's a legal map.",
     advance: { on: "next" },
-  },
-  {
-    text: "Legal map? Hit **Submit**.",
-    highlight: "#btn-submit",
-    advance: { on: "submit" },
   },
 ];
 
@@ -146,20 +132,18 @@ const TUTORIAL_003: TutorialStep[] = [
     advance: { on: "click-target" },
   },
   {
-    text: "That's the whole picture. Draw your three districts — keep them balanced and connected, like before — then hit **Submit**.",
-    highlight: ["#district-toolbar", "#btn-submit"],
-    advance: { on: "submit" },
+    text: "That's the whole picture. Hit **Done**, then draw your three districts — balanced and connected — and **Submit** once the **Map Validity** panel is all green.",
+    advance: { on: "next" },
   },
 ];
 
 /**
  * tutorial-004 — "Capstone" (DESIGN-012 / GAME-099). A light orientation over a fuller map
  * with every tool visible from the start (nothing hidden, no `reveal`): orient → paint → a
- * closing read-only "Done" beat that releases the player. Unlike T1–T3, the capstone does NOT
- * end on Submit inside the overlay — the final step locks the map, and clicking **Done** ends
- * the tutorial and unlocks everything, so the player pans/inspects/submits on their own (the
- * bridge to the real campaign). The player synthesises T1–T3 — connected districts, read the
- * lean + result.
+ * closing "Done" beat that releases the player. Like T2/T3, it ends on **Done**, not an
+ * in-overlay Submit — the final step is frozen (no highlight), so clicking Done ends the
+ * tutorial and unlocks everything, and the player pans/inspects/submits on their own (the bridge
+ * to the real campaign). The player synthesises T1–T3 — connected districts, read the lean + result.
  */
 const TUTORIAL_004: TutorialStep[] = [
   {
@@ -173,7 +157,6 @@ const TUTORIAL_004: TutorialStep[] = [
   },
   {
     text: "You've drawn a district — you've got this. Hit **Done** and the map is yours: pan around, watch the **Map Validity** panel, and **Submit** when your four districts are balanced and connected. Then on to the real thing.",
-    readOnly: true,
     advance: { on: "next" },
   },
 ];
@@ -378,14 +361,15 @@ function runOverlay(id: string, script: TutorialStep[], store: StoreLike): void 
     const targets = selectorsToElements(step.highlight);
     targets.forEach((el) => el.classList.add("tutorial-highlight"));
 
-    // Input is always locked while the coach is up: only the highlighted target(s), the painter,
-    // and the map stay clickable (the player can always paint), plus Next/Skip at body level.
-    // Everything else — the view toolbar, undo/redo, reset, etc. — is inert, so the player can't
-    // wander off whatever the guidance is pointing at. A `readOnly` step locks the map + painter
-    // too: nothing but the coach is clickable (used for a closing "click Done" beat).
+    // Input is locked while the coach is up: only the highlighted target(s) stay clickable, plus
+    // Next/Skip at body level. The map + painter unlock ONLY on steps that ask the player to paint
+    // (paint-count / any-map-click). So an intro or "watch the panel" step freezes everything but
+    // Next/Skip — the player can't wander off and knock a control into an unexpected state — and a
+    // closing "Done" beat (next-advance, no highlight) is frozen too, releasing the editor on Done.
     editorRoots.forEach((r) => r.classList.add("tutorial-paused"));
-    const alwaysInteractive = step.readOnly ? [] : selectorsToElements(["#map-svg", "#district-toolbar"]);
-    [...targets, ...alwaysInteractive].forEach((el) =>
+    const paints = step.advance.on === "paint-count" || step.advance.on === "any-map-click";
+    const paintTargets = paints ? selectorsToElements(["#map-svg", "#district-toolbar"]) : [];
+    [...targets, ...paintTargets].forEach((el) =>
       el.classList.add("tutorial-interactive"),
     );
 


### PR DESCRIPTION
## Summary

Playtest fixes for the guided tutorials and the result screen (from your local-serve pass).

**Guided overlay (`overlay.ts`)**
- **Freeze by default.** While the coach is up, the editor is locked except the highlighted
  target(s) and Next/Skip. The map + painter unlock **only** on steps that ask the player to paint
  (`paint-count` / `any-map-click`). So the intro and "watch the panel" steps no longer leave the
  painter live — you can't knock a control into an unexpected state before the guidance points at
  it (bug: T001/T002 weren't frozen at the start). All editor controls sit under `#app-header` /
  `#main` (both paused), so the freeze is complete. This makes the old `readOnly` flag redundant —
  a `next`-advance step with no highlight is now frozen automatically — so it's removed.
- **T002 / T003 no longer end on an in-overlay Submit.** Submitting an illegal map mid-tutorial
  used to pop the fail screen and end the walkthrough. Both now close on a **frozen "Done" beat**
  ("…hit **Done**, then even it out / draw your districts and **Submit** once the panel's all
  green"): submit is unreachable until Done unlocks the editor, so you finish on your own. T004
  already did this; **T001 keeps its Submit terminal** (no validity gate → always wins; submitting
  *is* the lesson).
  - *Note:* T003 wasn't in your report, but it has the same gate + "draw your districts" terminal,
    and the freeze rule forces the same fix — converting it too is the clean resolution.

**Result screen (`index.html`, `main.ts`)**
- **"Next Scenario"** now loads the next scenario in the active list (`./?s=<next>&campaign=…`),
  showing the wrap-up only when there's no next (the last scenario). Previously it went to select.
- **New "Back to Menu"** button (in both the results and debrief action rows) → the scenario-select
  / menu screen (the old "Next Scenario" behavior).

## Affected machines / services

- Static browser game (`game/web`) only — guided-overlay engine, tutorial scripts, result screen.
  No infra services, no scenario-data change.

## Validation performed

- [x] `bazel test //game/web:e2e_test //game/web:app_typecheck_test` — green.
- [x] tutorial-002 / tutorial-003 guided e2e updated to the Done-beat terminals (assert the map is
      frozen on the final step, the button reads **Done**, and Done unlocks the editor without
      routing through the result screen). T001 (submit terminal) and T004 (Done beat) still pass.
- [x] Verified every editor control is under `#app-header` / `#main` (paused), so a frozen step
      leaves only Next/Skip interactive.
- [x] Wrap-up e2e still green (tutorial-004 is last in the manifest → "no next ⇒ wrap-up" holds).

## Deployment steps

- N/A — static web app; merge rebuilds the bundle. No migrations.

## Tickets addressed

- None — guided-tutorial + result-screen UX polish.

## Rollback

- Revert this commit; the overlay returns to always-interactive map + Submit terminals, and the
  result screen's "Next Scenario" returns to the select-screen behavior.
