### PR TITLE
docs(agents): one canonical deploy invocation + beta env

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -106,21 +106,22 @@ research docs: $ts/research/ | YYYY-MM-DD-<description>.md + .compressed.md comp
 frontmatter: date researcher git_commit branch repository topic tags status last_updated last_updated_by
 
 §DEPLOY
-tool: game/release.main.kts — run from game/ or repo root
+tool: ALWAYS invoke `game/release.main.kts -- <cmd>` from REPO ROOT (never `./release.main.kts`, never cd game/ — one form so the permission allowlist matches; the `--` separates kotlin args from script args). Avoid trailing `| tail`; capture via `> /tmp/out` if needed.
 
-environments: dev=dev.pastthepost.gg staging=staging.pastthepost.gg production=pastthepost.gg
-vTEST-* builds: ONLY allowed to dev; staging+production require semver (main)
-production: NEVER deploy without explicit user sign-off
+environments: dev=dev.pastthepost.gg beta=beta.pastthepost.gg staging=staging.pastthepost.gg production=pastthepost.gg
+vTEST-* builds: ONLY to dev; beta/staging/production require a semver release (main)
+production: NEVER deploy without explicit user sign-off (every time). NOTE prod currently serves the Coming Soon splash; the game runs on beta until launch
+deploy auto-detects the sole staged version — OMIT --version (pass it only if several are staged)
 
-branch deploy (dev only — vTEST builds):
-  VERSION=$(./release.main.kts -- prepare)           # vTEST-<commitid>; no tag
-  ./release.main.kts -- deploy --env dev --version "$VERSION"
+dev (vTEST) build — on a branch:
+  game/release.main.kts -- prepare                   # vTEST-<commitid>; no tag
+  game/release.main.kts -- deploy --env dev
 
 release deploy (on main):
