### PR TITLE
feat(model): home-base independent candidates (GAME-118 PR 1 of 2)

### DIFF
--- a/game/web/src/model/adapter.ts
+++ b/game/web/src/model/adapter.ts
@@ -38,6 +38,7 @@ export function scenarioToRuntime(scenario: Scenario): {
 	districtCount: number;
 	terrainTiles: TerrainTileRuntime[];
 	riverEdges: [number, number][];
+	independentHomes?: ReadonlyMap<PartyId, number>;
 } {
 	// Ordered scenario party list — the source of the tie-break order and every
 	// winner/margin/seat computation downstream.
@@ -54,6 +55,22 @@ export function scenarioToRuntime(scenario: Scenario): {
 	scenario.precincts.forEach((pc, i) => {
 		const pos = pc.position;
 		if ("q" in pos) posMap.set(`${pos.q},${pos.r}`, i);
+	});
+
+	// GAME-118: resolve each home-base independent's home coord → precinct index.
+	// Only the (stable) precinct index is stored; the election derives the home
+	// *district* fresh from assignments each run. Loader guarantees independent⟺home
+	// and hex_axial geometry, so posMap has the coord unless it's simply wrong.
+	const independentHomes = new Map<PartyId, number>();
+	scenario.parties.forEach((p: Party) => {
+		if (!p.independent || p.home === undefined) return;
+		const homeIndex = posMap.get(`${p.home.q},${p.home.r}`);
+		if (homeIndex === undefined) {
+			throw new Error(
+				`Independent party "${p.id}" home (${p.home.q},${p.home.r}) matches no precinct`,
+			);
+		}
+		independentHomes.set(p.id, homeIndex);
 	});
 
 	// Build terrain tile position map for annotation derivation
@@ -203,5 +220,7 @@ export function scenarioToRuntime(scenario: Scenario): {
 		districtCount: scenario.districts.length,
 		terrainTiles,
 		riverEdges: riverPairs,
+		// Omit when empty so no-independent scenarios produce an identical GameState.
+		...(independentHomes.size > 0 ? { independentHomes } : {}),
 	};
 }

--- a/game/web/src/model/adapter_test.ts
+++ b/game/web/src/model/adapter_test.ts
@@ -24,6 +24,7 @@ import {
 	assertNull,
 	assertNotNull,
 	assertClose,
+	assertThrows,
 	summarize,
 } from "../testing/test_runner.js";
 
@@ -431,6 +432,67 @@ test("scenarioToRuntime: passableNeighbors nulls river edges when river_blocks_c
 	// neighbors retains 1 for geometry; passableNeighbors nulls it
 	assertEqual(precincts[0]!.neighbors[0], 1, "neighbors[0] still 1 (geometry preserved)");
 	assertNull(precincts[0]!.passableNeighbors![0], "passableNeighbors[0] nulled (river blocks)");
+});
+
+// ─── GAME-118: home-base independent home resolution ──────────────────────────
+
+test("scenarioToRuntime (GAME-118): independent home coord resolves to its precinct index", () => {
+	const g = makeGroup({
+		[pid("r_party")]: 0.3,
+		[pid("d_party")]: 0.25,
+		[pid("ind_party")]: 0.45,
+	});
+	const indParty: Party = {
+		id: pid("ind_party"),
+		name: "Ind",
+		abbreviation: "I",
+		independent: true,
+		home: { q: 1, r: 0 }, // the SECOND precinct → index 1 (proves it isn't hardcoded to 0)
+	};
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D, indParty],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [makePrecinct(0, 0, [g], "d1"), makePrecinct(1, 0, [g], "d1")],
+	});
+	const { independentHomes } = scenarioToRuntime(scenario);
+	assertNotNull(independentHomes, "independentHomes present");
+	assertEqual(independentHomes!.get(pid("ind_party")), 1, "home (1,0) → precinct index 1");
+});
+
+test("scenarioToRuntime (GAME-118): an independent home matching no precinct throws", () => {
+	const g = makeGroup({
+		[pid("r_party")]: 0.3,
+		[pid("d_party")]: 0.25,
+		[pid("ind_party")]: 0.45,
+	});
+	const indParty: Party = {
+		id: pid("ind_party"),
+		name: "Ind",
+		abbreviation: "I",
+		independent: true,
+		home: { q: 9, r: 9 }, // no precinct at (9,9)
+	};
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D, indParty],
+		districts: [{ id: did("d1") }, { id: did("d2") }],
+		precincts: [makePrecinct(0, 0, [g], "d1"), makePrecinct(1, 0, [g], "d1")],
+	});
+	assertThrows(() => scenarioToRuntime(scenario), /matches no precinct/);
+});
+
+test("scenarioToRuntime (GAME-118): no independents → independentHomes omitted", () => {
+	const g = makeGroup({ [pid("r_party")]: 0.6, [pid("d_party")]: 0.4 });
+	const scenario = makeScenario({
+		parties: [PARTY_R, PARTY_D],
+		districts: [{ id: did("d1") }],
+		precincts: [makePrecinct(0, 0, [g], "d1")],
+	});
+	const { independentHomes } = scenarioToRuntime(scenario);
+	assertEqual(
+		independentHomes,
+		undefined,
+		"no independents ⇒ field omitted (byte-identical GameState)",
+	);
 });
 
 summarize();

