### PR TITLE
docs(tickets): file GAME-111 lint-coverage meta-test follow-up

### DIFF
--- a/thoughts/shared/tickets/GAME-111-lint-coverage-meta-test.md
+++ b/thoughts/shared/tickets/GAME-111-lint-coverage-meta-test.md
@@ -1,0 +1,44 @@
+---
+id: GAME-111
+title: Meta-test that every game/web/src subpackage is wired into the lint gate
+area: game, ci, code-quality
+status: open
+created: 2026-06-28
+---
+
+## Summary
+
+The GAME-107 Biome lint gate (`//game/web:lint_test`) lints each `game/web/src` subpackage via a
+per-package `:lint_sources` filegroup in the test's `data` (Bazel `glob` doesn't cross package
+boundaries). A **future** new subpackage (its own `BUILD.bazel`) that forgets to add a
+`:lint_sources` filegroup — or to wire it into `lint_test`'s `data` — would be lint-clean on a cold
+run but never re-checked on edit until an unrelated cache bust. That's the same gate-erosion class
+GAME-109's `unwired_tests_test` guards for `*_test.ts` files. Raised in the PR #308 review.
+
+## Current State
+
+- `lint_test` (`game/web/BUILD.bazel`) `data` lists the root `src/**/*.ts` glob + `e2e/**/*.ts` +
+  one `:lint_sources` filegroup per `src/` subpackage (model, simulation, store, audio, pipeline).
+  All 6 current packages are correctly wired.
+- Nothing asserts that EVERY subpackage with `*.ts` is represented. A new `src/<pkg>/BUILD.bazel`
+  with sources is invisible to the gate's cache-invalidation until someone notices.
+
+## Goals / Acceptance Criteria
+
+- [ ] Add a meta-test (sh_test, mirroring `//game/web:unwired_tests_test`) that fails when a
+      `game/web/src` subpackage contains `*.ts` but has no `:lint_sources` filegroup wired into
+      `lint_test`'s `data` (or, equivalently, asserts every package's `.ts` files are reachable by
+      the lint gate's data deps).
+- [ ] Prove it: temporarily add a dummy `src/<newpkg>/BUILD.bazel` + a `.ts` file not wired to
+      `:lint_sources`, confirm the meta-test FAILS, then remove the dummy.
+- [ ] Keep it a backstop, not a macro — don't auto-generate the filegroups.
+
+## Test Coverage
+
+This ticket **is** a test. The AC above is the proof.
+
+## References
+
+- PR #308 review: https://github.com/cgruber/redistricting-sim/pull/308#discussion_r3489642354
+- `game/web/BUILD.bazel` (`lint_test`, `:lint_sources` filegroups), `game/web/unwired_tests_test.sh` (the GAME-109 sibling pattern to mirror)
+- Related: GAME-107 (the lint gate), GAME-109 (the `*_test.ts` unwired backstop)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -119,6 +119,7 @@ tests should be written alongside or before implementation, not as a backfill. W
 | `GAME-096-city-limits-overlay.md` | game, rendering, UX | Basic cosmetic city-limits overlay (reuse county border mechanism); third View-toolbar Overlays entry; no gameplay effect. Prerequisite for tutorial-003's (GAME-098) lean/county/city view set |
 | `GAME-098-tutorial-003-reading-the-vote.md` | game, UX, tutorial, content | Tutorial-003 "Reading the Vote": first electoral layer — reveal the election-result panel together with the lean view, then county/city; terrain + partisan lean + counties/urban core. Reuses overlay engine + reveal action; needs GAME-096. See plan 2026-06-24-tutorial-redesign |
 | `GAME-100-terrain-feature-generation.md` | game, tooling | Make the terrain stage GENERATE features (route rivers, place coasts/mountains/lakes from intent) instead of passthrough of hand-authored coordinates; feeds population suitability + optional demographics. Incl. river-validity constraint (loose-ended segments invalid). Fixes the broken tutorial-003/004 rivers. Do after T2/T3 playtest fixes, before T4 capstone revisit |
+| `GAME-111-lint-coverage-meta-test.md` | game, ci, code-quality | Meta-test that every `game/web/src` subpackage with `*.ts` is wired into the GAME-107 lint gate (`:lint_sources` in `lint_test` data) — a future subpackage could otherwise escape lint cache-invalidation. Mirrors GAME-109's unwired-tests backstop. From the PR #308 review |
 ---
 
 ## Resolved


### PR DESCRIPTION
## Summary

Files **GAME-111**, the one non-blocking finding from the PR #308 (GAME-107) review: the new Biome
lint gate wires each `game/web/src` subpackage via a per-package `:lint_sources` filegroup, but
nothing asserts a **future** new subpackage gets wired in — it would lint-clean on a cold run yet
escape cache-invalidation on edit. Same gate-erosion class GAME-109's `unwired_tests_test` guards
for `*_test.ts`. The ticket proposes a sibling meta-test.

Docs/tickets only — no code change.

## Affected machines / services

- None. One ticket file + the TICKETS.md index.

## Validation performed

- [x] Highest GAME id checked (110 was the prior max; 111 is next).
- [x] TICKETS.md Open index updated in the same change as the ticket file.
- [ ] N/A — docs only; no build/test impact.

## Deployment steps

- N/A — documentation change.

## Tickets addressed

- Files GAME-111 (does not resolve it).

## Rollback

- Revert this commit.
