### PR TITLE
tools: add gh-dependabot-alerts.main.kts (reviewed wrapper)

### DIFF
--- a/tools/gh-dependabot-alerts.main.kts
+++ b/tools/gh-dependabot-alerts.main.kts
@@ -1,0 +1,136 @@
+#!/usr/bin/env kotlin
+@file:DependsOn("com.github.ajalt.clikt:clikt-jvm:4.4.0")
+@file:DependsOn("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
+
+/**
+ * gh-dependabot-alerts
+ *
+ * Lists Dependabot vulnerability alerts for a GitHub repository: severity,
+ * package (ecosystem), the manifest that pulls it in, the advisory summary,
+ * the vulnerable range + first patched version, and the alert URL. Sorted
+ * highest-severity first.
+ *
+ * This wraps `gh api repos/<owner>/<repo>/dependabot/alerts` so the call is a
+ * reviewed, permitted tool rather than an ad-hoc `gh api` invocation. Requires
+ * `gh auth login` with a token that can read the repo's security alerts
+ * (repo admin, or org member with security-events read).
+ *
+ * Usage:
+ *   tools/gh-dependabot-alerts.main.kts
+ *   tools/gh-dependabot-alerts.main.kts --state all --severity high
+ *   tools/gh-dependabot-alerts.main.kts --owner cgruber --repo redistricting-sim
+ *
+ * Flags:
+ *   --owner      GitHub owner/org (default: cgruber)
+ *   --repo       GitHub repo name (default: redistricting-sim)
+ *   --state      Alert state: open | dismissed | fixed | auto_dismissed | all (default: open)
+ *   --severity   Filter by severity: critical | high | medium | low (default: all)
+ *   --ecosystem  Filter by ecosystem: npm | pip | maven | … (default: all)
+ */
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+fun sh(vararg command: String): String {
+    val proc = ProcessBuilder(*command).redirectErrorStream(true).start()
+    val output = proc.inputStream.bufferedReader().readText()
+    val exit = proc.waitFor()
+    if (exit != 0) {
+        System.err.println("Command failed (exit $exit): ${command.joinToString(" ")}\n$output")
+        kotlin.system.exitProcess(exit)
+    }
+    return output
+}
+
+class GhDependabotAlerts : CliktCommand(
+    name = "gh-dependabot-alerts",
+    help = "List Dependabot vulnerability alerts for a GitHub repository"
+) {
+    val owner     by option("--owner",     help = "GitHub owner/org").default("cgruber")
+    val repo      by option("--repo",      help = "GitHub repo name").default("redistricting-sim")
+    val state     by option("--state",     help = "open | dismissed | fixed | auto_dismissed | all").default("open")
+    val severity  by option("--severity",  help = "critical | high | medium | low (default: all)").default("")
+    val ecosystem by option("--ecosystem", help = "npm | pip | maven | … (default: all)").default("")
+
+    val mapper = jacksonObjectMapper()
+
+    override fun run() {
+        // Build the gh api call. The Dependabot alerts API takes state/severity/ecosystem
+        // as QUERY params on a GET. We append them to the URL path directly rather than via
+        // `-f key=value` — `-f` flips `gh api` to a POST, which 404s on this GET-only route.
+        val params = mutableListOf<String>()
+        if (state != "all")         params += "state=$state"
+        if (severity.isNotBlank())  params += "severity=$severity"
+        if (ecosystem.isNotBlank()) params += "ecosystem=$ecosystem"
+        params += "per_page=100"
+        val path = "repos/$owner/$repo/dependabot/alerts?" + params.joinToString("&")
+
+        // gh api --jq emits one JSON object per line when paginating.
+        val alerts = sh("gh", "api", path, "--paginate", "--jq", ".[]").lines()
+            .filter { it.isNotBlank() }
+            .map { mapper.readTree(it) }
+
+        val scope = buildString {
+            append("state=$state")
+            if (severity.isNotBlank()) append(", severity=$severity")
+            if (ecosystem.isNotBlank()) append(", ecosystem=$ecosystem")
+        }
+
+        if (alerts.isEmpty()) {
+            println("No Dependabot alerts for $owner/$repo ($scope).")
+            return
+        }
+
+        val counts = alerts.groupingBy { sev(it) }.eachCount()
+        val summary = listOf("critical", "high", "medium", "low")
+            .filter { counts.containsKey(it) }
+            .joinToString(", ") { "${counts[it]} $it" }
+        println("$owner/$repo Dependabot alerts ($scope) — ${alerts.size} total: $summary")
+        println("─".repeat(76))
+
+        alerts.sortedWith(compareBy({ severityOrder(sev(it)) }, { pkgName(it) }))
+            .forEach { a ->
+                val vuln = a["security_vulnerability"]
+                val adv = a["security_advisory"]
+                val range = vuln?.get("vulnerable_version_range")?.asText() ?: "?"
+                val patched = vuln?.get("first_patched_version")?.get("identifier")?.asText() ?: "none yet"
+                val manifest = a["dependency"]?.get("manifest_path")?.asText() ?: "?"
+                val ghsa = adv?.get("ghsa_id")?.asText() ?: ""
+                val summaryText = adv?.get("summary")?.asText() ?: ""
+                val url = a["html_url"]?.asText() ?: ""
+                val stateText = a["state"]?.asText() ?: ""
+                val badge = sev(a).uppercase().padEnd(8)
+
+                println("  $badge #${a["number"]?.asText() ?: "?"}  ${pkgName(a)}  [$stateText]")
+                println("       $summaryText")
+                println("       manifest:    $manifest")
+                println("       vulnerable:  $range   →   patched: $patched")
+                if (ghsa.isNotBlank()) println("       advisory:    $ghsa")
+                if (url.isNotBlank()) println("       $url")
+                println()
+            }
+    }
+
+    private fun sev(a: JsonNode): String =
+        a["security_advisory"]?.get("severity")?.asText()?.lowercase() ?: "unknown"
+
+    private fun pkgName(a: JsonNode): String {
+        val dep = a["dependency"]?.get("package")
+        val eco = dep?.get("ecosystem")?.asText() ?: "?"
+        val name = dep?.get("name")?.asText() ?: "?"
+        return "$eco:$name"
+    }
+
+    private fun severityOrder(s: String): Int = when (s) {
+        "critical" -> 0
+        "high"     -> 1
+        "medium"   -> 2
+        "low"      -> 3
+        else       -> 4
+    }
+}
+
+GhDependabotAlerts().main(args)


### PR DESCRIPTION
## Summary

Adds `tools/gh-dependabot-alerts.main.kts` — a reviewed, permitted Kotlin wrapper around
`gh api repos/<owner>/<repo>/dependabot/alerts`, so listing Dependabot alerts is a named tool
rather than an ad-hoc `gh api` call (which isn't on the permission allowlist). Mirrors the existing
`tools/gh-pr-checks.main.kts` (clikt + jackson, shells out to `gh`).

Lists alerts highest-severity-first with severity, `ecosystem:package`, the manifest that pulls it
in, the advisory summary, vulnerable range + first patched version, GHSA id, and the alert URL.
Filters: `--state` (default `open`), `--severity`, `--ecosystem`; `--owner`/`--repo` default to
this repo. Candidate for promotion to the infra tools catalog later.

Implementation note: the Dependabot alerts API is GET-only and takes filters as query params —
passing them via `gh api -f` flips the request to POST and 404s, so the script appends them to the
URL path.

First real output (the alerts flagged after the Biome add — both are in the **spike**, not the
shipped game, and not introduced by recent work):
```
HIGH    #2  npm:vite   spike/001-game-poc/package-lock.json   <= 6.4.2 → patched 6.4.3  (server.fs.deny bypass, Windows)
MEDIUM  #3  npm:vite   spike/001-game-poc/package-lock.json   <= 6.4.2 → patched 6.4.3  (launch-editor NTLMv2, Windows)
```

## Affected machines / services

- Local dev tooling only (`tools/`). No runtime/build/deploy change; the script isn't in the Bazel graph.

## Validation performed

- [x] Ran it against `cgruber/redistricting-sim` — lists the 2 open alerts correctly (output above).
- [x] Confirmed the GET-vs-`-f`-POST 404 gotcha and fixed it (query params in the URL path).
- [x] `settings.local.json` permission rule added locally (gitignored — not in this PR).
- [ ] N/A — no Bazel target; not part of `bazel test`.

## Deployment steps

- N/A — a local tool. Run `tools/gh-dependabot-alerts.main.kts` (needs `gh auth login` with security-alert read).

## Tickets addressed

- None — tooling, requested in review of the GAME-107 dependabot heads-up.

## Rollback

- Revert this commit / delete the script.
