### PR TITLE
fix(ui): style the result-screen Back to Menu button

### DIFF
--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -1058,7 +1058,7 @@ body {
   margin-top: 4px;
 }
 
-#btn-keep-drawing, #btn-continue, #btn-debrief-back {
+#btn-keep-drawing, #btn-continue, #btn-debrief-back, #btn-back-to-menu, #btn-debrief-menu {
   padding: 8px 18px;
   background: #0f3460;
   color: #e0e0e0;
@@ -1068,7 +1068,7 @@ body {
   font-size: 0.88rem;
 }
 
-#btn-keep-drawing:hover, #btn-continue:hover, #btn-debrief-back:hover { background: #1a4a7a; }
+#btn-keep-drawing:hover, #btn-continue:hover, #btn-debrief-back:hover, #btn-back-to-menu:hover, #btn-debrief-menu:hover { background: #1a4a7a; }
 
 #btn-next-scenario, #btn-debrief-next {
   padding: 8px 18px;


### PR DESCRIPTION
## Summary

Styles the result-screen "Back to Menu" buttons added in #294, which had no CSS and rendered as
browser-default buttons. Both (`#btn-back-to-menu` in the results row, `#btn-debrief-menu` in the
debrief row) now use the existing **secondary** button treatment (blue — same as Keep Drawing /
Back to results), keeping **Next Scenario** as the primary green action.

## Affected machines / services

- Static browser game (`game/web`) — `styles.css` only. No infra services, no logic change.

## Validation performed

- [x] Selectors verified against the HTML button ids (`#btn-back-to-menu`, `#btn-debrief-menu`).
- [x] Reuses the existing secondary-button rule (proven style); Next Scenario stays primary.
- [ ] N/A — CSS-only; no automated test covers button color. Visual confirmation on local serve.

## Deployment steps (POST-MERGE)

- Ship to beta: `./release.main.kts -- prepare` (from main) → `deploy --env beta`.

## Tickets addressed

- None — result-screen UI polish (follow-up to #294).

## Rollback

- Revert this commit; the buttons return to browser-default styling.