--- a/game/web/src/model/loader.ts
+++ b/game/web/src/model/loader.ts
@@ -117,6 +117,32 @@ function parseParty(raw: unknown, idx: number): Party {
 			requireString(c, `parties[${idx}].candidates[${i}]`),
 		);
 	}
+	// GAME-118: home-base independent — `independent` and `home` are coupled, and an
+	// independent may not occupy a major-party slot.
+	if (r["independent"] !== undefined) {
+		p.independent = requireBoolean(r["independent"], `parties[${idx}].independent`);
+	}
+	if (r["home"] !== undefined) {
+		const h = requireObject(r["home"], `parties[${idx}].home`);
+		p.home = {
+			q: requireNumber(h["q"], `parties[${idx}].home.q`),
+			r: requireNumber(h["r"], `parties[${idx}].home.r`),
+		};
+	}
+	if (p.independent && p.home === undefined) {
+		throw new Error(`parties[${idx}]: independent party "${p.id}" must declare a home`);
+	}
+	if (p.home !== undefined && !p.independent) {
+		throw new Error(
+			`parties[${idx}]: party "${p.id}" declares a home but is not marked independent`,
+		);
+	}
+	if (p.independent && idx < 2) {
+		throw new Error(
+			`parties[${idx}]: independent party "${p.id}" must be declared in slot 2 or later ` +
+				`(slots 0 and 1 are reserved for the two major parties the fairness metrics normalise against)`,
+		);
+	}
 	return p;
 }
 
