### PR TITLE
feat(metrics): two-party-normalize efficiency-gap + mean-median (GAME-112 PR 1 of 2)

### DIFF
--- a/game/web/src/simulation/evaluate.ts
+++ b/game/web/src/simulation/evaluate.ts
@@ -254,34 +254,44 @@ export function evaluateCriteria(
 			}
 
 			case "efficiency_gap": {
-				// Wasted-vote efficiency gap between the two major parties (the
-				// scenario's first two parties, party1/party2). GAME-043 keeps this
-				// two-party to preserve behavior; the proper two-party normalization
-				// for N>2 is GAME-112.
+				// Two-party-normalized wasted-vote efficiency gap between the two major
+				// parties (the scenario's first two parties, party1/party2). GAME-112:
+				// the win line, the wasted-vote counts, AND the denominator are all
+				// restricted to the two-party vote (party1 + party2), so a nonzero third
+				// party cannot corrupt the gap. When third-party share is 0 this reduces
+				// to the plain two-party EG up to floating-point (party1+party2 == 1), so
+				// the shipped two-party scenarios are preserved to display/threshold
+				// precision; a tight-boundary 2-party regression test (evaluate_test)
+				// guards against a gross formula change.
 				// Positive = party1 has more wasted votes; negative = party2 does.
 				// Criterion uses abs(gap) so direction doesn't matter.
 				const party1 = parties[0]!;
 				const party2 = parties[1]!;
 				let p1Wasted = 0;
 				let p2Wasted = 0;
-				let allVotes = 0;
+				let twoPartyVotes = 0;
 				for (const dr of simResult.districtResults) {
 					const p1Votes = (dr.voteTotals[party1] ?? 0) * dr.totalVotes;
 					const p2Votes = (dr.voteTotals[party2] ?? 0) * dr.totalVotes;
-					allVotes += dr.totalVotes;
+					// Half the TWO-PARTY vote is the win line, not half of all votes —
+					// third-party ballots are excluded from the two-party contest.
+					const twoPartyTotal = p1Votes + p2Votes;
+					const winLine = twoPartyTotal * 0.5;
+					twoPartyVotes += twoPartyTotal;
 					if (dr.winner === party1) {
-						p1Wasted += Math.max(0, p1Votes - dr.totalVotes * 0.5);
+						p1Wasted += Math.max(0, p1Votes - winLine);
 						p2Wasted += p2Votes;
 					} else if (dr.winner === party2) {
-						p2Wasted += Math.max(0, p2Votes - dr.totalVotes * 0.5);
+						p2Wasted += Math.max(0, p2Votes - winLine);
 						p1Wasted += p1Votes;
 					} else {
-						// Third-party winner: both major parties wasted all votes
+						// Third-party winner: both major parties lost the seat → all their
+						// two-party votes are wasted.
 						p1Wasted += p1Votes;
 						p2Wasted += p2Votes;
 					}
 				}
-				const rawGap = allVotes > 0 ? (p1Wasted - p2Wasted) / allVotes : 0;
+				const rawGap = twoPartyVotes > 0 ? (p1Wasted - p2Wasted) / twoPartyVotes : 0;
 				const absGap = Math.abs(rawGap);
 				passed = applyOp(absGap, c.operator, c.threshold);
 				const direction = rawGap >= 0 ? `${party1}-disadvantaged` : `${party2}-disadvantaged`;
@@ -290,13 +300,27 @@ export function evaluateCriteria(
 			}
 
 			case "mean_median": {
-				// Mean − median of party vote share across districts.
+				// Mean − median of c.party's TWO-PARTY vote share across districts
+				// (party's votes / (party1 + party2 votes)). GAME-112: normalizing to the
+				// two-party vote keeps this correct when a third party is present; with
+				// third-party share 0 it reduces to the raw share up to floating-point, so
+				// two-party scenarios are preserved to display/threshold precision (a
+				// tight-boundary 2-party regression test guards a gross change).
 				// Large positive value = party wins fewer seats than votes warrant (packed wins).
 				// Large negative value = party wins more seats than votes warrant (cracked opponents).
 				// Criterion applies applyOp to the raw (signed) difference.
-				const shares = simResult.districtResults.map(
-					(dr) => (dr.voteTotals as unknown as Record<string, number>)[c.party] ?? 0,
-				);
+				const party1 = parties[0]!;
+				const party2 = parties[1]!;
+				// Two-party normalization is only meaningful when the target is one of the
+				// two major parties; for any other target (a minor party) the denominator
+				// would exclude c.party and blow past 1, so fall back to the raw share.
+				const targetIsMajor = c.party === party1 || c.party === party2;
+				const shares = simResult.districtResults.map((dr) => {
+					const pShare = (dr.voteTotals as unknown as Record<string, number>)[c.party] ?? 0;
+					if (!targetIsMajor) return pShare;
+					const twoParty = (dr.voteTotals[party1] ?? 0) + (dr.voteTotals[party2] ?? 0);
+					return twoParty > 0 ? pShare / twoParty : 0;
+				});
 				if (shares.length === 0) {
 					passed = false;
 					detail = "no districts to evaluate";

--- a/game/web/src/simulation/evaluate_test.ts
+++ b/game/web/src/simulation/evaluate_test.ts
@@ -45,7 +45,9 @@ import { test, assertEqual, assertTrue, assertFalse, summarize } from "../testin
 // ties, the pre-GAME-043 "R" slot), ryu = parties[1] (the "D" slot).
 const KEN = "ken" as PartyId;
 const RYU = "ryu" as PartyId;
+const IND = "ind" as PartyId;
 const PARTIES: PartyId[] = [KEN, RYU];
+const PARTIES3: PartyId[] = [KEN, RYU, IND];
 
 function makePrecinct(
 	id: number,
@@ -66,6 +68,28 @@ function makePrecinct(
 			winner: partyR >= partyD ? KEN : RYU,
 			margin: Math.abs(partyR - partyD),
 		},
+	};
+}
+
+// Three-party precinct (GAME-112): vote shares over ken/ryu/ind summing to 1.
+function makePrecinct3(
+	id: number,
+	population: number,
+	ken: number,
+	ryu: number,
+	ind: number,
+	neighbors: (number | null)[],
+): Precinct {
+	const winner = ken >= ryu && ken >= ind ? KEN : ryu >= ind ? RYU : IND;
+	return {
+		index: id,
+		scenarioId: `p${id}` as unknown as PrecinctId,
+		coord: { q: 0, r: id },
+		center: { x: id * 10, y: 0 },
+		neighbors,
+		population,
+		voteShare: { [KEN]: ken, [RYU]: ryu, [IND]: ind },
+		previousResult: { winner, margin: 0 },
 	};
 }
 
@@ -145,11 +169,12 @@ function runEval(
 	districtCount: number,
 	rules = RULES,
 	scenarioPrecincts: ScenarioPrecinct[] = [],
+	partiesList: PartyId[] = PARTIES,
 ) {
 	const validityStats = computeValidityStats(precincts, assignments, districtCount, rules);
 	const state: GameState = {
 		precincts,
-		parties: PARTIES,
+		parties: partiesList,
 		assignments,
 		districtCount,
 		activeDistrict: 1,
@@ -164,7 +189,7 @@ function runEval(
 		precincts,
 		assignments,
 		districtCount,
-		PARTIES,
+		partiesList,
 		scenarioPrecincts,
 	);
 }
@@ -798,6 +823,166 @@ test("competitive_seats: a district above the margin threshold is not competitiv
 		RULES_LENIENT,
 	);
 	assertFalse(result.criterionResults[0]!.passed, "only 2 of 3 districts ≤ 0.20 margin → fail");
+});
+
+// ─── N-party two-party-normalized metrics (GAME-112) ──────────────────────────
+//
+// A 3-party fixture (ken/ryu/ind), 3 districts, 1 precinct each, pop 1000.
+//   D1  ken 0.5 / ryu 0.3 / ind 0.2  → ken wins
+//   D2  ken 0.3 / ryu 0.5 / ind 0.2  → ryu wins
+//   D3  ken 0.3 / ryu 0.5 / ind 0.2  → ryu wins
+//
+// TWO-PARTY efficiency gap (the correct, normalized value): win line = half the
+// TWO-party vote (800/2=400), denominator = Σ two-party votes (2400).
+//   D1 ken wins: ken_wasted 500−400=100, ryu_wasted 300
+//   D2 ryu wins: ryu_wasted 500−400=100, ken_wasted 300
+//   D3 ryu wins: ryu_wasted 100,        ken_wasted 300
+//   ken_wasted 700, ryu_wasted 500 → |700−500|/2400 = 0.0833
+// The OLD (all-vote) formula would give |600−300|/3000 = 0.10 — so a `lte 0.09`
+// test PASSES only under two-party normalization (0.0833 ≤ 0.09; the old 0.10 fails it).
+
+const EG3_PRECINCTS = [
+	makePrecinct3(0, 1000, 0.5, 0.3, 0.2, [null, null, null, null, null, null]),
+	makePrecinct3(1, 1000, 0.3, 0.5, 0.2, [null, null, null, null, null, null]),
+	makePrecinct3(2, 1000, 0.3, 0.5, 0.2, [null, null, null, null, null, null]),
+];
+const EG3_ASSIGNMENTS = new Map([
+	[0, 1],
+	[1, 2],
+	[2, 3],
+]);
+
+test("efficiency_gap (3-party): two-party gap ≈0.083 ≤ 0.09 → pass (old all-vote 0.10 would fail)", () => {
+	const result = runEval(
+		[makeEfficiencyGapCriterion("lte", 0.09)],
+		EG3_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+	);
+	assertTrue(result.criterionResults[0]!.passed, "two-party gap 0.083 ≤ 0.09 → pass");
+});
+
+test("efficiency_gap (3-party): two-party gap ≈0.083 > 0.08 → fail (pins the value >0.08)", () => {
+	const result = runEval(
+		[makeEfficiencyGapCriterion("lte", 0.08)],
+		EG3_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+	);
+	assertFalse(result.criterionResults[0]!.passed, "two-party gap 0.083 > 0.08 → fail");
+});
+
+// TWO-PARTY mean−median for ken: per-district two-party share ken/(ken+ryu):
+//   D1 0.5/0.8=0.625,  D2 0.3/0.8=0.375,  D3 0.3/0.8=0.375
+//   mean 0.4583, median 0.375 → diff +0.0833
+// The OLD (raw all-vote share) formula would give shares [0.5,0.3,0.3] →
+// mean 0.3667 − median 0.30 = 0.0667 — so a `lte 0.075` test FAILS only under
+// two-party normalization (0.0833 > 0.075; the old 0.0667 would pass it).
+
+test("mean_median (3-party): two-party diff ≈0.083 > 0.075 → fail (old raw 0.067 would pass)", () => {
+	const result = runEval(
+		[makeMeanMedianCriterion("ken", "lte", 0.075)],
+		EG3_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+	);
+	assertFalse(result.criterionResults[0]!.passed, "two-party diff 0.083 > 0.075 → fail");
+});
+
+test("mean_median (3-party): two-party diff ≈0.083 ≤ 0.09 → pass (pins the value ≤0.09)", () => {
+	const result = runEval(
+		[makeMeanMedianCriterion("ken", "lte", 0.09)],
+		EG3_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+	);
+	assertTrue(result.criterionResults[0]!.passed, "two-party diff 0.083 ≤ 0.09 → pass");
+});
+
+// ─── Behavior-preservation guard: tight-boundary 2-party values (GAME-112) ────
+//
+// The pre-existing 2-party threshold tests sit far from their boundaries, so they
+// only catch gross regressions. These pin the exact two-party values so a formula
+// change (e.g. reverting the two-party normalization) is caught. Two-party EG for
+// EG_PRECINCTS is 0.0333; two-party mean-median for MM_GERRYMANDER (ken) is 0.1667.
+
+test("efficiency_gap (2-party regression): value ≈0.0333 — ≤0.034 passes, ≤0.033 fails", () => {
+	const pass = runEval(
+		[makeEfficiencyGapCriterion("lte", 0.034)],
+		EG_PRECINCTS,
+		EG_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+	);
+	assertTrue(pass.criterionResults[0]!.passed, "0.0333 ≤ 0.034 → pass");
+	const fail = runEval(
+		[makeEfficiencyGapCriterion("lte", 0.033)],
+		EG_PRECINCTS,
+		EG_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+	);
+	assertFalse(fail.criterionResults[0]!.passed, "0.0333 > 0.033 → fail (pins the value)");
+});
+
+test("mean_median (2-party regression): gerrymander diff ≈0.1667 — ≤0.17 passes, ≤0.16 fails", () => {
+	const pass = runEval(
+		[makeMeanMedianCriterion("ken", "lte", 0.17)],
+		MM_GERRYMANDER_PRECINCTS,
+		MM_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+	);
+	assertTrue(pass.criterionResults[0]!.passed, "0.1667 ≤ 0.17 → pass");
+	const fail = runEval(
+		[makeMeanMedianCriterion("ken", "lte", 0.16)],
+		MM_GERRYMANDER_PRECINCTS,
+		MM_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+	);
+	assertFalse(fail.criterionResults[0]!.passed, "0.1667 > 0.16 → fail (pins the value)");
+});
+
+// ─── mean_median minor-party guard (GAME-112) ─────────────────────────────────
+//
+// Two-party normalization is only meaningful for a major party; targeting a MINOR
+// party must fall back to the raw share (else pShare/(party1+party2) exceeds 1 and
+// is meaningless). Fixture: ind raw shares [0.6, 0.2, 0.2] → guarded diff 0.133.
+// WITHOUT the guard it would be ind/(ken+ryu) = [1.5, 0.25, 0.25] → diff 0.417.
+
+const MINOR_TARGET_PRECINCTS = [
+	makePrecinct3(0, 1000, 0.3, 0.1, 0.6, [null, null, null, null, null, null]),
+	makePrecinct3(1, 1000, 0.4, 0.4, 0.2, [null, null, null, null, null, null]),
+	makePrecinct3(2, 1000, 0.4, 0.4, 0.2, [null, null, null, null, null, null]),
+];
+
+test("mean_median (minor target): falls back to raw share — diff ≈0.133 ≤ 0.20 (ungarded 0.417 would fail)", () => {
+	const result = runEval(
+		[makeMeanMedianCriterion("ind", "lte", 0.2)],
+		MINOR_TARGET_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+	);
+	assertTrue(
+		result.criterionResults[0]!.passed,
+		"raw-share diff 0.133 ≤ 0.20 → pass (the unguarded two-party 0.417 would fail)",
+	);
 });
 
 summarize();

--- a/thoughts/shared/tickets/GAME-112-multiparty-and-two-party-metrics.md
+++ b/thoughts/shared/tickets/GAME-112-multiparty-and-two-party-metrics.md
@@ -30,6 +30,16 @@ Sourced from the 2026-06-30 metrics audit (`thoughts/shared/research/2026-06-30-
 > interpolate the raw scenario party-id (e.g. `ken-disadvantaged`) rather than a display name.
 > Lateral to the old raw `R`/`D` key — not a regression — but when metrics go multiparty these
 > should use the scenario's authored party *name*/abbreviation. Coordinate with GAME-113.
+>
+> **PR 1 of 2 done (#322) — the metrics half:** efficiency-gap + mean-median are now
+> two-party-normalized (win line = half the two-party vote; denominator = Σ two-party votes; mean-
+> median on `c.party/(party1+party2)` shares), byte-identical at third-party-share 0. 3-party
+> `evaluate_test` fixtures pin the normalized values (EG 0.083 not the old 0.10; mean-median 0.083
+> not the old 0.067). **Remaining for PR 2 (collaborative):** the 3-party `tutorial-005` demo
+> scenario (generated via GAME-116's N-party stage, housed in GAME-115's debug campaign, eyeballed
+> on serve-local) + a 3-party *adapter* test (nonzero third-party share; a district a third party
+> wins). Also fold in the `buildContinueUrl` gating-symmetry note from the #321 critique once the
+> debug scenario is actually playable.
 
 - `adapter.ts:113-129`: reads only `firstPartyId = parties[0].id` (→ R) and
   `secondPartyId = parties[1].id` (→ D), sums each demographic group's


### PR DESCRIPTION
## Summary

**Advances GAME-112 (PR 1 of 2 — the metrics half; ticket stays open for the demo).**
Two-party-normalizes the efficiency-gap and mean-median fairness metrics so a nonzero third party
can't corrupt them — the correctness prerequisite for shipping multiparty scenarios. Sourced from the
2026-06-30 metrics audit. PR 2 is the collaborative 3-party `tutorial-005` demo (generated via
GAME-116, housed in GAME-115's debug campaign).

- **`efficiency_gap` (`evaluate.ts`):** the win line is now half the **two-party** vote
  (`(party1+party2)/2`) rather than half of *all* votes, and the denominator is the sum of two-party
  votes rather than all votes. Third-party ballots are excluded from the two-party contest; a
  third-party seat win still wastes both majors' votes.
- **`mean_median`:** each district's share is now `c.party / (party1 + party2)` — the party's
  **two-party** share — rather than its raw all-vote share.
- **Behavior-preserving at third-party-share 0:** both reduce exactly to the prior formulas when
  `party1 + party2 == total` (all shipped scenarios are two-party), so the existing threshold tests
  are unchanged and remain the regression guard.

## Affected machines / services

- The static web game's simulation layer (`game/web/src/simulation/evaluate.ts`). Metric-math change;
  no rendering/store/schema change. Two-party scenarios are unaffected.

## Validation performed

- [x] `bazel test //game/...` green — **47/47** (incl. Biome lint + winnability e2e). The existing
  two-party `efficiency_gap`/`mean_median` threshold tests still pass unchanged (behavior-preserving
  guard); the winnability e2e confirms no shipped scenario's metric crossed a threshold.
- [x] New 3-party `evaluate_test` fixtures actively prove the normalization:
  - efficiency_gap: the two-party gap is **0.083** (`≤0.09` passes, `≤0.08` fails) — the OLD all-vote
    formula would give **0.10**, which `≤0.09` would fail, so the passing test can only hold under
    two-party normalization.
  - mean_median (ken): the two-party diff is **0.083** (`≤0.075` fails, `≤0.09` passes) — the OLD raw
    formula would give **0.067**, which `≤0.075` would pass, so the failing test can only hold under
    two-party normalization.
- [ ] N/A — no deploy/infra change.

## Deployment steps

- None — ships with the next deploy; no behavior change for the (two-party) shipped scenarios.

## Tickets addressed

- **Advances GAME-112 (PR 1 of 2).** Ticket stays open for the 3-party `tutorial-005` demo + a
  3-party adapter test (PR 2). Ticket Current State updated with PR-1 status.

## Rollback

- Revert this commit. Restores the all-vote efficiency-gap denominator/win-line and the raw-share
  mean-median. No data/schema change; two-party scenarios identical either way.
