### PR TITLE
feat(ui): home-base independent map pin + off-ballot notes (GAME-118 PR 2 of 2 — resolves)

### DIFF
--- a/game/web/BUILD.bazel
+++ b/game/web/BUILD.bazel
@@ -210,6 +210,7 @@ sh_test(
         "e2e/submit-on-invalid.spec.ts",
         "e2e/sprint5.spec.ts",
         "e2e/tutorial-005-multiparty.spec.ts",
+        "e2e/home-independent.spec.ts",
         # Playwright packages as declared Bazel deps — ensures the cache key includes
         # the playwright version and the files are available in runfiles.
         "//game:node_modules/@playwright/test",

--- a/game/web/e2e/home-independent.spec.ts
+++ b/game/web/e2e/home-independent.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * GAME-118 PR 2: home-base independent map surfaces (home pin + party-only note).
+ *
+ * tutorial-005 already ships a third-party candidate (Dhalsim) in party slot 2. Here we
+ * intercept its JSON and flag that party as a home-base independent — `independent` + a
+ * `home` precinct — so GAME-118's render paths light up without waiting on GAME-121's
+ * authored independent tutorial. Asserts the "⌂ name" pin renders at the home precinct and
+ * that, once districts are drawn, a non-home district's result card marks the independent
+ * "(not on ballot)" with the explanatory footnote. Full visual polish is a serve-local
+ * eyeball. &debug reaches the gated debug campaign (as in tutorial-005-multiparty.spec).
+ */
+
+import { expect, test } from "@playwright/test";
+
+test("home-base independent: ⌂ pin renders and a non-home district reads party-only", async ({
+	page,
+}) => {
+	const errors: string[] = [];
+	page.on("pageerror", (e) => errors.push(String(e)));
+
+	// Patch tutorial-005 in flight: promote the slot-2 party (Dhalsim) to a home-base
+	// independent homed at the first precinct. The route must be registered before navigation.
+	await page.route("**/scenarios/tutorial-005.json", async (route) => {
+		const response = await route.fetch();
+		const scenario = await response.json();
+		const independent = scenario.parties[2];
+		independent.independent = true;
+		independent.home = {
+			q: scenario.precincts[0].position.q,
+			r: scenario.precincts[0].position.r,
+		};
+		await route.fulfill({ json: scenario });
+	});
+
+	await page.goto("/?s=tutorial-005&campaign=debug&debug");
+	await page.emulateMedia({ reducedMotion: "reduce" });
+
+	const skip = page.locator("#btn-intro-skip");
+	await expect(skip).toBeVisible({ timeout: 15_000 });
+	await skip.click();
+
+	await expect(page.locator("path.hex").first()).toBeVisible({ timeout: 15_000 });
+
+	// The home pin renders on load (no districting needed) — "⌂ <independent name>" at the
+	// home precinct. Its presence proves the map renderer's home-pin path (mapRenderer.ts).
+	const pin = page.locator("text.home-pin");
+	await expect(pin).toHaveCount(1);
+	await expect(pin).toContainText("⌂");
+	await expect(pin).toContainText("Dhalsim");
+
+	// Draw districts so result cards appear: the home precinct (index 0) alone in D1, every
+	// other precinct in D2. D1 holds the independent's home; D2 is a party-only race.
+	await page.evaluate(() => {
+		const store = (
+			window as unknown as {
+				__gameStore?: {
+					getState: () => {
+						precincts: unknown[];
+						paintStroke: (ids: number[], district: number) => void;
+					};
+				};
+			}
+		).__gameStore;
+		if (!store) throw new Error("__gameStore not found on window");
+		const state = store.getState();
+		const others: number[] = [];
+		for (let i = 1; i < state.precincts.length; i++) others.push(i);
+		state.paintStroke([0], 1);
+		state.paintStroke(others, 2);
+	});
+
+	// The non-home district (D2) shows the independent's map-wide lean but marks it off-ballot,
+	// and a one-time footnote explains the ⌂ pin (renderResults, panels.ts). Exactly one card —
+	// the home district (D1) lists the independent as a contender, not off-ballot.
+	await expect(page.locator(".result-district").filter({ hasText: "(not on ballot)" })).toHaveCount(
+		1,
+	);
+	// The home district (D1) lists the independent as a contender, marked ⌂ — not off-ballot. Only
+	// D1's card carries ⌂: the map pin's ⌂ lives in text.home-pin, the legend's in .results-footnote,
+	// so filtering .result-district by ⌂ isolates the home-contender branch (panels.ts).
+	await expect(page.locator(".result-district").filter({ hasText: "⌂" })).toHaveCount(1);
+	await expect(page.locator(".results-footnote")).toContainText("home district");
+
+	// The precinct info panel reads lean ≠ ballot too (mapRenderer.ts): hovering a non-home precinct
+	// (D2) shows the independent's map-wide lean flagged "(not on ballot)"; hovering the home precinct
+	// (D1) marks it ⌂. data-precinct-id is the precinct index (0 = home precinct, painted into D1).
+	await page.locator('path.hex[data-precinct-id="1"]').hover();
+	await expect(page.locator("#precinct-info")).toContainText("(not on ballot)");
+	await page.locator('path.hex[data-precinct-id="0"]').hover();
+	await expect(page.locator("#precinct-info")).toContainText("⌂");
+
+	expect(errors, `page errors on the independent render path: ${errors.join("; ")}`).toHaveLength(
+		0,
+	);
+});

--- a/game/web/src/render/mapRenderer.ts
+++ b/game/web/src/render/mapRenderer.ts
@@ -248,6 +248,7 @@ export class SvgMapRenderer implements MapRenderer {
 	private hoverHighlightGroup: GSel;
 	private riverGroup: GSel;
 	private previewBorderGroup: GSel;
+	private homePinGroup: GSel;
 	private getState: () => GameStore;
 	private paintStroke: GameStore["paintStroke"];
 	private setActiveDistrict: GameStore["setActiveDistrict"];
@@ -350,6 +351,8 @@ export class SvgMapRenderer implements MapRenderer {
 	private static readonly FOOTHILL_INTRUSION_DEPTH = 6;
 	private static readonly LAKE_INTRUSION_DEPTH = 5;
 	private static readonly COORD_LABEL_FONT_SIZE = 9; // apparent px at any zoom level
+	// Home-pin (GAME-118) label size — apparent px at any zoom level, like coord labels.
+	private static readonly HOME_PIN_FONT_SIZE = 12;
 
 	// Keyboard precinct navigation state
 	private focusedPrecinctId: number | null = null;
@@ -395,6 +398,9 @@ export class SvgMapRenderer implements MapRenderer {
 			.append("g")
 			.attr("class", "coord-labels")
 			.attr("display", "none");
+		// Home-base independents (GAME-118): a "⌂ name" label pinned at each independent's home
+		// precinct. Appended last so it sits above every map layer and is never occluded.
+		this.homePinGroup = this.zoomGroup.append("g").attr("class", "home-pins");
 
 		const pops = getState().precincts.map((p) => p.population);
 		this.popMin = Math.min(...pops);
@@ -1068,6 +1074,11 @@ export class SvgMapRenderer implements MapRenderer {
 						.attr("font-size", fs)
 						.attr("stroke-width", 3 / this.currentK);
 				}
+				// Home pins keep a constant apparent size like coord labels.
+				this.homePinGroup
+					.selectAll("text.home-pin")
+					.attr("font-size", SvgMapRenderer.HOME_PIN_FONT_SIZE / this.currentK)
+					.attr("stroke-width", 3.5 / this.currentK);
 			});
 
 		// Prevent context menu on right-click so drag-pan isn't interrupted.
@@ -1133,6 +1144,45 @@ export class SvgMapRenderer implements MapRenderer {
 			.attr("opacity", (d) => this.hexOpacity(d, assignments));
 
 		this.renderBoundaries(computeBoundarySegments(precincts, assignments, this.terrainFacingEdges));
+		this.renderHomePins();
+	}
+
+	// Home pins (GAME-118): a "⌂ name" label at each home-base independent's home precinct.
+	// An independent contests only its home district, so the pin tells the player where that
+	// candidate is actually on the ballot. Font/stroke divide by currentK so the label keeps a
+	// constant apparent size at any zoom (mirrors coord labels); the zoom handler re-applies both.
+	private renderHomePins() {
+		const { precincts, independentHomes } = this.getState();
+		const homes = independentHomes ? [...independentHomes] : [];
+		const pins = homes.flatMap(([party, precinctIndex]) => {
+			const precinct = precincts[precinctIndex];
+			if (precinct === undefined) return [];
+			const name = this.partyNames[party] ?? partyLabel(this.parties, party);
+			return [{ party, x: precinct.center.x, y: precinct.center.y, label: `⌂ ${name}` }];
+		});
+		this.homePinGroup
+			.selectAll<SVGTextElement, (typeof pins)[number]>("text.home-pin")
+			.data(pins, (d) => String(d.party))
+			.join(
+				(enter) =>
+					enter
+						.append("text")
+						.attr("class", "home-pin")
+						.attr("text-anchor", "middle")
+						.attr("dominant-baseline", "central")
+						.attr("font-weight", 700)
+						.attr("fill", "white")
+						.attr("stroke", "rgba(0,0,0,0.8)")
+						.attr("paint-order", "stroke")
+						.attr("pointer-events", "none"),
+				(update) => update,
+				(exit) => exit.remove(),
+			)
+			.attr("x", (d) => d.x)
+			.attr("y", (d) => d.y)
+			.attr("font-size", SvgMapRenderer.HOME_PIN_FONT_SIZE / this.currentK)
+			.attr("stroke-width", 3.5 / this.currentK)
+			.text((d) => d.label);
 	}
 
 	private renderBoundaries(segments: Segment[]) {
@@ -1258,7 +1308,7 @@ export class SvgMapRenderer implements MapRenderer {
 					.attr("opacity", SvgMapRenderer.BOUNDARY_OPACITY)
 					.style("pointer-events", "none");
 
-				const { assignments } = this.getState();
+				const { assignments, independentHomes } = this.getState();
 				const dId = assignments.get(d.index);
 				const infoPanel = document.getElementById("precinct-info");
 				if (infoPanel !== null) {
@@ -1287,10 +1337,19 @@ export class SvgMapRenderer implements MapRenderer {
 							)
 							.join("");
 						const legend = ranked
-							.map(
-								({ p, pct }) =>
-									`${escapeHtml(this.partyNames[p] ?? partyLabel(this.parties, p))} ${pct.toFixed(0)}%`,
-							)
+							.map(({ p, pct }) => {
+								const entry = `${escapeHtml(this.partyNames[p] ?? partyLabel(this.parties, p))} ${pct.toFixed(0)}%`;
+								// Home-base independent (GAME-118): on the ballot only where its home
+								// precinct's district matches this precinct's. Its lean shows everywhere
+								// (map-wide), so mark on-ballot precincts with ⌂ and flag the rest — the
+								// precinct info panel is where lean ≠ ballot is easiest to misread.
+								const homeIdx = independentHomes?.get(p);
+								if (homeIdx === undefined) return entry;
+								const homeDist = assignments.get(homeIdx);
+								return homeDist !== undefined && homeDist === dId
+									? `⌂ ${entry}`
+									: `${entry} <span class="off-ballot">(not on ballot)</span>`;
+							})
 							.join(" · ");
 						breakdownHtml =
 							`<div class="vote-bar-multi" style="margin:5px 0 3px">${bar}</div>` +

--- a/game/web/src/render/panels.ts
+++ b/game/web/src/render/panels.ts
@@ -40,6 +40,17 @@ export function renderResults(
 	};
 
 	const { districtResults } = state.simulationResult;
+	// Home-base independents (GAME-118): declared with a home precinct, they carry a map-wide
+	// lean but appear on the ballot only in the district holding that precinct. `homeDistrictOf`
+	// resolves the live home district (the home precinct's current assignment); an unassigned
+	// home is `undefined`, so the independent reads as off-ballot everywhere — correct, it is on
+	// no ballot at all. Absent `independentHomes` (every shipped scenario today) → all false.
+	const independentHomes = state.independentHomes;
+	const isIndependent = (p: PartyId): boolean => independentHomes?.has(p) ?? false;
+	const homeDistrictOf = (p: PartyId): number | undefined => {
+		const idx = independentHomes?.get(p);
+		return idx === undefined ? undefined : (state.assignments.get(idx) ?? undefined);
+	};
 	const html = districtResults
 		.map((r) => {
 			const color = districtColor(r.districtId);
@@ -60,7 +71,17 @@ export function renderResults(
 							`<span style="width:${pct.toFixed(1)}%;background:${colorOf(p)}"></span>`,
 					)
 					.join("");
-				const details = ranked.map(({ p, pct }) => `${labelOf(p)} ${pct.toFixed(1)}%`).join(" · ");
+				const details = ranked
+					.map(({ p, pct }) => {
+						const entry = `${labelOf(p)} ${pct.toFixed(1)}%`;
+						if (!isIndependent(p)) return entry;
+						// In its home district the independent is a real contender — mark it with the same
+						// ⌂ glyph as the map pin. Elsewhere its lean shows but it isn't on the ballot.
+						return homeDistrictOf(p) === r.districtId
+							? `⌂ ${entry}`
+							: `${entry} <span class="off-ballot">(not on ballot)</span>`;
+					})
+					.join(" · ");
 				return `
       <div class="result-district" style="border-left-color:${color}">
         <div class="dist-name">District ${r.districtId}</div>
@@ -89,7 +110,13 @@ export function renderResults(
 		})
 		.join("");
 
-	container.innerHTML = html;
+	// One-time legend for the ⌂ pin / off-ballot marker — shown only when the scenario has an
+	// independent, so scenarios without one render exactly as before (GAME-118).
+	const footnote =
+		(independentHomes?.size ?? 0) > 0
+			? `<div class="results-footnote">⌂ Independent candidates run only in their home district (pinned on the map). Elsewhere their support is shown for context, but they are not on the ballot.</div>`
+			: "";
+	container.innerHTML = html + footnote;
 }
 
 export function renderDistrictButtons(

--- a/game/web/styles.css
+++ b/game/web/styles.css
@@ -519,6 +519,21 @@ body {
 	margin-bottom: 4px;
 }
 
+/* GAME-118: a home-base independent's lean still shows in non-home districts (result card and
+   precinct info panel), muted with "(not on ballot)" since it can't win the seat there. */
+.off-ballot {
+	color: #707088;
+	font-style: italic;
+}
+
+/* GAME-118: one-time legend under the result cards explaining the ⌂ pin / off-ballot marker. */
+.results-footnote {
+	margin-top: 8px;
+	font-size: 0.72rem;
+	line-height: 1.4;
+	color: #707088;
+}
+
 #precinct-info {
 	background: #0a1f3a;
 	border: 1px solid #1a3a5c;


### PR DESCRIPTION
## Summary

PR 2 of 2 for **GAME-118 — home-base independent candidates**. Follows #326 (PR 1),
which added the model + loader + election: a party flagged `independent: true` with a
`home` precinct carries a **map-wide lean** but is on the ballot **only in the district
that holds its home precinct**. This PR adds the three render surfaces the ticket AC calls
for ("home pin on map; non-home districts' **result/info** convey the party-only contest").

### Surfaces (AC coverage)

| Surface | Behavior |
|---|---|
| **Map home pin** (`mapRenderer.ts`) | A `⌂ name` label pinned at each independent's home precinct — where that candidate is actually on the ballot. Constant apparent size at any zoom (like coord labels); topmost layer, never occluded. |
| **Result card** (`panels.ts`) | In its home district the independent reads as a contender, marked `⌂`. Elsewhere its lean still shows but is flagged `(not on ballot)`. A one-time footnote legend explains the `⌂`. |
| **Precinct info panel** (`mapRenderer.ts`) | The per-party hover breakdown flags the independent the same way — `⌂` where the hovered precinct's district holds the home, `(not on ballot)` otherwise. This is where lean ≠ ballot is easiest to misread, so the flag matters most here. |

The **lean map itself is unchanged** — the independent's support is map-wide, which is
exactly the lean ≠ ballot distinction the mechanic teaches.

**Backward-compatible by construction:** all three surfaces are no-ops when a scenario
declares no independent — `independentHomes` is empty, every `isIndependent(p)` is false,
the footnote is omitted, output is byte-identical. Every shipped scenario is in that state.

### ⚠️ Renders nothing in the game today

**No shipped scenario declares an independent yet.** `tutorial-005`'s slot-2 party
(Dhalsim) is a plain party; the only references to `independent`/`home` in the tree are
`loader.ts` + its tests. So this PR changes **nothing a player sees right now** — the
visual payoff lands with **GAME-121**'s authored independent tutorial (tutorial-006),
which will declare a real home-base independent and exercise these exact surfaces.

### 📦 Packaging question (for @cgruber)

Because nothing renders without an authored independent, the usual "hold for a serve-local
eyeball" doesn't apply to *this* PR standalone — there's nothing to look at yet. The choice:

- **(a) Merge now** as e2e-verified plumbing; eyeball the visuals for real alongside
  GAME-121's scenario; **or**
- **(b) Hold** this branch and merge it together with GAME-121 so the first eyeball covers
  both mechanic and scenario at once.

I'll wait for your call before merging.

## Affected machines / services

None. Client-side, render-only change to the game web app (`game/web`). No server, infra,
migration, config, or deploy surface is touched.

## Validation performed

Full web suite green locally — **46/46** (`bazel test //game/web/...`): typecheck, unit,
lint (Biome clean), and e2e all pass.

New `e2e/home-independent.spec.ts` route-intercepts `tutorial-005.json`, promotes its
slot-2 party to a home-base independent homed at the first precinct (zero repo footprint —
no test scenario shipped), then asserts:
- the `⌂ name` map pin renders at the home precinct;
- **both** result-card branches — the home district's `⌂` contender **and** a non-home
  district's `(not on ballot)`;
- the footnote legend;
- **both** info-panel hover states (`(not on ballot)` on a non-home precinct, `⌂` on the
  home precinct);
- **zero page errors** on the whole render path.

## Deployment steps

None. No deploy in this PR. Merges to `main`; the change ships whenever the next manual
`beta` deploy runs (deploys are manual in this project). Nothing renders for players until
a scenario declares an independent (GAME-121).

## Tickets addressed

- **GAME-118** — home-base independent candidates (PR 2 of 2 — resolves). Follows #326 (PR 1 of 2).

## Rollback

Revert the merge commit. Fully backward-compatible — no schema, data, or migration change;
`independentHomes` is empty for every shipped scenario, so all three surfaces are inert and
a revert is a no-op for players.

## Checklist

- [x] Full web suite green locally (46/46)
- [x] AC covered: home pin + result-card note + info-panel note (result **and** info)
- [x] No-independent scenarios render byte-identically (backward-compatible)
- [x] New e2e wired into `BUILD.bazel`; Biome clean
- [ ] Serve-local visual eyeball — **N/A**: nothing renders until a scenario declares an independent; first visual eyeball happens with GAME-121
- [ ] Flip GAME-118 → resolved in `TICKETS.md` — **POST-MERGE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