-  ./release.main.kts -- prepare                      # auto-bumps semver; creates+pushes tag
-  ./release.main.kts -- deploy --env staging         # auto-detects staged version
-  # stop here; wait for explicit user approval before prod
-  ./release.main.kts -- deploy --env production      # only with user sign-off
+  game/release.main.kts -- prepare                   # auto-bumps semver; creates+pushes tag
+  game/release.main.kts -- deploy --env beta         # or --env staging
+  # production only AFTER explicit user approval:
+  game/release.main.kts -- deploy --env production
 
 §CHAIN Bootstrap — execute exactly one branch (stop after match):
 when {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,46 +200,51 @@ These are **mandatory reads** — especially after context compaction, where pro
 
 ## Deploying the Game
 
-The deploy tool is `game/release.main.kts` (a Kotlin script). It replaces the old `prepare-release.sh` and `deploy.sh` shell scripts. Run it from `game/` or the repo root.
+The deploy tool is `game/release.main.kts` (a Kotlin script).
+
+**Always invoke it exactly as `game/release.main.kts -- <cmd>` from the repo root.** Do **not** `cd` into `game/`, and do **not** use `./release.main.kts` — a single consistent form is what the permission allowlist matches, so routine deploys don't re-prompt. (The `--` separates the Kotlin runner's args from the script's.) Omit any trailing pipe when you can; if you capture output, redirect to a file (`… > /tmp/out`) rather than `… | tail`.
 
 ### Subcommands
 
 **`prepare [--version v0.x.y]`**
 
-Builds `//web:deployable` via Bazel and stages the artifact in `game/.deploy_pkg/<version>/`. The staged directory contains `artifact.zip` and `prepare-metadata.json`. It is gitignored and persists across deploys so the same build can go to multiple environments.
+Builds `//game/web:deployable` via Bazel and stages the artifact in `game/.deploy_pkg/<version>/` (contains `artifact.zip` + `prepare-metadata.json`; gitignored; persists across deploys so one build can ship to multiple envs).
 
-- **On main** (or an empty commit directly atop main): produces a semver version. Auto-bumps the patch number from the latest tag unless `--version` is passed explicitly. Creates and pushes a jj tag.
-- **On any other branch**: produces `vTEST-<commitid>`. No tag is created. Safe for branch/PR testing.
-- Passing an explicit semver when not on main is an error.
-- Emits the version string to **stdout** so callers can capture it: `VERSION=$(./release.main.kts -- prepare)`
+- **On main** (or an empty commit directly atop main): semver, auto-bumped from the latest tag unless `--version` is passed; creates + pushes a jj tag.
+- **On any other branch**: `vTEST-<commitid>`, no tag. Branch/PR testing only.
+- Passing an explicit semver off-main is an error.
 
-**`deploy --env <staging|production> [--version <v>]`**
+**`deploy --env <dev|beta|staging|production> [--version <v>]`**
 
-Reads the staged artifact from `game/.deploy_pkg/<version>/` and deploys it. If `--version` is omitted, uses the sole prepared version (errors if zero or multiple exist). The `.deploy_pkg/<version>/` directory is **not** deleted after deploy — keep it to deploy the same build to production after validating on staging.
+Reads the staged artifact and deploys it. **Omit `--version`** — it auto-detects the sole staged version (only pass `--version vX.Y.Z` if several are staged). The `.deploy_pkg/<version>/` directory is **not** deleted after deploy, so the same build can go to multiple envs.
 
-Internally: creates a jj workspace → `jj new web_deploy` → extracts zip → writes `deployment-metadata.json` → commits → sets `web_deploy` bookmark → pushes → polls verify URL → cleans up workspace.
+Internally: creates a jj workspace → `jj new web_deploy` → extracts zip → writes `deployment-metadata.json` → commits → sets `web_deploy` bookmark → pushes → polls the verify URL → cleans up the workspace.
+
+- **vTEST-* builds may ONLY deploy to `dev`.** `beta`, `staging`, and `production` require a semver release built from main.
+- **production: NEVER deploy without explicit user sign-off — every time.**
 
 ### Typical workflows
 
 ```bash
-# Branch test deploy:
-VERSION=$(./release.main.kts -- prepare)                              # vTEST-<commitid>
-./release.main.kts -- deploy --env staging --version "$VERSION"
-# test at https://staging.pastthepost.gg
-# merge PR, then do the real release from main
+# Branch (vTEST) build → dev:
+game/release.main.kts -- prepare                  # vTEST-<commitid>, no tag
+game/release.main.kts -- deploy --env dev
 
 # Release from main:
-./release.main.kts -- prepare                                         # auto-bumps semver
-./release.main.kts -- deploy --env staging                            # validates
-./release.main.kts -- deploy --env production                         # promotes same build
+game/release.main.kts -- prepare                  # auto-bumps semver + pushes tag
+game/release.main.kts -- deploy --env beta        # or --env staging
+# production only AFTER explicit user approval:
+game/release.main.kts -- deploy --env production
 ```
 
 ### Environments
 
-| Env | URL | Verify endpoint |
+| Env | URL | Notes |
 |---|---|---|
-| staging | https://staging.pastthepost.gg | `/deployment-metadata.json` |
-| production | https://pastthepost.gg | `/deployment-metadata.json` |
+| dev | https://dev.pastthepost.gg | vTEST builds OK |
+| beta | https://beta.pastthepost.gg | public sneak-peek; semver only |
+| staging | https://staging.pastthepost.gg | internal pre-prod; semver only |
+| production | https://pastthepost.gg | semver only; explicit sign-off each time. **Currently serves the Coming Soon splash — the game runs on `beta` until launch.** |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the AGENTS deploy guidance so the release tool has **one canonical invocation**, which is what
kept causing inconsistent paths (`./release.main.kts` vs `game/release.main.kts`, with/without `--`)
and per-version permission prompts.

- **Canonical form:** always `game/release.main.kts -- <cmd>` from the **repo root** — never
  `./release.main.kts`, never `cd game/`. The `--` separates the Kotlin runner's args from the
  script's. Avoid a trailing `| tail` (redirect to a file if you need to capture output).
- **Add the `beta` environment** (public sneak-peek) alongside dev / staging / production.
- **Drop the `VERSION=$(…)` command-substitution** examples — `deploy` auto-detects the sole staged
  version, so omit `--version`.
- **Fix the branch-test example:** vTEST builds go to `dev` (not staging — beta/staging/prod require
  a semver release from main).
- Note that **production currently serves the Coming Soon splash**; the game runs on `beta` until launch.

Updated both `AGENTS.md` and its `AGENTS.compressed.md` sibling (per the two-form doc convention).

## Affected machines / services

- Documentation only (`AGENTS.md`, `AGENTS.compressed.md`). No code, no services.

## Validation performed

- [x] Both AGENTS forms updated consistently (human + compressed).
- [x] Canonical form matches the deploy permission allow-rules so routine `prepare`/`deploy` to
      beta/staging/dev no longer prompt.
- [ ] N/A — docs only; no build/test impact.

## Deployment steps

- N/A — documentation change.

## Tickets addressed

- None — agent-guidance fix.

## Rollback

- Revert this commit.