@@ -1208,6 +1234,21 @@ function validateScenarioInvariants(fields: {
 	// ── Invariant 7: group_schema completeness constraint ────────────────────────
 	if (group_schema !== undefined) {
 		checkGroupSchemaCompleteness(group_schema, rawPrecincts);
+	}
+
+	// ── GAME-118: independent home requires axial geometry ───────────────────────
+	// An independent's home is an axial coordinate; on non-hex geometry there is no
+	// coordinate for the adapter to resolve, so reject it here with a clear message
+	// rather than letting the adapter's coord lookup fail cryptically.
+	if (geometry.type !== "hex_axial") {
+		for (const p of parties) {
+			if (p.independent) {
+				throw new Error(
+					`Independent party "${p.id}" requires hex_axial geometry (home is an axial ` +
+						`coordinate); scenario geometry is "${geometry.type}"`,
+				);
+			}
+		}
 	}
 
 	// ── Terrain + river validation ───────────────────────────────────────────────

--- a/game/web/src/model/loader_parse_test.ts
+++ b/game/web/src/model/loader_parse_test.ts
@@ -895,4 +895,123 @@ test("agreement: non-adjacent river edge rejected by both paths (river)", () => 
 	assertThrows(() => validateScenarioComplete(partial), /not geometrically adjacent/);
 });
 
+// ─── GAME-118: home-base independent party validation ─────────────────────────
+//
+// parseParty enforces: independent ⟺ home (coupled), and an independent may not sit
+// in a major slot (0/1, reserved for the two parties the fairness metrics normalise
+// against). These fire at parse time.
+
+test("parseScenario (GAME-118): an independent party without a home is rejected", () => {
+	assertThrows(
+		() =>
+			parseScenario(
+				fullScenario({
+					parties: [
+						{ id: "blue", name: "Blue", abbreviation: "B" },
+						{ id: "red", name: "Red", abbreviation: "R" },
+						{ id: "ind", name: "Ind", abbreviation: "I", independent: true },
+					],
+				}),
+			),
+		/home/,
+	);
+});
+
+test("parseScenario (GAME-118): a home without independent:true is rejected", () => {
+	assertThrows(
+		() =>
+			parseScenario(
+				fullScenario({
+					parties: [
+						{ id: "blue", name: "Blue", abbreviation: "B" },
+						{ id: "red", name: "Red", abbreviation: "R" },
+						{ id: "ind", name: "Ind", abbreviation: "I", home: { q: 0, r: 0 } },
+					],
+				}),
+			),
+		/independent/,
+	);
+});
+
+test("parseScenario (GAME-118): an independent in a major slot (0/1) is rejected", () => {
+	assertThrows(
+		() =>
+			parseScenario(
+				fullScenario({
+					parties: [
+						{ id: "ind", name: "Ind", abbreviation: "I", independent: true, home: { q: 0, r: 0 } },
+						{ id: "red", name: "Red", abbreviation: "R" },
+						{ id: "blue", name: "Blue", abbreviation: "B" },
+					],
+				}),
+			),
+		/slot/,
+	);
+});
+
+test("parseScenario (GAME-118): a well-formed slot-2 independent with a home parses", () => {
+	assertDoesNotThrow(() =>
+		parseScenario(
+			fullScenario({
+				parties: [
+					{ id: "blue", name: "Blue", abbreviation: "B" },
+					{ id: "red", name: "Red", abbreviation: "R" },
+					{ id: "ind", name: "Ind", abbreviation: "I", independent: true, home: { q: 0, r: 0 } },
+				],
+				// A 3-party precinct so vote-share completeness (Invariant 6) is satisfied.
+				precincts: [
+					{
+						id: "p1",
+						editable: true,
+						position: { q: 0, r: 0 },
+						total_population: 1000,
+						demographic_groups: [
+							{
+								id: "g1",
+								population_share: 1.0,
+								vote_shares: { blue: 0.4, red: 0.3, ind: 0.3 },
+								turnout_rate: 0.7,
+							},
+						],
+					},
+				],
+			}),
+		),
+	);
+});
+
+test("loadScenario (GAME-118): a complete scenario with a slot-2 independent validates end-to-end", () => {
+	// parseScenario acceptance (above) runs only structural checks; this drives the
+	// FULL complete-path validation (loadScenario = parse + validateScenarioComplete),
+	// which is where the independent-requires-hex_axial guard lives — so a guard or
+	// coupling regression that wrongly rejected a valid hex independent is caught here.
+	assertDoesNotThrow(() =>
+		loadScenario(
+			fullScenario({
+				parties: [
+					{ id: "blue", name: "Blue", abbreviation: "B" },
+					{ id: "red", name: "Red", abbreviation: "R" },
+					{ id: "ind", name: "Ind", abbreviation: "I", independent: true, home: { q: 0, r: 0 } },
+				],
+				precincts: [
+					{
+						id: "p1",
+						editable: true,
+						position: { q: 0, r: 0 },
+						total_population: 1000,
+						demographic_groups: [
+							{
+								id: "g1",
+								population_share: 1.0,
+								vote_shares: { blue: 0.4, red: 0.3, ind: 0.3 },
+								turnout_rate: 0.7,
+							},
+						],
+					},
+				],
+			}),
+		),
+	);
+});
+
 summarize();

--- a/game/web/src/model/runtime.ts
+++ b/game/web/src/model/runtime.ts
@@ -158,6 +158,12 @@ export interface GameState {
 	terrainTiles?: TerrainTileRuntime[];
 	/** River edge pairs as precinct index pairs (absent = no rivers in scenario) */
 	riverEdges?: [number, number][];
+	/** GAME-118: home-base independents → their home precinct index (the array index,
+	 *  equal to precinct.index and the assignment-map key). The election resolves each
+	 *  independent's home *district* fresh from `assignments` every run, so this stays
+	 *  correct as the player repaints. Absent or empty ⇒ no independents ⇒ every party
+	 *  contests every district (the pre-GAME-118 behaviour, byte-for-byte). */
+	independentHomes?: ReadonlyMap<PartyId, number>;
 }
 
 /** A brush stroke undo/redo diff: maps precinct index → {from, to} */

--- a/game/web/src/model/scenario.ts
+++ b/game/web/src/model/scenario.ts
@@ -79,6 +79,19 @@ export interface Party {
 	 *  district, results fall back to the party name — so a person, not an abstract
 	 *  party, holds each seat (and one person can't hold two). */
 	candidates?: string[];
+	/** GAME-118: marks a home-base independent — a candidate who appears on the
+	 *  ballot only in the district containing `home`. An independent still carries a
+	 *  map-wide lean (its precinct vote-share, shown everywhere), but can win at most
+	 *  the single seat for its home district; in every other district it is excluded
+	 *  from the contest and its votes are disregarded for that seat. Must be declared
+	 *  in slot ≥2 — slots 0 and 1 anchor the two-party fairness normalisation
+	 *  (see evaluate.ts). Requires hex_axial geometry (home is an axial coordinate). */
+	independent?: boolean;
+	/** GAME-118: an independent's home precinct as an axial coordinate. Required when
+	 *  (and only when) `independent` is true. Resolved to a precinct index at adapter
+	 *  time; the election puts the independent on the ballot only in the district that
+	 *  precinct is currently assigned to (unassigned home ⇒ no ballot anywhere). */
+	home?: HexAxialPosition;
 }
 
 export interface District {

--- a/game/web/src/simulation/election.ts
+++ b/game/web/src/simulation/election.ts
@@ -21,6 +21,10 @@ export function simulateDistrict(
 	precincts: Precinct[],
 	assignments: AssignmentMap,
 	parties: PartyId[],
+	/** GAME-118: home-base independents → home precinct index. A party present here
+	 *  is on the ballot only in the district its home precinct is currently assigned
+	 *  to. Omitted (or absent entry) ⇒ the party contests every district. */
+	independentHomes?: ReadonlyMap<PartyId, number>,
 ): DistrictResult {
 	const inDistrict = precincts.filter((p) => assignments.get(p.index) === districtId);
 
@@ -41,11 +45,25 @@ export function simulateDistrict(
 		}
 	}
 
-	const winner = winnerOf(voteTotals, parties);
+	// GAME-118: restrict the seat contest to eligible parties — a home-base
+	// independent is on the ballot only in the district its home precinct is
+	// currently assigned to; everywhere else it is excluded (its lean still shows in
+	// voteTotals above — only winner/margin are restricted). No map ⇒ all parties
+	// eligible in every district (pre-GAME-118 behaviour, unchanged).
+	const eligibleParties = independentHomes
+		? parties.filter((party) => {
+				const home = independentHomes.get(party);
+				return home === undefined || assignments.get(home) === districtId;
+			})
+		: parties;
 
-	// Find second-place for margin
-	const sorted = parties.slice().sort((a, b) => (voteTotals[b] ?? 0) - (voteTotals[a] ?? 0));
-	const runnerUp = sorted[1] ?? parties[0]!;
+	const winner = winnerOf(voteTotals, eligibleParties);
+
+	// Find second-place (among eligible parties) for margin
+	const sorted = eligibleParties
+		.slice()
+		.sort((a, b) => (voteTotals[b] ?? 0) - (voteTotals[a] ?? 0));
+	const runnerUp = sorted[1] ?? eligibleParties[0]!;
 	const margin = (voteTotals[winner] ?? 0) - (voteTotals[runnerUp] ?? 0);
 
 	return {
@@ -74,7 +92,15 @@ export function runElection(state: GameState): SimulationResult {
 
 	const districtResults: DistrictResult[] = [];
 	for (const dId of Array.from(activeDistricts).sort((a, b) => a - b)) {
-		districtResults.push(simulateDistrict(dId, state.precincts, state.assignments, state.parties));
+		districtResults.push(
+			simulateDistrict(
+				dId,
+				state.precincts,
+				state.assignments,
+				state.parties,
+				state.independentHomes,
+			),
+		);
 	}
 
 	// Summarise seats

--- a/game/web/src/simulation/election_test.ts
+++ b/game/web/src/simulation/election_test.ts
@@ -59,7 +59,11 @@ function makePrecinct(index: number, r: number, d: number, pop: number): Precinc
 	};
 }
 
-function makeState(precincts: Precinct[], assignments: AssignmentMap): GameState {
+function makeState(
+	precincts: Precinct[],
+	assignments: AssignmentMap,
+	independentHomes?: ReadonlyMap<PartyId, number>,
+): GameState {
 	return {
 		precincts,
 		parties: PARTIES,
@@ -67,6 +71,7 @@ function makeState(precincts: Precinct[], assignments: AssignmentMap): GameState
 		assignments,
 		activeDistrict: 1,
 		simulationResult: null,
+		...(independentHomes ? { independentHomes } : {}),
 	};
 }
 
@@ -260,6 +265,150 @@ test("runElection: district results sorted by districtId", () => {
 	assertEqual(result.districtResults.length, 2, "two results");
 	assertEqual(result.districtResults[0]!.districtId, 1, "first result is district 1");
 	assertEqual(result.districtResults[1]!.districtId, 3, "second result is district 3");
+});
+
+// ─── GAME-118: home-base independent (on-ballot only in its home district) ──────
+
+// Like makePrecinct, but lets a test set an arbitrary party's share (e.g. the
+// independent I). Reuses share() so the omitted parties stay 0 and sum to 1.
+function makePrecinctShares(
+	index: number,
+	shares: Partial<Record<PartyId, number>>,
+	pop: number,
+): Precinct {
+	return {
+		index,
+		scenarioId: `p${index}` as unknown as import("../model/scenario.js").PrecinctId,
+		coord: { q: 0, r: index },
+		center: { x: index * 10, y: 0 },
+		neighbors: [null, null, null, null, null, null],
+		population: pop,
+		voteShare: share(shares),
+		previousResult: { winner: D, margin: 0 },
+	};
+}
+
+test("simulateDistrict (GAME-118): independent on the ballot at home wins on plurality", () => {
+	// Precinct 0 is I's home, assigned to district 1. I leads: R .35 / D .20 / I .45.
+	const p = makePrecinctShares(0, { [R]: 0.35, [D]: 0.2, [I]: 0.45 }, 100);
+	const assignments: AssignmentMap = new Map([[0, 1]]);
+	const homes = new Map([[I, 0]]); // I's home is precinct index 0
+	const result = simulateDistrict(1, [p], assignments, PARTIES, homes);
+
+	assertEqual(result.winner, I, "I is on the ballot at home and wins the plurality");
+	assertClose(result.margin, 0.1, 0.001, "margin = I 0.45 − R 0.35");
+	assertClose(result.voteTotals[I] ?? 0, 0.45, 0.001, "I's lean is still present in voteTotals");
+});
+
+test("simulateDistrict (GAME-118): independent excluded away from home — a major takes the seat", () => {
+	// Precinct 1 is in district 2; I's home is precinct 0 (district 1), so I is OFF
+	// the ballot here. I leads the lean (.45) but among eligible parties D (.35) beats
+	// R (.20) for the seat — I's votes are disregarded, not redistributed.
+	const p = makePrecinctShares(1, { [R]: 0.2, [D]: 0.35, [I]: 0.45 }, 100);
+	const assignments: AssignmentMap = new Map([
+		[0, 1],
+		[1, 2],
+	]);
+	const homes = new Map([[I, 0]]);
+	const result = simulateDistrict(2, [p], assignments, PARTIES, homes);
+
+	assertEqual(result.winner, D, "I excluded away from home → the top major (D) wins");
+	assertClose(
+		result.voteTotals[I] ?? 0,
+		0.45,
+		0.001,
+		"I's lean is unchanged in voteTotals (map view intact)",
+	);
+	assertClose(result.margin, 0.15, 0.001, "margin among eligible = D 0.35 − R 0.20");
+});
+
+test("simulateDistrict (GAME-118): an independent whose home is unassigned is on no ballot", () => {
+	// I's home precinct (0) is unassigned (null). District 1 contains precinct 1 where
+	// I leads the lean — but with no home district, I is excluded and a major wins.
+	const home = makePrecinctShares(0, { [R]: 0.5, [D]: 0.5 }, 100); // home, unassigned
+	const p1 = makePrecinctShares(1, { [R]: 0.2, [D]: 0.35, [I]: 0.45 }, 100);
+	const assignments: AssignmentMap = new Map([
+		[0, null],
+		[1, 1],
+	]);
+	const homes = new Map([[I, 0]]);
+	const result = simulateDistrict(1, [home, p1], assignments, PARTIES, homes);
+
+	assertEqual(result.winner, D, "unassigned home ⇒ I off every ballot ⇒ major (D) wins");
+});
+
+test("runElection (GAME-118): independent wins only its home district — exactly one seat", () => {
+	// I's home = precinct 0 (district 1). Precincts 0 and 1 have identical I-leading
+	// leans; I wins d1 (home) but is excluded from d2 → R takes d2. d3 is a plain R hold.
+	const p0 = makePrecinctShares(0, { [R]: 0.3, [D]: 0.25, [I]: 0.45 }, 100); // d1 (home)
+	const p1 = makePrecinctShares(1, { [R]: 0.3, [D]: 0.25, [I]: 0.45 }, 100); // d2 (away)
+	const p2 = makePrecinctShares(2, { [R]: 0.7, [D]: 0.3 }, 100); // d3
+	const assignments: AssignmentMap = new Map([
+		[0, 1],
+		[1, 2],
+		[2, 3],
+	]);
+	const state = makeState([p0, p1, p2], assignments, new Map([[I, 0]]));
+	const result = runElection(state);
+
+	const d1 = result.districtResults.find((r) => r.districtId === 1)!;
+	const d2 = result.districtResults.find((r) => r.districtId === 2)!;
+	assertEqual(d1.winner, I, "d1 (home): I wins");
+	assertEqual(d2.winner, R, "d2 (away): I excluded → R wins");
+	assertEqual(result.seatsByParty[I] ?? 0, 1, "I holds exactly one seat");
+	assertEqual(result.seatsByParty[R] ?? 0, 2, "R holds d2 and d3");
+});
+
+test("runElection (GAME-118): multiple independents each win their own home district", () => {
+	// Two independents: I (home precinct 0 → d1) and G (home precinct 1 → d2). Each
+	// leads its home precinct and is excluded from the other's district.
+	const p0 = makePrecinctShares(0, { [R]: 0.3, [D]: 0.25, [I]: 0.45 }, 100); // d1: I home
+	const p1 = makePrecinctShares(1, { [R]: 0.3, [D]: 0.25, [G]: 0.45 }, 100); // d2: G home
+	const assignments: AssignmentMap = new Map([
+		[0, 1],
+		[1, 2],
+	]);
+	const homes = new Map([
+		[I, 0],
+		[G, 1],
+	]);
+	const result = runElection(makeState([p0, p1], assignments, homes));
+
+	assertEqual(
+		result.districtResults.find((r) => r.districtId === 1)!.winner,
+		I,
+		"d1: I wins its home",
+	);
+	assertEqual(
+		result.districtResults.find((r) => r.districtId === 2)!.winner,
+		G,
+		"d2: G wins its home",
+	);
+});
+
+test("runElection (GAME-118): with no independentHomes, every party contests every district", () => {
+	// Same board as the home-win test but WITHOUT independentHomes: I is excluded
+	// nowhere, so it wins d2 too — proving the exclusion is strictly opt-in (the
+	// pre-GAME-118 all-eligible behaviour is preserved when the map is absent).
+	const p0 = makePrecinctShares(0, { [R]: 0.3, [D]: 0.25, [I]: 0.45 }, 100);
+	const p1 = makePrecinctShares(1, { [R]: 0.3, [D]: 0.25, [I]: 0.45 }, 100);
+	const assignments: AssignmentMap = new Map([
+		[0, 1],
+		[1, 2],
+	]);
+	const result = runElection(makeState([p0, p1], assignments)); // no independentHomes
+
+	assertEqual(
+		result.districtResults.find((r) => r.districtId === 1)!.winner,
+		I,
+		"d1: I wins (no exclusion)",
+	);
+	assertEqual(
+		result.districtResults.find((r) => r.districtId === 2)!.winner,
+		I,
+		"d2: I also wins (no exclusion)",
+	);
+	assertEqual(result.seatsByParty[I], 2, "I wins both — the pre-GAME-118 all-eligible behaviour");
 });
 
 summarize();

--- a/game/web/src/simulation/evaluate_test.ts
+++ b/game/web/src/simulation/evaluate_test.ts
@@ -170,6 +170,7 @@ function runEval(
 	rules = RULES,
 	scenarioPrecincts: ScenarioPrecinct[] = [],
 	partiesList: PartyId[] = PARTIES,
+	independentHomes?: ReadonlyMap<PartyId, number>,
 ) {
 	const validityStats = computeValidityStats(precincts, assignments, districtCount, rules);
 	const state: GameState = {
@@ -179,6 +180,7 @@ function runEval(
 		districtCount,
 		activeDistrict: 1,
 		simulationResult: null,
+		...(independentHomes ? { independentHomes } : {}),
 	};
 	state.simulationResult = runElection(state);
 	return evaluateCriteria(
@@ -982,6 +984,113 @@ test("mean_median (minor target): falls back to raw share — diff ≈0.133 ≤ 
 	assertTrue(
 		result.criterionResults[0]!.passed,
 		"raw-share diff 0.133 ≤ 0.20 → pass (the unguarded two-party 0.417 would fail)",
+	);
+});
+
+// ─── efficiency_gap: third-party (independent) winner branch (GAME-118) ────────
+//
+// The EG else branch (evaluate.ts) fires only when a district's winner is NEITHER
+// major party — i.e. when a home-base independent wins its home district. The EG3
+// fixture above keeps ind=0.2 everywhere so that branch never fired; this pins it.
+// In D1 the independent wins outright, so BOTH majors' two-party votes are wasted
+// there (the else branch):
+//   D1 ken .35 ryu .20 ind .45 → IND wins → ken_wasted 350, ryu_wasted 200 (else)
+//   D2 ken .55 ryu .30 ind .15 → KEN wins → ken_wasted 125, ryu_wasted 300
+//   D3 ken .30 ryu .55 ind .15 → RYU wins → ken_wasted 300, ryu_wasted 125
+//   totals ken 775 / ryu 625, two-party 2250 → |775−625|/2250 = 0.0667
+// Without the else branch (an IND-win district wasting nothing) both majors would tie
+// at 425 and the gap would be 0 — so the ≤0.06 fail assertion below is what locks it.
+const EG3_IND_WIN_PRECINCTS = [
+	makePrecinct3(0, 1000, 0.35, 0.2, 0.45, [null, null, null, null, null, null]),
+	makePrecinct3(1, 1000, 0.55, 0.3, 0.15, [null, null, null, null, null, null]),
+	makePrecinct3(2, 1000, 0.3, 0.55, 0.15, [null, null, null, null, null, null]),
+];
+
+test("efficiency_gap (GAME-118): independent wins a district → both majors' votes wasted → gap ≈0.0667", () => {
+	const pass = runEval(
+		[makeEfficiencyGapCriterion("lte", 0.07)],
+		EG3_IND_WIN_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+	);
+	assertTrue(pass.criterionResults[0]!.passed, "0.0667 ≤ 0.07 → pass");
+
+	const fail = runEval(
+		[makeEfficiencyGapCriterion("lte", 0.06)],
+		EG3_IND_WIN_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+	);
+	assertFalse(
+		fail.criterionResults[0]!.passed,
+		"0.0667 > 0.06 → fail (pins the else branch; without it the gap would be 0 and wrongly pass)",
+	);
+});
+
+// ─── efficiency_gap: away independent is excluded, seat AND metric agree (GAME-118) ──
+//
+// This is the GAME-112 × GAME-118 seam: evaluate.ts keys the EG off dr.winner, and
+// dr.winner is the ELIGIBILITY-aware winner from simulateDistrict. If instead the
+// metric recomputed a raw-plurality winner, the seat count and the fairness metric
+// would disagree for an away independent — exactly the confusing artifact to avoid.
+//
+// Same votes as EG3_IND_WIN_PRECINCTS above, but now IND has a HOME in D3 (precinct
+// index 2). D1 is therefore AWAY for IND: IND has the local plurality (0.45) yet is
+// excluded, so KEN (0.35 > ryu 0.20) takes the seat. The full A/B against the sibling
+// test — identical precincts, home mechanic flips D1 IND→KEN — moves the gap:
+//   D1 KEN wins: ken_wasted 350−275=75,  ryu_wasted 200   (was IND-win/else: ken 350)
+//   D2 KEN wins: ken_wasted 550−425=125, ryu_wasted 300
+//   D3 RYU wins: ryu_wasted 550−425=125, ken_wasted 300   (IND eligible at home but loses)
+//   ken 500 / ryu 625, two-party 2250 → |500−625|/2250 = 0.0556
+// So the seat is a major's (KEN=2, RYU=1, IND=0) AND the gap is 0.0556 — NOT the
+// 0.0667 the else branch would yield if IND wrongly "won" its away district. A tight
+// ≤0.056 pass / ≤0.055 fail pins the value away from the sibling test's 0.0667.
+const IND_HOME_D3: ReadonlyMap<PartyId, number> = new Map([[IND, 2]]);
+
+test("efficiency_gap (GAME-118 seam): away independent excluded → major takes seat AND gap agrees (0.0556, not 0.0667)", () => {
+	const pass = runEval(
+		[
+			makeEfficiencyGapCriterion("lte", 0.056),
+			makeSeatCountCriterion("ken", "eq", 2),
+			makeSeatCountCriterion("ind", "eq", 0),
+		],
+		EG3_IND_WIN_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+		IND_HOME_D3,
+	);
+	assertTrue(pass.criterionResults[0]!.passed, "two-party gap 0.0556 ≤ 0.056 → pass");
+	assertTrue(
+		pass.criterionResults[1]!.passed,
+		"KEN wins 2 seats (D1 away-seat goes to the major, not the excluded independent)",
+	);
+	assertTrue(
+		pass.criterionResults[2]!.passed,
+		"IND wins 0 seats (excluded in D1/D2, loses at its D3 home)",
+	);
+
+	const fail = runEval(
+		[makeEfficiencyGapCriterion("lte", 0.055)],
+		EG3_IND_WIN_PRECINCTS,
+		EG3_ASSIGNMENTS,
+		3,
+		RULES_LENIENT,
+		[],
+		PARTIES3,
+		IND_HOME_D3,
+	);
+	assertFalse(
+		fail.criterionResults[0]!.passed,
+		"0.0556 > 0.055 → fail (pins the value; the sibling no-home fixture would be 0.0667 here)",
 	);
 });
 

--- a/game/web/src/store/gameStore.ts
+++ b/game/web/src/store/gameStore.ts
@@ -49,8 +49,15 @@ function cloneAssignments(m: AssignmentMap): AssignmentMap {
  * Called once in main.ts after fetching + validating the scenario JSON.
  */
 export function createGameStore(scenario: Scenario) {
-	const { precincts, parties, assignments, districtCount, terrainTiles, riverEdges } =
-		scenarioToRuntime(scenario);
+	const {
+		precincts,
+		parties,
+		assignments,
+		districtCount,
+		terrainTiles,
+		riverEdges,
+		independentHomes,
+	} = scenarioToRuntime(scenario);
 
 	// Snapshot of initial assignments — used by resetToInitial() to restore scenario start state
 	const initialAssignments: AssignmentMap = new Map(assignments);
@@ -64,6 +71,9 @@ export function createGameStore(scenario: Scenario) {
 		simulationResult: null,
 		terrainTiles,
 		riverEdges,
+		// Conditional spread: with exactOptionalPropertyTypes, an absent independent set
+		// must OMIT the field, not set it to undefined.
+		...(independentHomes ? { independentHomes } : {}),
 	};
 	initialState.simulationResult = runElection(initialState);
 

--- a/game/web/src/store/gameStore_test.ts
+++ b/game/web/src/store/gameStore_test.ts
@@ -247,4 +247,89 @@ test("undo: reverts assignments but leaves the live active district untouched (G
 	assertEqual(store.getState().activeDistrict, 1, "activeDistrict unchanged by undo (stays 1)");
 });
 
+// ─── GAME-118: home-base independent wiring (adapter → store → runElection) ─────
+//
+// The advisor's gate: a pure simulateDistrict test can't catch a dropped wire. This
+// exercises the real path — createGameStore runs the adapter (resolving the home
+// coord), builds GameState, and runs the election. If independentHomes fails to
+// thread through, the independent silently wins everywhere it leads and both asserts
+// below break.
+
+const PARTY_IND: Party = { id: pid("ind"), name: "Independent", abbreviation: "I" };
+
+function makeGroup3(rShare: number, dShare: number, indShare: number) {
+	return {
+		id: pcid("g1") as unknown as import("../model/scenario.js").GroupId,
+		population_share: 1.0,
+		vote_shares: {
+			[pid("r")]: rShare,
+			[pid("d")]: dShare,
+			[pid("ind")]: indShare,
+		} as unknown as Record<PartyId, number>,
+		turnout_rate: 1.0,
+	};
+}
+
+function makePrecinct3(
+	q: number,
+	r: number,
+	districtId: string,
+	group: ReturnType<typeof makeGroup3>,
+): ScenarioPrecinct {
+	return {
+		id: pcid(`p${q}_${r}`),
+		editable: true,
+		position: { q, r },
+		total_population: 100,
+		demographic_groups: [group],
+		initial_district_id: did(districtId),
+	};
+}
+
+// A 3-party scenario with a home-base independent (slot 2) whose home is precinct p0
+// at (0,0) in district 1. Both precincts lean independent (.45); the independent must
+// win d1 (home) and be excluded from d2 (a major takes it).
+function makeIndependentScenario(): Scenario {
+	return {
+		format_version: "1",
+		id: "test-ind-001" as unknown as Scenario["id"],
+		title: "Test Independent",
+		election_type: "congressional",
+		region: { id: "r1" as unknown as Scenario["region"]["id"], name: "Test Region" },
+		geometry: { type: "hex_axial" },
+		events: [],
+		rules: { population_tolerance: 0.05, contiguity: "allowed" },
+		success_criteria: [],
+		narrative: {
+			character: { name: "T", role: "Tester", motivation: "Testing" },
+			intro_slides: [],
+			objective: "Test",
+		},
+		parties: [PARTY_R, PARTY_D, { ...PARTY_IND, independent: true, home: { q: 0, r: 0 } }],
+		districts: [DISTRICT_1, DISTRICT_2],
+		precincts: [
+			makePrecinct3(0, 0, "d1", makeGroup3(0.3, 0.25, 0.45)), // I's home (d1)
+			makePrecinct3(1, 0, "d2", makeGroup3(0.3, 0.25, 0.45)), // away (d2)
+		],
+	};
+}
+
+test("createGameStore (GAME-118): independentHomes is carried from the scenario into GameState", () => {
+	const { store } = createGameStore(makeIndependentScenario());
+	const { independentHomes } = store.getState();
+	assertNotNull(independentHomes, "independentHomes present on GameState");
+	assertEqual(independentHomes!.get(pid("ind")), 0, "I's home resolves to precinct index 0");
+});
+
+test("createGameStore (GAME-118): independent wins its home district but is excluded elsewhere", () => {
+	const { store } = createGameStore(makeIndependentScenario());
+	const result = store.getState().simulationResult!;
+	const d1 = result.districtResults.find((r) => r.districtId === 1)!;
+	const d2 = result.districtResults.find((r) => r.districtId === 2)!;
+
+	assertEqual(d1.winner, pid("ind"), "d1 (home): independent wins");
+	assertEqual(d2.winner, pid("r"), "d2 (away): independent excluded → R wins");
+	assertEqual(result.seatsByParty[pid("ind")] ?? 0, 1, "independent holds exactly one seat");
+});
+
 summarize();


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: GAME-117 (#325) is on `main`

## Summary
Home-base independents (GAME-118, **PR 1 of 2** — the mechanic).

An independent carries a map-wide lean like any party, but is on the ballot only
in the district containing its `home` precinct:
- **Home district:** winner = plurality over the parties + the independent.
- **Every other district:** the independent is excluded from the seat contest;
  its votes are disregarded for the seat (not redistributed), so a major wins.
- **≤ 1 seat** per independent; an **unassigned home** ⇒ on no ballot anywhere.
- **Zero-or-more** independents per scenario, each with its own home.

The **lean map view is unchanged** — `voteTotals` still spans every party; only
the winner/margin are restricted to eligible parties. When a scenario declares no
independents, `GameState.independentHomes` is omitted and the runtime is
byte-identical to today.

Loader validation: `independent ⟺ home`; an independent may not sit in a major
slot (0/1, which anchor the two-party fairness metrics); a home requires
`hex_axial` geometry.

This PR is the mechanic + tests only. **PR 2** adds the home-pin (`⌂ name`) and
the non-home party-only note in the map surfaces (visual; held for eyeball).

## Validation performed
- [x] `bazel test //game/web/...` — 46/46 pass (incl. `e2e_test`, `lint_test`)
- [x] New coverage: election mechanic (6), `efficiency_gap` third-party branch,
      loader validation (4) + end-to-end `loadScenario` (1), adapter resolution +
      bad-coord throw (3), store end-to-end wiring (2)
- [x] No-independent regression: identical results with `independentHomes` absent
      (opt-in confirmed; byte-identical `GameState`)
- [ ] Home-pin visual on serve-local (N/A — PR 2)

## Affected machines / services
- None. Client-side TypeScript game logic; no services and no deploy in this PR.

## Deployment steps (POST-MERGE)
- None. Merges to `main`; the game deploys separately via `release.main.kts` when
  a release is cut.

## Tickets addressed
- see GAME-118 (PR 1 of 2 — mechanic; PR 2 adds the map home-pin visual)

## Rollback
- Revert the PR. The change is additive and opt-in — no shipped scenario declares
  an independent yet, so reverting restores identical behavior.
