### PR TITLE
chore(deps): dependabot.yml scoped to /game + --dismiss for the alerts tool

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot version-update PRs.
+#
+# SCOPE NOTE: this file governs Dependabot *version-update PRs* only. It does NOT
+# affect Dependabot *security alerts* — those are generated from GitHub's dependency
+# graph, which indexes every manifest in the repo (including spike/). There is no
+# committed-config way to path-exclude a directory from alerts; spike alerts are
+# handled by dismissal (reason: not_used — frozen POC, not deployed).
+#
+# We intentionally scope updates to the live game (/game) and deliberately do NOT
+# list spike/* : the spikes (spike/001-game-poc, spike/002-build-poc) are frozen
+# proof-of-concept illustrations of past work, not maintained code, so they must
+# never receive dependency-bump PRs.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/game" # game/package.json — the live web game's deps
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # One grouped PR per run instead of one-per-dependency, to keep noise low.
+      npm:
+        patterns:
+          - "*"

--- a/tools/gh-dependabot-alerts.main.kts
+++ b/tools/gh-dependabot-alerts.main.kts
@@ -20,17 +20,29 @@
  *   tools/gh-dependabot-alerts.main.kts --state all --severity high
  *   tools/gh-dependabot-alerts.main.kts --owner cgruber --repo redistricting-sim
  *
- * Flags:
+ * Flags (listing):
  *   --owner      GitHub owner/org (default: cgruber)
  *   --repo       GitHub repo name (default: redistricting-sim)
  *   --state      Alert state: open | dismissed | fixed | auto_dismissed | all (default: open)
  *   --severity   Filter by severity: critical | high | medium | low (default: all)
  *   --ecosystem  Filter by ecosystem: npm | pip | maven | … (default: all)
+ *
+ * Flags (dismissing — a reviewed write, no raw gh PATCH needed):
+ *   --dismiss N  Alert number(s) to dismiss (repeatable). Switches to dismiss mode.
+ *   --reason R   Dismiss reason: fix_started | inaccurate | no_bandwidth | not_used |
+ *                tolerable_risk (default: not_used)
+ *   --comment C  Optional note recorded with the dismissal
+ *
+ * Example:
+ *   tools/gh-dependabot-alerts.main.kts --dismiss 2 --dismiss 3 --reason not_used \
+ *     --comment "spike/001-game-poc is a frozen POC illustration, not deployed"
  */
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
@@ -54,10 +66,40 @@ class GhDependabotAlerts : CliktCommand(
     val state     by option("--state",     help = "open | dismissed | fixed | auto_dismissed | all").default("open")
     val severity  by option("--severity",  help = "critical | high | medium | low (default: all)").default("")
     val ecosystem by option("--ecosystem", help = "npm | pip | maven | … (default: all)").default("")
+    val dismiss   by option("--dismiss",   help = "alert number to dismiss (repeatable)").int().multiple()
+    val reason    by option("--reason",    help = "dismiss reason").default("not_used")
+    val comment   by option("--comment",   help = "note recorded with the dismissal").default("")
 
     val mapper = jacksonObjectMapper()
 
+    private val dismissReasons = setOf("fix_started", "inaccurate", "no_bandwidth", "not_used", "tolerable_risk")
+
     override fun run() {
+        if (dismiss.isNotEmpty()) {
+            dismissAlerts()
+            return
+        }
+        listAlerts()
+    }
+
+    private fun dismissAlerts() {
+        if (reason !in dismissReasons) {
+            System.err.println("Invalid --reason '$reason'. Must be one of: ${dismissReasons.sorted().joinToString(", ")}")
+            kotlin.system.exitProcess(2)
+        }
+        for (n in dismiss) {
+            val cmd = mutableListOf(
+                "gh", "api", "-X", "PATCH", "repos/$owner/$repo/dependabot/alerts/$n",
+                "-f", "state=dismissed", "-f", "dismissed_reason=$reason",
+            )
+            if (comment.isNotBlank()) cmd += listOf("-f", "dismissed_comment=$comment")
+            cmd += listOf("--jq", "{number, state, dismissed_reason, package: .dependency.package.name}")
+            val res = sh(*cmd.toTypedArray()).trim()
+            println("dismissed #$n ($reason): $res")
+        }
+    }
+
+    private fun listAlerts() {
         // Build the gh api call. The Dependabot alerts API takes state/severity/ecosystem
         // as QUERY params on a GET. We append them to the URL path directly rather than via
         // `-f key=value` — `-f` flips `gh api` to a POST, which 404s on this GET-only route.


### PR DESCRIPTION
## Summary

Stops Dependabot noise on the spikes (frozen POC illustrations of past work, not maintained code),
and makes alert-dismissal a reviewed tool action.

- **`.github/dependabot.yml`** scopes version-update PRs to `/game` (the live web game) only.
  `spike/*` is deliberately not listed, so the spikes never receive dependency-bump PRs. Grouped
  weekly npm PRs, limit 5. A `SCOPE NOTE` documents the key nuance: this governs **update PRs**, not
  **security alerts** — alerts come from the dependency graph (which indexes every manifest and
  can't be path-excluded by config), so spike alerts are handled by dismissal instead.
- **`tools/gh-dependabot-alerts.main.kts`** gains a reviewed `--dismiss N [--reason R] [--comment C]`
  mode (PATCH `state=dismissed`), so dismissing is a named tool action, not a raw `gh` PATCH. Used it
  to dismiss the two spike `vite` alerts (#2 HIGH, #3 MEDIUM) as `not_used` — the open-alert list is
  now **clear**.

## Affected machines / services

- GitHub Dependabot config for the repo + local tooling. No runtime/build change.

## Validation performed

- [x] Ran `--dismiss 2 --dismiss 3 --reason not_used` — both returned `state: dismissed`; a follow-up `--state open` listing shows **no open alerts**.
- [x] `dependabot.yml` validated against the v2 schema (npm, `/game`, weekly, grouped).
- [x] Confirmed `/game` is where the live `package.json`/`package-lock.json` live and `spike/*` is excluded.
- [ ] N/A — no Bazel target / no `bazel test` impact.

## Deployment steps

- N/A — GitHub picks up `.github/dependabot.yml` automatically; first grouped npm update PR (if any) lands on the next weekly run.

## Tickets addressed

- None — repo hygiene, requested in review of the Dependabot alerts.

## Rollback

- Revert this commit. Re-dismissing/un-dismissing alerts is done via the tool's `--dismiss` (or the Security UI).
